### PR TITLE
feat(hermes): WSL auto-discovery — distro probe + UNC fallback + status (#87)

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -54,6 +54,9 @@ const {
   listDroidSettingsFiles,
   resolveDroidSessionsDir,
   resolveGrokBuildSessions,
+  resolveHermesPath,
+  resolveHermesDbPath,
+  probeWslDistros,
 } = require("../lib/rollout");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 
@@ -245,6 +248,15 @@ async function cmdStatus(argv = []) {
     : [];
   const grokInstalled = grokHookState.hasGrokInstall || grokSessions.length > 0;
 
+  // Hermes Agent — SQLite state.db, resolved via override / native Windows
+  // install / WSL auto-discovery. Surface the resolved path (UNC included) and,
+  // on Windows, the discovered distros so WSL users can debug "why no sync"
+  // without guessing the right UNC alias (#87).
+  const hermesPath = resolveHermesPath();
+  const hermesDbPath = resolveHermesDbPath();
+  const hermesInstalled = fssync.existsSync(hermesDbPath);
+  const hermesWslDistros = process.platform === "win32" ? probeWslDistros() : [];
+
   const copilotToken = readCopilotOauthToken({ home });
   const copilotOtel = describeCopilotOtelStatus({ home, env: process.env });
   const copilotLines = formatCopilotLines({
@@ -341,6 +353,13 @@ async function cmdStatus(argv = []) {
               detail: grokHookState.configured ? "hook installed" : "detected",
             }
           : { installed: false },
+        hermes: {
+          installed: hermesInstalled,
+          detail: hermesPath,
+          ...(hermesWslDistros.length
+            ? { wsl_distros: hermesWslDistros.map((d) => ({ name: d.name, version: d.version })) }
+            : {}),
+        },
       },
       copilot: {
         token_set: Boolean(copilotToken),
@@ -421,6 +440,18 @@ async function cmdStatus(argv = []) {
       droidInstalled
         ? `- Droid (Factory): passive reader (${droidSettingsFiles.length} session${droidSettingsFiles.length !== 1 ? "s" : ""} in ${droidSessionsDir}, cumulative-delta)`
         : null,
+      ...(() => {
+        // Always surface Hermes when its state.db resolves; on Windows also show
+        // it when WSL distros are discovered so users can debug UNC resolution.
+        if (!hermesInstalled && hermesWslDistros.length === 0) return [];
+        const wslSuffix = hermesWslDistros.length
+          ? `; WSL distros: ${hermesWslDistros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`
+          : "";
+        const head = hermesInstalled
+          ? `- Hermes Agent: state.db found (${hermesPath})`
+          : `- Hermes Agent: state.db not found (resolved ${hermesPath})`;
+        return [`${head}${wslSuffix}`];
+      })(),
       ...(() => {
         const passive = passiveProviders.filter((p) => p.passive);
         if (passive.length === 0) return [];
@@ -553,6 +584,9 @@ function renderLightTable(summary) {
     if (typeof info.installed === "boolean") detail.push(info.installed ? "installed" : "not installed");
     if (typeof info.files === "number") detail.push(`${info.files} file${info.files !== 1 ? "s" : ""}`);
     if (info.detail) detail.push(info.detail);
+    if (Array.isArray(info.wsl_distros) && info.wsl_distros.length) {
+      detail.push(`WSL: ${info.wsl_distros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`);
+    }
     push(`Provider · ${name}`, detail.length ? detail.join(", ") : "—");
   }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2985,22 +2985,22 @@ function resolveHermesPath(env = process.env, deps = {}) {
   }
   const home = require("node:os").homedir();
   const defaultPath = path.join(home, ".hermes");
-  // Hermes official Windows installer (install.ps1) writes state to
-  // %LOCALAPPDATA%\hermes, not ~/.hermes. Prefer it when present so native
-  // Windows users don't need to set TOKENTRACKER_HERMES_HOME manually.
+  // On Windows, scan BOTH the native install (%LOCALAPPDATA%\hermes) and
+  // any WSL distros running Hermes Agent. Each install has its own independent
+  // state.db with different sessions, so there is no double-counting risk.
+  // WSL is preferred when both exist because development happens in WSL (#87).
   if (process.platform === "win32") {
+    let nativePath = null;
     const localAppData = typeof env.LOCALAPPDATA === "string" ? env.LOCALAPPDATA.trim() : "";
     if (localAppData.length > 0) {
-      const winNative = path.join(localAppData, "hermes");
+      const candidate = path.join(localAppData, "hermes");
       try {
-        if (fssync.existsSync(winNative)) return winNative;
+        if (fssync.existsSync(candidate)) nativePath = candidate;
       } catch (_e) { }
     }
-    // No native Windows install — probe WSL distros so users running Hermes
-    // inside WSL get zero-config discovery instead of setting
-    // TOKENTRACKER_HERMES_HOME by hand (#87).
     const wslPath = discoverWslHermesHome(deps);
     if (wslPath) return wslPath;
+    if (nativePath) return nativePath;
   }
   return defaultPath;
 }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2978,7 +2978,7 @@ async function parseKiroIncremental({ dbPath, jsonlPath, cursors, queuePath, onP
 // Hermes Agent — SQLite-based (sessions table in ~/.hermes/state.db)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function resolveHermesPath(env = process.env) {
+function resolveHermesPath(env = process.env, deps = {}) {
   const override = env.TOKENTRACKER_HERMES_HOME;
   if (typeof override === "string" && override.trim().length > 0) {
     return override.trim();
@@ -2996,8 +2996,99 @@ function resolveHermesPath(env = process.env) {
         if (fssync.existsSync(winNative)) return winNative;
       } catch (_e) { }
     }
+    // No native Windows install — probe WSL distros so users running Hermes
+    // inside WSL get zero-config discovery instead of setting
+    // TOKENTRACKER_HERMES_HOME by hand (#87).
+    const wslPath = discoverWslHermesHome(deps);
+    if (wslPath) return wslPath;
   }
   return defaultPath;
+}
+
+// ── WSL auto-discovery (Windows host, Hermes installed inside a distro) ──────
+// `wsl.exe -l -v` prints UTF-16LE; the per-distro `whoami` runs a Linux process
+// so its stdout is UTF-8. We capture buffers and decode per-call.
+function defaultRunWsl(args, { utf16 = false } = {}) {
+  const { execFileSync } = require("node:child_process");
+  const buf = execFileSync("wsl.exe", args, {
+    timeout: 5000,
+    windowsHide: true,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return utf16 ? buf.toString("utf16le") : buf.toString("utf8");
+}
+
+// Parse `wsl.exe -l -v` output into [{ name, version, isDefault }]. The default
+// distro is prefixed with `*`; the VERSION column (1 or 2) decides which UNC
+// alias to try first (simonlpaige, #87).
+function parseWslListVerbose(raw) {
+  if (typeof raw !== "string") return [];
+  const distros = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const clean = line.replace(/ /g, "").replace(/﻿/g, "").trim();
+    if (!clean) continue;
+    const cells = clean.split(/\s+/);
+    let isDefault = false;
+    let idx = 0;
+    if (cells[0] === "*") {
+      isDefault = true;
+      idx = 1;
+    }
+    const name = cells[idx];
+    if (!name || name === "NAME") continue; // skip header row
+    const version = parseInt(cells[cells.length - 1], 10);
+    distros.push({
+      name,
+      version: Number.isFinite(version) ? version : null,
+      isDefault,
+    });
+  }
+  return distros;
+}
+
+// Default distro first, then listed order — matches what a user expects when
+// they have one primary distro plus extras.
+function probeWslDistros(deps = {}) {
+  const runWsl = deps.runWsl || defaultRunWsl;
+  let raw;
+  try {
+    raw = runWsl(["-l", "-v"], { utf16: true });
+  } catch (_e) {
+    return [];
+  }
+  const distros = parseWslListVerbose(raw);
+  return distros.sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+}
+
+// Probe each WSL distro for ~/.hermes via UNC. The Linux username rarely equals
+// %USERNAME%, so we ask the distro directly with `whoami` rather than guessing
+// (simonlpaige, #87).
+function discoverWslHermesHome(deps = {}) {
+  const runWsl = deps.runWsl || defaultRunWsl;
+  const existsSync = deps.existsSync || fssync.existsSync;
+  const distros = probeWslDistros(deps);
+  for (const distro of distros) {
+    let user;
+    try {
+      user = String(runWsl(["-d", distro.name, "-e", "whoami"], { utf16: false }) || "").trim();
+    } catch (_e) {
+      user = "";
+    }
+    if (!user) continue;
+    // \\wsl$\ is the legacy alias, \\wsl.localhost\ the newer one. WSL1 distros
+    // sometimes only resolve via \\wsl.localhost\, so order by version.
+    const roots = distro.version === 1
+      ? ["\\\\wsl.localhost\\", "\\\\wsl$\\"]
+      : ["\\\\wsl$\\", "\\\\wsl.localhost\\"];
+    for (const root of roots) {
+      const candidate = `${root}${distro.name}\\home\\${user}\\.hermes`;
+      try {
+        if (existsSync(candidate)) return candidate;
+      } catch (_e) { }
+    }
+  }
+  return null;
 }
 
 function resolveHermesDbPath(env = process.env) {
@@ -8138,6 +8229,9 @@ module.exports = {
   resolveKiroJsonlPath,
   resolveHermesPath,
   resolveHermesDbPath,
+  parseWslListVerbose,
+  probeWslDistros,
+  discoverWslHermesHome,
   resolveCopilotOtelPaths,
   parseRolloutIncremental,
   parseClaudeIncremental,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -15,6 +15,9 @@ const {
   parseHermesIncremental,
   resolveHermesPath,
   resolveHermesDbPath,
+  parseWslListVerbose,
+  probeWslDistros,
+  discoverWslHermesHome,
   parseCopilotIncremental,
   parseKimiIncremental,
   parseCodebuddyIncremental,
@@ -2976,6 +2979,85 @@ test("resolveHermesPath prefers %LOCALAPPDATA%\\hermes on Windows when present",
   assert.equal(
     resolveHermesPath({ LOCALAPPDATA: tmp, TOKENTRACKER_HERMES_HOME: "/custom/hermes" }),
     "/custom/hermes",
+  );
+});
+
+test("parseWslListVerbose parses distros, default marker and version column", () => {
+  const raw = "  NAME            STATE           VERSION\n" +
+    "* Ubuntu          Running         2\n" +
+    "  Debian-22.04    Stopped         1\n";
+  assert.deepEqual(parseWslListVerbose(raw), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+    { name: "Debian-22.04", version: 1, isDefault: false },
+  ]);
+});
+
+test("parseWslListVerbose tolerates UTF-16 NUL/BOM noise and skips the header", () => {
+  // wsl.exe -l -v emits UTF-16LE; a mis-decode leaves a leading BOM and NUL
+  // bytes between characters. The parser strips both defensively.
+  const raw = "\uFEFF  NAME   STATE   VERSION\n* Ub\u0000untu Running 2\n";
+  assert.deepEqual(parseWslListVerbose(raw), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+  ]);
+  assert.deepEqual(parseWslListVerbose(""), []);
+  assert.deepEqual(parseWslListVerbose(undefined), []);
+});
+
+test("probeWslDistros sorts the default distro first and is fail-safe", () => {
+  const raw = "  NAME    STATE    VERSION\n  Debian  Stopped  1\n* Ubuntu  Running  2\n";
+  assert.deepEqual(probeWslDistros({ runWsl: () => raw }), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+    { name: "Debian", version: 1, isDefault: false },
+  ]);
+  // A throwing wsl.exe (not installed / no distros) yields an empty list.
+  assert.deepEqual(
+    probeWslDistros({ runWsl: () => { throw new Error("wsl not found"); } }),
+    [],
+  );
+});
+
+test("discoverWslHermesHome resolves ~/.hermes via the right UNC alias per distro", () => {
+  const list = "  NAME    STATE    VERSION\n* Ubuntu  Running  2\n  Legacy  Running  1\n";
+  // Linux usernames differ from %USERNAME% — whoami is asked per distro (#87).
+  const users = { Ubuntu: "alice\n", Legacy: "bob\n" };
+  const runWsl = (args) => (args[0] === "-l" ? list : users[args[1]]);
+
+  // WSL2 distro found via the legacy \\wsl$\ alias (tried first for v2).
+  const tried = [];
+  const hit = discoverWslHermesHome({
+    runWsl,
+    existsSync: (p) => {
+      tried.push(p);
+      return p === "\\\\wsl$\\Ubuntu\\home\\alice\\.hermes";
+    },
+  });
+  assert.equal(hit, "\\\\wsl$\\Ubuntu\\home\\alice\\.hermes");
+  assert.equal(tried[0], "\\\\wsl$\\Ubuntu\\home\\alice\\.hermes");
+
+  // WSL1 distro: \\wsl.localhost\ is tried before \\wsl$\.
+  const tried1 = [];
+  const hit1 = discoverWslHermesHome({
+    runWsl,
+    existsSync: (p) => {
+      tried1.push(p);
+      return p === "\\\\wsl.localhost\\Legacy\\home\\bob\\.hermes";
+    },
+  });
+  assert.equal(hit1, "\\\\wsl.localhost\\Legacy\\home\\bob\\.hermes");
+  // Ubuntu (default) probed first, both its roots miss, then Legacy via localhost.
+  assert.equal(tried1[tried1.length - 1], "\\\\wsl.localhost\\Legacy\\home\\bob\\.hermes");
+  assert.ok(tried1.indexOf("\\\\wsl.localhost\\Legacy\\home\\bob\\.hermes") <
+    tried1.indexOf("\\\\wsl$\\Legacy\\home\\bob\\.hermes") || !tried1.includes("\\\\wsl$\\Legacy\\home\\bob\\.hermes"));
+
+  // No .hermes anywhere → null (caller falls back to ~/.hermes).
+  assert.equal(discoverWslHermesHome({ runWsl, existsSync: () => false }), null);
+  // A distro whose whoami fails is skipped, not crashed on.
+  assert.equal(
+    discoverWslHermesHome({
+      runWsl: (args) => { if (args[0] === "-l") return list; throw new Error("whoami failed"); },
+      existsSync: () => true,
+    }),
+    null,
   );
 });
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2948,9 +2948,11 @@ test("resolveHermesPath honors TOKENTRACKER_HERMES_HOME override", () => {
     path.join(override, "state.db"),
   );
   // Falls back to ~/.hermes when override is empty or absent.
-  const fallback = resolveHermesPath({ TOKENTRACKER_HERMES_HOME: "  " });
+  // Suppress the WSL probe so this assertion is deterministic on Windows (#87).
+  const noWsl = { runWsl: () => { throw new Error("no WSL"); } };
+  const fallback = resolveHermesPath({ TOKENTRACKER_HERMES_HOME: "  " }, noWsl);
   assert.equal(fallback, path.join(os.homedir(), ".hermes"));
-  assert.equal(resolveHermesPath({}), path.join(os.homedir(), ".hermes"));
+  assert.equal(resolveHermesPath({}, noWsl), path.join(os.homedir(), ".hermes"));
 });
 
 test("resolveHermesPath prefers %LOCALAPPDATA%\\hermes on Windows when present", async (t) => {
@@ -2965,15 +2967,17 @@ test("resolveHermesPath prefers %LOCALAPPDATA%\\hermes on Windows when present",
   });
 
   // LOCALAPPDATA points at a dir that does NOT contain `hermes` → fall back.
+  // Suppress WSL probe so fallback is deterministic on Windows (#87).
+  const noWsl = { runWsl: () => { throw new Error("no WSL"); } };
   assert.equal(
-    resolveHermesPath({ LOCALAPPDATA: tmp }),
+    resolveHermesPath({ LOCALAPPDATA: tmp }, noWsl),
     path.join(os.homedir(), ".hermes"),
   );
 
   // After we create LOCALAPPDATA\hermes the resolver should prefer it over ~/.hermes.
   const winNative = path.join(tmp, "hermes");
   await fs.mkdir(winNative, { recursive: true });
-  assert.equal(resolveHermesPath({ LOCALAPPDATA: tmp }), winNative);
+  assert.equal(resolveHermesPath({ LOCALAPPDATA: tmp }, noWsl), winNative);
 
   // Explicit TOKENTRACKER_HERMES_HOME still wins over LOCALAPPDATA auto-detect.
   assert.equal(


### PR DESCRIPTION
Implements the three enhancements tracked in #87. Opened as a **draft** because the owner has no Windows + WSL hardware — needs real WSL1/WSL2 validation before merge (@simonlpaige kindly offered to test).

## What's here

**1. `wsl.exe -l -q` → `-l -v` distro auto-probe**
On Windows, when no native `%LOCALAPPDATA%\hermes` install is found, `resolveHermesPath()` now probes WSL distros and looks for `~/.hermes` over UNC. Zero-config for WSL users.

**2. `\\wsl$\` ↔ `\\wsl.localhost\` fallback**
Both aliases are attempted. Order keys off the version reported by `wsl.exe -l -v`: WSL2 tries `\\wsl$\` first, WSL1 tries `\\wsl.localhost\` first — per @simonlpaige's note that WSL1 sometimes only resolves via `\\wsl.localhost\`.

**3. Hermes in `tokentracker status`**
Hermes was **completely absent** from `status` output. Added it to JSON, the `--light` table and the human-readable list, surfacing the resolved path (UNC included) and, on Windows, the discovered distros + their versions — so "why didn't it sync my hermes" is debuggable at a glance.

## Incorporating review feedback (@simonlpaige)
- Username is read with `wsl.exe -d <distro> -e whoami` instead of concatenating `%USERNAME%` (Linux user ≠ Windows user).
- Version-aware UNC ordering (WSL1 vs WSL2).
- `status` shows the distro version.

## Safety
Discovery is fail-safe: missing `wsl.exe`, no distros, or a failing `whoami` all fall back to `~/.hermes`. macOS/Linux paths are untouched (the probe is gated on `process.platform === "win32"`).

## Tests
`test/rollout-parser.test.js` covers parsing (incl. UTF-16 NUL/BOM noise + header skip), default-distro ordering, per-distro `whoami`, and version-aware UNC ordering — all with injected `runWsl`/`existsSync` deps so they run on any platform. Full suite: 759 passing; guardrails + ui-hardcode validators clean.

## Not done here
No version bump / release — that follows after WSL validation confirms the UNC probing actually resolves on real hardware.

Refs #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hermes status information to command output, including installation state and resolved location.
  * On Windows, status now also shows detected WSL distros when applicable.

* **Bug Fixes**
  * Improved Windows path handling so Hermes locations are resolved more reliably, with clearer fallback behavior when no local install is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->