### PR TITLE
fix: anchor menu bar popover in fullscreen spaces

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -26,6 +26,7 @@ final class StatusBarController: NSObject {
 
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let popover = NSPopover()
+    private var popoverAnchorWindow: NSWindow?
     private let viewModel: DashboardViewModel
     private let serverManager: ServerManager
     private let launchAtLoginManager: LaunchAtLoginManager
@@ -103,6 +104,7 @@ final class StatusBarController: NSObject {
         if popover.isShown {
             popover.performClose(nil)
         }
+        popoverAnchorWindow?.orderOut(nil)
     }
 
     /// React to setting changes pushed by the dashboard SettingsPage via NativeBridge.
@@ -510,7 +512,10 @@ final class StatusBarController: NSObject {
             object: popover,
             queue: .main
         ) { [weak self] _ in
-            self?.updateStatsDisplay()
+            Task { @MainActor [weak self] in
+                self?.popoverAnchorWindow?.orderOut(nil)
+                self?.updateStatsDisplay()
+            }
         }
     }
 
@@ -532,7 +537,8 @@ final class StatusBarController: NSObject {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            guard let anchorView = positionPopoverAnchorWindow(under: button) else { return }
+            popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .minY)
 
             // Keep keyboard focus inside the popover while it is visible.
             if let window = popover.contentViewController?.view.window {
@@ -543,6 +549,44 @@ final class StatusBarController: NSObject {
             // Refresh data when popover opens
             Task { await viewModel.loadAll() }
         }
+    }
+
+    private func makePopoverAnchorWindow() -> NSWindow {
+        let anchorSize = NSSize(width: 2, height: 1)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: anchorSize),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSView(frame: NSRect(origin: .zero, size: anchorSize))
+        window.backgroundColor = .clear
+        window.alphaValue = 0
+        window.isOpaque = false
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.level = .statusBar
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary]
+        window.isReleasedWhenClosed = false
+        return window
+    }
+
+    private func positionPopoverAnchorWindow(under button: NSStatusBarButton) -> NSView? {
+        guard let buttonWindow = button.window else { return nil }
+        let buttonRectInWindow = button.convert(button.bounds, to: nil)
+        let buttonRectOnScreen = buttonWindow.convertToScreen(buttonRectInWindow)
+        let anchorSize = NSSize(width: 2, height: 1)
+        let anchorFrame = NSRect(
+            x: buttonRectOnScreen.midX - anchorSize.width / 2,
+            y: buttonRectOnScreen.minY,
+            width: anchorSize.width,
+            height: anchorSize.height
+        )
+        let window = popoverAnchorWindow ?? makePopoverAnchorWindow()
+        popoverAnchorWindow = window
+        window.setFrame(anchorFrame, display: false)
+        window.orderFrontRegardless()
+        return window.contentView
     }
 
     // MARK: - Right-Click Menu

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const statusBarControllerPath = path.join(
+  __dirname,
+  "..",
+  "TokenTrackerBar",
+  "TokenTrackerBar",
+  "Services",
+  "StatusBarController.swift",
+);
+
+function readStatusBarController() {
+  return fs.readFileSync(statusBarControllerPath, "utf8");
+}
+
+test("menu-bar popover is anchored to an app-owned positioning window", () => {
+  const source = readStatusBarController();
+
+  assert.match(
+    source,
+    /private\s+var\s+popoverAnchorWindow:\s*NSWindow\?/,
+    "StatusBarController should keep an app-owned anchor window for stable popover positioning.",
+  );
+  assert.match(
+    source,
+    /private\s+func\s+makePopoverAnchorWindow\(\)\s*->\s*NSWindow[\s\S]*styleMask:\s*\[\.borderless\][\s\S]*collectionBehavior\s*=\s*\[[^\]]*\.canJoinAllSpaces[^\]]*\.fullScreenAuxiliary[^\]]*\.ignoresCycle[^\]]*\.stationary[^\]]*\]/,
+    "The anchor window should be borderless, invisible, and allowed in full-screen Spaces.",
+  );
+  assert.match(
+    source,
+    /private\s+func\s+positionPopoverAnchorWindow\(under\s+button:\s*NSStatusBarButton\)\s*->\s*NSView\?[\s\S]*button\.window[\s\S]*convertToScreen[\s\S]*setFrame\(anchorFrame,\s*display:\s*false\)[\s\S]*orderFrontRegardless\(\)/,
+    "The anchor window should be positioned from the clicked status button's screen rect before showing the popover.",
+  );
+  assert.match(
+    source,
+    /guard\s+let\s+anchorView\s*=\s*positionPopoverAnchorWindow\(under:\s*button\)[\s\S]*popover\.show\(relativeTo:\s*anchorView\.bounds,\s*of:\s*anchorView,\s*preferredEdge:\s*\.minY\)/,
+    "The popover should show relative to the app-owned anchor view, not the system status button window.",
+  );
+  assert.match(
+    source,
+    /private\s+func\s+closePopoverIfShown\(\)\s*\{[\s\S]*if\s+popover\.isShown\s*\{[\s\S]*popover\.performClose\(nil\)[\s\S]*\}\s*popoverAnchorWindow\?\.orderOut\(nil\)/,
+    "Closing the popover path should also hide the app-owned anchor window.",
+  );
+  assert.match(
+    source,
+    /forName:\s*NSPopover\.didCloseNotification[\s\S]*object:\s*popover[\s\S]*\)\s*\{\s*\[weak self\]\s+_\s+in[\s\S]*Task\s*\{\s*@MainActor\s*\[weak self\]\s+in[\s\S]*self\?\.popoverAnchorWindow\?\.orderOut\(nil\)[\s\S]*self\?\.updateStatsDisplay\(\)/,
+    "The popover did-close observer should hide the app-owned anchor window before refreshing status display.",
+  );
+});


