### PR TITLE
Skip forked Codex replay usage

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -824,6 +824,7 @@ async function parseRolloutFile({
       totals = totalUsage;
     }
 
+    // date matching is conservative; same-day fork replays are still counted.
     if (isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate })) continue;
 
     const bucketStart = toUtcHalfHourStart(tokenTimestamp);

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -746,6 +746,9 @@ async function parseRolloutFile({
   let model = typeof lastModel === "string" ? lastModel : null;
   let totals = lastTotal && typeof lastTotal === "object" ? lastTotal : null;
   let currentCwd = null;
+  let currentDate = null;
+  let isForkedRollout = false;
+  const rolloutDate = rolloutDateFromPath(filePath);
   let currentProjectRef = projectRef || null;
   let currentProjectKey = projectKey || null;
   let eventsAggregated = 0;
@@ -756,7 +759,10 @@ async function parseRolloutFile({
     const maybeTurnContext =
       !maybeTokenCount &&
       (line.includes('"turn_context"') || line.includes('"session_meta"')) &&
-      (line.includes('"model"') || line.includes('"cwd"'));
+      (line.includes('"model"') ||
+        line.includes('"cwd"') ||
+        line.includes('"current_date"') ||
+        line.includes('"forked_from_id"'));
     if (!maybeTokenCount && !maybeTurnContext) continue;
 
     let obj;
@@ -771,6 +777,12 @@ async function parseRolloutFile({
       obj?.payload &&
       typeof obj.payload === "object"
     ) {
+      if (obj.type === "session_meta" && typeof obj.payload.forked_from_id === "string") {
+        isForkedRollout = obj.payload.forked_from_id.trim().length > 0;
+      }
+      if (obj.type === "turn_context" && typeof obj.payload.current_date === "string") {
+        currentDate = normalizeIsoDate(obj.payload.current_date);
+      }
       if (typeof obj.payload.model === "string") {
         model = obj.payload.model;
       }
@@ -811,6 +823,8 @@ async function parseRolloutFile({
     if (totalUsage && typeof totalUsage === "object") {
       totals = totalUsage;
     }
+
+    if (isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate })) continue;
 
     const bucketStart = toUtcHalfHourStart(tokenTimestamp);
     if (!bucketStart) continue;
@@ -1770,6 +1784,21 @@ function toUtcHalfHourStart(ts) {
     ),
   );
   return bucketStart.toISOString();
+}
+
+function rolloutDateFromPath(filePath) {
+  const match = path.basename(String(filePath || "")).match(/^rollout-(\d{4}-\d{2}-\d{2})T/);
+  return match ? match[1] : null;
+}
+
+function normalizeIsoDate(value) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  const match = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : null;
+}
+
+function isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate }) {
+  return Boolean(isForkedRollout && rolloutDate && currentDate && currentDate < rolloutDate);
 }
 
 function normalizeNonNegativeNumber(value) {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -616,6 +616,79 @@ test("parseRolloutIncremental splits usage into half-hour buckets", async () => 
   }
 });
 
+test("parseRolloutIncremental skips historical replay tokens in forked Codex rollouts", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(
+      tmp,
+      "2026",
+      "06",
+      "09",
+      "rollout-2026-06-09T20-46-23-fork.jsonl",
+    );
+    await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const replayUsage = {
+      input_tokens: 100,
+      cached_input_tokens: 0,
+      output_tokens: 10,
+      reasoning_output_tokens: 0,
+      total_tokens: 110,
+    };
+    const liveUsage = {
+      input_tokens: 7,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 10,
+    };
+    const liveTotals = {
+      input_tokens: replayUsage.input_tokens + liveUsage.input_tokens,
+      cached_input_tokens: 0,
+      output_tokens: replayUsage.output_tokens + liveUsage.output_tokens,
+      reasoning_output_tokens: 0,
+      total_tokens: replayUsage.total_tokens + liveUsage.total_tokens,
+    };
+
+    const lines = [
+      buildSessionMetaLine({
+        model: "gpt-5.5",
+        cwd: tmp,
+        forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c",
+      }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-05-08" }),
+      buildTokenCountLine({
+        ts: "2026-06-09T20:46:26.530Z",
+        last: replayUsage,
+        total: replayUsage,
+      }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({
+        ts: "2026-06-09T20:47:00.000Z",
+        last: liveUsage,
+        total: liveTotals,
+      }),
+    ];
+    await fs.writeFile(rolloutPath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(res.filesProcessed, 1);
+    assert.equal(res.eventsAggregated, 1);
+    assert.equal(res.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, liveUsage.input_tokens);
+    assert.equal(queued[0].output_tokens, liveUsage.output_tokens);
+    assert.equal(queued[0].total_tokens, liveUsage.total_tokens);
+    assert.deepEqual(cursors.files[rolloutPath].lastTotal, liveTotals);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental migrates v1 hourly buckets without resetting totals", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
@@ -2496,10 +2569,13 @@ test("parseClaudeIncremental defaults missing model to unknown", async () => {
   }
 });
 
-function buildTurnContextLine({ model, cwd }) {
+function buildTurnContextLine({ model, cwd, currentDate }) {
   const payload = { model };
   if (typeof cwd === "string" && cwd.length > 0) {
     payload.cwd = cwd;
+  }
+  if (typeof currentDate === "string" && currentDate.length > 0) {
+    payload.current_date = currentDate;
   }
   return JSON.stringify({
     type: "turn_context",
@@ -2507,10 +2583,13 @@ function buildTurnContextLine({ model, cwd }) {
   });
 }
 
-function buildSessionMetaLine({ model, cwd }) {
+function buildSessionMetaLine({ model, cwd, forkedFromId }) {
   const payload = { model };
   if (typeof cwd === "string" && cwd.length > 0) {
     payload.cwd = cwd;
+  }
+  if (typeof forkedFromId === "string" && forkedFromId.length > 0) {
+    payload.forked_from_id = forkedFromId;
   }
   return JSON.stringify({
     type: "session_meta",


### PR DESCRIPTION
## Summary
- skip historical replay token_count rows in forked Codex rollouts
- keep skipped replay rows advancing the cumulative cursor baseline so later live deltas stay correct
- add a regression test for the replay inflation case

## Tests
- node --test test/rollout-parser.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollout parsing to detect per-file rollout dates and fork markers so events from forked replays occurring before a rollout are skipped, ensuring live token usage is tracked accurately.

* **Tests**
  * Added tests for forked rollout scenarios to confirm historical replay tokens are excluded and cumulative totals are maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->