### PR TITLE
feat(windows): add in-app click-to-update via GitHub releases

### DIFF
--- a/TokenTrackerWin/TrayApplicationContext.cs
+++ b/TokenTrackerWin/TrayApplicationContext.cs
@@ -33,6 +33,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private readonly ToolStripMenuItem _petSizeMedium;
     private readonly ToolStripMenuItem _petSizeLarge;
     private readonly ToolStripMenuItem _startupItem;
+    private readonly ToolStripMenuItem _checkUpdatesItem;
 
     // Right-click-the-pet context menu (separate ToolStrip items — an item can't
     // live in two menus at once).
@@ -55,6 +56,10 @@ internal sealed class TrayApplicationContext : ApplicationContext
         TrayMenuRenderer.PaletteFor(NativeTheme.ResolveIsLight(NativeTheme.CurrentPreference));
     private Font? _menuFont;
     private Font? _summaryFont;
+
+    private readonly UpdateChecker _updateChecker = new();
+    private UpdateStrings _updateStrings = UpdateStrings.For(NativeLocalization.CurrentResolvedLocale);
+    private bool _updateBalloonShown;
 
     // Lightweight UI-thread tick so the tooltip follows a currency change within a
     // couple of seconds without needing a right-click. Cheap: it only touches the
@@ -116,6 +121,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _startupItem = CreateMenuItem("", OnToggleStartup);
         _startupItem.Checked = LaunchAtStartup.IsEnabled;
         _startupItem.CheckOnClick = false;
+        _checkUpdatesItem = CreateMenuItem("", (_, _) => OnCheckUpdatesClicked());
         _starItem = CreateMenuItem("", (_, _) => OpenInBrowser(Constants.GitHubUrl));
         _quitItem = CreateMenuItem("", (_, _) => Quit());
 
@@ -138,6 +144,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _menu.Items.Add(_petSizeItem);
         _menu.Items.Add(CreateSeparator());
         _menu.Items.Add(_startupItem);
+        _menu.Items.Add(_checkUpdatesItem);
         _menu.Items.Add(_starItem);
         _menu.Items.Add(CreateSeparator());
         _menu.Items.Add(_quitItem);
@@ -177,6 +184,13 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _syncTimer.Tick += (_, _) => TriggerBackgroundSync();
         _refreshTimer.Start();
         _ = _server.EnsureServerRunningAsync();
+
+        // Click-to-update: keep the menu item in sync with the checker, quit when it's
+        // ready to hand off to the installer, and run one quiet check on launch (the
+        // checker self-skips dev builds and only surfaces availability — never auto-installs).
+        _updateChecker.Changed += () => PostToUi(RefreshUpdateMenuItem);
+        _updateChecker.QuitRequested += () => PostToUi(Quit);
+        _ = _updateChecker.CheckAsync(silent: true);
 
         // The desktop pet is the app's visible presence now — the dashboard no longer
         // auto-opens. Show the pet on a normal launch, or whenever it was open last exit.