### PR DESCRIPTION
## Summary

Fix the macOS menu bar popover jumping to the opposite display in multi-display full-screen Spaces by anchoring the existing `NSPopover` to a tiny app-owned positioning window under the clicked status item.

### Bug behavior

- In a two-display setup, when one display contains a full-screen app, clicking the TokenTrackerBar menu bar icon on the other display can briefly flash the popover under the clicked icon and then relocate it under the status item on the opposite display.
- The inverse can also happen when clicking the icon on the display with the full-screen app: the popover appears on the other display.
- Reproduced on my current system: macOS 27.0 beta (`26A5353q`), Darwin 27.0.0 arm64, Xcode 27.0 beta (`27A5194q`), MacOSX27.0 SDK.

I ONLY tested it on my local setup

I also tested this with the macOS menu bar auto-hide setting changed to “Never”. When the menu bar remains visible even while the second display has a full-screen app, this bug does not occur.

### Fix

- Keep the existing `NSPopover` and visible UI unchanged.
- Add a 2x1 transparent, borderless app-owned `NSWindow` as the popover positioning anchor.
- Position that anchor from the clicked `NSStatusBarButton` screen rect before showing the popover.
- Give the anchor full-screen Space-friendly collection behavior and hide it when the popover closes.

Reference used while debugging: [NSPopover application does not always appear where it should](https://stackoverflow.com/questions/46300086/nspopover-application-does-not-always-appear-where-it-should). The relevant approach is using an invisible/app-owned window as the `NSPopover` positioning view when status-item positioning becomes unreliable.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (N/A; no new user-facing strings)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- Existing popover content, sizing, and visible design stay unchanged.
- The invisible anchor window must not receive mouse events and must be hidden when the popover closes.
- This is local AppKit window-positioning behavior only; it does not change auth, sync, public exposure, or external gateways.

### Boundary matrix (list at least 3)

- Normal menu bar click without any full-screen Space: popover still opens under the clicked menu bar item through the existing `NSPopover`.
- Multi-display setup with a full-screen app on either display: the anchor is positioned from the clicked status item screen rect before showing the popover.
- Popover close/dismiss path: the invisible anchor window is ordered out before the status display refreshes.

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

N/A: this PR has no public exposure surface.

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** One commit: `fix: anchor menu bar popover in fullscreen spaces`.
- **Intended behavior / invariants:** Clicking the menu bar icon should show the popover under the clicked icon, even when another display is in a full-screen Space. The existing `NSPopover` UI remains unchanged; only the positioning anchor changes from the system status item button to an app-owned invisible window.
- **Edge cases covered:** Missing `button.window` returns without showing; close paths hide the anchor window; the anchor joins all Spaces and is allowed as a full-screen auxiliary window.
- **Tests run (command + result):**
  - `node --test test/macos-popover-anchor-window.test.js` — passed
  - `npm test` — passed, 912 tests
  - `git diff --check` — passed
  - `xcodebuild -project TokenTrackerBar/TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Debug -destination 'platform=macOS' build` — passed
- **Known gaps / out of scope:** The added test is a static regression guard for the AppKit contract. This repo does not currently have an automated UI test that can drive a real two-display full-screen Space setup. Manual reporter validation confirmed the fixed build stopped the cross-display jump, reverting this change reproduced it again, and restoring it fixed it again.

### Most likely regression surface

- macOS menu bar popover positioning and popover close lifecycle.

### Verification method (choose at least one)

- Static regression test for the expected AppKit anchoring implementation.
- Full Node test suite.
- macOS Xcode build.
- Manual two-display/full-screen Space validation on macOS 27.0 beta.

### Uncovered scope

- Manual validation on older macOS releases.
- Fully automated multi-display/full-screen Space UI automation.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover window positioning and anchor behavior for accurate display placement
  * Enhanced popover closing behavior with status bar display refresh

* **Tests**
  * Added tests verifying popover anchor window creation, positioning, and display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->