### PR TITLE
Reduce Gemini idle sync parsing

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1185,6 +1185,7 @@ async function cmdSync(argv) {
           projectQueuePath,
           projectQueueStatePath,
           projectState: cursors.projectHourly,
+          cursors,
         });
         meta.purge_pending = false;
         meta.purged_at = new Date().toISOString();

--- a/src/lib/project-usage-purge.js
+++ b/src/lib/project-usage-purge.js
@@ -8,9 +8,10 @@ async function purgeProjectUsage({
   projectQueuePath,
   projectQueueStatePath,
   projectState,
+  cursors,
 }) {
   if (!projectKey || !projectQueuePath || !projectQueueStatePath || !projectState) {
-    return { removed: 0, kept: 0, removedBuckets: 0 };
+    return { removed: 0, kept: 0, removedBuckets: 0, removedProjectCursors: 0 };
   }
 
   let previousOffset = 0;
@@ -36,6 +37,16 @@ async function purgeProjectUsage({
     }
   }
   projectState.buckets = buckets;
+
+  let removedProjectCursors = 0;
+  const files = cursors?.files && typeof cursors.files === "object" ? cursors.files : {};
+  for (const cursor of Object.values(files)) {
+    if (!cursor || typeof cursor !== "object") continue;
+    if (cursor.project?.projectKey === projectKey) {
+      delete cursor.project;
+      removedProjectCursors += 1;
+    }
+  }
 
   let removed = 0;
   let kept = 0;
@@ -100,7 +111,7 @@ async function purgeProjectUsage({
 
   await fsp.writeFile(projectQueueStatePath, JSON.stringify({ offset: nextOffset }), "utf8");
 
-  return { removed, kept, removedBuckets };
+  return { removed, kept, removedBuckets, removedProjectCursors };
 }
 
 module.exports = { purgeProjectUsage };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -412,6 +412,26 @@ async function parseGeminiIncremental({
     const key = filePath;
     const prev = cursors.files[key] || null;
     const inode = st.ino || 0;
+    const size = Number.isFinite(st.size) ? st.size : 0;
+    const mtimeMs = Number.isFinite(st.mtimeMs) ? st.mtimeMs : 0;
+    const sameFileMetadata =
+      prev &&
+      prev.inode === inode &&
+      prev.size === size &&
+      prev.mtimeMs === mtimeMs;
+    if (!projectEnabled && sameFileMetadata) {
+      if (cb) {
+        cb({
+          index: idx + 1,
+          total: totalFiles,
+          filePath,
+          filesProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+      continue;
+    }
     let startIndex = prev && prev.inode === inode ? Number(prev.lastIndex || -1) : -1;
     let lastTotals = prev && prev.inode === inode ? prev.lastTotals || null : null;
     let lastModel = prev && prev.inode === inode ? prev.lastModel || null : null;
@@ -427,12 +447,38 @@ async function parseGeminiIncremental({
       : null;
     const projectRef = projectContext?.projectRef || null;
     const projectKey = projectContext?.projectKey || null;
+    const projectCursor =
+      projectKey &&
+      prev?.project &&
+      prev.project.projectKey === projectKey &&
+      prev.project.projectRef === projectRef
+        ? prev.project
+        : null;
+    const projectUpToDate =
+      projectKey &&
+      sameFileMetadata &&
+      projectCursor &&
+      Number(projectCursor.lastIndex ?? -1) >= Number(prev?.lastIndex ?? -1);
+    if (projectUpToDate) {
+      if (cb) {
+        cb({
+          index: idx + 1,
+          total: totalFiles,
+          filePath,
+          filesProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+      continue;
+    }
 
     const result = await parseGeminiFile({
       filePath,
       startIndex,
       lastTotals,
       lastModel,
+      projectCursor,
       hourlyState,
       touchedBuckets,
       source: fileSource,
@@ -444,11 +490,25 @@ async function parseGeminiIncremental({
 
     cursors.files[key] = {
       inode,
+      size,
+      mtimeMs,
       lastIndex: result.lastIndex,
       lastTotals: result.lastTotals,
       lastModel: result.lastModel,
       updatedAt: new Date().toISOString(),
     };
+    if (projectKey) {
+      cursors.files[key].project = {
+        projectKey,
+        projectRef,
+        lastIndex: result.projectLastIndex,
+        lastTotals: result.projectLastTotals,
+        lastModel: result.projectLastModel,
+        updatedAt: new Date().toISOString(),
+      };
+    } else if (prev?.project) {
+      cursors.files[key].project = prev.project;
+    }
 
     filesProcessed += 1;
     eventsAggregated += result.eventsAggregated;
@@ -1070,6 +1130,7 @@ async function parseGeminiFile({
   startIndex,
   lastTotals,
   lastModel,
+  projectCursor,
   hourlyState,
   touchedBuckets,
   source,
@@ -1098,57 +1159,96 @@ async function parseGeminiFile({
   let eventsAggregated = 0;
   let model = typeof lastModel === "string" ? lastModel : null;
   let totals = lastTotals && typeof lastTotals === "object" ? lastTotals : null;
-  const begin = Number.isFinite(startIndex) ? startIndex + 1 : 0;
+  const projectActive = Boolean(projectKey && projectState && projectTouchedBuckets);
+  let projectStartIndex =
+    projectActive && Number.isFinite(projectCursor?.lastIndex)
+      ? Number(projectCursor.lastIndex)
+      : -1;
+  let projectModel =
+    projectActive && typeof projectCursor?.lastModel === "string"
+      ? projectCursor.lastModel
+      : null;
+  let projectTotals =
+    projectActive && projectCursor?.lastTotals && typeof projectCursor.lastTotals === "object"
+      ? projectCursor.lastTotals
+      : null;
+  if (projectActive && projectStartIndex >= messages.length) {
+    projectStartIndex = -1;
+    projectTotals = null;
+    projectModel = null;
+  }
+  const hourlyBegin = Number.isFinite(startIndex) ? startIndex + 1 : 0;
+  const projectBegin = projectActive ? projectStartIndex + 1 : Number.POSITIVE_INFINITY;
+  const begin = Math.min(hourlyBegin, projectBegin);
 
   for (let idx = begin; idx < messages.length; idx++) {
     const msg = messages[idx];
     if (!msg || typeof msg !== "object") continue;
 
     const normalizedModel = normalizeModelInput(msg.model);
-    if (normalizedModel) model = normalizedModel;
+    if (normalizedModel && idx >= hourlyBegin) model = normalizedModel;
+    if (normalizedModel && idx >= projectBegin) projectModel = normalizedModel;
 
     const timestamp = typeof msg.timestamp === "string" ? msg.timestamp : null;
     const currentTotals = normalizeGeminiTokens(msg.tokens);
-    if (!timestamp || !currentTotals) {
+    if (idx >= hourlyBegin && (!timestamp || !currentTotals)) {
       totals = currentTotals || totals;
+    }
+    if (idx >= projectBegin && (!timestamp || !currentTotals)) {
+      projectTotals = currentTotals || projectTotals;
+    }
+    if (!timestamp || !currentTotals) {
       continue;
     }
 
-    const delta = diffGeminiTotals(currentTotals, totals);
-    if (!delta || isAllZeroUsage(delta)) {
-      totals = currentTotals;
-      continue;
+    let bucketStart = null;
+    if (idx >= hourlyBegin) {
+      const delta = diffGeminiTotals(currentTotals, totals);
+      if (!delta || isAllZeroUsage(delta)) {
+        totals = currentTotals;
+      } else {
+        delta.conversation_count = 1;
+        bucketStart = toUtcHalfHourStart(timestamp);
+        if (bucketStart) {
+          const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
+          addTotals(bucket.totals, delta);
+          touchedBuckets.add(bucketKey(source, model, bucketStart));
+          eventsAggregated += 1;
+        }
+        totals = currentTotals;
+      }
     }
-    delta.conversation_count = 1;
 
-    const bucketStart = toUtcHalfHourStart(timestamp);
-    if (!bucketStart) {
-      totals = currentTotals;
-      continue;
+    if (idx >= projectBegin) {
+      const projectDelta = diffGeminiTotals(currentTotals, projectTotals);
+      if (!projectDelta || isAllZeroUsage(projectDelta)) {
+        projectTotals = currentTotals;
+        continue;
+      }
+      projectDelta.conversation_count = 1;
+      bucketStart = bucketStart || toUtcHalfHourStart(timestamp);
+      if (bucketStart) {
+        const projectBucket = getProjectBucket(
+          projectState,
+          projectKey,
+          source,
+          bucketStart,
+          projectRef,
+        );
+        addTotals(projectBucket.totals, projectDelta);
+        projectTouchedBuckets.add(projectBucketKey(projectKey, source, bucketStart));
+      }
+      projectTotals = currentTotals;
     }
-
-    const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
-    addTotals(bucket.totals, delta);
-    touchedBuckets.add(bucketKey(source, model, bucketStart));
-    if (projectKey && projectState && projectTouchedBuckets) {
-      const projectBucket = getProjectBucket(
-        projectState,
-        projectKey,
-        source,
-        bucketStart,
-        projectRef,
-      );
-      addTotals(projectBucket.totals, delta);
-      projectTouchedBuckets.add(projectBucketKey(projectKey, source, bucketStart));
-    }
-    eventsAggregated += 1;
-    totals = currentTotals;
   }
 
   return {
     lastIndex: messages.length - 1,
     lastTotals: totals,
     lastModel: model,
+    projectLastIndex: projectActive ? messages.length - 1 : null,
+    projectLastTotals: projectTotals,
+    projectLastModel: projectModel,
     eventsAggregated,
   };
 }

--- a/test/project-usage-purge.test.js
+++ b/test/project-usage-purge.test.js
@@ -59,3 +59,46 @@ test("purgeProjectUsage preserves queue offset after removing lines", async () =
   const expectedOffset = Buffer.byteLength(`${line2}\n`, "utf8");
   assert.equal(state.offset, expectedOffset);
 });
+
+test("purgeProjectUsage clears matching per-file project cursors", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-purge-cursors-"));
+  try {
+    const queuePath = path.join(tmp, "project.queue.jsonl");
+    const statePath = path.join(tmp, "project.queue.state.json");
+    await fs.writeFile(queuePath, "", "utf8");
+
+    const projectState = {
+      buckets: {
+        "blocked|gemini|2026-01-01T00:00:00.000Z": { totals: { input_tokens: 1 } },
+      },
+    };
+    const cursors = {
+      files: {
+        "/tmp/a.json": {
+          project: { projectKey: "blocked", lastIndex: 3 },
+        },
+        "/tmp/b.json": {
+          project: { projectKey: "keep", lastIndex: 4 },
+        },
+        "/tmp/c.json": {
+          lastIndex: 5,
+        },
+      },
+    };
+
+    const res = await purgeProjectUsage({
+      projectKey: "blocked",
+      projectQueuePath: queuePath,
+      projectQueueStatePath: statePath,
+      projectState,
+      cursors,
+    });
+
+    assert.equal(res.removedProjectCursors, 1);
+    assert.equal(cursors.files["/tmp/a.json"].project, undefined);
+    assert.deepEqual(cursors.files["/tmp/b.json"].project, { projectKey: "keep", lastIndex: 4 });
+    assert.equal(cursors.files["/tmp/c.json"].lastIndex, 5);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -45,6 +45,7 @@ const {
   resolveKimiCodeDefaultModel,
   listRolloutFilesDeep,
 } = require("../src/lib/rollout");
+const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
 const antigravityTestTokens = (text) => estimateAntigravityTokens(text || "");
 
@@ -1227,6 +1228,147 @@ test("parseGeminiIncremental recomputes total when Gemini reported total exclude
   }
 });
 
+test("parseGeminiIncremental keeps cumulative totals across messages without tokens", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-missing-tokens-"));
+  try {
+    const sessionPath = path.join(tmp, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+        {
+          id: "m2",
+          type: "assistant",
+          timestamp: "2025-12-26T08:10:00.000Z",
+          model: "gemini-3-flash-preview",
+        },
+        {
+          id: "m3",
+          type: "assistant",
+          timestamp: "2025-12-26T08:15:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 8, output: 2, cached: 0, thoughts: 0, tool: 0, total: 10 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+
+    const res = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(res.filesProcessed, 1);
+    assert.equal(res.eventsAggregated, 2);
+    assert.equal(res.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 8);
+    assert.equal(queued[0].output_tokens, 2);
+    assert.equal(queued[0].total_tokens, 10);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental skips duplicate cumulative snapshots in one file", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-duplicate-"));
+  try {
+    const sessionPath = path.join(tmp, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const snapshot = { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 };
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: snapshot,
+        },
+        {
+          id: "m2",
+          type: "assistant",
+          timestamp: "2025-12-26T08:10:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: snapshot,
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+
+    const res = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 1);
+    assert.equal(res.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 5);
+    assert.equal(queued[0].output_tokens, 1);
+    assert.equal(queued[0].total_tokens, 6);
+    assert.equal(queued[0].conversation_count, 1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental advances baseline for messages with tokens but no timestamp", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-missing-timestamp-"));
+  try {
+    const sessionPath = path.join(tmp, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+        {
+          id: "m2",
+          type: "assistant",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 8, output: 2, cached: 0, thoughts: 0, tool: 0, total: 10 },
+        },
+        {
+          id: "m3",
+          type: "assistant",
+          timestamp: "2025-12-26T08:15:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 9, output: 3, cached: 0, thoughts: 0, tool: 0, total: 12 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+
+    const res = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 2);
+    assert.equal(res.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 6);
+    assert.equal(queued[0].output_tokens, 2);
+    assert.equal(queued[0].total_tokens, 8);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseGeminiIncremental is idempotent with unchanged totals", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-"));
   try {
@@ -1256,6 +1398,255 @@ test("parseGeminiIncremental is idempotent with unchanged totals", async () => {
 
     const afterSecond = await readJsonLines(queuePath);
     assert.equal(afterSecond.length, afterFirst.length);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental skips unchanged files when project state is disabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-"));
+  try {
+    const sessionPath = path.join(tmp, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+
+    const first = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(first.eventsAggregated, 1);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "gemini");
+    assert.equal(queued[0].model, "gemini-3-flash-preview");
+    assert.equal(queued[0].hour_start, "2025-12-26T08:00:00.000Z");
+    assert.equal(queued[0].input_tokens, 5);
+    assert.equal(queued[0].output_tokens, 1);
+    assert.equal(queued[0].total_tokens, 6);
+
+    const cursor = structuredClone(cursors.files[sessionPath]);
+    assert.equal(typeof cursor.size, "number");
+    assert.equal(typeof cursor.mtimeMs, "number");
+
+    const second = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(second.filesProcessed, 0);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.deepEqual(cursors.files[sessionPath].lastIndex, cursor.lastIndex);
+    assert.deepEqual(cursors.files[sessionPath].lastTotals, cursor.lastTotals);
+    assert.deepEqual(cursors.files[sessionPath].lastModel, cursor.lastModel);
+
+    const afterSecond = await readJsonLines(queuePath);
+    assert.deepEqual(afterSecond, queued);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental reprocesses old cursors without unchanged metadata", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-"));
+  try {
+    const sessionPath = path.join(tmp, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+    await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    delete cursors.files[sessionPath].size;
+    delete cursors.files[sessionPath].mtimeMs;
+
+    const second = await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.equal(typeof cursors.files[sessionPath].size, "number");
+    assert.equal(typeof cursors.files[sessionPath].mtimeMs, "number");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental still processes unchanged files when project state is enabled", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-"));
+  try {
+    const projectRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(projectRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionPath = path.join(projectRoot, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+    await parseGeminiIncremental({ sessionFiles: [sessionPath], cursors, queuePath });
+    const queueAfterFirst = await readJsonLines(queuePath);
+    assert.equal(queueAfterFirst.length, 1);
+
+    const second = await parseGeminiIncremental({
+      sessionFiles: [sessionPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver: async ({ projectRef }) => ({
+        status: "public_verified",
+        projectKey: "acme/alpha",
+        projectRef,
+      }),
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.equal(second.projectBucketsQueued, 1);
+
+    const queueAfterSecond = await readJsonLines(queuePath);
+    assert.deepEqual(queueAfterSecond, queueAfterFirst);
+
+    const projectQueued = await readJsonLines(projectQueuePath);
+    assert.equal(projectQueued.length, 1);
+    assert.equal(projectQueued[0].project_key, "acme/alpha");
+    assert.equal(projectQueued[0].project_ref, "https://github.com/acme/alpha");
+    assert.equal(projectQueued[0].source, "gemini");
+    assert.equal(projectQueued[0].hour_start, "2025-12-26T08:00:00.000Z");
+    assert.equal(projectQueued[0].input_tokens, 5);
+    assert.equal(projectQueued[0].output_tokens, 1);
+    assert.equal(projectQueued[0].total_tokens, 6);
+
+    const third = await parseGeminiIncremental({
+      sessionFiles: [sessionPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver: async ({ projectRef }) => ({
+        status: "public_verified",
+        projectKey: "acme/alpha",
+        projectRef,
+      }),
+    });
+    assert.equal(third.filesProcessed, 0);
+    assert.equal(third.eventsAggregated, 0);
+    assert.equal(third.bucketsQueued, 0);
+    assert.equal(third.projectBucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGeminiIncremental rebuilds project buckets after purge clears file project cursor", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-gemini-purge-"));
+  try {
+    const projectRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(projectRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionPath = path.join(projectRoot, "session.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const projectQueueStatePath = path.join(tmp, "project.queue.state.json");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const publicRepoResolver = async ({ projectRef }) => ({
+      status: "public_verified",
+      projectKey: "acme/alpha",
+      projectRef,
+    });
+
+    const session = buildGeminiSession({
+      messages: [
+        {
+          id: "m1",
+          type: "assistant",
+          timestamp: "2025-12-26T08:05:00.000Z",
+          model: "gemini-3-flash-preview",
+          tokens: { input: 5, output: 1, cached: 0, thoughts: 0, tool: 0, total: 6 },
+        },
+      ],
+    });
+
+    await fs.writeFile(sessionPath, JSON.stringify(session), "utf8");
+    const first = await parseGeminiIncremental({
+      sessionFiles: [sessionPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver,
+    });
+    assert.equal(first.projectBucketsQueued, 1);
+    assert.equal(cursors.files[sessionPath].project.projectKey, "acme/alpha");
+
+    const purge = await purgeProjectUsage({
+      projectKey: "acme/alpha",
+      projectQueuePath,
+      projectQueueStatePath,
+      projectState: cursors.projectHourly,
+      cursors,
+    });
+    assert.equal(purge.removed, 1);
+    assert.equal(purge.removedBuckets, 1);
+    assert.equal(purge.removedProjectCursors, 1);
+    assert.equal(cursors.files[sessionPath].project, undefined);
+
+    const second = await parseGeminiIncremental({
+      sessionFiles: [sessionPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.equal(second.projectBucketsQueued, 1);
+
+    const mainQueued = await readJsonLines(queuePath);
+    assert.equal(mainQueued.length, 1);
+
+    const projectQueued = await readJsonLines(projectQueuePath);
+    assert.equal(projectQueued.length, 1);
+    assert.equal(projectQueued[0].project_key, "acme/alpha");
+    assert.equal(projectQueued[0].source, "gemini");
+    assert.equal(projectQueued[0].total_tokens, 6);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a Gemini unchanged-file fast path using inode + size + mtime metadata, so idle syncs can skip JSON parsing when project attribution is not active
- keep a separate per-file Gemini project cursor so enabling project attribution can backfill project buckets without replaying main hourly usage
- clear matching per-file project cursors during project purge so public -> blocked/purged -> public can rebuild project buckets instead of being skipped
- preserve legacy cursor compatibility by requiring the new size/mtime metadata before fast skipping

## Tests
- `node --test test/project-usage-purge.test.js test/rollout-parser.test.js` (183/183 passed)
- `npm test` (1058/1058 passed)

## Notes
- Parser/sync-only scope; no macOS/Swift changes.
- `codex-workflow` read-only review identified the stale project cursor after purge case; this PR includes the fix and regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved incremental processing for Gemini session data, including better handling of unchanged files and per-project progress.
  * Added support for rebuilding project-level buckets after project-specific data is cleared.

* **Bug Fixes**
  * Preserved accurate totals even when some messages do not include per-message usage details.
  * Reduced unnecessary reprocessing by using stronger file-change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->