### PR TITLE
[codex] fix macOS update alert state

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/NativeBridge.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/NativeBridge.swift
@@ -43,6 +43,11 @@ final class NativeBridge {
             .sink { [weak self] _ in self?.pushSettings() }
             .store(in: &cancellables)
 
+        NotificationCenter.default.publisher(for: .updateCheckerStatusDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.pushSettings() }
+            .store(in: &cancellables)
+
         // Mirror local limits preference changes (e.g. toggled in the
         // menu-bar popover) so the embedded dashboard reflects them without a
         // page reload.

--- a/TokenTrackerBar/TokenTrackerBar/Services/UpdateChecker.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/UpdateChecker.swift
@@ -475,6 +475,7 @@ final class UpdateChecker {
     /// 更新提示必须压过菜单栏 Popover（NSPanel）；仅用 sheet 仍可能被 Popover 挡住，故统一 `runModal` 并把模态窗提到高层级。
     /// 注意：不要在这里 order front 仪表盘窗口——靠下方的 level bump 已足够置顶，强开仪表盘会打扰用户。
     private func presentAlert(_ alert: NSAlert, completion: @escaping (NSApplication.ModalResponse) -> Void) {
+        let previousActivationPolicy = NSApp.activationPolicy()
         NSApp.setActivationPolicy(.regular)
         StatusBarController.prepareForSystemAlert()
         NSApp.activate(ignoringOtherApps: true)
@@ -499,7 +500,7 @@ final class UpdateChecker {
 
         let response = alert.runModal()
         bumpTimer?.invalidate()
-        NSApp.setActivationPolicy(.accessory)
+        NSApp.setActivationPolicy(previousActivationPolicy)
         completion(response)
     }
 

--- a/test/macos-update-alert-activation-policy.test.js
+++ b/test/macos-update-alert-activation-policy.test.js
@@ -1,0 +1,53 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const updateCheckerPath = path.join(
+  __dirname,
+  "..",
+  "TokenTrackerBar",
+  "TokenTrackerBar",
+  "Services",
+  "UpdateChecker.swift",
+);
+
+function readUpdateChecker() {
+  return fs.readFileSync(updateCheckerPath, "utf8");
+}
+
+function extractPresentAlert(source) {
+  const start = source.indexOf("private func presentAlert");
+  const end = source.indexOf("private final class BumpAttempts");
+
+  assert.notEqual(start, -1, "UpdateChecker should define presentAlert().");
+  assert.notEqual(end, -1, "UpdateChecker should keep BumpAttempts after presentAlert().");
+
+  return source.slice(start, end);
+}
+
+test("update alerts restore the previous activation policy after closing", () => {
+  const source = readUpdateChecker();
+  const presentAlert = extractPresentAlert(source);
+
+  assert.match(
+    presentAlert,
+    /let\s+previousActivationPolicy\s*=\s*NSApp\.activationPolicy\(\)/,
+    "presentAlert should capture the activation policy before promoting the app for a modal alert.",
+  );
+  assert.match(
+    presentAlert,
+    /NSApp\.setActivationPolicy\(\.regular\)/,
+    "presentAlert should still promote the menu-bar app so the native alert is visible.",
+  );
+  assert.match(
+    presentAlert,
+    /let\s+response\s*=\s*alert\.runModal\(\)[\s\S]*NSApp\.setActivationPolicy\(previousActivationPolicy\)[\s\S]*completion\(response\)/,
+    "Closing the update alert should restore the prior policy so an open Dashboard window stays active.",
+  );
+  assert.doesNotMatch(
+    presentAlert,
+    /NSApp\.setActivationPolicy\(\.accessory\)/,
+    "presentAlert must not always switch back to accessory mode; that can hide or deactivate the Dashboard window.",
+  );
+});

--- a/test/native-bridge-sync-feedback.test.js
+++ b/test/native-bridge-sync-feedback.test.js
@@ -27,6 +27,26 @@ test("NativeBridge pushes settings when sync state changes", () => {
   );
 });
 
+test("NativeBridge pushes settings when update checker status changes", () => {
+  const source = fs.readFileSync(nativeBridgePath, "utf8");
+
+  assert.match(
+    source,
+    /"updateStatus":\s*UpdateChecker\.shared\.statusText\s*\?\?\s*NSNull\(\)/,
+    "settings payload should expose the current update checker status text",
+  );
+  assert.match(
+    source,
+    /"updateBusy":\s*UpdateChecker\.shared\.isBusy/,
+    "settings payload should expose whether the update checker is busy",
+  );
+  assert.match(
+    source,
+    /NotificationCenter\.default\.publisher\(for:\s*\.updateCheckerStatusDidChange\)[\s\S]*?\.sink\s*\{\s*\[weak self\]\s*_\s*in\s*self\?\.pushSettings\(\)\s*\}/,
+    "update checker status changes should be pushed to the dashboard settings UI",
+  );
+});
+
 test("NativeBridge settings fingerprint tracks available menu items", () => {
   const source = fs.readFileSync(nativeBridgePath, "utf8");
 


### PR DESCRIPTION
## Summary

Fix macOS update-check alert state so closing the native update alert keeps the Dashboard stable and refreshes the Settings update button when the check completes.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no new user-facing strings)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `ci:` / `test:`)
- [x] PR description explains *why*, not just *what*

---

The macOS update checker temporarily promotes the menu-bar app to a regular activation policy so `NSAlert.runModal()` is visible above the popover. It previously always restored `.accessory` after the modal closed. That was correct for the menu-bar-only case, but wrong when the Dashboard window was already open: closing the "up to date" alert could hide/deactivate the Dashboard or move focus to another app. This now restores the activation policy that was active before presenting the alert.

The Settings page also disables the "Check for updates" button from the native bridge's `updateBusy` value. The bridge pushed settings shortly after starting a check, but it did not subscribe to `UpdateChecker` completion/status changes, so the Dashboard could keep rendering the stale busy state after the alert was dismissed. The bridge now republishes settings whenever `updateCheckerStatusDidChange` fires.

Validation:

- `node --test test/native-bridge-sync-feedback.test.js test/macos-update-alert-activation-policy.test.js`
- `npm test` (923 tests passing)
- `xcodebuild -project TokenTrackerBar/TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Debug -destination platform=macOS MARKETING_VERSION=0.53.5 build`

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- Native update alerts may temporarily promote the app to present a modal alert, but must restore the previous activation policy afterward.
- Dashboard Settings must receive update-check completion state so `updateBusy` does not remain stale.

### Boundary matrix (list at least 3)

- Menu-bar-only app state: alert still promotes the app so the modal is visible.
- Dashboard-open app state: alert closure restores the prior activation policy instead of forcing accessory mode.
- Update-check completion state: native bridge republishes settings after `UpdateChecker` status changes.

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

Not applicable; this PR only changes local macOS app window/state behavior.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS app activation policy handling to properly preserve and restore app state when displaying update alerts
  * Improved real-time synchronization of update checker status to the dashboard

* **Tests**
  * Added verification tests for update alert activation policy behavior
  * Added verification tests for update checker status synchronization to dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->