### PR TITLE
Fix menu bar popover reopen anchor cleanup

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -512,11 +512,13 @@ final class StatusBarController: NSObject {
             object: popover,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.popoverAnchorWindow?.orderOut(nil)
-                self?.updateStatsDisplay()
-            }
+            MainActor.assumeIsolated { self?.handlePopoverDidClose() }
         }
+    }
+
+    private func handlePopoverDidClose() {
+        popoverAnchorWindow?.orderOut(nil)
+        updateStatsDisplay()
     }
 
     // MARK: - Click Handling
@@ -535,20 +537,21 @@ final class StatusBarController: NSObject {
         guard let button = statusItem.button else { return }
 
         if popover.isShown {
-            popover.performClose(nil)
-        } else {
-            guard let anchorView = positionPopoverAnchorWindow(under: button) else { return }
-            popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .minY)
-
-            // Keep keyboard focus inside the popover while it is visible.
-            if let window = popover.contentViewController?.view.window {
-                NSApp.activate(ignoringOtherApps: true)
-                window.makeKey()
-            }
-
-            // Refresh data when popover opens
-            Task { await viewModel.loadAll() }
+            closePopoverIfShown()
+            return
         }
+
+        guard let anchorView = positionPopoverAnchorWindow(under: button) else { return }
+        popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .minY)
+
+        // Keep keyboard focus inside the popover while it is visible.
+        if let window = popover.contentViewController?.view.window {
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKey()
+        }
+
+        // Refresh data when popover opens
+        Task { await viewModel.loadAll() }
     }
 
     private func makePopoverAnchorWindow() -> NSWindow {

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -18,6 +18,9 @@ function readStatusBarController() {
 
 test("menu-bar popover is anchored to an app-owned positioning window", () => {
   const source = readStatusBarController();
+  const didCloseStart = source.indexOf("forName: NSPopover.didCloseNotification");
+  const didCloseEnd = source.indexOf("// MARK: - Click Handling");
+  const didCloseObserver = source.slice(didCloseStart, didCloseEnd);
 
   assert.match(
     source,
@@ -46,7 +49,22 @@ test("menu-bar popover is anchored to an app-owned positioning window", () => {
   );
   assert.match(
     source,
-    /forName:\s*NSPopover\.didCloseNotification[\s\S]*object:\s*popover[\s\S]*\)\s*\{\s*\[weak self\]\s+_\s+in[\s\S]*Task\s*\{\s*@MainActor\s*\[weak self\]\s+in[\s\S]*self\?\.popoverAnchorWindow\?\.orderOut\(nil\)[\s\S]*self\?\.updateStatsDisplay\(\)/,
-    "The popover did-close observer should hide the app-owned anchor window before refreshing status display.",
+    /if\s+popover\.isShown\s*\{\s*closePopoverIfShown\(\)\s*return\s*\}/,
+    "Left-click toggling should use the same synchronous close cleanup path as other close triggers.",
+  );
+  assert.match(
+    didCloseObserver,
+    /queue:\s*\.main/,
+    "The did-close cleanup uses MainActor.assumeIsolated, so the observer must run on the main queue.",
+  );
+  assert.match(
+    source,
+    /forName:\s*NSPopover\.didCloseNotification[\s\S]*object:\s*popover[\s\S]*\)\s*\{\s*\[weak self\]\s+_\s+in\s*MainActor\.assumeIsolated\s*\{\s*self\?\.handlePopoverDidClose\(\)\s*\}/,
+    "The popover did-close observer should clean up synchronously on the main actor before the next open can reuse the anchor window.",
+  );
+  assert.doesNotMatch(
+    didCloseObserver,
+    /Task\s*\{\s*@MainActor/,
+    "The did-close cleanup must not be deferred through an unstructured MainActor task.",
   );
 });


### PR DESCRIPTION
## Summary
- Keep the popover anchor-window cleanup synchronous when NSPopover sends didCloseNotification.
- Route left-click close toggles through the same closePopoverIfShown cleanup path used by other close triggers.
- Extend the macOS popover anchor regression guard so close/reopen cleanup cannot be deferred through an unstructured MainActor task.

## Root Cause
After the previous anchor-window fix, the didClose observer wrapped cleanup in `Task { @MainActor ... }`. That deferred hiding the anchor window until a later main-actor turn. In a quick open -> close -> reopen sequence, the stale close cleanup could run after the next open positioned and ordered the anchor window, making NSPopover lose the stable anchor and fall back into the old wrong-display behavior.

## Test Plan
- [x] `node --test test/macos-popover-anchor-window.test.js`
- [x] `git diff --check`
- [x] `npm test`
- [x] `xcodebuild -project TokenTrackerBar/TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Debug -destination 'platform=macOS' build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined popover window management with centralized cleanup operations to ensure reliable, consistent behavior when toggling the popover and managing display state.

* **Tests**
  * Enhanced test coverage with new assertions verifying popover close operations execute properly, maintain consistency, and work correctly across all interaction paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->