### PR TITLE
fix: reduce macOS idle energy usage

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum BackgroundRefreshPolicy {
+    static let defaultRefreshInterval: TimeInterval = 300
+    static let defaultSyncInterval: TimeInterval = 1_800
+
+    static func shouldRunSync(
+        now: Date,
+        lastSyncAt: Date?,
+        syncInterval: TimeInterval = defaultSyncInterval
+    ) -> Bool {
+        guard syncInterval > 0 else { return false }
+        guard let lastSyncAt else { return true }
+        return now.timeIntervalSince(lastSyncAt) >= syncInterval
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
@@ -75,6 +75,7 @@ final class DesktopPetWindowController: NSObject, NSWindowDelegate {
     func show() {
         let panel = panel ?? makePanel()
         self.panel = panel
+        uiState.isWindowVisible = true
         panel.orderFrontRegardless()
         UserDefaults.standard.set(true, forKey: Self.showDefaultsKey)
         keepActive()
@@ -82,6 +83,7 @@ final class DesktopPetWindowController: NSObject, NSWindowDelegate {
 
     func hide() {
         panel?.orderOut(nil)
+        uiState.isWindowVisible = false
         UserDefaults.standard.set(false, forKey: Self.showDefaultsKey)
         sleepTimer?.invalidate()
         sleepTimer = nil
@@ -478,6 +480,7 @@ private struct DesktopPetHost: View {
 final class PetWindowState: ObservableObject {
     static let alwaysAllowed = PetWindowState()
     @Published var bubbleAllowed = true
+    @Published var isWindowVisible = true
     @Published var isTucked = false
     @Published var isHovered = false
     @Published var isRightEdge = true

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -58,6 +58,7 @@ class DashboardViewModel: ObservableObject {
     @Published private(set) var topModels: [TopModel] = []
 
     private var refreshTask: Task<Void, Never>?
+    private var lastBackgroundSyncAt: Date?
     private let resetDetector = WeeklyLimitResetDetector()
 
     // MARK: - Computed Properties
@@ -242,12 +243,17 @@ class DashboardViewModel: ObservableObject {
     /// Initial launch: sync data first, then load dashboard.
     func syncThenLoad() async {
         isSyncing = true
+        var didSync = false
         do {
             _ = try await APIClient.shared.triggerSync()
+            didSync = true
         } catch {
             // Sync failure is non-fatal — proceed with whatever data exists
         }
         isSyncing = false
+        if didSync {
+            lastBackgroundSyncAt = Date()
+        }
         await loadAll()
     }
 
@@ -256,6 +262,7 @@ class DashboardViewModel: ObservableObject {
         isSyncing = true
         do {
             _ = try await APIClient.shared.triggerSync(drain: true)
+            lastBackgroundSyncAt = Date()
             await loadAll()
         } catch {
             self.error = error.localizedDescription
@@ -265,13 +272,25 @@ class DashboardViewModel: ObservableObject {
 
     // MARK: - Auto Refresh
 
-    func startAutoRefresh(interval: TimeInterval = 300) {
+    func startAutoRefresh(
+        interval: TimeInterval = BackgroundRefreshPolicy.defaultRefreshInterval,
+        syncInterval: TimeInterval = BackgroundRefreshPolicy.defaultSyncInterval
+    ) {
         stopAutoRefresh()
         refreshTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
                 guard !Task.isCancelled, let self else { break }
-                await self.syncThenLoad()
+                let shouldSync = BackgroundRefreshPolicy.shouldRunSync(
+                    now: Date(),
+                    lastSyncAt: self.lastBackgroundSyncAt,
+                    syncInterval: syncInterval
+                )
+                if shouldSync {
+                    await self.syncThenLoad()
+                } else {
+                    await self.loadAll()
+                }
             }
         }
     }

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -242,7 +242,9 @@ class DashboardViewModel: ObservableObject {
 
     /// Initial launch: sync data first, then load dashboard.
     func syncThenLoad() async {
+        guard !isSyncing else { return }
         isSyncing = true
+        defer { isSyncing = false }
         var didSync = false
         do {
             _ = try await APIClient.shared.triggerSync()
@@ -250,7 +252,6 @@ class DashboardViewModel: ObservableObject {
         } catch {
             // Sync failure is non-fatal — proceed with whatever data exists
         }
-        isSyncing = false
         if didSync {
             lastBackgroundSyncAt = Date()
         }

--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -326,7 +326,10 @@ struct ClawdCompanionView: View {
     }
 
     private var characterView: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { timeline in
+        TimelineView(.animation(
+            minimumInterval: characterFrameInterval,
+            paused: characterTimelinePaused
+        )) { timeline in
             Canvas { context, size in
                 let s = px
                 let yBase: CGFloat = 6
@@ -365,6 +368,28 @@ struct ClawdCompanionView: View {
                 case .miniSleep:       Self.drawMiniSleep(ctx: ctx, context: &context)
                 }
             }
+        }
+    }
+
+    private var characterTimelinePaused: Bool {
+        if layout == .floating, !petState.isWindowVisible {
+            return true
+        }
+        return clawdState == .miniIdle
+    }
+
+    private var characterFrameInterval: TimeInterval {
+        switch clawdState {
+        case .workingTyping, .workingThinking, .workingUltrathink, .error, .yawning, .waking:
+            return 1.0 / 15.0
+        case .disconnected, .miniAlert, .miniPeek, .miniHappy:
+            return 1.0 / 5.0
+        case .idleLiving, .idleLook:
+            return hoveringCharacter ? 1.0 / 8.0 : 1.0 / 3.0
+        case .idleDoze, .sleeping, .miniSleep:
+            return 1.0
+        case .miniIdle:
+            return 60.0
         }
     }
 

--- a/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+final class BackgroundRefreshPolicyTests: XCTestCase {
+    func testRunsSyncWhenNoPreviousSyncExists() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: nil,
+                syncInterval: 1_800
+            ),
+            true
+        )
+    }
+
+    func testSkipsSyncInsideInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: Date(timeIntervalSince1970: 100),
+                syncInterval: 1_800
+            ),
+            false
+        )
+    }
+
+    func testRunsSyncAfterInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunSync(
+                now: Date(timeIntervalSince1970: 2_000),
+                lastSyncAt: Date(timeIntervalSince1970: 100),
+                syncInterval: 1_800
+            ),
+            true
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -120,6 +120,7 @@ targets:
       - path: TokenTrackerBar/Models/UsageLimits.swift
       - path: TokenTrackerBar/Models/LimitPace.swift
       - path: TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+      - path: TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.tests

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -151,6 +151,20 @@ async function parseRolloutIncremental({
     const lastTotal = prev && prev.inode === inode ? prev.lastTotal || null : null;
     const lastModel = prev && prev.inode === inode ? prev.lastModel || null : null;
 
+    if (!projectEnabled && prev && prev.inode === inode && startOffset >= st.size) {
+      if (cb) {
+        cb({
+          index: idx + 1,
+          total: totalFiles,
+          filePath,
+          filesProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+      continue;
+    }
+
     const projectContext = projectEnabled
       ? await resolveProjectContextForFile({
           filePath,
@@ -165,6 +179,7 @@ async function parseRolloutIncremental({
 
     const result = await parseRolloutFile({
       filePath,
+      fileStat: st,
       startOffset,
       lastTotal,
       lastModel,
@@ -269,6 +284,20 @@ async function parseClaudeIncremental({
     const inode = st.ino || 0;
     const startOffset = prev && prev.inode === inode ? prev.offset || 0 : 0;
 
+    if (!projectEnabled && prev && prev.inode === inode && startOffset >= st.size) {
+      if (cb) {
+        cb({
+          index: idx + 1,
+          total: totalFiles,
+          filePath,
+          filesProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+      continue;
+    }
+
     const projectContext = projectEnabled
       ? await resolveProjectContextForFile({
           filePath,
@@ -283,6 +312,7 @@ async function parseClaudeIncremental({
 
     const result = await parseClaudeFile({
       filePath,
+      fileStat: st,
       startOffset,
       hourlyState,
       touchedBuckets,
@@ -770,6 +800,7 @@ function codexSessionIdFromPath(filePath) {
 
 async function parseRolloutFile({
   filePath,
+  fileStat,
   startOffset,
   lastTotal,
   lastModel,
@@ -786,7 +817,7 @@ async function parseRolloutFile({
   seenCodexEvents,
   sessionId,
 }) {
-  const st = await fs.stat(filePath);
+  const st = fileStat || (await fs.stat(filePath));
   const endOffset = st.size;
   if (startOffset >= endOffset) {
     return { endOffset, lastTotal, lastModel, eventsAggregated: 0 };
@@ -926,6 +957,7 @@ async function parseRolloutFile({
 
 async function parseClaudeFile({
   filePath,
+  fileStat,
   startOffset,
   hourlyState,
   touchedBuckets,
@@ -936,7 +968,7 @@ async function parseClaudeFile({
   projectKey,
   seenMessageHashes,
 }) {
-  const st = await fs.stat(filePath).catch(() => null);
+  const st = fileStat || (await fs.stat(filePath).catch(() => null));
   if (!st || !st.isFile()) return { endOffset: startOffset, eventsAggregated: 0 };
 
   const endOffset = st.size;

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -147,11 +147,14 @@ async function parseRolloutIncremental({
     const key = filePath;
     const prev = cursors.files[key] || null;
     const inode = st.ino || 0;
-    const startOffset = prev && prev.inode === inode ? prev.offset || 0 : 0;
-    const lastTotal = prev && prev.inode === inode ? prev.lastTotal || null : null;
-    const lastModel = prev && prev.inode === inode ? prev.lastModel || null : null;
+    const sameInode = prev && prev.inode === inode;
+    const prevOffset = sameInode ? prev.offset || 0 : 0;
+    const truncated = sameInode && prevOffset > st.size;
+    const startOffset = sameInode && !truncated ? prevOffset : 0;
+    const lastTotal = sameInode && !truncated ? prev.lastTotal || null : null;
+    const lastModel = sameInode && !truncated ? prev.lastModel || null : null;
 
-    if (!projectEnabled && prev && prev.inode === inode && startOffset >= st.size) {
+    if (!projectEnabled && sameInode && !truncated && startOffset >= st.size) {
       if (cb) {
         cb({
           index: idx + 1,
@@ -282,9 +285,12 @@ async function parseClaudeIncremental({
     const key = filePath;
     const prev = cursors.files[key] || null;
     const inode = st.ino || 0;
-    const startOffset = prev && prev.inode === inode ? prev.offset || 0 : 0;
+    const sameInode = prev && prev.inode === inode;
+    const prevOffset = sameInode ? prev.offset || 0 : 0;
+    const truncated = sameInode && prevOffset > st.size;
+    const startOffset = sameInode && !truncated ? prevOffset : 0;
 
-    if (!projectEnabled && prev && prev.inode === inode && startOffset >= st.size) {
+    if (!projectEnabled && sameInode && !truncated && startOffset >= st.size) {
       if (cb) {
         cb({
           index: idx + 1,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -515,7 +515,6 @@ test("parseRolloutIncremental re-reads same-inode truncation when project state 
     );
 
     await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
-    const beforeStat = await fs.stat(rolloutPath);
     const beforeOffset = cursors.files[rolloutPath].offset;
 
     const secondUsage = {
@@ -531,10 +530,18 @@ test("parseRolloutIncremental re-reads same-inode truncation when project state 
         last: secondUsage,
         total: secondUsage,
       }) + "\n";
-    await fs.truncate(rolloutPath, 0);
-    await fs.appendFile(rolloutPath, truncatedBody, "utf8");
+    const rewriteHandle = await fs.open(rolloutPath, "r+");
+    let beforeStat;
+    let afterStat;
+    try {
+      beforeStat = await rewriteHandle.stat();
+      await rewriteHandle.truncate(0);
+      await rewriteHandle.write(truncatedBody, 0, "utf8");
+      afterStat = await rewriteHandle.stat();
+    } finally {
+      await rewriteHandle.close();
+    }
 
-    const afterStat = await fs.stat(rolloutPath);
     assert.equal(afterStat.ino, beforeStat.ino);
     assert.ok(afterStat.size < beforeOffset);
 
@@ -550,15 +557,18 @@ test("parseRolloutIncremental re-reads same-inode truncation when project state 
       reasoning_output_tokens: 0,
       total_tokens: 10,
     };
-    await fs.appendFile(
-      rolloutPath,
+    const appendedBody =
       buildTokenCountLine({
         ts: "2026-01-26T00:30:00.000Z",
         last: thirdUsage,
         total: thirdUsage,
-      }) + "\n",
-      "utf8",
-    );
+      }) + "\n";
+    const appendHandle = await fs.open(rolloutPath, "a");
+    try {
+      await appendHandle.writeFile(appendedBody, "utf8");
+    } finally {
+      await appendHandle.close();
+    }
     const third = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
     assert.equal(third.filesProcessed, 1);
     assert.equal(third.eventsAggregated, 1);

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -443,6 +443,130 @@ test("parseRolloutIncremental skips unchanged files when project state is disabl
   }
 });
 
+test("parseRolloutIncremental still processes unchanged files when project state is enabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental re-reads same-inode truncation when project state is disabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const firstUsage = {
+      input_tokens: 20,
+      cached_input_tokens: 0,
+      output_tokens: 5,
+      reasoning_output_tokens: 0,
+      total_tokens: 25,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({
+          ts: "2026-01-26T00:10:00.000Z",
+          last: firstUsage,
+          total: firstUsage,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    const beforeStat = await fs.stat(rolloutPath);
+    const beforeOffset = cursors.files[rolloutPath].offset;
+
+    const secondUsage = {
+      input_tokens: 3,
+      cached_input_tokens: 0,
+      output_tokens: 4,
+      reasoning_output_tokens: 0,
+      total_tokens: 7,
+    };
+    const truncatedBody =
+      buildTokenCountLine({
+        ts: "2026-01-26T00:20:00.000Z",
+        last: secondUsage,
+        total: secondUsage,
+      }) + "\n";
+    await fs.truncate(rolloutPath, 0);
+    await fs.appendFile(rolloutPath, truncatedBody, "utf8");
+
+    const afterStat = await fs.stat(rolloutPath);
+    assert.equal(afterStat.ino, beforeStat.ino);
+    assert.ok(afterStat.size < beforeOffset);
+
+    const second = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 1);
+    assert.equal(cursors.files[rolloutPath].offset, afterStat.size);
+
+    const thirdUsage = {
+      input_tokens: 5,
+      cached_input_tokens: 0,
+      output_tokens: 5,
+      reasoning_output_tokens: 0,
+      total_tokens: 10,
+    };
+    await fs.appendFile(
+      rolloutPath,
+      buildTokenCountLine({
+        ts: "2026-01-26T00:30:00.000Z",
+        last: thirdUsage,
+        total: thirdUsage,
+      }) + "\n",
+      "utf8",
+    );
+    const third = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(third.filesProcessed, 1);
+    assert.equal(third.eventsAggregated, 1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental uses session_meta cwd to resolve project context", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
@@ -2657,6 +2781,47 @@ test("parseClaudeIncremental aggregates usage into half-hour buckets", async () 
     assert.equal(resAgain.filesProcessed, 0);
     assert.equal(resAgain.eventsAggregated, 0);
     assert.equal(resAgain.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseClaudeIncremental still processes unchanged files when project state is enabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-claude-"));
+  try {
+    const claudePath = path.join(tmp, "agent-claude.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const model = "claude-sonnet-4";
+    await fs.writeFile(
+      claudePath,
+      buildClaudeUsageLine({
+        ts: "2025-12-25T01:10:00.000Z",
+        input: 100,
+        output: 50,
+        model,
+      }) + "\n",
+      "utf8",
+    );
+
+    const first = await parseClaudeIncremental({
+      projectFiles: [{ path: claudePath, source: "claude" }],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+
+    const second = await parseClaudeIncremental({
+      projectFiles: [{ path: claudePath, source: "claude" }],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -398,6 +398,51 @@ test("parseRolloutIncremental uses turn_context cwd to resolve project context",
   }
 });
 
+test("parseRolloutIncremental skips unchanged files when project state is disabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "2026", "01", "26");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const rolloutPath = path.join(sessionsDir, "rollout-test.jsonl");
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(second.filesProcessed, 0);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental uses session_meta cwd to resolve project context", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
@@ -2609,6 +2654,8 @@ test("parseClaudeIncremental aggregates usage into half-hour buckets", async () 
       cursors,
       queuePath,
     });
+    assert.equal(resAgain.filesProcessed, 0);
+    assert.equal(resAgain.eventsAggregated, 0);
     assert.equal(resAgain.bucketsQueued, 0);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -533,41 +533,37 @@ test("parseRolloutIncremental re-reads same-inode truncation when project state 
     const rewriteHandle = await fs.open(rolloutPath, "r+");
     let beforeStat;
     let afterStat;
+    let second;
     try {
       beforeStat = await rewriteHandle.stat();
       await rewriteHandle.truncate(0);
       await rewriteHandle.write(truncatedBody, 0, "utf8");
       afterStat = await rewriteHandle.stat();
+
+      assert.equal(afterStat.ino, beforeStat.ino);
+      assert.ok(afterStat.size < beforeOffset);
+
+      second = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+      assert.equal(second.filesProcessed, 1);
+      assert.equal(second.eventsAggregated, 1);
+      assert.equal(cursors.files[rolloutPath].offset, afterStat.size);
+
+      const thirdUsage = {
+        input_tokens: 5,
+        cached_input_tokens: 0,
+        output_tokens: 5,
+        reasoning_output_tokens: 0,
+        total_tokens: 10,
+      };
+      const appendedBody =
+        buildTokenCountLine({
+          ts: "2026-01-26T00:30:00.000Z",
+          last: thirdUsage,
+          total: thirdUsage,
+        }) + "\n";
+      await rewriteHandle.write(appendedBody, afterStat.size, "utf8");
     } finally {
       await rewriteHandle.close();
-    }
-
-    assert.equal(afterStat.ino, beforeStat.ino);
-    assert.ok(afterStat.size < beforeOffset);
-
-    const second = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
-    assert.equal(second.filesProcessed, 1);
-    assert.equal(second.eventsAggregated, 1);
-    assert.equal(cursors.files[rolloutPath].offset, afterStat.size);
-
-    const thirdUsage = {
-      input_tokens: 5,
-      cached_input_tokens: 0,
-      output_tokens: 5,
-      reasoning_output_tokens: 0,
-      total_tokens: 10,
-    };
-    const appendedBody =
-      buildTokenCountLine({
-        ts: "2026-01-26T00:30:00.000Z",
-        last: thirdUsage,
-        total: thirdUsage,
-      }) + "\n";
-    const appendHandle = await fs.open(rolloutPath, "a");
-    try {
-      await appendHandle.writeFile(appendedBody, "utf8");
-    } finally {
-      await appendHandle.close();
     }
     const third = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
     assert.equal(third.filesProcessed, 1);


### PR DESCRIPTION
## Summary
Reduce idle work in the macOS menu bar app by separating lightweight background reloads from full local syncs, and tighten incremental parser behavior around unchanged/truncated Codex and Claude inputs.

## Scope
- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist
- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [x] Commits follow conventional style
- [x] PR description explains why, not just what

## Changes
- Gate macOS background full syncs with `BackgroundRefreshPolicy` while keeping lightweight local data reloads on the existing 5-minute cadence.
- Keep launch/manual sync paths immediate, so explicit user sync still runs right away.
- Throttle the desktop pet animation timeline when idle/sleeping and pause it when the floating window is hidden.
- Reuse already-read file stats in Codex/Claude parsers and skip unchanged EOF files only when project attribution is disabled.
- Reset parser offsets to zero on same-inode truncation instead of treating truncated files as unchanged.
- Add regression coverage for background refresh policy, unchanged parser skips, same-inode truncation, and project-enabled unchanged-file semantics.

## Tests run
- `node --test test/rollout-parser.test.js` — 171/171 passed
- `npm test` — 1015/1015 passed
- `npm run dashboard:build` — passed
- `npm run validate:copy` — passed with existing unused-copy warnings
- `npm run validate:ui-hardcode` — passed
- `npm run validate:guardrails` — passed
- `node --test test/architecture-guardrails.test.js` — 4/4 passed
- `npm --prefix dashboard run typecheck` — passed
- `xcodebuild test -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBarTests -destination 'platform=macOS'` — 46/46 passed

## Known gaps / out of scope
- This is not a full source-scoped sync redesign; default sync still scans all enabled source families.
- Provider visibility/order/display preferences remain presentation-only and do not disable collection or sync.
- Project attribution backfill for files parsed before project attribution is enabled should be handled in a follow-up with a separate attribution cursor or explicit forward-only behavior.
- Runtime energy impact was validated by code/test coverage, not Instruments measurements.

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers
- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants
- Manual sync remains immediate.
- Background reloads can refresh already-local data without forcing full sync every 5 minutes.
- Project-enabled parser paths must not use the unchanged-file skip that would bypass project attribution work.

### Boundary matrix
- macOS launch/manual sync: full sync still runs immediately.
- macOS idle refresh: lightweight reload every 5 minutes, full sync only after policy interval.
- Parser without project queue: unchanged EOF file can be skipped.
- Parser with project queue: unchanged file still enters parser path to preserve project semantics.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added window-visibility state for the floating companion and wired it into reactive UI behavior.
  * Background syncing now follows configurable timing rules and records the last successful sync to choose between sync vs. reload.

* **Bug Fixes**
  * Improved incremental rollout parsing resilience to truncation and prevents re-parsing files already fully processed.
  * Updated animation redraw timing to throttle adaptively and pause when the companion window isn’t visible/idle.

* **Tests**
  * Added unit tests for background refresh timing and expanded incremental rollout parser coverage for project-state gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->