@@ -244,6 +258,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
     private void ApplyLocaleToMenu()
     {
         _strings = TrayStrings.For(NativeLocalization.ResolveLocale(_localePreference));
+        _updateStrings = UpdateStrings.For(NativeLocalization.ResolveLocale(_localePreference));
 
         _menuFont?.Dispose();
         _summaryFont?.Dispose();
@@ -273,6 +288,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _startupItem.Text = _strings.LaunchAtLogin;
         _starItem.Text = _strings.StarOnGitHub;
         _quitItem.Text = _strings.Quit;
+        RefreshUpdateMenuItem();
 
         ApplyThemeToMenu();
 
@@ -497,6 +513,89 @@ internal sealed class TrayApplicationContext : ApplicationContext
     {
         LaunchAtStartup.Toggle();
         _startupItem.Checked = LaunchAtStartup.IsEnabled;
+    }
+
+    /// <summary>
+    /// Tray "Check for Updates" / "Update to vX". When a prior (silent) check already
+    /// found a version, the item IS the update action — go straight to download+install.
+    /// Otherwise run a manual check and report the outcome via a dialog.
+    /// </summary>
+    private void OnCheckUpdatesClicked()
+    {
+        switch (_updateChecker.State)
+        {
+            case UpdateChecker.UpdateState.UpdateAvailable:
+                _ = _updateChecker.DownloadAndInstallAsync();
+                break;
+            case UpdateChecker.UpdateState.Idle:
+                _ = RunManualCheckAsync();
+                break;
+            // Checking / Downloading / Installing: already busy — ignore the click.
+        }
+    }
+
+    private async Task RunManualCheckAsync()
+    {
+        var outcome = await _updateChecker.CheckAsync(silent: false);
+        switch (outcome)
+        {
+            case UpdateChecker.CheckOutcome.UpdateAvailable:
+                var confirm = MessageBox.Show(
+                    string.Format(_updateStrings.UpdateFoundPrompt, _updateChecker.LatestVersion, _updateChecker.CurrentVersion),
+                    _updateStrings.UpdateFoundTitle,
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+                if (confirm == DialogResult.Yes) _ = _updateChecker.DownloadAndInstallAsync();
+                break;
+            case UpdateChecker.CheckOutcome.UpToDate:
+                MessageBox.Show(
+                    string.Format(_updateStrings.UpToDateMessage, _updateChecker.CurrentVersion),
+                    _updateStrings.UpToDateTitle,
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                break;
+            case UpdateChecker.CheckOutcome.Failed:
+                MessageBox.Show(
+                    _updateStrings.ErrorMessage, _updateStrings.ErrorTitle,
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                break;
+            // Skipped: nothing to report.
+        }
+    }
+
+    /// <summary>Reflect the checker's state in the menu item label + enabled state, and
+    /// fire a one-time balloon when a background check surfaces a new version.</summary>
+    private void RefreshUpdateMenuItem()
+    {
+        switch (_updateChecker.State)
+        {
+            case UpdateChecker.UpdateState.Checking:
+                _checkUpdatesItem.Text = _updateStrings.Checking;
+                _checkUpdatesItem.Enabled = false;
+                break;
+            case UpdateChecker.UpdateState.UpdateAvailable:
+                _checkUpdatesItem.Text = string.Format(_updateStrings.UpdateNow, _updateChecker.LatestVersion);
+                _checkUpdatesItem.Enabled = true;
+                if (!_updateBalloonShown)
+                {
+                    _updateBalloonShown = true;
+                    _trayIcon.ShowBalloonTip(5000, Constants.AppDisplayName,
+                        string.Format(_updateStrings.NewVersionBalloon, _updateChecker.LatestVersion),
+                        ToolTipIcon.Info);
+                }
+                break;
+            case UpdateChecker.UpdateState.Downloading:
+                _checkUpdatesItem.Text = string.Format(_updateStrings.Downloading, _updateChecker.ProgressPercent);
+                _checkUpdatesItem.Enabled = false;
+                break;
+            case UpdateChecker.UpdateState.Installing:
+                _checkUpdatesItem.Text = _updateStrings.Installing;
+                _checkUpdatesItem.Enabled = false;
+                break;
+            default: // Idle
+                _checkUpdatesItem.Text = _updateStrings.CheckForUpdates;
+                _checkUpdatesItem.Enabled = true;
+                break;
+        }
+        _checkUpdatesItem.ForeColor = _checkUpdatesItem.Enabled ? _menuPalette.Text : _menuPalette.DisabledText;
     }
 
     private void OnServerStatusChanged(ServerManager.ServerStatus status)

--- a/TokenTrackerWin/UpdateChecker.cs
+++ b/TokenTrackerWin/UpdateChecker.cs
@@ -180,9 +180,10 @@ internal sealed class UpdateChecker
             foreach (var asset in assets.EnumerateArray())
             {
                 var name = asset.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
-                // The release asset is "TokenTracker-Setup.exe" (see installer OutputBaseFilename).
-                if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
-                    && name.Contains("Setup", StringComparison.OrdinalIgnoreCase)
+                // The release uploads a stable, version-less "TokenTracker-Setup.exe"
+                // (release-windows.yml renames the versioned Inno output before upload).
+                // Match it exactly so a future co-released .exe can't be picked instead.
+                if (name.Equals("TokenTracker-Setup.exe", StringComparison.OrdinalIgnoreCase)
                     && asset.TryGetProperty("browser_download_url", out var u))
                 {
                     setupUrl = u.GetString();

--- a/TokenTrackerWin/UpdateChecker.cs
+++ b/TokenTrackerWin/UpdateChecker.cs
@@ -1,0 +1,312 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
+
+namespace TokenTrackerWin;
+
+/// <summary>
+/// Windows counterpart of <c>TokenTrackerBar/Services/UpdateChecker.swift</c>.
+///
+/// Checks the GitHub "latest release" for a newer version, downloads the
+/// <c>TokenTracker-Setup.exe</c> asset, and runs it fully silently. Because a
+/// silent Inno install does not relaunch the app (its <c>[Run]</c> postinstall is
+/// <c>skipifsilent</c>), we drive the close → install → relaunch sequence
+/// ourselves: a small detached <c>cmd</c> runs the installer and then restarts
+/// this exe once the upgrade finishes (see <see cref="DownloadAndInstallAsync"/>).
+///
+/// This type does NO UI — it only manages state and raises <see cref="Changed"/>;
+/// the tray context owns every dialog/balloon (mirrors how <see cref="UsagePoller"/>
+/// stays UI-free). The HTTP client here, unlike the loopback ones in
+/// <see cref="ServerManager"/>/<see cref="UsagePoller"/>, MUST honour the system /
+/// env proxy: it talks to github.com (external), which CN proxy users can only
+/// reach through their proxy — so it uses a default handler (UseProxy stays true).
+/// </summary>
+internal sealed class UpdateChecker
+{
+    public enum UpdateState { Idle, Checking, UpdateAvailable, Downloading, Installing }
+    public enum CheckOutcome { UpToDate, UpdateAvailable, Failed, Skipped }
+
+    private const string Repo = "mm7894215/TokenTracker";
+
+    // External host (github.com): keep the DEFAULT proxy behaviour so CN proxy/VPN
+    // users can reach it. The long timeout covers the installer download; the quick
+    // API check wraps its own short cancellation token instead.
+    private static readonly HttpClient Http = CreateClient();
+
+    private static HttpClient CreateClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("TokenTracker-Windows-Updater");
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        return client;
+    }
+
+    /// <summary>Raised (off the UI thread) whenever <see cref="State"/> or <see cref="ProgressPercent"/> changes.</summary>
+    public event Action? Changed;
+
+    /// <summary>Raised once the installer has been spawned; the tray must quit so its files unlock.</summary>
+    public event Action? QuitRequested;
+
+    public UpdateState State { get; private set; } = UpdateState.Idle;
+    public string? LatestVersion { get; private set; }
+    public int ProgressPercent { get; private set; }
+
+    private string? _setupUrl;
+    private long _setupSize;
+
+    public string CurrentVersion { get; } = ResolveCurrentVersion();
+
+    // ── Public API ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Check GitHub for a newer release. <paramref name="silent"/> launch checks are
+    /// skipped for dev builds (no embedded server next to the exe) so a developer run
+    /// is never nudged to "update" to an official release.
+    /// </summary>
+    public async Task<CheckOutcome> CheckAsync(bool silent)
+    {
+        if (State is UpdateState.Checking or UpdateState.Downloading or UpdateState.Installing)
+            return CheckOutcome.Skipped;
+        if (silent && !IsInstalledBuild())
+        {
+            Diag.Log("update", "silent check skipped: not an installed build");
+            return CheckOutcome.Skipped;
+        }
+
+        SetState(UpdateState.Checking);
+        try
+        {
+            var release = await FetchLatestReleaseAsync();
+            if (release is null)
+            {
+                SetState(UpdateState.Idle);
+                return CheckOutcome.Failed;
+            }
+
+            var latest = release.Value.Version;
+            if (CompareVersions(CurrentVersion, latest) < 0 && release.Value.SetupUrl is not null)
+            {
+                LatestVersion = latest;
+                _setupUrl = release.Value.SetupUrl;
+                _setupSize = release.Value.SetupSize;
+                SetState(UpdateState.UpdateAvailable);
+                Diag.Log("update", $"update available current={CurrentVersion} latest={latest}");
+                return CheckOutcome.UpdateAvailable;
+            }
+
+            SetState(UpdateState.Idle);
+            Diag.Log("update", $"up to date current={CurrentVersion} latest={latest}");
+            return CheckOutcome.UpToDate;
+        }
+        catch (Exception ex)
+        {
+            Diag.Log("update", $"check failed: {ex.Message}");
+            SetState(UpdateState.Idle);
+            return CheckOutcome.Failed;
+        }
+    }
+
+    /// <summary>
+    /// Download the prepared setup asset and launch it silently, then ask the tray to
+    /// quit so the installer can overwrite the running files and relaunch us. Must be
+    /// called only after a check left <see cref="State"/> == <see cref="UpdateState.UpdateAvailable"/>.
+    /// Returns false (and surfaces nothing) if there is no pending asset or the download fails.
+    /// </summary>
+    public async Task<bool> DownloadAndInstallAsync()
+    {
+        if (State != UpdateState.UpdateAvailable || _setupUrl is null) return false;
+
+        SetState(UpdateState.Downloading);
+        ProgressPercent = 0;
+        Changed?.Invoke();
+
+        string setupPath;
+        try
+        {
+            setupPath = await DownloadSetupAsync(_setupUrl, _setupSize);
+        }
+        catch (Exception ex)
+        {
+            Diag.Log("update", $"download failed: {ex.Message}");
+            SetState(UpdateState.UpdateAvailable);   // let the user retry
+            return false;
+        }
+
+        SetState(UpdateState.Installing);
+        try
+        {
+            LaunchSilentInstaller(setupPath);
+        }
+        catch (Exception ex)
+        {
+            Diag.Log("update", $"installer launch failed: {ex.Message}");
+            SetState(UpdateState.UpdateAvailable);
+            return false;
+        }
+
+        QuitRequested?.Invoke();
+        return true;
+    }
+
+    // ── GitHub ─────────────────────────────────────────────────────────
+
+    private readonly record struct ReleaseInfo(string Version, string? SetupUrl, long SetupSize);
+
+    private static async Task<ReleaseInfo?> FetchLatestReleaseAsync()
+    {
+        var url = $"https://api.github.com/repos/{Repo}/releases/latest";
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var resp = await Http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        if (!resp.IsSuccessStatusCode)
+        {
+            Diag.Log("update", $"github api status {(int)resp.StatusCode}");
+            return null;
+        }
+
+        await using var stream = await resp.Content.ReadAsStreamAsync(cts.Token);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
+        var root = doc.RootElement;
+
+        var tag = root.TryGetProperty("tag_name", out var t) ? t.GetString() ?? "" : "";
+        var version = tag.StartsWith('v') ? tag[1..] : tag;
+        if (string.IsNullOrWhiteSpace(version)) return null;
+
+        string? setupUrl = null;
+        long setupSize = 0;
+        if (root.TryGetProperty("assets", out var assets) && assets.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var asset in assets.EnumerateArray())
+            {
+                var name = asset.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                // The release asset is "TokenTracker-Setup.exe" (see installer OutputBaseFilename).
+                if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                    && name.Contains("Setup", StringComparison.OrdinalIgnoreCase)
+                    && asset.TryGetProperty("browser_download_url", out var u))
+                {
+                    setupUrl = u.GetString();
+                    setupSize = asset.TryGetProperty("size", out var s) && s.TryGetInt64(out var sv) ? sv : 0;
+                    break;
+                }
+            }
+        }
+
+        return new ReleaseInfo(version, setupUrl, setupSize);
+    }
+
+    // ── Download ───────────────────────────────────────────────────────
+
+    private async Task<string> DownloadSetupAsync(string url, long expectedSize)
+    {
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TokenTracker", "updates");
+        Directory.CreateDirectory(dir);
+        var dest = Path.Combine(dir, "TokenTracker-Setup.exe");
+
+        // A leftover from a previous (interrupted) attempt would be locked/partial; replace it.
+        if (File.Exists(dest)) { try { File.Delete(dest); } catch { /* will overwrite below */ } }
+
+        using var resp = await Http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+        resp.EnsureSuccessStatusCode();
+        var total = resp.Content.Headers.ContentLength ?? expectedSize;
+
+        await using (var src = await resp.Content.ReadAsStreamAsync())
+        await using (var dst = File.Create(dest))
+        {
+            var buffer = new byte[81920];
+            long received = 0;
+            int read;
+            int lastPct = -1;
+            while ((read = await src.ReadAsync(buffer)) > 0)
+            {
+                await dst.WriteAsync(buffer.AsMemory(0, read));
+                received += read;
+                if (total > 0)
+                {
+                    var pct = (int)Math.Min(99, received * 100 / total);
+                    if (pct != lastPct)
+                    {
+                        lastPct = pct;
+                        ProgressPercent = pct;
+                        Changed?.Invoke();
+                    }
+                }
+            }
+        }
+
+        Diag.Log("update", $"downloaded setup -> {dest}");
+        return dest;
+    }
+
+    // ── Install + relaunch ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Run the installer fully silently and restart this exe once it finishes. The
+    /// <c>cmd</c> we spawn is detached from this process (and from the server's job
+    /// object), so it survives the tray quitting; the installer's <c>CloseApplications</c>
+    /// is the backstop for any instance still holding a file lock. We restart via the
+    /// current exe path so an in-place upgrade relaunches the same install location.
+    /// </summary>
+    private static void LaunchSilentInstaller(string setupPath)
+    {
+        var appExe = Environment.ProcessPath
+                     ?? Path.Combine(AppContext.BaseDirectory, "TokenTracker.exe");
+
+        // cmd /c ""<setup>" /VERYSILENT ... & start "" "<app>""
+        // The setup runs inline (cmd waits for it); then `start` relaunches the app detached.
+        var arguments =
+            $"/c \"\"{setupPath}\" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART & start \"\" \"{appExe}\"\"";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "cmd.exe",
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            WorkingDirectory = Path.GetTempPath(),
+        };
+        Process.Start(psi);
+        Diag.Log("update", $"silent installer spawned: {setupPath} -> relaunch {appExe}");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private void SetState(UpdateState state)
+    {
+        if (State == state) return;
+        State = state;
+        Changed?.Invoke();
+    }
+
+    /// <summary>Installed builds ship the embedded server next to the exe; dev runs do not.</summary>
+    private static bool IsInstalledBuild()
+        => File.Exists(Path.Combine(AppContext.BaseDirectory, "EmbeddedServer", "node.exe"));
+
+    private static string ResolveCurrentVersion()
+    {
+        var info = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(info))
+            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+        // Strip the "+<sha>" / "-<suffix>" build metadata: "0.42.0+abc123" -> "0.42.0".
+        return info.Split('+', '-')[0];
+    }
+
+    /// <summary>Numeric dotted compare. Returns &lt;0 if a&lt;b, 0 if equal, &gt;0 if a&gt;b.</summary>
+    private static int CompareVersions(string a, string b)
+    {
+        var pa = a.Split('.');
+        var pb = b.Split('.');
+        var count = Math.Max(pa.Length, pb.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var va = i < pa.Length && int.TryParse(pa[i], out var x) ? x : 0;
+            var vb = i < pb.Length && int.TryParse(pb[i], out var y) ? y : 0;
+            if (va != vb) return va < vb ? -1 : 1;
+        }
+        return 0;
+    }
+}

--- a/TokenTrackerWin/UpdateStrings.cs
+++ b/TokenTrackerWin/UpdateStrings.cs
@@ -1,0 +1,95 @@
+namespace TokenTrackerWin;
+
+/// <summary>
+/// Localized strings for the "check for updates" tray flow, mirroring the
+/// <see cref="TrayStrings"/> per-locale pattern. Kept separate so the (already
+/// long) positional <see cref="TrayStrings"/> record stays focused on the core
+/// menu. Format placeholders: <c>{0}</c> = version, and for
+/// <see cref="UpToDateMessage"/> the current version.
+/// </summary>
+internal sealed record UpdateStrings(
+    string CheckForUpdates,
+    string Checking,
+    string UpdateNow,          // "{0}" = new version
+    string Downloading,        // "{0}" = percent
+    string Installing,
+    string UpToDateTitle,
+    string UpToDateMessage,    // "{0}" = current version
+    string UpdateFoundTitle,
+    string UpdateFoundPrompt,  // "{0}" = new version, "{1}" = current version
+    string ErrorTitle,
+    string ErrorMessage,
+    string NewVersionBalloon)  // "{0}" = new version
+{
+    public static UpdateStrings For(string locale)
+    {
+        return locale switch
+        {
+            NativeLocalization.ChineseLocale => new(
+                "检查更新",
+                "正在检查更新…",
+                "更新到 {0}",
+                "正在下载 {0}%",
+                "正在安装更新…",
+                "已是最新版本",
+                "你正在使用最新版本（{0}）。",
+                "发现新版本",
+                "新版本 {0} 可用（当前 {1}）。现在更新吗？",
+                "检查更新失败",
+                "无法连接到更新服务器，请稍后重试或前往 GitHub 手动下载。",
+                "新版本 {0} 可用，点击托盘菜单「更新」即可升级。"),
+            NativeLocalization.TraditionalChineseLocale => new(
+                "檢查更新",
+                "正在檢查更新…",
+                "更新到 {0}",
+                "正在下載 {0}%",
+                "正在安裝更新…",
+                "已是最新版本",
+                "你正在使用最新版本（{0}）。",
+                "發現新版本",
+                "新版本 {0} 可用（目前 {1}）。現在更新嗎？",
+                "檢查更新失敗",
+                "無法連線到更新伺服器，請稍後重試或前往 GitHub 手動下載。",
+                "新版本 {0} 可用，點擊系統匣選單「更新」即可升級。"),
+            NativeLocalization.JapaneseLocale => new(
+                "アップデートを確認",
+                "アップデートを確認中…",
+                "{0} に更新",
+                "ダウンロード中 {0}%",
+                "アップデートをインストール中…",
+                "最新バージョンです",
+                "最新バージョン（{0}）を使用しています。",
+                "新しいバージョン",
+                "新しいバージョン {0} が利用可能です（現在 {1}）。今すぐ更新しますか？",
+                "アップデートの確認に失敗",
+                "アップデートサーバーに接続できません。後でもう一度試すか、GitHub から手動でダウンロードしてください。",
+                "新しいバージョン {0} が利用可能です。トレイメニューの「更新」から更新できます。"),
+            NativeLocalization.KoreanLocale => new(
+                "업데이트 확인",
+                "업데이트 확인 중…",
+                "{0}(으)로 업데이트",
+                "다운로드 중 {0}%",
+                "업데이트 설치 중…",
+                "최신 버전입니다",
+                "최신 버전({0})을 사용하고 있습니다.",
+                "새 버전",
+                "새 버전 {0}을(를) 사용할 수 있습니다(현재 {1}). 지금 업데이트하시겠습니까?",
+                "업데이트 확인 실패",
+                "업데이트 서버에 연결할 수 없습니다. 나중에 다시 시도하거나 GitHub에서 직접 다운로드하세요.",
+                "새 버전 {0}을(를) 사용할 수 있습니다. 트레이 메뉴의 '업데이트'에서 업그레이드하세요."),
+            _ => new(
+                "Check for Updates",
+                "Checking for updates…",
+                "Update to {0}",
+                "Downloading {0}%",
+                "Installing update…",
+                "You're up to date",
+                "You're on the latest version ({0}).",
+                "Update available",
+                "Version {0} is available (current {1}). Update now?",
+                "Update check failed",
+                "Couldn't reach the update server. Try again later or download manually from GitHub.",
+                "Version {0} is available — choose \"Update\" in the tray menu to upgrade."),
+        };
+    }
+}

--- a/TokenTrackerWin/installer/TokenTracker.iss
+++ b/TokenTrackerWin/installer/TokenTracker.iss
@@ -46,8 +46,11 @@ OutputBaseFilename=TokenTracker-Setup-v{#MyAppVersion}
 Compression=lzma2/max
 SolidCompression=yes
 WizardStyle=modern
-; Close a running tray instance before overwriting its files on upgrade.
+; Close a running tray instance (and its EmbeddedServer\node.exe child, which
+; holds a file lock) before overwriting its files on upgrade. We drive the
+; relaunch ourselves after a silent update, so don't let Restart Manager do it.
 CloseApplications=yes
+RestartApplications=no
 
 ; A language picker appears at setup start (Inno shows it automatically when more
 ; than one language is listed). English ships with Inno; the Chinese message files


### PR DESCRIPTION
## What

Adds an in-app updater to the Windows tray app so users no longer have to manually download and re-run the installer. A tray-menu **Check for Updates** item flips to **Update to vX.Y.Z** when a newer GitHub release exists; choosing it downloads `TokenTracker-Setup.exe`, runs it fully silently, and relaunches the app in place.

A quiet check on launch only *surfaces* availability (a balloon + the menu label) and never auto-installs. It self-skips dev builds (no embedded server next to the exe), so a developer run is never nudged to "update" to an official release.

## Why

The macOS app already has `UpdateChecker.swift` (check → download DMG → mount/copy → relaunch). Windows had no update path at all, so every release required a manual re-download + reinstall.

## Design notes

- **Proxy direction is intentionally opposite the loopback clients.** This client talks to github.com (external), so it keeps the default proxy behaviour (`UseProxy` stays true) — proxy/VPN users (common in CN) can only reach releases through their proxy. The loopback clients in `ServerManager`/`UsagePoller` keep `UseProxy=false` (PR #152); this one must not.
- **Silent install + self-relaunch.** A silent Inno install does not relaunch the app (its `[Run]` postinstall is `skipifsilent`), so the app drives close → install → relaunch itself: it spawns a detached `cmd` that runs the installer and then restarts the current exe (`Environment.ProcessPath`) once the upgrade finishes. The spawned process is outside the server's job object, so it survives the tray quitting; the installer's existing `CloseApplications=yes` is the backstop. The installer is per-user (no UAC).
- **Parity with macOS:** the update entry lives in the tray menu only, matching macOS where it is in the menu-bar menu and not in the pet's context menu.
- **No UI in the checker.** `UpdateChecker` only manages state and raises events (mirrors `UsagePoller`); all dialogs/balloons live in `TrayApplicationContext`. Strings for 5 locales follow the existing `TrayStrings.For(locale)` pattern in a parallel `UpdateStrings`.

## Files

- `TokenTrackerWin/UpdateChecker.cs` (new) — GitHub `releases/latest` check, version compare, asset download with progress, silent install + relaunch.
- `TokenTrackerWin/UpdateStrings.cs` (new) — localized strings (en / zh-CN / zh-TW / ja / ko).
- `TokenTrackerWin/TrayApplicationContext.cs` — menu item, event wiring, launch-time silent check.

No version bumps (left to the maintainer's release process).

## Verification

- Builds clean (0 warnings / 0 errors) on the current `main` (v0.53.4) base.
- The full loop — launch-time check → download → silent install → quit → in-place relaunch — was exercised end-to-end locally (with a temporarily lowered build version to trigger the "update available" path); confirmed via `windows-host.log`.
- GitHub API reachability through a system proxy confirmed; the latest release asset is still `TokenTracker-Setup.exe`, which the matcher selects.
- The launch-time check only notifies and never auto-installs, so even if a release ever shipped a version/tag mismatch it would not loop into repeated reinstalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Check for Updates”** option to the system tray menu.
  * Perform an automatic update check on startup and reflect status in the menu.
  * Provide a manual update flow with download progress and localized prompts/notifications.
* **Improvements**
  * Updates now install silently when available, then relaunch the app after installation.
  * Improved upgrade behavior when a tray instance is running (avoids lock-related issues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->