### PR TITLE
feat(dashboard): add provider icons for roocode, goose, kilocode, zed

### DIFF
--- a/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
+++ b/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
@@ -205,6 +205,46 @@ function ZcodeIcon({ size = 16, className = "" }) {
   );
 }
 
+// RooCode (Roo-Cline) — official mono logomark from @lobehub/icons.
+// A stylized bird/kangaroo silhouette, mono with currentColor for dark/light.
+function RoocodeIcon({ size = 16, className = "" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" className={className}>
+      <path d="M20.113 5.5l-.442 1.557a.157.157 0 01-.196.106l-7.414-2.157a.16.16 0 00-.143.028l-7.342 5.74a.159.159 0 01-.074.032l-4.37.656a.154.154 0 00-.132.162l.02.245c.005.078.071.14.152.141l5.074.128.058.002 3.75-1.953a.16.16 0 01.164.01l2.657 1.847a.152.152 0 01.066.125l-.023 2.45c0 .032.01.063.028.089l3.737 5.227c.03.04.077.065.129.065h1.182a.153.153 0 00.14-.224l-2.664-4.919a.15.15 0 01.005-.152l1.389-2.169a.156.156 0 01.062-.055l4.965-2.456a.16.16 0 01.158.01l1.418.921a.16.16 0 00.087.026h1.289c.125 0 .2-.136.13-.237l-3.578-5.29c-.074-.109-.246-.082-.282.044z" />
+    </svg>
+  );
+}
+
+// Goose (Block) — official mono logomark from @lobehub/icons.
+// A goose silhouette in flight, mono with currentColor for dark/light.
+function GooseIcon({ size = 16, className = "" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" className={className}>
+      <path d="M21.595 23.61c1.167-.254 2.405-.944 2.405-.944l-2.167-1.784a12.124 12.124 0 01-2.695-3.131 12.127 12.127 0 00-3.97-4.049l-.794-.462a1.115 1.115 0 01-.488-.815.844.844 0 01.154-.575c.413-.582 2.548-3.115 2.94-3.44.503-.416 1.065-.762 1.586-1.159.074-.056.148-.112.221-.17.003-.002.007-.004.009-.007.167-.131.325-.272.45-.438.453-.524.563-.988.59-1.193-.061-.197-.244-.639-.753-1.148.319.02.705.272 1.056.569.235-.376.481-.773.727-1.171.165-.266-.08-.465-.086-.471h-.001V3.22c-.007-.007-.206-.25-.471-.086-.567.35-1.134.702-1.639 1.021 0 0-.597-.012-1.305.599a2.464 2.464 0 00-.438.45l-.007.009c-.058.072-.114.147-.17.221-.397.521-.743 1.083-1.16 1.587-.323.391-2.857 2.526-3.44 2.94a.842.842 0 01-.574.153 1.115 1.115 0 01-.815-.488l-.462-.794a12.123 12.123 0 00-4.049-3.97 12.133 12.133 0 01-3.13-2.695L1.332 0S.643 1.238.39 2.405c.352.428 1.27 1.49 2.34 2.302C1.58 4.167.73 3.75.06 3.4c-.103.765-.063 1.92.043 2.816.726.317 1.961.806 3.219 1.066-1.006.236-2.11.278-2.961.262.15.554.358 1.119.64 1.688.119.263.25.52.39.77.452.125 2.222.383 3.164.171l-2.51.897a27.776 27.776 0 002.544 2.726c2.031-1.092 2.494-1.241 4.018-2.238-2.467 2.008-3.108 2.828-3.8 3.67l-.483.678c-.25.351-.469.725-.65 1.117-.61 1.31-1.47 4.1-1.47 4.1-.154.486.202.842.674.674 0 0 2.79-.861 4.1-1.47.392-.182.766-.4 1.118-.65l.677-.483c.227-.187.453-.37.701-.586 0 0 1.705 2.02 3.458 3.349l.896-2.511c-.211.942.046 2.712.17 3.163.252.142.509.272.772.392.569.28 1.134.49 1.688.64-.016-.853.026-1.956.261-2.962.26 1.258.75 2.493 1.067 3.219.895.106 2.051.146 2.816.043a73.87 73.87 0 01-1.308-2.67c.811 1.07 1.874 1.988 2.302 2.34h-.001z" />
+    </svg>
+  );
+}
+
+// KiloCode — official mono logomark from @lobehub/icons.
+// A stylized grid/maze pattern, mono with currentColor for dark/light.
+function KilocodeIcon({ size = 16, className = "" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" className={className}>
+      <path d="M0 0v24h24V0H0zm22.222 22.222H1.778V1.778h20.444v20.444zm-7.555-4.964h2.222v1.778h-2.794L12.89 17.83v-2.794h1.778v2.222zm4 0h-1.778v-2.222h-2.222v-1.778h2.793l1.207 1.207v2.793zm-7.556-2.591H9.333v-1.778h1.778v1.778zm-5.778-1.778h1.778v4h4v1.778H6.54L5.333 17.46V12.89zm13.334-3.556v1.778h-5.778V9.333h1.987V7.111h-1.987V5.333h2.558l1.206 1.207v2.793h2.014zm-11.556-2h2.222l1.778 1.778v2H9.333v-2H7.111v2H5.333V5.333h1.778v2zm4 0H9.333v-2h1.778v2z" />
+    </svg>
+  );
+}
+
+// Zed Agent — official Zed logomark from zed-industries/zed assets.
+// A stylized "Z" with grid accents, mono with currentColor for dark/light.
+function ZedIcon({ size = 16, className = "" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path fillRule="evenodd" clipRule="evenodd" d="M3.125 2.75C2.9179 2.75 2.75 2.9179 2.75 3.125V11.375H2V3.125C2 2.50368 2.50368 2 3.125 2H13.1723C13.6735 2 13.9244 2.6059 13.5701 2.96025L7.38189 9.14843H9.125V8.375H9.875V9.33593C9.875 9.6466 9.6232 9.8984 9.3125 9.8984H6.63189L5.34282 11.1875H11.1875V6.5H11.9375V11.1875C11.9375 11.6017 11.6017 11.9375 11.1875 11.9375H4.59282L3.28032 13.25H12.875C13.0821 13.25 13.25 13.0821 13.25 12.875V4.625H14V12.875C14 13.4963 13.4963 14 12.875 14H2.82767C2.32653 14 2.07557 13.3941 2.42992 13.0397L8.59468 6.875H6.875V7.625H6.125V6.6875C6.125 6.37684 6.37684 6.125 6.6875 6.125H9.34468L10.6571 4.8125H4.8125V9.5H4.0625V4.8125C4.0625 4.39829 4.39829 4.0625 4.8125 4.0625H11.4071L12.7197 2.75H3.125Z" />
+    </svg>
+  );
+}
+
 const PROVIDER_ICON_MAP = {
   CLAUDE: ClaudeIcon,
   ZCODE: ZcodeIcon,
@@ -218,13 +258,17 @@ const PROVIDER_ICON_MAP = {
   DROID: DroidIcon,
   GEMINI: GeminiIcon,
   GITHUB: GithubIcon,
+  GOOSE: GooseIcon,
   GROK: GrokIcon,
   HERMES: HermesIcon,
   KIMI: KimiIcon,
   KIRO: KiroIcon,
+  KILOCODE: KilocodeIcon,
   OPENCODE: OpenCodeIcon,
   OMP: OmpIcon,
   PI: PiIcon,
+  ROOCODE: RoocodeIcon,
+  ZED: ZedIcon,
 };
 
 // Multi-color brand SVG assets in /public/brand-logos/. Only logos that have


### PR DESCRIPTION
Add missing brand icons for 4 AI coding tools that were previously showing placeholder circles in the dashboard:

- RooCode: stylized bird/kangaroo silhouette (from @lobehub/icons)
- Goose: goose in flight silhouette (from @lobehub/icons)
- KiloCode: grid/maze pattern (from @lobehub/icons)
- Zed Agent: stylized Z logomark (from zed-industries/zed assets)

All icons use currentColor for dark/light mode support.

## Summary

<!-- One sentence: what does this PR do, and why? -->

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [ ] `npm test` passes
- [ ] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [ ] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [ ] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

-

### Boundary matrix (list at least 3)

-

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

### Most likely regression surface

-

### Verification method (choose at least one)

-

### Uncovered scope

-

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new provider icons for Roocode, Goose, Kilocode, and Zed.
  * Expanded provider icon support so these providers now display a matching icon in the dashboard.
* **Bug Fixes**
  * Providers without a logo now fall back more consistently to an inline icon or placeholder when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->