### PR TITLE
Optimize scoped sync and Codex session scanning

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -992,10 +992,11 @@ try {
     try { fs.writeFileSync(throttlePath, String(now), 'utf8'); } catch (_) {}
     const hasLocalRuntime = fs.existsSync(trackerBinPath);
     const hasLocalDeps = fs.existsSync(depsMarkerPath);
+    const syncArgs = ['sync', '--auto', '--from-notify', '--source', source];
     if (hasLocalRuntime && hasLocalDeps) {
-      spawnDetached([process.execPath, trackerBinPath, 'sync', '--auto', '--from-notify']);
+      spawnDetached([process.execPath, trackerBinPath, ...syncArgs]);
     } else {
-      spawnDetached(['npx', '--yes', fallbackPkg, 'sync', '--auto', '--from-notify']);
+      spawnDetached(['npx', '--yes', fallbackPkg, ...syncArgs]);
     }
   }
 } catch (_) {}

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -157,6 +157,43 @@ const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
 // one-time repair purges all source=mimo data from the local queues + cursor
 // state so the next sync (providerID-filtered reader) rebuilds it correctly.
 const MIMO_PROVIDER_REPAIR_KEY = "mimoClaudeMislabelRepair_2026_06";
+const AUTO_SYNC_SOURCE_ALIASES = new Map([
+  ["code", "every-code"],
+  ["everycode", "every-code"],
+  ["kilo", "kilo-cli"],
+  ["kilo-code", "kilocode"],
+  ["kimi_code", "kimi-code"],
+  ["roo-code", "roocode"],
+]);
+const AUTO_SYNC_SOURCES = new Set([
+  "antigravity",
+  "claude",
+  "codebuddy",
+  "codex",
+  "copilot",
+  "craft",
+  "cursor",
+  "droid",
+  "every-code",
+  "gemini",
+  "goose",
+  "grok",
+  "hermes",
+  "kilo-cli",
+  "kilocode",
+  "kiro",
+  "kimi",
+  "kimi-code",
+  "mimo",
+  "omp",
+  "opencode",
+  "openclaw",
+  "pi",
+  "roocode",
+  "workbuddy",
+  "zcode",
+  "zed",
+]);
 
 function warnProviderParseFailure(label, err, opts) {
   if (opts?.auto) return;
@@ -218,55 +255,74 @@ async function cmdSync(argv) {
     const mimoHome = process.env.MIMO_HOME || path.join(xdgDataHome, "mimocode");
     const zcodeHome = process.env.ZCODE_HOME || path.join(home, ".zcode");
 
-    // OpenClaw session plugin integration: allow the plugin to request incremental parsing for a single session jsonl.
-    // We still parse all regular sources so model/source attribution stays complete (e.g. Kimi sessions).
+    // OpenClaw session plugin integration: lifecycle hooks request an
+    // OpenClaw-only auto sync so unrelated providers do not get walked.
     const openclawSignal = opts.fromOpenclaw
       ? resolveOpenclawSignal({ home, env: process.env })
       : null;
 
-    const sources = [
-      { source: "codex", sessionsDir: path.join(codexHome, "sessions") },
-      // Codex-Manager archives sessions to ~/.codex/archived_sessions/ on every
-      // account/channel switch (issue #187). Scanning it too keeps that usage
-      // counted instead of orphaning it in the cloud (a re-upload's upsert can
-      // never delete cloud rows whose local source file has vanished). Safe
-      // against double-counting: the codex event dedup keys on sessionUUID (in
-      // the filename) + event timestamp, both stable across a sessions/ ->
-      // archived_sessions/ move, so re-reading an archived copy is a no-op.
-      { source: "codex", sessionsDir: path.join(codexHome, "archived_sessions"), deep: true },
-      { source: "every-code", sessionsDir: path.join(codeHome, "sessions") },
-    ];
+    const autoSourceScope = resolveAutoSourceScope(opts);
+    const isFullSourceScan = !autoSourceScope;
+    const sourceAllowed = (...sources) =>
+      !autoSourceScope || sources.includes(autoSourceScope);
+
+    const sources = [];
+    if (sourceAllowed("codex")) {
+      sources.push(
+        { source: "codex", sessionsDir: path.join(codexHome, "sessions"), codexInventoryCache: true },
+        // Codex-Manager archives sessions to ~/.codex/archived_sessions/ on every
+        // account/channel switch (issue #187). Scanning it too keeps that usage
+        // counted instead of orphaning it in the cloud (a re-upload's upsert can
+        // never delete cloud rows whose local source file has vanished). Safe
+        // against double-counting: the codex event dedup keys on sessionUUID (in
+        // the filename) + event timestamp, both stable across a sessions/ ->
+        // archived_sessions/ move, so re-reading an archived copy is a no-op.
+        { source: "codex", sessionsDir: path.join(codexHome, "archived_sessions"), deep: true },
+      );
+    }
+    if (sourceAllowed("every-code")) {
+      sources.push({ source: "every-code", sessionsDir: path.join(codeHome, "sessions") });
+    }
 
     const rolloutFiles = [];
     const seenSessions = new Set();
+    const codexDayInventoryCache =
+      cursors.codexDayInventoryCache && typeof cursors.codexDayInventoryCache === "object"
+        ? cursors.codexDayInventoryCache
+        : { version: 1, days: {} };
+    if (sourceAllowed("codex")) cursors.codexDayInventoryCache = codexDayInventoryCache;
     for (const entry of sources) {
       if (seenSessions.has(entry.sessionsDir)) continue;
       seenSessions.add(entry.sessionsDir);
       const files = entry.deep
         ? await listRolloutFilesDeep(entry.sessionsDir)
-        : await listRolloutFiles(entry.sessionsDir);
+        : await listRolloutFiles(entry.sessionsDir, entry.codexInventoryCache
+          ? { dayInventoryCache: codexDayInventoryCache }
+          : undefined);
       for (const filePath of files) {
         rolloutFiles.push({ path: filePath, source: entry.source });
       }
     }
 
-    await migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rolloutFiles });
-    await repairCodexRescanInflation({
-      cursors,
-      queuePath,
-      queueStatePath,
-      projectQueuePath,
-      projectQueueStatePath,
-      rolloutFiles,
-    });
-    await repairDroidDuplicateSessionInflation({ cursors, queuePath, queueStatePath });
-    await repairMimoClaudeMislabel({
-      cursors,
-      queuePath,
-      queueStatePath,
-      projectQueuePath,
-      projectQueueStatePath,
-    });
+    if (isFullSourceScan) {
+      await migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rolloutFiles });
+      await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles,
+      });
+      await repairDroidDuplicateSessionInflation({ cursors, queuePath, queueStatePath });
+      await repairMimoClaudeMislabel({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+      });
+    }
 
     const openclawFiles = openclawSignal?.sessionFile
       ? [{ path: openclawSignal.sessionFile, source: "openclaw" }]
@@ -300,7 +356,7 @@ async function cmdSync(argv) {
     }
 
     let openclawResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (openclawFiles.length > 0) {
+    if (sourceAllowed("openclaw") && openclawFiles.length > 0) {
       // Only runs when explicitly triggered by the OpenClaw session plugin.
       try {
         openclawResult = await parseOpenclawIncremental({
@@ -316,30 +372,34 @@ async function cmdSync(argv) {
     }
 
     let openclawFallback = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    try {
-      openclawFallback = await applyOpenclawTotalsFallback({
-        trackerDir,
-        signal: openclawSignal,
-        cursors,
-        queuePath,
-        projectQueuePath,
-      });
-    } catch (err) {
-      warnProviderParseFailure("OpenClaw", err, opts);
+    if (sourceAllowed("openclaw")) {
+      try {
+        openclawFallback = await applyOpenclawTotalsFallback({
+          trackerDir,
+          signal: openclawSignal,
+          cursors,
+          queuePath,
+          projectQueuePath,
+        });
+      } catch (err) {
+        warnProviderParseFailure("OpenClaw", err, opts);
+      }
     }
     openclawResult.filesProcessed += openclawFallback.filesProcessed;
     openclawResult.eventsAggregated += openclawFallback.eventsAggregated;
     openclawResult.bucketsQueued += openclawFallback.bucketsQueued;
 
-    const claudeFiles = await listClaudeProjectFiles(claudeProjectsDir);
-    await reincludeClaudeMemObserverFiles({ cursors, claudeFiles, queuePath, queueStatePath });
-    await repairClaudeQueueFromGroundTruth({
-      cursors,
-      queuePath,
-      queueStatePath,
-      projectQueuePath,
-      projectQueueStatePath,
-    });
+    const claudeFiles = sourceAllowed("claude") ? await listClaudeProjectFiles(claudeProjectsDir) : [];
+    if (isFullSourceScan) {
+      await reincludeClaudeMemObserverFiles({ cursors, claudeFiles, queuePath, queueStatePath });
+      await repairClaudeQueueFromGroundTruth({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+      });
+    }
     let claudeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (claudeFiles.length > 0) {
       if (progress?.enabled) {
@@ -369,7 +429,7 @@ async function cmdSync(argv) {
       }
     }
 
-    const geminiFiles = await listGeminiSessionFiles(geminiTmpDir);
+    const geminiFiles = sourceAllowed("gemini") ? await listGeminiSessionFiles(geminiTmpDir) : [];
     let geminiResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (geminiFiles.length > 0) {
       if (progress?.enabled) {
@@ -399,7 +459,7 @@ async function cmdSync(argv) {
       }
     }
 
-    const antigravityFiles = await listAntigravityTranscripts(geminiHome);
+    const antigravityFiles = sourceAllowed("antigravity") ? await listAntigravityTranscripts(geminiHome) : [];
     let antigravityResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (antigravityFiles.length > 0) {
       if (progress?.enabled) {
@@ -429,7 +489,7 @@ async function cmdSync(argv) {
       }
     }
 
-    const opencodeFiles = await listOpencodeMessageFiles(opencodeStorageDir);
+    const opencodeFiles = sourceAllowed("opencode") ? await listOpencodeMessageFiles(opencodeStorageDir) : [];
     let opencodeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (opencodeFiles.length > 0) {
       if (progress?.enabled) {
@@ -462,7 +522,7 @@ async function cmdSync(argv) {
     // OpenCode v1.2+ stores messages in SQLite (opencode.db) instead of JSON files.
     const opencodeDbPath = path.join(opencodeHome, "opencode.db");
     let opencodeDbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const dbMessages = readOpencodeDbMessages(opencodeDbPath);
+    const dbMessages = sourceAllowed("opencode") ? readOpencodeDbMessages(opencodeDbPath) : [];
     if (dbMessages.length > 0) {
       if (progress?.enabled) {
         progress.start(
@@ -500,7 +560,7 @@ async function cmdSync(argv) {
     // the message indexes don't collide.
     const kiloDbPath = path.join(kiloHome, "kilo.db");
     let kiloResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kiloDbMessages = readOpencodeDbMessages(kiloDbPath);
+    const kiloDbMessages = sourceAllowed("kilo-cli") ? readOpencodeDbMessages(kiloDbPath) : [];
     if (kiloDbMessages.length > 0) {
       if (progress?.enabled) {
         progress.start(
@@ -540,7 +600,7 @@ async function cmdSync(argv) {
     // double-count and mislabel Claude usage as mimo.
     const mimoDbPath = path.join(mimoHome, "mimocode.db");
     let mimoResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const mimoDbMessages = readMimoDbMessages(mimoDbPath);
+    const mimoDbMessages = sourceAllowed("mimo") ? readMimoDbMessages(mimoDbPath) : [];
     if (mimoDbMessages.length > 0) {
       if (progress?.enabled) {
         progress.start(
@@ -581,7 +641,7 @@ async function cmdSync(argv) {
     // would double-count.
     const zcodeDbPath = path.join(zcodeHome, "cli", "db", "db.sqlite");
     let zcodeResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const zcodeDbMessages = readZcodeDbMessages(zcodeDbPath);
+    const zcodeDbMessages = sourceAllowed("zcode") ? readZcodeDbMessages(zcodeDbPath) : [];
     if (zcodeDbMessages.length > 0) {
       if (progress?.enabled) {
         progress.start(
@@ -612,7 +672,7 @@ async function cmdSync(argv) {
     }
 
     // ── Kilo Code VS Code extension (Cline-style ui_messages.json) ──
-    const kilocodeTaskFiles = resolveKilocodeTaskFiles(process.env);
+    const kilocodeTaskFiles = sourceAllowed("kilocode") ? resolveKilocodeTaskFiles(process.env) : [];
     let kilocodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (kilocodeTaskFiles.length > 0) {
       if (progress?.enabled) {
@@ -643,7 +703,7 @@ async function cmdSync(argv) {
     // ── Goose (Block) — SQLite sessions with cumulative tokens per session ──
     const gooseDbPath = resolveGooseDbPath(process.env);
     let gooseResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (fssync.existsSync(gooseDbPath)) {
+    if (sourceAllowed("goose") && fssync.existsSync(gooseDbPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Goose ${renderBar(0)} 0 sessions | buckets 0`);
       }
@@ -668,7 +728,7 @@ async function cmdSync(argv) {
     }
 
     // ── Droid (Factory CLI) — passive reader for ~/.factory/sessions/*.settings.json ──
-    const droidSettingsFiles = listDroidSettingsFiles(process.env);
+    const droidSettingsFiles = sourceAllowed("droid") ? listDroidSettingsFiles(process.env) : [];
     let droidResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (droidSettingsFiles.length > 0) {
       if (progress?.enabled) {
@@ -703,7 +763,7 @@ async function cmdSync(argv) {
     // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (fssync.existsSync(zedDbPath)) {
+    if (sourceAllowed("zed") && fssync.existsSync(zedDbPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Zed Agent ${renderBar(0)} 0 threads | buckets 0`);
       }
@@ -728,7 +788,7 @@ async function cmdSync(argv) {
     }
 
     // ── Roo Code VS Code extension (Cline-derived; rooveterinaryinc.roo-cline) ──
-    const roocodeTaskFiles = resolveRoocodeTaskFiles(process.env);
+    const roocodeTaskFiles = sourceAllowed("roocode") ? resolveRoocodeTaskFiles(process.env) : [];
     let roocodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (roocodeTaskFiles.length > 0) {
       if (progress?.enabled) {
@@ -762,10 +822,12 @@ async function cmdSync(argv) {
     // cursor records under model="unknown". Purge those local buckets, emit
     // zero retractions so the cloud upserts overwrite them to zero, and reset
     // the incremental cursor so the fixed parser re-fetches all affected rows.
-    await migrateCursorUnknownBuckets({ cursors, queuePath });
+    if (isFullSourceScan) {
+      await migrateCursorUnknownBuckets({ cursors, queuePath });
+    }
 
     let cursorResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (isCursorInstalled({ home })) {
+    if (sourceAllowed("cursor") && isCursorInstalled({ home })) {
       const cursorAuth = extractCursorSessionToken({ home });
       if (cursorAuth) {
         try {
@@ -808,7 +870,7 @@ async function cmdSync(argv) {
     let kiroResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const kiroDbPath = resolveKiroDbPath();
     const kiroJsonlPath = resolveKiroJsonlPath();
-    if (fssync.existsSync(kiroDbPath) || fssync.existsSync(kiroJsonlPath)) {
+    if (sourceAllowed("kiro") && (fssync.existsSync(kiroDbPath) || fssync.existsSync(kiroJsonlPath))) {
       if (progress?.enabled) {
         progress.start(`Parsing Kiro ${renderBar(0)} | buckets 0`);
       }
@@ -834,7 +896,7 @@ async function cmdSync(argv) {
     // ── Hermes Agent (SQLite-based) ──
     let hermesResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const hermesPath = resolveHermesPath();
-    if (fssync.existsSync(hermesPath)) {
+    if (sourceAllowed("hermes") && fssync.existsSync(hermesPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
       }
@@ -865,8 +927,8 @@ async function cmdSync(argv) {
     // 4 chars/token from user prompt chars and assistant response chars.
     let kiroCliResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const kiroCliDb = resolveKiroCliDbPath(process.env);
-    const kiroCliSessionFiles = resolveKiroCliSessionFiles(process.env);
-    if (fssync.existsSync(kiroCliDb) || kiroCliSessionFiles.length > 0) {
+    const kiroCliSessionFiles = sourceAllowed("kiro") ? resolveKiroCliSessionFiles(process.env) : [];
+    if (sourceAllowed("kiro") && (fssync.existsSync(kiroCliDb) || kiroCliSessionFiles.length > 0)) {
       if (progress?.enabled) {
         progress.start(`Parsing Kiro CLI ${renderBar(0)} | buckets 0`);
       }
@@ -892,7 +954,7 @@ async function cmdSync(argv) {
 
     // ── Kimi (passive wire.jsonl reader) ──
     let kimiResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kimiWireFiles = resolveKimiWireFiles(process.env);
+    const kimiWireFiles = sourceAllowed("kimi") ? resolveKimiWireFiles(process.env) : [];
     if (kimiWireFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Kimi Code ${renderBar(0)} | buckets 0`);
@@ -918,7 +980,7 @@ async function cmdSync(argv) {
 
     // ── Kimi Code official (@moonshot-ai/kimi-code, ~/.kimi-code) ──
     let kimiCodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kimiCodeWireFiles = resolveKimiCodeWireFiles(process.env);
+    const kimiCodeWireFiles = sourceAllowed("kimi-code") ? resolveKimiCodeWireFiles(process.env) : [];
     if (kimiCodeWireFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Kimi Code (official) ${renderBar(0)} | buckets 0`);
@@ -946,7 +1008,7 @@ async function cmdSync(argv) {
     // Tencent's CodeBuddy CLI is a Claude Code clone; no hook system, so we
     // tail the per-session JSONL conversation logs incrementally on each sync.
     let codebuddyResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const codebuddyFiles = resolveCodebuddyProjectFiles(process.env);
+    const codebuddyFiles = sourceAllowed("codebuddy") ? resolveCodebuddyProjectFiles(process.env) : [];
     if (codebuddyFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing CodeBuddy ${renderBar(0)} | buckets 0`);
@@ -976,7 +1038,7 @@ async function cmdSync(argv) {
     // sub-agent logs nest one level deeper, so the resolver recurses. See the
     // parser comment in rollout.js for the cache-aware token math.
     let workbuddyResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const workbuddyFiles = resolveWorkbuddyProjectFiles(process.env);
+    const workbuddyFiles = sourceAllowed("workbuddy") ? resolveWorkbuddyProjectFiles(process.env) : [];
     if (workbuddyFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing WorkBuddy ${renderBar(0)} | buckets 0`);
@@ -1002,7 +1064,7 @@ async function cmdSync(argv) {
 
     // ── oh-my-pi (passive ~/.omp/agent/sessions/**/*.jsonl reader) ──
     let ompResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const ompFiles = resolveOmpSessionFiles(process.env);
+    const ompFiles = sourceAllowed("omp") ? resolveOmpSessionFiles(process.env) : [];
     if (ompFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing oh-my-pi ${renderBar(0)} | buckets 0`);
@@ -1031,7 +1093,7 @@ async function cmdSync(argv) {
     // prevents double-counting when explicit overrides (TOKENTRACKER_OMP_AGENT_DIR /
     // TOKENTRACKER_PI_AGENT_DIR) bypass the install-signal disambiguator.
     let piResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const piFiles = piAgentDirCollidesWithOmp(process.env)
+    const piFiles = !sourceAllowed("pi") || piAgentDirCollidesWithOmp(process.env)
       ? []
       : resolvePiSessionFiles(process.env);
     if (piFiles.length > 0) {
@@ -1059,7 +1121,7 @@ async function cmdSync(argv) {
 
     // ── Craft Agents (passive ~/.craft-agent + workspaces session.jsonl reader) ──
     let craftResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const craftFiles = resolveCraftSessionFiles(process.env);
+    const craftFiles = sourceAllowed("craft") ? resolveCraftSessionFiles(process.env) : [];
     if (craftFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Craft ${renderBar(0)} | buckets 0`);
@@ -1086,9 +1148,9 @@ async function cmdSync(argv) {
     // ── Grok Build (xAI) ──
     let grokResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     // Full passive scan of all Grok sessions (historical + any not covered by hook)
-    const grokSessions = resolveGrokBuildSessions(process.env);
+    const grokSessions = sourceAllowed("grok") ? resolveGrokBuildSessions(process.env) : [];
     const grokSessionInputs = [...grokSessions];
-    if (grokHookSignal && typeof grokHookSignal === "object") {
+    if (sourceAllowed("grok") && grokHookSignal && typeof grokHookSignal === "object") {
       const hookSessionId =
         typeof grokHookSignal.sessionId === "string" && grokHookSignal.sessionId.trim()
           ? grokHookSignal.sessionId.trim()
@@ -1153,13 +1215,13 @@ async function cmdSync(argv) {
         bucketsQueued: grokResult.bucketsQueued + grokScanResult.bucketsQueued,
       };
     }
-    if (opts.repairGrok) {
+    if (isFullSourceScan && opts.repairGrok) {
       await repairGrokQueueFromSessionSnapshots({ cursors, queuePath, queueStatePath });
     }
 
     // ── GitHub Copilot CLI (OTEL JSONL files) ──
     let copilotResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const copilotPaths = resolveCopilotOtelPaths(process.env);
+    const copilotPaths = sourceAllowed("copilot") ? resolveCopilotOtelPaths(process.env) : [];
     if (copilotPaths.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Copilot ${renderBar(0)} | buckets 0`);
@@ -1183,7 +1245,7 @@ async function cmdSync(argv) {
       }
     }
 
-    if (cursors?.projectHourly?.projects && projectQueuePath && projectQueueStatePath) {
+    if (isFullSourceScan && cursors?.projectHourly?.projects && projectQueuePath && projectQueueStatePath) {
       for (const [projectKey, meta] of Object.entries(cursors.projectHourly.projects)) {
         if (!meta || typeof meta !== "object") continue;
         if (meta.status !== "blocked" || !meta.purge_pending) continue;
@@ -1198,7 +1260,9 @@ async function cmdSync(argv) {
       }
     }
 
-    await applyCloudConversationsBackfill({ cursors, queueStatePath });
+    if (isFullSourceScan) {
+      await applyCloudConversationsBackfill({ cursors, queueStatePath });
+    }
 
     cursors.updatedAt = new Date().toISOString();
     await writeJson(cursorsPath, cursors);
@@ -1274,7 +1338,8 @@ async function cmdSync(argv) {
           retryAtMs,
           reason: "backlog",
           pendingBytes,
-          source: "auto-backlog",
+          source: autoSourceScope ? `${autoSourceScope}-backlog` : "auto-backlog",
+          syncSource: autoSourceScope,
           autoRetryNoSpawn: runtime.autoRetryNoSpawn,
         });
       }
@@ -1367,6 +1432,7 @@ function parseArgs(argv) {
     fromNotify: false,
     fromRetry: false,
     fromOpenclaw: false,
+    source: null,
     drain: false,
     repairGrok: false,
   };
@@ -1376,11 +1442,32 @@ function parseArgs(argv) {
     else if (a === "--from-notify") out.fromNotify = true;
     else if (a === "--from-retry") out.fromRetry = true;
     else if (a === "--from-openclaw") out.fromOpenclaw = true;
+    else if (a === "--source") {
+      out.source = normalizeSyncSource(argv[i + 1]);
+      i += 1;
+    }
+    else if (a.startsWith("--source=")) out.source = normalizeSyncSource(a.slice("--source=".length));
     else if (a === "--drain") out.drain = true;
     else if (a === "--repair-grok") out.repairGrok = true;
     else throw new Error(`Unknown option: ${a}`);
   }
   return out;
+}
+
+function resolveAutoSourceScope(opts) {
+  if (!opts?.auto) return null;
+  if (opts.fromOpenclaw) return "openclaw";
+  if (opts.fromRetry) return normalizeSyncSource(opts.source);
+  if (!opts.fromNotify) return null;
+  return normalizeSyncSource(opts.source);
+}
+
+function normalizeSyncSource(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  const aliased = AUTO_SYNC_SOURCE_ALIASES.get(normalized) || normalized;
+  return AUTO_SYNC_SOURCES.has(aliased) ? aliased : null;
 }
 
 module.exports = {
@@ -1393,6 +1480,8 @@ module.exports = {
   reincludeClaudeMemObserverFiles,
   repairGrokQueueFromSessionSnapshots,
   applyCloudConversationsBackfill,
+  scheduleAutoRetry,
+  buildAutoRetryScript,
   CURSOR_UNKNOWN_MIGRATION_KEY,
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
   CODEX_RESCAN_DEDUP_REPAIR_KEY,
@@ -1574,6 +1663,7 @@ async function scheduleAutoRetry({
   reason,
   pendingBytes,
   source,
+  syncSource,
   autoRetryNoSpawn,
 }) {
   const retryMs = coerceRetryMs(retryAtMs);
@@ -1583,19 +1673,33 @@ async function scheduleAutoRetry({
   const nowMs = Date.now();
   const existing = await readJson(retryPath);
   const existingMs = coerceRetryMs(existing?.retryAtMs);
+  const normalizedSyncSource = normalizeSyncSource(syncSource);
   if (existingMs && existingMs >= retryMs - 1000) {
+    const existingSyncSource = normalizeSyncSource(existing?.syncSource);
+    if (existingSyncSource !== normalizedSyncSource) {
+      await writeJson(
+        retryPath,
+        buildAutoRetryPayload({
+          retryMs: existingMs,
+          nowMs,
+          reason,
+          pendingBytes,
+          source,
+          syncSource: normalizedSyncSource,
+        }),
+      );
+    }
     return { scheduled: false, retryAtMs: existingMs };
   }
 
-  const payload = {
-    version: 1,
-    retryAtMs: retryMs,
-    retryAt: new Date(retryMs).toISOString(),
-    reason: typeof reason === "string" && reason.length > 0 ? reason : "throttled",
-    pendingBytes: Math.max(0, Number(pendingBytes || 0)),
-    scheduledAt: new Date(nowMs).toISOString(),
-    source: typeof source === "string" ? source : "auto",
-  };
+  const payload = buildAutoRetryPayload({
+    retryMs,
+    nowMs,
+    reason,
+    pendingBytes,
+    source,
+    syncSource: normalizedSyncSource,
+  });
 
   await writeJson(retryPath, payload);
 
@@ -1612,6 +1716,20 @@ async function scheduleAutoRetry({
     delayMs,
   });
   return { scheduled: true, retryAtMs: retryMs };
+}
+
+function buildAutoRetryPayload({ retryMs, nowMs, reason, pendingBytes, source, syncSource }) {
+  const payload = {
+    version: 1,
+    retryAtMs: retryMs,
+    retryAt: new Date(retryMs).toISOString(),
+    reason: typeof reason === "string" && reason.length > 0 ? reason : "throttled",
+    pendingBytes: Math.max(0, Number(pendingBytes || 0)),
+    scheduledAt: new Date(nowMs).toISOString(),
+    source: typeof source === "string" ? source : "auto",
+  };
+  if (syncSource) payload.syncSource = syncSource;
+  return payload;
 }
 
 async function clearAutoRetry(trackerDir) {
@@ -1641,13 +1759,18 @@ function buildAutoRetryScript({ retryPath, trackerBinPath, fallbackPkg, delayMs 
     `const fallbackPkg = ${JSON.stringify(fallbackPkg)};\n` +
     `const delayMs = ${Math.max(0, Math.floor(delayMs || 0))};\n` +
     `setTimeout(() => {\n` +
+    `  let payload = null;\n` +
     `  let retryAtMs = 0;\n` +
     `  try {\n` +
     `    const raw = fs.readFileSync(retryPath, 'utf8');\n` +
-    `    retryAtMs = Number(JSON.parse(raw).retryAtMs || 0);\n` +
+    `    payload = JSON.parse(raw);\n` +
+    `    retryAtMs = Number(payload.retryAtMs || 0);\n` +
     `  } catch (_) {}\n` +
     `  if (!retryAtMs || Date.now() + 1000 < retryAtMs) process.exit(0);\n` +
     `  const argv = ['sync', '--auto', '--from-retry'];\n` +
+    `  if (payload && typeof payload.syncSource === 'string' && payload.syncSource.trim()) {\n` +
+    `    argv.push('--source', payload.syncSource.trim());\n` +
+    `  }\n` +
     `  const cmd = fs.existsSync(trackerBinPath)\n` +
     `    ? [process.execPath, trackerBinPath, ...argv]\n` +
     `    : ['npx', '--yes', fallbackPkg, ...argv];\n` +

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -251,7 +251,14 @@ async function cmdSync(argv) {
     }
 
     await migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rolloutFiles });
-    await repairCodexRescanInflation({ cursors, queuePath, queueStatePath, rolloutFiles });
+    await repairCodexRescanInflation({
+      cursors,
+      queuePath,
+      queueStatePath,
+      projectQueuePath,
+      projectQueueStatePath,
+      rolloutFiles,
+    });
     await repairDroidDuplicateSessionInflation({ cursors, queuePath, queueStatePath });
     await repairMimoClaudeMislabel({
       cursors,
@@ -1252,11 +1259,10 @@ async function cmdSync(argv) {
 
     const afterState = (await readJson(queueStatePath)) || { offset: 0 };
     const queueSize = await safeStatSize(queuePath);
-    const projectAfterState = (await readJson(projectQueueStatePath)) || { offset: 0 };
-    const projectQueueSize = await safeStatSize(projectQueuePath);
-    const pendingBytes =
-      Math.max(0, queueSize - Number(afterState.offset || 0)) +
-      Math.max(0, projectQueueSize - Number(projectAfterState.offset || 0));
+    // Only the main queue is uploaded by drainQueueToCloud. project.queue.jsonl
+    // is local project-usage state, so counting it here creates false backlog
+    // and can keep auto retry alive even after cloud sync has drained.
+    const pendingBytes = Math.max(0, queueSize - Number(afterState.offset || 0));
 
     if (pendingBytes <= 0) {
       await clearAutoRetry(trackerDir);
@@ -2397,7 +2403,14 @@ async function migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rollou
 // contributed is gone from disk (genuinely deleted — Codex-Manager log rotation
 // or user cleanup) the migration is skipped entirely — the forward dedup fix
 // still prevents new double-counting; only this historical correction is deferred.
-async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, rolloutFiles }) {
+async function repairCodexRescanInflation({
+  cursors,
+  queuePath,
+  queueStatePath,
+  projectQueuePath,
+  projectQueueStatePath,
+  rolloutFiles,
+}) {
   if (!cursors || typeof cursors !== "object") return false;
   const migrations = (cursors.migrations ||= {});
   // A COMPLETED run writes an ISO-string timestamp (final — never re-run). A
@@ -2418,6 +2431,7 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
     if (fp && src === "codex") codexFiles.push(fp);
   }
   const codexFileSet = new Set(codexFiles);
+  const projectRepairEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
 
   // GUARD (data-loss prevention, ref the v6 ground-truth-repair incident): the
   // rebuild can only reproduce buckets from the files this sync re-parses
@@ -2438,7 +2452,7 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
   }
   if (cursors.files && typeof cursors.files === "object") {
     for (const fp of Object.keys(cursors.files)) {
-      if (!/\/\.codex\/(?:archived_)?sessions\//.test(fp)) continue;
+      if (!isCodexSessionCursorPath(fp)) continue;
       if (codexFileSet.has(fp)) continue; // exact file re-scanned this run
       const id = codexSessionIdFromPath(fp);
       if (id && scannedSessionIds.has(id)) continue; // same session scanned elsewhere (moved)
@@ -2460,6 +2474,9 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
   // would permanently zero a user's codex history.
   let rebuilt;
   const tmpQueue = `${queuePath}.codexrebuild.${process.pid}.${Date.now()}`;
+  const tmpProjectQueue = projectRepairEnabled
+    ? `${projectQueuePath}.codexrebuild.${process.pid}.${Date.now()}`
+    : null;
   try {
     const tmpCursors = {
       version: 1,
@@ -2471,6 +2488,7 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
       rolloutFiles: codexFiles.map((p) => ({ path: p, source: "codex" })),
       cursors: tmpCursors,
       queuePath: tmpQueue,
+      projectQueuePath: tmpProjectQueue,
     });
     let tmpRaw = "";
     try {
@@ -2478,12 +2496,22 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
     } catch (e) {
       if (e?.code !== "ENOENT") throw e;
     }
+    let tmpProjectRaw = "";
+    if (tmpProjectQueue) {
+      try {
+        tmpProjectRaw = await fs.readFile(tmpProjectQueue, "utf8");
+      } catch (e) {
+        if (e?.code !== "ENOENT") throw e;
+      }
+    }
     rebuilt = {
       buckets: tmpCursors.hourly.buckets || {},
       groupQueued: tmpCursors.hourly.groupQueued || {},
       codexHashes: Array.isArray(tmpCursors.codexHashes) ? tmpCursors.codexHashes : [],
       files: tmpCursors.files || {},
       queueRows: tmpRaw.split("\n").filter((l) => l.trim()),
+      projectHourly: tmpCursors.projectHourly || null,
+      projectQueueRows: tmpProjectRaw.split("\n").filter((l) => l.trim()),
     };
   } catch (e) {
     console.error(
@@ -2493,6 +2521,7 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
     return false;
   } finally {
     await fs.rm(tmpQueue, { force: true }).catch(() => {});
+    if (tmpProjectQueue) await fs.rm(tmpProjectQueue, { force: true }).catch(() => {});
   }
 
   // SANITY: codex files exist on disk but the rebuild produced no codex buckets
@@ -2504,6 +2533,64 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
       `[sync] codex rescan repair: rebuild produced 0 codex buckets from ${codexFiles.length} files — skipping to avoid data loss`,
     );
     return false;
+  }
+  if (projectRepairEnabled) {
+    const malformedProjectRows = await countMalformedCodexProjectQueueRows(projectQueuePath);
+    if (malformedProjectRows > 0) {
+      console.error(
+        `[sync] codex rescan repair: found ${malformedProjectRows} malformed codex project queue row(s) — skipping to avoid data loss`,
+      );
+      return false;
+    }
+
+    const existingProjectKeys = new Set([
+      ...(await projectUsageKeysFromQueuePath(projectQueuePath, "codex")),
+      ...projectUsageKeysFromState(cursors.projectHourly, "codex"),
+    ]);
+    const rebuiltProjectKeys = new Set([
+      ...projectUsageKeysFromQueueRows(rebuilt.projectQueueRows, "codex"),
+      ...projectUsageKeysFromState(rebuilt.projectHourly, "codex"),
+    ]);
+    const missingProjectKeys = [...existingProjectKeys].filter((key) => !rebuiltProjectKeys.has(key));
+    if (missingProjectKeys.length > 0) {
+      console.error(
+        `[sync] codex rescan repair: project rebuild missed ${missingProjectKeys.length} existing codex project bucket(s) — skipping to avoid data loss`,
+      );
+      return false;
+    }
+
+    const existingProjectTotals = mergeMaxTotals(
+      await projectUsageTotalsFromQueuePath(projectQueuePath, "codex"),
+      projectUsageTotalsFromState(cursors.projectHourly, "codex"),
+    );
+    const rebuiltProjectTotals = mergeMaxTotals(
+      projectUsageTotalsFromQueueRows(rebuilt.projectQueueRows, "codex"),
+      projectUsageTotalsFromState(rebuilt.projectHourly, "codex"),
+    );
+    const existingMainHourTotals = mergeMaxTotals(
+      await mainUsageHourTotalsFromQueuePath(queuePath, "codex"),
+      mainUsageHourTotalsFromState(cursors.hourly, "codex"),
+    );
+    const rebuiltMainHourTotals = mergeMaxTotals(
+      mainUsageHourTotalsFromQueueRows(rebuilt.queueRows, "codex"),
+      mainUsageHourTotalsFromState({ buckets: rebuilt.buckets }, "codex"),
+    );
+    const partialProjectKeys = [];
+    for (const [key, existingTotal] of existingProjectTotals.entries()) {
+      const rebuiltTotal = rebuiltProjectTotals.get(key);
+      if (!Number.isFinite(rebuiltTotal) || rebuiltTotal >= existingTotal) continue;
+      const [, source, hourStart] = key.split("|");
+      const mainKey = `${source}|${hourStart}`;
+      const existingMainTotal = existingMainHourTotals.get(mainKey) || 0;
+      const rebuiltMainTotal = rebuiltMainHourTotals.get(mainKey) || 0;
+      if (rebuiltMainTotal >= existingMainTotal) partialProjectKeys.push(key);
+    }
+    if (partialProjectKeys.length > 0) {
+      console.error(
+        `[sync] codex rescan repair: project rebuild lowered ${partialProjectKeys.length} existing codex project bucket(s) without a matching main-bucket repair — skipping to avoid data loss`,
+      );
+      return false;
+    }
   }
 
   // COMMIT (only after a verified rebuild). A crash partway just leaves the
@@ -2559,14 +2646,65 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
   }
   cursors.files ||= {};
   for (const fp of Object.keys(cursors.files)) {
-    if (/\/\.codex\/(?:archived_)?sessions\//.test(fp)) delete cursors.files[fp];
+    if (isCodexSessionCursorPath(fp)) delete cursors.files[fp];
   }
   for (const [fp, v] of Object.entries(rebuilt.files)) {
     cursors.files[fp] = v;
   }
   cursors.codexHashes = rebuilt.codexHashes;
 
-  // 3. Reset the cloud upload offset so the corrected queue re-uploads. Other
+  // 3. Project usage mirrors the main Codex repair: drop inflated Codex project
+  //    rows, append the rebuilt rows, and swap only Codex project buckets. Project
+  //    metadata is merged so visibility/purge state from non-Codex sources stays.
+  if (projectRepairEnabled) {
+    let projectRaw = "";
+    try {
+      projectRaw = await fs.readFile(projectQueuePath, "utf8");
+    } catch (e) {
+      if (e?.code !== "ENOENT") throw e;
+    }
+    const keptProjectRows = [];
+    for (const line of projectRaw.split("\n")) {
+      if (!line.trim()) continue;
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch (_e) {
+        keptProjectRows.push(line);
+        continue;
+      }
+      if (row?.source === "codex") continue;
+      keptProjectRows.push(line);
+    }
+    await ensureDir(path.dirname(projectQueuePath));
+    const tmp = `${projectQueuePath}.tmp.${process.pid}.${Date.now()}`;
+    await fs.writeFile(
+      tmp,
+      keptProjectRows.concat(rebuilt.projectQueueRows).join("\n") + "\n",
+      "utf8",
+    );
+    await fs.rename(tmp, projectQueuePath);
+
+    const projectHourly = (cursors.projectHourly ||= { version: 2, buckets: {}, projects: {} });
+    projectHourly.version = 2;
+    projectHourly.buckets ||= {};
+    projectHourly.projects ||= {};
+    for (const [key, bucket] of Object.entries(projectHourly.buckets)) {
+      const source = typeof bucket?.source === "string" ? bucket.source : key.split("|")[1];
+      if (source === "codex") delete projectHourly.buckets[key];
+    }
+    const rebuiltProjectHourly = rebuilt.projectHourly || {};
+    for (const [key, bucket] of Object.entries(rebuiltProjectHourly.buckets || {})) {
+      const source = typeof bucket?.source === "string" ? bucket.source : key.split("|")[1];
+      if (source === "codex") projectHourly.buckets[key] = bucket;
+    }
+    for (const [key, meta] of Object.entries(rebuiltProjectHourly.projects || {})) {
+      if (meta && typeof meta === "object") projectHourly.projects[key] = meta;
+    }
+    projectHourly.updatedAt = new Date().toISOString();
+  }
+
+  // 4. Reset the cloud upload offset so the corrected queue re-uploads. Other
   //    sources re-upsert idempotently (last emission per key wins).
   if (typeof queueStatePath === "string" && queueStatePath) {
     let uploadState = {};
@@ -2580,9 +2718,247 @@ async function repairCodexRescanInflation({ cursors, queuePath, queueStatePath, 
     uploadState.note = "reset_after_codex_rescan_dedup_2026_06";
     await fs.writeFile(queueStatePath, JSON.stringify(uploadState));
   }
+  if (projectRepairEnabled && typeof projectQueueStatePath === "string" && projectQueueStatePath) {
+    let uploadState = {};
+    try {
+      uploadState = JSON.parse(await fs.readFile(projectQueueStatePath, "utf8"));
+    } catch (_e) {
+      uploadState = {};
+    }
+    uploadState.offset = 0;
+    uploadState.updatedAt = new Date().toISOString();
+    uploadState.note = "reset_after_codex_rescan_dedup_2026_06";
+    await fs.writeFile(projectQueueStatePath, JSON.stringify(uploadState));
+  }
 
   migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY] = new Date().toISOString();
   return true;
+}
+
+function isCodexSessionCursorPath(filePath) {
+  if (typeof filePath !== "string") return false;
+  const normalized = filePath.replace(/\\/g, "/");
+  return /\/\.codex\/(?:archived_)?sessions\//.test(normalized);
+}
+
+async function projectUsageKeysFromQueuePath(queuePath, source) {
+  if (typeof queuePath !== "string" || !queuePath) return [];
+  let raw = "";
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+    return [];
+  }
+  return projectUsageKeysFromQueueRows(raw.split("\n").filter((line) => line.trim()), source);
+}
+
+function projectUsageKeysFromQueueRows(rows, source) {
+  const keys = [];
+  for (const line of Array.isArray(rows) ? rows : []) {
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    const key = projectUsageKeyFromFields({
+      projectKey: row?.project_key,
+      source: row?.source,
+      hourStart: row?.hour_start,
+    });
+    if (key && row?.source === source) keys.push(key);
+  }
+  return keys;
+}
+
+function projectUsageKeysFromState(projectState, source) {
+  const buckets =
+    projectState && typeof projectState === "object" && projectState.buckets
+      ? projectState.buckets
+      : {};
+  const keys = [];
+  for (const [key, bucket] of Object.entries(buckets)) {
+    const bucketSource = typeof bucket?.source === "string" ? bucket.source : key.split("|")[1];
+    if (bucketSource !== source) continue;
+    const usageKey =
+      projectUsageKeyFromFields({
+        projectKey: bucket?.project_key,
+        source: bucketSource,
+        hourStart: bucket?.hour_start,
+      }) || key;
+    keys.push(usageKey);
+  }
+  return keys;
+}
+
+function projectUsageKeyFromFields({ projectKey, source, hourStart }) {
+  if (
+    typeof projectKey !== "string" ||
+    typeof source !== "string" ||
+    typeof hourStart !== "string" ||
+    !projectKey ||
+    !source ||
+    !hourStart
+  ) {
+    return null;
+  }
+  return `${projectKey}|${source}|${hourStart}`;
+}
+
+async function countMalformedCodexProjectQueueRows(queuePath) {
+  if (typeof queuePath !== "string" || !queuePath) return 0;
+  let raw = "";
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+    return 0;
+  }
+  let count = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    if (row?.source !== "codex") continue;
+    const key = projectUsageKeyFromFields({
+      projectKey: row?.project_key,
+      source: row?.source,
+      hourStart: row?.hour_start,
+    });
+    if (!key) count += 1;
+  }
+  return count;
+}
+
+async function projectUsageTotalsFromQueuePath(queuePath, source) {
+  if (typeof queuePath !== "string" || !queuePath) return new Map();
+  let raw = "";
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+    return new Map();
+  }
+  return projectUsageTotalsFromQueueRows(raw.split("\n").filter((line) => line.trim()), source);
+}
+
+function projectUsageTotalsFromQueueRows(rows, source) {
+  const totals = new Map();
+  for (const line of Array.isArray(rows) ? rows : []) {
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    const key = projectUsageKeyFromFields({
+      projectKey: row?.project_key,
+      source: row?.source,
+      hourStart: row?.hour_start,
+    });
+    if (!key || row?.source !== source) continue;
+    setMaxTotal(totals, key, Number(row.total_tokens || 0));
+  }
+  return totals;
+}
+
+function projectUsageTotalsFromState(projectState, source) {
+  const buckets =
+    projectState && typeof projectState === "object" && projectState.buckets
+      ? projectState.buckets
+      : {};
+  const totals = new Map();
+  for (const [key, bucket] of Object.entries(buckets)) {
+    const bucketSource = typeof bucket?.source === "string" ? bucket.source : key.split("|")[1];
+    if (bucketSource !== source) continue;
+    const usageKey =
+      projectUsageKeyFromFields({
+        projectKey: bucket?.project_key,
+        source: bucketSource,
+        hourStart: bucket?.hour_start,
+      }) || key;
+    setMaxTotal(totals, usageKey, Number(bucket?.totals?.total_tokens || 0));
+  }
+  return totals;
+}
+
+async function mainUsageHourTotalsFromQueuePath(queuePath, source) {
+  if (typeof queuePath !== "string" || !queuePath) return new Map();
+  let raw = "";
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+    return new Map();
+  }
+  return mainUsageHourTotalsFromQueueRows(raw.split("\n").filter((line) => line.trim()), source);
+}
+
+function mainUsageHourTotalsFromQueueRows(rows, source) {
+  const modelTotals = new Map();
+  for (const line of Array.isArray(rows) ? rows : []) {
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    if (row?.source !== source || typeof row?.hour_start !== "string") continue;
+    const model = typeof row?.model === "string" && row.model ? row.model : "unknown";
+    setMaxTotal(modelTotals, `${row.source}|${model}|${row.hour_start}`, Number(row.total_tokens || 0));
+  }
+  return collapseModelTotalsByHour(modelTotals);
+}
+
+function mainUsageHourTotalsFromState(hourlyState, source) {
+  const buckets =
+    hourlyState && typeof hourlyState === "object" && hourlyState.buckets
+      ? hourlyState.buckets
+      : {};
+  const modelTotals = new Map();
+  for (const [key, bucket] of Object.entries(buckets)) {
+    const parts = key.split("|");
+    const bucketSource = typeof bucket?.source === "string" ? bucket.source : parts[0];
+    if (bucketSource !== source) continue;
+    const model = typeof bucket?.model === "string" && bucket.model ? bucket.model : parts[1] || "unknown";
+    const hourStart =
+      typeof bucket?.hour_start === "string" && bucket.hour_start ? bucket.hour_start : parts[2];
+    if (typeof hourStart !== "string" || !hourStart) continue;
+    setMaxTotal(modelTotals, `${bucketSource}|${model}|${hourStart}`, Number(bucket?.totals?.total_tokens || 0));
+  }
+  return collapseModelTotalsByHour(modelTotals);
+}
+
+function collapseModelTotalsByHour(modelTotals) {
+  const totals = new Map();
+  for (const [key, total] of modelTotals.entries()) {
+    const [source, , hourStart] = key.split("|");
+    const hourKey = `${source}|${hourStart}`;
+    totals.set(hourKey, (totals.get(hourKey) || 0) + total);
+  }
+  return totals;
+}
+
+function mergeMaxTotals(...maps) {
+  const merged = new Map();
+  for (const map of maps) {
+    if (!(map instanceof Map)) continue;
+    for (const [key, total] of map.entries()) {
+      setMaxTotal(merged, key, total);
+    }
+  }
+  return merged;
+}
+
+function setMaxTotal(map, key, total) {
+  if (!key || !Number.isFinite(total)) return;
+  const prev = map.get(key);
+  if (!Number.isFinite(prev) || total > prev) map.set(key, total);
 }
 
 // One-time repair (#204): when the SAME Droid session id existed in two folders

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -10,6 +10,7 @@ const {
   listRolloutFiles,
   listRolloutFilesDeep,
   codexSessionIdFromPath,
+  filterColdCodexRolloutFiles,
   listClaudeProjectFiles,
   listGeminiSessionFiles,
   listOpencodeMessageFiles,
@@ -152,6 +153,8 @@ const CLOUD_CONVERSATIONS_BACKFILL_KEY = "cloudConversationsBackfill_2026_06";
 // would lose that history (ref the v6 ground-truth-repair data-loss incident).
 const CODEX_RESCAN_DEDUP_REPAIR_KEY = "codexRescanDedupRepair_2026_06";
 const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
+const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CODEX_COLD_SCAN_AUDIT_MAX_SYNCS = 288;
 // 0.57.0 mis-attributed mimocode's mirrored Claude/claude-mem history to
 // source=mimo (read the whole DB instead of only providerID=mimo rows). This
 // one-time repair purges all source=mimo data from the local queues + cursor
@@ -324,20 +327,35 @@ async function cmdSync(argv) {
       });
     }
 
+    const codexColdSkipEnabled = opts.auto && isFullSourceScan && sourceAllowed("codex");
+    const codexColdAuditDue = codexColdSkipEnabled
+      ? isCodexColdScanAuditDue(cursors)
+      : false;
+    const codexColdFilter = codexColdSkipEnabled
+      ? await filterColdCodexRolloutFiles({
+          rolloutFiles,
+          cursors,
+          projectEnabled: true,
+          auditDue: codexColdAuditDue,
+        })
+      : { rolloutFiles, skipped: 0 };
+    const rolloutFilesForParse = codexColdFilter.rolloutFiles;
+
     const openclawFiles = openclawSignal?.sessionFile
       ? [{ path: openclawSignal.sessionFile, source: "openclaw" }]
       : [];
 
     if (progress?.enabled) {
       progress.start(
-        `Parsing ${renderBar(0)} 0/${formatNumber(rolloutFiles.length)} files | buckets 0`,
+        `Parsing ${renderBar(0)} 0/${formatNumber(rolloutFilesForParse.length)} files | buckets 0`,
       );
     }
 
     let parseResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    let codexParseSucceeded = false;
     try {
       parseResult = await parseRolloutIncremental({
-        rolloutFiles,
+        rolloutFiles: rolloutFilesForParse,
         cursors,
         queuePath,
         projectQueuePath,
@@ -351,8 +369,15 @@ async function cmdSync(argv) {
           );
         },
       });
+      codexParseSucceeded = true;
     } catch (err) {
       warnProviderParseFailure("Codex", err, opts);
+    }
+    if (codexColdSkipEnabled && codexParseSucceeded) {
+      recordCodexColdScanAudit(cursors, {
+        fullAudit: codexColdAuditDue,
+        skipped: codexColdFilter.skipped,
+      });
     }
 
     let openclawResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -1470,6 +1495,54 @@ function normalizeSyncSource(value) {
   return AUTO_SYNC_SOURCES.has(aliased) ? aliased : null;
 }
 
+function isCodexColdScanAuditDue(cursors, nowMs = Date.now()) {
+  const state = cursors?.codexColdScanAudit;
+  if (!state || typeof state !== "object" || state.version !== 1) return true;
+  const lastFullScanAtMs = Number(state.lastFullScanAtMs);
+  if (!Number.isFinite(lastFullScanAtMs) || lastFullScanAtMs <= 0) return true;
+  if (Number.isFinite(nowMs) && lastFullScanAtMs - nowMs > 5 * 60 * 1000) return true;
+  if (Number.isFinite(nowMs) && nowMs - lastFullScanAtMs >= CODEX_COLD_SCAN_AUDIT_INTERVAL_MS) {
+    return true;
+  }
+  const syncsSinceFullScan = Number(state.syncsSinceFullScan || 0);
+  return (
+    Number.isFinite(syncsSinceFullScan) &&
+    syncsSinceFullScan >= CODEX_COLD_SCAN_AUDIT_MAX_SYNCS
+  );
+}
+
+function recordCodexColdScanAudit(cursors, { fullAudit = false, skipped = 0 } = {}, nowMs = Date.now()) {
+  if (!cursors || typeof cursors !== "object") return;
+  const prev =
+    cursors.codexColdScanAudit && typeof cursors.codexColdScanAudit === "object"
+      ? cursors.codexColdScanAudit
+      : {};
+  const previousSyncs = Number(prev.syncsSinceFullScan || 0);
+  const lastFullScanAtMs = Number(prev.lastFullScanAtMs);
+  const next = {
+    version: 1,
+    lastFullScanAtMs: Number.isFinite(lastFullScanAtMs) && lastFullScanAtMs > 0
+      ? lastFullScanAtMs
+      : nowMs,
+    syncsSinceFullScan: Number.isFinite(previousSyncs) && previousSyncs > 0
+      ? previousSyncs
+      : 0,
+    lastSkippedFiles: Math.max(0, Number(skipped) || 0),
+    updatedAt: new Date(nowMs).toISOString(),
+  };
+  if (fullAudit) {
+    next.lastFullScanAtMs = nowMs;
+    next.lastFullScanAt = new Date(nowMs).toISOString();
+    next.syncsSinceFullScan = 0;
+  } else {
+    next.lastFullScanAt = Number.isFinite(next.lastFullScanAtMs)
+      ? new Date(next.lastFullScanAtMs).toISOString()
+      : null;
+    next.syncsSinceFullScan += 1;
+  }
+  cursors.codexColdScanAudit = next;
+}
+
 module.exports = {
   cmdSync,
   migrateCursorUnknownBuckets,
@@ -1482,6 +1555,8 @@ module.exports = {
   applyCloudConversationsBackfill,
   scheduleAutoRetry,
   buildAutoRetryScript,
+  isCodexColdScanAuditDue,
+  recordCodexColdScanAudit,
   CURSOR_UNKNOWN_MIGRATION_KEY,
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
   CODEX_RESCAN_DEDUP_REPAIR_KEY,

--- a/src/lib/openclaw-session-plugin.js
+++ b/src/lib/openclaw-session-plugin.js
@@ -437,14 +437,14 @@ function buildSessionPluginIndex({ trackerDir, packageName = "tokentracker-cli",
     `  api.on('gateway_start', async () => {\n` +
     `    try {\n` +
     `      if (!allowTrigger('gateway_start', 'gateway', 'startup')) return;\n` +
-    `      spawnSync({ args: ['sync', '--auto'] });\n` +
+    `      spawnSync({ args: ['sync', '--auto', '--from-openclaw'] });\n` +
     `    } catch (_) {}\n` +
     `  });\n` +
     `\n` +
     `  api.on('gateway_stop', async () => {\n` +
     `    try {\n` +
     `      if (!allowTrigger('gateway_stop', 'gateway', 'stop')) return;\n` +
-    `      spawnSync({ args: ['sync', '--auto'] });\n` +
+    `      spawnSync({ args: ['sync', '--auto', '--from-openclaw'] });\n` +
     `    } catch (_) {}\n` +
     `  });\n` +
     `}\n` +

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -14,6 +14,7 @@ const CLAUDE_MEM_OBSERVER_PATH_SEGMENT = "--claude-mem-observer-sessions";
 const CLAUDE_MEM_OBSERVER_PROJECT_REF =
   "https://local.tokentracker/claude-mem/observer-sessions";
 const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_CODEX_COLD_SKIP_RECENT_DAYS = 2;
 
 async function listRolloutFiles(sessionsDir, options = {}) {
   const out = [];
@@ -347,6 +348,108 @@ async function parseRolloutIncremental({
   }
 
   return { filesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
+}
+
+async function filterColdCodexRolloutFiles({
+  rolloutFiles,
+  cursors,
+  projectEnabled = false,
+  auditDue = false,
+  nowMs = Date.now(),
+  recentDays = DEFAULT_CODEX_COLD_SKIP_RECENT_DAYS,
+} = {}) {
+  const files = Array.isArray(rolloutFiles) ? rolloutFiles : [];
+  if (auditDue || !cursors?.files || typeof cursors.files !== "object") {
+    return { rolloutFiles: files, skipped: 0 };
+  }
+
+  const activeDates = activeCodexRolloutDates(files, { nowMs, recentDays });
+  const freshnessCache = new Map();
+  const out = [];
+  let skipped = 0;
+
+  for (const entry of files) {
+    const filePath = typeof entry === "string" ? entry : entry?.path;
+    const source =
+      typeof entry === "string"
+        ? DEFAULT_SOURCE
+        : normalizeSourceInput(entry?.source) || DEFAULT_SOURCE;
+    if (!filePath || source !== DEFAULT_SOURCE) {
+      out.push(entry);
+      continue;
+    }
+
+    const rolloutDate = rolloutDateFromPath(filePath);
+    if (!rolloutDate || activeDates.has(rolloutDate)) {
+      out.push(entry);
+      continue;
+    }
+
+    const prev = cursors.files[filePath];
+    const cachedSize = Number(prev?.offset);
+    if (!Number.isFinite(cachedSize) || cachedSize <= 0) {
+      out.push(entry);
+      continue;
+    }
+
+    if (projectEnabled) {
+      const projectOffset = Number(prev?.projectOffset);
+      if (!Number.isFinite(projectOffset) || projectOffset < cachedSize) {
+        out.push(entry);
+        continue;
+      }
+      if (
+        !(await isProjectFileContextFresh(prev?.projectFileContext, {
+          freshnessCache,
+          nowMs,
+        }))
+      ) {
+        out.push(entry);
+        continue;
+      }
+    }
+
+    skipped += 1;
+  }
+
+  return { rolloutFiles: out, skipped };
+}
+
+function activeCodexRolloutDates(
+  rolloutFiles,
+  { nowMs = Date.now(), recentDays = DEFAULT_CODEX_COLD_SKIP_RECENT_DAYS } = {},
+) {
+  const active = new Set();
+  const days = Math.max(1, Math.floor(Number(recentDays) || 1));
+  const now = new Date(nowMs);
+  if (Number.isFinite(now.getTime())) {
+    for (let i = 0; i < days; i += 1) {
+      const d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+      active.add(formatLocalDate(d));
+    }
+  }
+
+  let latest = null;
+  for (const entry of Array.isArray(rolloutFiles) ? rolloutFiles : []) {
+    const filePath = typeof entry === "string" ? entry : entry?.path;
+    const source =
+      typeof entry === "string"
+        ? DEFAULT_SOURCE
+        : normalizeSourceInput(entry?.source) || DEFAULT_SOURCE;
+    if (source !== DEFAULT_SOURCE) continue;
+    const rolloutDate = rolloutDateFromPath(filePath);
+    if (rolloutDate && (!latest || rolloutDate > latest)) latest = rolloutDate;
+  }
+  if (latest) active.add(latest);
+
+  return active;
+}
+
+function formatLocalDate(value) {
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 async function parseClaudeIncremental({
@@ -9437,6 +9540,7 @@ module.exports = {
   listRolloutFiles,
   listRolloutFilesDeep,
   codexSessionIdFromPath,
+  filterColdCodexRolloutFiles,
   listClaudeProjectFiles,
   listGeminiSessionFiles,
   listOpencodeMessageFiles,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -154,7 +154,26 @@ async function parseRolloutIncremental({
     const lastTotal = sameInode && !truncated ? prev.lastTotal || null : null;
     const lastModel = sameInode && !truncated ? prev.lastModel || null : null;
 
-    if (!projectEnabled && sameInode && !truncated && startOffset >= st.size) {
+    const codexProjectFastPath = projectEnabled && fileSource === DEFAULT_SOURCE;
+    const projectOffset = sameInode && !truncated ? Number(prev.projectOffset || 0) : 0;
+    const projectUpToDate =
+      codexProjectFastPath &&
+      typeof publicRepoResolver !== "function" &&
+      projectOffset >= st.size &&
+      (await isProjectFileContextFresh(prev?.projectFileContext));
+    const projectContextOnlyScan =
+      codexProjectFastPath &&
+      typeof publicRepoResolver !== "function" &&
+      sameInode &&
+      !truncated &&
+      startOffset >= st.size &&
+      !projectUpToDate;
+    if (
+      sameInode &&
+      !truncated &&
+      startOffset >= st.size &&
+      (!projectEnabled || projectUpToDate)
+    ) {
       if (cb) {
         cb({
           index: idx + 1,
@@ -180,33 +199,54 @@ async function parseRolloutIncremental({
     const projectRef = projectContext?.projectRef || null;
     const projectKey = projectContext?.projectKey || null;
 
-    const result = await parseRolloutFile({
-      filePath,
-      fileStat: st,
-      startOffset,
-      lastTotal,
-      lastModel,
-      hourlyState,
-      touchedBuckets,
-      source: fileSource,
-      projectState,
-      projectTouchedBuckets,
-      projectRef,
-      projectKey,
-      projectMetaCache,
-      publicRepoCache,
-      publicRepoResolver,
-      seenCodexEvents,
-      sessionId: codexSessionIdFromPath(filePath),
-    });
+    const result = projectContextOnlyScan
+      ? await scanRolloutProjectFileContexts({
+          filePath,
+          fileStat: st,
+          lastTotal,
+          lastModel,
+          projectState,
+          projectMetaCache,
+          publicRepoCache,
+          publicRepoResolver,
+          projectContext,
+        })
+      : await parseRolloutFile({
+          filePath,
+          fileStat: st,
+          startOffset,
+          lastTotal,
+          lastModel,
+          hourlyState,
+          touchedBuckets,
+          source: fileSource,
+          projectState,
+          projectTouchedBuckets,
+          projectRef,
+          projectKey,
+          projectMetaCache,
+          publicRepoCache,
+          publicRepoResolver,
+          projectContext,
+          seenCodexEvents,
+          sessionId: codexSessionIdFromPath(filePath),
+        });
 
-    cursors.files[key] = {
+    const nextCursor = {
       inode,
       offset: result.endOffset,
       lastTotal: result.lastTotal,
       lastModel: result.lastModel,
       updatedAt: new Date().toISOString(),
     };
+    if (codexProjectFastPath) {
+      nextCursor.projectOffset = result.endOffset;
+      nextCursor.projectFileContext = buildProjectFileContext(result.projectFileContexts);
+    } else if (Number.isFinite(prev?.projectOffset)) {
+      nextCursor.projectOffset = prev.projectOffset;
+      if (prev?.projectFileContext) nextCursor.projectFileContext = prev.projectFileContext;
+    }
+    cursors.files[key] = nextCursor;
 
     filesProcessed += 1;
     eventsAggregated += result.eventsAggregated;
@@ -820,13 +860,16 @@ async function parseRolloutFile({
   projectMetaCache,
   publicRepoCache,
   publicRepoResolver,
+  projectContext,
   seenCodexEvents,
   sessionId,
 }) {
   const st = fileStat || (await fs.stat(filePath));
   const endOffset = st.size;
+  const projectFileContexts = [];
+  addProjectFileContext(projectFileContexts, projectContext);
   if (startOffset >= endOffset) {
-    return { endOffset, lastTotal, lastModel, eventsAggregated: 0 };
+    return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
   }
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
@@ -888,6 +931,7 @@ async function parseRolloutFile({
           currentCwd = nextCwd;
           currentProjectRef = context?.projectRef || null;
           currentProjectKey = context?.projectKey || null;
+          addProjectFileContext(projectFileContexts, context);
         }
       }
       continue;
@@ -958,7 +1002,73 @@ async function parseRolloutFile({
     eventsAggregated += 1;
   }
 
-  return { endOffset, lastTotal: totals, lastModel: model, eventsAggregated };
+  return { endOffset, lastTotal: totals, lastModel: model, eventsAggregated, projectFileContexts };
+}
+
+async function scanRolloutProjectFileContexts({
+  filePath,
+  fileStat,
+  lastTotal,
+  lastModel,
+  projectState,
+  projectMetaCache,
+  publicRepoCache,
+  publicRepoResolver,
+  projectContext,
+}) {
+  const st = fileStat || (await fs.stat(filePath));
+  const endOffset = st.size;
+  const projectFileContexts = [];
+  addProjectFileContext(projectFileContexts, projectContext);
+  if (!projectState || endOffset <= 0) {
+    return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
+  }
+
+  const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: 0 });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let currentCwd = null;
+
+  for await (const line of rl) {
+    if (
+      !line ||
+      !(
+        line.includes('"turn_context"') ||
+        line.includes('"session_meta"')
+      ) ||
+      !line.includes('"cwd"')
+    ) {
+      continue;
+    }
+
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+    if (
+      (obj?.type !== "turn_context" && obj?.type !== "session_meta") ||
+      !obj?.payload ||
+      typeof obj.payload !== "object" ||
+      typeof obj.payload.cwd !== "string"
+    ) {
+      continue;
+    }
+
+    const nextCwd = obj.payload.cwd.trim();
+    if (!nextCwd || nextCwd === currentCwd) continue;
+    const context = await resolveProjectContextForPath({
+      startDir: nextCwd,
+      projectMetaCache,
+      publicRepoCache,
+      publicRepoResolver,
+      projectState,
+    });
+    currentCwd = nextCwd;
+    addProjectFileContext(projectFileContexts, context);
+  }
+
+  return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
 }
 
 async function parseClaudeFile({
@@ -1987,9 +2097,17 @@ async function resolveProjectMetaForPath(startDir, cache) {
 
     const configPath = await resolveGitConfigPath(current);
     if (configPath) {
+      const configStat = await fs.stat(configPath).catch(() => null);
       const remoteUrl = await readGitRemoteUrl(configPath);
       const projectRef = canonicalizeProjectRef(remoteUrl);
-      const meta = { projectRef: projectRef || null, repoRoot: current };
+      const meta = {
+        projectRef: projectRef || null,
+        repoRoot: current,
+        configPath,
+        configMtimeMs:
+          configStat && Number.isFinite(configStat.mtimeMs) ? configStat.mtimeMs : null,
+        configSize: configStat && Number.isFinite(configStat.size) ? configStat.size : null,
+      };
       if (cache) {
         for (const entry of visited) cache.set(entry, meta);
       }
@@ -2006,6 +2124,69 @@ async function resolveProjectMetaForPath(startDir, cache) {
     for (const entry of visited) cache.set(entry, null);
   }
   return null;
+}
+
+function addProjectFileContext(contexts, projectContext) {
+  if (!Array.isArray(contexts) || !projectContext || typeof projectContext !== "object") return;
+  const configPath =
+    typeof projectContext.configPath === "string" && projectContext.configPath
+      ? projectContext.configPath
+      : null;
+  if (!configPath) return;
+  contexts.push(projectContext);
+}
+
+function buildProjectFileContext(projectContexts) {
+  const contexts = Array.isArray(projectContexts)
+    ? projectContexts
+    : projectContexts && typeof projectContexts === "object"
+      ? [projectContexts]
+      : [];
+  const seen = new Set();
+  const configs = [];
+  for (const context of contexts) {
+    const configPath =
+      typeof context?.configPath === "string" && context.configPath ? context.configPath : null;
+    if (!configPath || seen.has(configPath)) continue;
+    seen.add(configPath);
+    configs.push({
+      configPath,
+      configMtimeMs: Number.isFinite(context.configMtimeMs) ? context.configMtimeMs : null,
+      configSize: Number.isFinite(context.configSize) ? context.configSize : null,
+    });
+  }
+  if (configs.length === 0) return { absent: true };
+  if (configs.length > 1) return { configs };
+  const [config] = configs;
+  return {
+    ...config,
+    configs,
+  };
+}
+
+async function isProjectFileContextFresh(projectFileContext) {
+  if (!projectFileContext || typeof projectFileContext !== "object") return false;
+  if (projectFileContext.absent === true) return false;
+  if (Array.isArray(projectFileContext.configs)) {
+    if (projectFileContext.configs.length === 0) return false;
+    for (const config of projectFileContext.configs) {
+      if (!(await isSingleProjectConfigFresh(config))) return false;
+    }
+    return true;
+  }
+  return isSingleProjectConfigFresh(projectFileContext);
+}
+
+async function isSingleProjectConfigFresh(projectFileContext) {
+  const configPath =
+    typeof projectFileContext.configPath === "string" ? projectFileContext.configPath : null;
+  if (!configPath) return false;
+  const st = await fs.stat(configPath).catch(() => null);
+  if (!st || !st.isFile()) return false;
+  return (
+    st.mtimeMs === projectFileContext.configMtimeMs &&
+    st.size === projectFileContext.configSize
+  );
 }
 
 function hashRepoRoot(repoRoot) {
@@ -2127,15 +2308,28 @@ async function resolveProjectContextForPath({
     projectKey: meta?.projectKey || null,
     status: meta?.status || "blocked",
     repoRootHash: meta?.repoRootHash || repoRootHash,
+    configPath: projectMeta.configPath || null,
+    configMtimeMs: projectMeta.configMtimeMs ?? null,
+    configSize: projectMeta.configSize ?? null,
   };
   recordProjectMeta(projectState, normalized);
   if (normalized.status !== "public_verified") {
-    return { projectRef: normalized.projectRef, projectKey: null, status: normalized.status };
+    return {
+      projectRef: normalized.projectRef,
+      projectKey: null,
+      status: normalized.status,
+      configPath: normalized.configPath,
+      configMtimeMs: normalized.configMtimeMs,
+      configSize: normalized.configSize,
+    };
   }
   return {
     projectRef: normalized.projectRef,
     projectKey: normalized.projectKey,
     status: normalized.status,
+    configPath: normalized.configPath,
+    configMtimeMs: normalized.configMtimeMs,
+    configSize: normalized.configSize,
   };
 }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -14,8 +14,22 @@ const CLAUDE_MEM_OBSERVER_PATH_SEGMENT = "--claude-mem-observer-sessions";
 const CLAUDE_MEM_OBSERVER_PROJECT_REF =
   "https://local.tokentracker/claude-mem/observer-sessions";
 
-async function listRolloutFiles(sessionsDir) {
+async function listRolloutFiles(sessionsDir, options = {}) {
   const out = [];
+  const dayInventoryCache =
+    options?.dayInventoryCache && typeof options.dayInventoryCache === "object"
+      ? options.dayInventoryCache
+      : null;
+  const stats = options?.stats && typeof options.stats === "object" ? options.stats : null;
+  if (dayInventoryCache) {
+    if (dayInventoryCache.version !== 1) {
+      dayInventoryCache.days = {};
+    }
+    dayInventoryCache.version = 1;
+    if (!dayInventoryCache.days || typeof dayInventoryCache.days !== "object") {
+      dayInventoryCache.days = {};
+    }
+  }
   const years = await safeReadDir(sessionsDir);
   for (const y of years) {
     if (!/^[0-9]{4}$/.test(y.name) || !y.isDirectory()) continue;
@@ -28,18 +42,66 @@ async function listRolloutFiles(sessionsDir) {
       for (const d of days) {
         if (!/^[0-9]{2}$/.test(d.name) || !d.isDirectory()) continue;
         const dayDir = path.join(monthDir, d.name);
-        const files = await safeReadDir(dayDir);
-        for (const f of files) {
-          if (!f.isFile()) continue;
-          if (!f.name.startsWith("rollout-") || !f.name.endsWith(".jsonl")) continue;
-          out.push(path.join(dayDir, f.name));
-        }
+        const files = await listRolloutDayFiles(dayDir, { dayInventoryCache, stats });
+        out.push(...files);
       }
     }
   }
 
   out.sort((a, b) => a.localeCompare(b));
   return out;
+}
+
+async function listRolloutDayFiles(dayDir, { dayInventoryCache, stats } = {}) {
+  const cacheDays = dayInventoryCache?.days;
+  const dayStat = dayInventoryCache ? await fs.stat(dayDir).catch(() => null) : null;
+  const statKey = dayStat && dayStat.isDirectory() ? directoryInventoryStatKey(dayStat) : null;
+  const cached = cacheDays && cacheDays[dayDir];
+  if (
+    statKey &&
+    cached &&
+    typeof cached === "object" &&
+    cached.statKey === statKey &&
+    Array.isArray(cached.files) &&
+    cached.files.every(isRolloutFileName)
+  ) {
+    if (stats) stats.dayInventoryCacheHits = Number(stats.dayInventoryCacheHits || 0) + 1;
+    return cached.files.map((name) => path.join(dayDir, name));
+  }
+
+  if (stats && cached) stats.dayInventoryCacheMisses = Number(stats.dayInventoryCacheMisses || 0) + 1;
+  const entries = await safeReadDir(dayDir);
+  const files = [];
+  for (const f of entries) {
+    if (!f.isFile()) continue;
+    if (!isRolloutFileName(f.name)) continue;
+    files.push(f.name);
+  }
+  files.sort((a, b) => a.localeCompare(b));
+  if (cacheDays && statKey) {
+    cacheDays[dayDir] = {
+      statKey,
+      files,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  return files.map((name) => path.join(dayDir, name));
+}
+
+function isRolloutFileName(name) {
+  if (typeof name !== "string") return false;
+  if (name.includes("/") || name.includes("\\")) return false;
+  if (name !== path.basename(name)) return false;
+  return name.startsWith("rollout-") && name.endsWith(".jsonl");
+}
+
+function directoryInventoryStatKey(st) {
+  return [
+    Number(st.ino || 0),
+    Number(st.size || 0),
+    Number(st.mtimeMs || 0),
+    Number(st.ctimeMs || 0),
+  ].join(":");
 }
 
 // Collect rollout-*.jsonl at ANY depth under dir. listRolloutFiles requires the

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -13,6 +13,7 @@ const BUCKET_SEPARATOR = "|";
 const CLAUDE_MEM_OBSERVER_PATH_SEGMENT = "--claude-mem-observer-sessions";
 const CLAUDE_MEM_OBSERVER_PROJECT_REF =
   "https://local.tokentracker/claude-mem/observer-sessions";
+const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
 
 async function listRolloutFiles(sessionsDir, options = {}) {
   const out = [];
@@ -181,6 +182,8 @@ async function parseRolloutIncremental({
   const projectTouchedBuckets = projectEnabled ? new Set() : null;
   const projectMetaCache = projectEnabled ? new Map() : null;
   const publicRepoCache = projectEnabled ? new Map() : null;
+  const projectFreshnessCache = projectEnabled ? new Map() : null;
+  const projectFreshnessNowMs = Date.now();
   const touchedBuckets = new Set();
   const defaultSource = normalizeSourceInput(source) || DEFAULT_SOURCE;
 
@@ -222,7 +225,10 @@ async function parseRolloutIncremental({
       codexProjectFastPath &&
       typeof publicRepoResolver !== "function" &&
       projectOffset >= st.size &&
-      (await isProjectFileContextFresh(prev?.projectFileContext));
+      (await isProjectFileContextFresh(prev?.projectFileContext, {
+        freshnessCache: projectFreshnessCache,
+        nowMs: projectFreshnessNowMs,
+      }));
     const projectContextOnlyScan =
       codexProjectFastPath &&
       typeof publicRepoResolver !== "function" &&
@@ -303,7 +309,10 @@ async function parseRolloutIncremental({
     };
     if (codexProjectFastPath) {
       nextCursor.projectOffset = result.endOffset;
-      nextCursor.projectFileContext = buildProjectFileContext(result.projectFileContexts);
+      nextCursor.projectFileContext = buildProjectFileContext(
+        result.projectFileContexts,
+        projectFreshnessNowMs,
+      );
     } else if (Number.isFinite(prev?.projectOffset)) {
       nextCursor.projectOffset = prev.projectOffset;
       if (prev?.projectFileContext) nextCursor.projectFileContext = prev.projectFileContext;
@@ -2198,7 +2207,7 @@ function addProjectFileContext(contexts, projectContext) {
   contexts.push(projectContext);
 }
 
-function buildProjectFileContext(projectContexts) {
+function buildProjectFileContext(projectContexts, checkedAtMs = Date.now()) {
   const contexts = Array.isArray(projectContexts)
     ? projectContexts
     : projectContexts && typeof projectContexts === "object"
@@ -2217,7 +2226,7 @@ function buildProjectFileContext(projectContexts) {
       configSize: Number.isFinite(context.configSize) ? context.configSize : null,
     });
   }
-  if (configs.length === 0) return { absent: true };
+  if (configs.length === 0) return { absent: true, checkedAtMs };
   if (configs.length > 1) return { configs };
   const [config] = configs;
   return {
@@ -2226,24 +2235,41 @@ function buildProjectFileContext(projectContexts) {
   };
 }
 
-async function isProjectFileContextFresh(projectFileContext) {
+async function isProjectFileContextFresh(projectFileContext, options = {}) {
   if (!projectFileContext || typeof projectFileContext !== "object") return false;
-  if (projectFileContext.absent === true) return false;
+  const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+  const absentTtlMs = Number.isFinite(options.absentTtlMs)
+    ? options.absentTtlMs
+    : PROJECT_ABSENT_CONTEXT_RESCAN_MS;
+  const freshnessCache =
+    options.freshnessCache && typeof options.freshnessCache === "object"
+      ? options.freshnessCache
+      : null;
+  if (projectFileContext.absent === true) {
+    const checkedAtMs = Number(projectFileContext.checkedAtMs);
+    return Number.isFinite(checkedAtMs) && checkedAtMs > 0 && nowMs - checkedAtMs < absentTtlMs;
+  }
   if (Array.isArray(projectFileContext.configs)) {
     if (projectFileContext.configs.length === 0) return false;
     for (const config of projectFileContext.configs) {
-      if (!(await isSingleProjectConfigFresh(config))) return false;
+      if (!(await isSingleProjectConfigFresh(config, freshnessCache))) return false;
     }
     return true;
   }
-  return isSingleProjectConfigFresh(projectFileContext);
+  return isSingleProjectConfigFresh(projectFileContext, freshnessCache);
 }
 
-async function isSingleProjectConfigFresh(projectFileContext) {
+async function isSingleProjectConfigFresh(projectFileContext, freshnessCache = null) {
   const configPath =
     typeof projectFileContext.configPath === "string" ? projectFileContext.configPath : null;
   if (!configPath) return false;
-  const st = await fs.stat(configPath).catch(() => null);
+  let st;
+  if (freshnessCache && freshnessCache.has(configPath)) {
+    st = freshnessCache.get(configPath);
+  } else {
+    st = await fs.stat(configPath).catch(() => null);
+    if (freshnessCache) freshnessCache.set(configPath, st);
+  }
   if (!st || !st.isFile()) return false;
   return (
     st.mtimeMs === projectFileContext.configMtimeMs &&

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -4,7 +4,11 @@ const path = require("node:path");
 const fs = require("node:fs/promises");
 const { test } = require("node:test");
 
-const { cmdSync, scheduleAutoRetry } = require("../src/commands/sync");
+const {
+  cmdSync,
+  isCodexColdScanAuditDue,
+  scheduleAutoRetry,
+} = require("../src/commands/sync");
 const { listRolloutFiles } = require("../src/lib/rollout");
 
 function tokenCountLine({ ts, last, total }) {
@@ -103,6 +107,21 @@ async function countReaddir(fn, predicate = () => true) {
     return { count, value };
   } finally {
     fs.readdir = realReaddir;
+  }
+}
+
+async function countStat(fn, predicate = () => true) {
+  const realStat = fs.stat;
+  let count = 0;
+  fs.stat = async function countedStat(target, ...args) {
+    if (predicate(String(target))) count += 1;
+    return realStat.call(this, target, ...args);
+  };
+  try {
+    const value = await fn();
+    return { count, value };
+  } finally {
+    fs.stat = realStat;
   }
 }
 
@@ -494,6 +513,107 @@ test("full auto sync persists Codex day inventory cache between runs", async () 
     );
     assert.equal(count, 0, "unchanged cached day should not be readdir'd on the next full auto sync");
   });
+});
+
+test("full auto sync cold-skips historical Codex rollout file stats after audit baseline", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    const rolloutPath = await writeCodexRollout(
+      codexHome,
+      "2026-01-01",
+      "019f16bd-aaaa-7000-8000-aaaaaaaaaaaa",
+      29,
+    );
+    await writeCodexRollout(
+      codexHome,
+      "2026-07-02",
+      "019f16bd-bbbb-7000-8000-bbbbbbbbbbbb",
+      31,
+    );
+
+    await cmdSync(["--auto"]);
+    const { count } = await countStat(
+      () => cmdSync(["--auto"]),
+      (target) => target === rolloutPath,
+    );
+
+    assert.equal(count, 0, "historical EOF Codex rollout should not be stat'ed on idle sync");
+    const cursors = JSON.parse(
+      await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
+    );
+    assert.equal(cursors.codexColdScanAudit.lastSkippedFiles, 1);
+  });
+});
+
+test("manual sync still stats historical Codex rollouts after auto cold-skip baseline", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    const rolloutPath = await writeCodexRollout(
+      codexHome,
+      "2026-01-01",
+      "019f16bd-cccc-7000-8000-cccccccccccc",
+      37,
+    );
+    await writeCodexRollout(
+      codexHome,
+      "2026-07-02",
+      "019f16bd-dddd-7000-8000-dddddddddddd",
+      41,
+    );
+
+    await cmdSync(["--auto"]);
+    const { count } = await countStat(
+      () => cmdSync([]),
+      (target) => target === rolloutPath,
+    );
+
+    assert.ok(count > 0, "manual full sync should keep historical file validation");
+  });
+});
+
+test("Codex cold scan audit treats future full-scan timestamps as due", () => {
+  const nowMs = Date.UTC(2026, 6, 2, 0, 0, 0);
+
+  assert.equal(
+    isCodexColdScanAuditDue({
+      codexColdScanAudit: {
+        version: 1,
+        lastFullScanAtMs: nowMs + 10 * 60 * 1000,
+        syncsSinceFullScan: 0,
+      },
+    }, nowMs),
+    true,
+  );
+  assert.equal(
+    isCodexColdScanAuditDue({
+      codexColdScanAudit: {
+        version: 1,
+        lastFullScanAtMs: nowMs - 60 * 60 * 1000,
+        syncsSinceFullScan: 0,
+      },
+    }, nowMs),
+    false,
+  );
+  assert.equal(
+    isCodexColdScanAuditDue({
+      codexColdScanAudit: {
+        version: 1,
+        lastFullScanAtMs: nowMs - 25 * 60 * 60 * 1000,
+        syncsSinceFullScan: 0,
+      },
+    }, nowMs),
+    true,
+  );
+  assert.equal(
+    isCodexColdScanAuditDue({
+      codexColdScanAudit: {
+        version: 1,
+        lastFullScanAtMs: nowMs - 60 * 60 * 1000,
+        syncsSinceFullScan: 288,
+      },
+    }, nowMs),
+    true,
+  );
 });
 
 test("Codex day inventory cache reduces repeated old-day readdir", async () => {

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -1,0 +1,630 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { cmdSync, scheduleAutoRetry } = require("../src/commands/sync");
+const { listRolloutFiles } = require("../src/lib/rollout");
+
+function tokenCountLine({ ts, last, total }) {
+  return JSON.stringify({
+    type: "event_msg",
+    timestamp: ts,
+    payload: { type: "token_count", info: { last_token_usage: last, total_token_usage: total } },
+  });
+}
+
+async function writeCodexRollout(codexHome, date, uuid, totalTokens = 12) {
+  const [year, month, day] = date.split("-");
+  const dir = path.join(codexHome, "sessions", year, month, day);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `rollout-${date}T00-00-00-${uuid}.jsonl`);
+  const usage = {
+    input_tokens: totalTokens,
+    cached_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+  };
+  await fs.writeFile(
+    filePath,
+    tokenCountLine({ ts: `${date}T00:00:00.000Z`, last: usage, total: usage }) + "\n",
+    "utf8",
+  );
+  return filePath;
+}
+
+async function writeArchivedCodexRollout(codexHome, date, uuid, totalTokens = 12) {
+  const dir = path.join(codexHome, "archived_sessions");
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `rollout-${date}T00-00-00-${uuid}.jsonl`);
+  const usage = {
+    input_tokens: totalTokens,
+    cached_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+  };
+  await fs.writeFile(
+    filePath,
+    tokenCountLine({ ts: `${date}T00:00:00.000Z`, last: usage, total: usage }) + "\n",
+    "utf8",
+  );
+  return filePath;
+}
+
+async function withTempSyncEnv(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-source-scope-"));
+  const saved = {
+    HOME: process.env.HOME,
+    CODEX_HOME: process.env.CODEX_HOME,
+    CODE_HOME: process.env.CODE_HOME,
+    GEMINI_HOME: process.env.GEMINI_HOME,
+    OPENCODE_HOME: process.env.OPENCODE_HOME,
+    XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+    TOKENTRACKER_DEVICE_TOKEN: process.env.TOKENTRACKER_DEVICE_TOKEN,
+    TOKENTRACKER_OPENCLAW_AGENT_ID: process.env.TOKENTRACKER_OPENCLAW_AGENT_ID,
+    TOKENTRACKER_OPENCLAW_PREV_SESSION_ID: process.env.TOKENTRACKER_OPENCLAW_PREV_SESSION_ID,
+    TOKENTRACKER_OPENCLAW_SESSION_KEY: process.env.TOKENTRACKER_OPENCLAW_SESSION_KEY,
+    TOKENTRACKER_OPENCLAW_HOME: process.env.TOKENTRACKER_OPENCLAW_HOME,
+  };
+  try {
+    process.env.HOME = home;
+    process.env.CODEX_HOME = path.join(home, ".codex");
+    process.env.CODE_HOME = path.join(home, ".code");
+    process.env.GEMINI_HOME = path.join(home, ".gemini");
+    process.env.OPENCODE_HOME = path.join(home, ".opencode");
+    process.env.XDG_DATA_HOME = path.join(home, ".local", "share");
+    process.env.TOKENTRACKER_OPENCLAW_HOME = path.join(home, ".openclaw");
+    delete process.env.TOKENTRACKER_OPENCLAW_AGENT_ID;
+    delete process.env.TOKENTRACKER_OPENCLAW_PREV_SESSION_ID;
+    delete process.env.TOKENTRACKER_OPENCLAW_SESSION_KEY;
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    return await fn(home);
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+async function countReaddir(fn, predicate = () => true) {
+  const realReaddir = fs.readdir;
+  let count = 0;
+  fs.readdir = async function countedReaddir(target, ...args) {
+    if (predicate(String(target))) count += 1;
+    return realReaddir.call(this, target, ...args);
+  };
+  try {
+    const value = await fn();
+    return { count, value };
+  } finally {
+    fs.readdir = realReaddir;
+  }
+}
+
+test("non-Codex notify auto sync does not enumerate Codex sessions or archives", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-1111-7222-8333-444444444444",
+      42,
+    );
+    await fs.mkdir(path.join(codexHome, "archived_sessions"), { recursive: true });
+
+    const codexRoot = path.join(codexHome);
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto", "--from-notify", "--source=gemini"]),
+      (target) => target.startsWith(codexRoot),
+    );
+
+    assert.equal(count, 0, "gemini notify scope must not readdir ~/.codex/sessions or archived_sessions");
+    await assert.rejects(
+      fs.stat(path.join(home, ".tokentracker", "tracker", "queue.jsonl")),
+      /ENOENT/,
+    );
+  });
+});
+
+test("unknown notify source falls back to full scan instead of skipping everything", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-2222-7333-8444-555555555555",
+      17,
+    );
+
+    const sessionsRoot = path.join(codexHome, "sessions");
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto", "--from-notify", "--source=unknown-provider"]),
+      (target) => target.startsWith(sessionsRoot),
+    );
+
+    assert.ok(count > 0, "unknown source should degrade to a full scan");
+    const queue = await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.jsonl"), "utf8");
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":17/);
+  });
+});
+
+test("source-scoped retry auto sync does not enumerate Codex sessions", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-3333-7444-8555-666666666666",
+      19,
+    );
+
+    const codexRoot = path.join(codexHome);
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto", "--from-retry", "--source=gemini"]),
+      (target) => target.startsWith(codexRoot),
+    );
+
+    assert.equal(count, 0, "gemini retry scope must not readdir ~/.codex");
+    await assert.rejects(
+      fs.stat(path.join(home, ".tokentracker", "tracker", "queue.jsonl")),
+      /ENOENT/,
+    );
+  });
+});
+
+test("legacy retry auto sync without source remains a full scan", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-4444-7555-8666-777777777777",
+      23,
+    );
+
+    const sessionsRoot = path.join(codexHome, "sessions");
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto", "--from-retry"]),
+      (target) => target.startsWith(sessionsRoot),
+    );
+
+    assert.ok(count > 0, "retry without a source should preserve the legacy full scan");
+    const queue = await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.jsonl"), "utf8");
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":23/);
+  });
+});
+
+test("OpenClaw auto sync does not enumerate Codex sessions", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-4545-7666-8777-888888888888",
+      31,
+    );
+
+    const codexRoot = path.join(codexHome);
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto", "--from-openclaw"]),
+      (target) => target.startsWith(codexRoot),
+    );
+
+    assert.equal(count, 0, "OpenClaw lifecycle sync should only inspect OpenClaw state");
+  });
+});
+
+test("auto retry refreshes stale source scope without rescheduling later retry", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-auto-retry-"));
+  try {
+    const trackerDir = path.join(tmp, "tracker");
+    const retryPath = path.join(trackerDir, "auto.retry.json");
+    await fs.mkdir(trackerDir, { recursive: true });
+
+    const laterRetryAtMs = Date.now() + 60_000;
+    await fs.writeFile(
+      retryPath,
+      JSON.stringify({
+        version: 1,
+        retryAtMs: laterRetryAtMs,
+        retryAt: new Date(laterRetryAtMs).toISOString(),
+        reason: "backlog",
+        pendingBytes: 5,
+        scheduledAt: new Date().toISOString(),
+        source: "auto-backlog",
+      }),
+      "utf8",
+    );
+
+    const scoped = await scheduleAutoRetry({
+      trackerDir,
+      retryAtMs: Date.now() + 30_000,
+      reason: "backlog",
+      pendingBytes: 11,
+      source: "gemini-backlog",
+      syncSource: "gemini",
+      autoRetryNoSpawn: true,
+    });
+
+    assert.equal(scoped.scheduled, false);
+    assert.equal(scoped.retryAtMs, laterRetryAtMs);
+    const scopedPayload = JSON.parse(await fs.readFile(retryPath, "utf8"));
+    assert.equal(scopedPayload.retryAtMs, laterRetryAtMs);
+    assert.equal(scopedPayload.syncSource, "gemini");
+
+    const full = await scheduleAutoRetry({
+      trackerDir,
+      retryAtMs: Date.now() + 30_000,
+      reason: "backlog",
+      pendingBytes: 13,
+      source: "auto-backlog",
+      syncSource: null,
+      autoRetryNoSpawn: true,
+    });
+
+    assert.equal(full.scheduled, false);
+    assert.equal(full.retryAtMs, laterRetryAtMs);
+    const fullPayload = JSON.parse(await fs.readFile(retryPath, "utf8"));
+    assert.equal(fullPayload.retryAtMs, laterRetryAtMs);
+    assert.equal(Object.hasOwn(fullPayload, "syncSource"), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("non-Grok notify auto sync leaves pending Grok hook signal untouched", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    const signalPath = path.join(trackerDir, "grok-last-session.json");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      signalPath,
+      JSON.stringify({
+        sessionId: "grok-session-1",
+        totalTokens: 44,
+        contextTokensUsed: 44,
+        lastActive: "2026-06-30T00:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    await cmdSync(["--auto", "--from-notify", "--source=gemini"]);
+
+    const signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
+    assert.equal(signal.sessionId, "grok-session-1");
+  });
+});
+
+test("source-scoped notify sync does not run project purge reconciliation", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const projectQueuePath = path.join(trackerDir, "project.queue.jsonl");
+    const projectQueueStatePath = path.join(trackerDir, "project.queue.state.json");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      cursorsPath,
+      JSON.stringify({
+        version: 1,
+        files: {},
+        projectHourly: {
+          buckets: {
+            "project-1|gemini|2026-06-30T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/project-1",
+              project_key: "project-1",
+              source: "gemini",
+              hour_start: "2026-06-30T00:00:00.000Z",
+              totals: { total_tokens: 5 },
+            },
+          },
+          projects: {
+            "project-1": { status: "blocked", purge_pending: true },
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      projectQueuePath,
+      JSON.stringify({
+        project_ref: "https://github.com/acme/project-1",
+        project_key: "project-1",
+        source: "gemini",
+        hour_start: "2026-06-30T00:00:00.000Z",
+        total_tokens: 5,
+      }) + "\n",
+      "utf8",
+    );
+    await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 0 }), "utf8");
+
+    await cmdSync(["--auto", "--from-notify", "--source=gemini"]);
+
+    const cursors = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+    assert.equal(cursors.projectHourly.projects["project-1"].purge_pending, true);
+    const projectQueue = await fs.readFile(projectQueuePath, "utf8");
+    assert.match(projectQueue, /"project_key":"project-1"/);
+  });
+});
+
+test("full sync still runs project purge reconciliation", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const projectQueuePath = path.join(trackerDir, "project.queue.jsonl");
+    const projectQueueStatePath = path.join(trackerDir, "project.queue.state.json");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      cursorsPath,
+      JSON.stringify({
+        version: 1,
+        files: {},
+        projectHourly: {
+          buckets: {
+            "project-1|gemini|2026-06-30T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/project-1",
+              project_key: "project-1",
+              source: "gemini",
+              hour_start: "2026-06-30T00:00:00.000Z",
+              totals: { total_tokens: 5 },
+            },
+            "project-2|gemini|2026-06-30T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/project-2",
+              project_key: "project-2",
+              source: "gemini",
+              hour_start: "2026-06-30T00:00:00.000Z",
+              totals: { total_tokens: 7 },
+            },
+          },
+          projects: {
+            "project-1": { status: "blocked", purge_pending: true },
+            "project-2": { status: "public_verified", purge_pending: false },
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      projectQueuePath,
+      [
+        JSON.stringify({
+          project_ref: "https://github.com/acme/project-1",
+          project_key: "project-1",
+          source: "gemini",
+          hour_start: "2026-06-30T00:00:00.000Z",
+          total_tokens: 5,
+        }),
+        JSON.stringify({
+          project_ref: "https://github.com/acme/project-2",
+          project_key: "project-2",
+          source: "gemini",
+          hour_start: "2026-06-30T00:00:00.000Z",
+          total_tokens: 7,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 999 }), "utf8");
+
+    await cmdSync(["--auto"]);
+
+    const cursors = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+    assert.equal(cursors.projectHourly.projects["project-1"].purge_pending, false);
+    assert.ok(!cursors.projectHourly.buckets["project-1|gemini|2026-06-30T00:00:00.000Z"]);
+    assert.ok(cursors.projectHourly.buckets["project-2|gemini|2026-06-30T00:00:00.000Z"]);
+    const projectQueue = await fs.readFile(projectQueuePath, "utf8");
+    assert.doesNotMatch(projectQueue, /"project_key":"project-1"/);
+    assert.match(projectQueue, /"project_key":"project-2"/);
+  });
+});
+
+test("manual sync remains a full scan and discovers Codex usage", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-5555-7666-8777-888888888888",
+      33,
+    );
+
+    const sessionsRoot = path.join(codexHome, "sessions");
+    const { count } = await countReaddir(
+      () => cmdSync([]),
+      (target) => target.startsWith(sessionsRoot),
+    );
+
+    assert.ok(count > 0, "manual sync must enumerate Codex sessions");
+    const queue = await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.jsonl"), "utf8");
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":33/);
+  });
+});
+
+test("full auto sync still scans flat Codex archives", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeArchivedCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-6666-7777-8888-999999999999",
+      29,
+    );
+
+    const archiveRoot = path.join(codexHome, "archived_sessions");
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto"]),
+      (target) => target.startsWith(archiveRoot),
+    );
+
+    assert.ok(count > 0, "full auto sync must enumerate archived Codex sessions");
+    const queue = await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.jsonl"), "utf8");
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":29/);
+  });
+});
+
+test("full auto sync persists Codex day inventory cache between runs", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    const rolloutPath = await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-9999-7000-8000-999999999999",
+      21,
+    );
+    const dayDir = path.dirname(rolloutPath);
+
+    await cmdSync(["--auto"]);
+
+    const cursorsPath = path.join(home, ".tokentracker", "tracker", "cursors.json");
+    const cursors = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+    assert.equal(cursors.codexDayInventoryCache?.version, 1);
+    assert.ok(cursors.codexDayInventoryCache.days[dayDir], "first sync should cache the Codex day");
+
+    const { count } = await countReaddir(
+      () => cmdSync(["--auto"]),
+      (target) => target === dayDir,
+    );
+    assert.equal(count, 0, "unchanged cached day should not be readdir'd on the next full auto sync");
+  });
+});
+
+test("Codex day inventory cache reduces repeated old-day readdir", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-cache-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    await writeCodexRollout(tmp, "2026-06-28", "019f16bd-aaaa-7000-8000-aaaaaaaaaaaa", 1);
+    await writeCodexRollout(tmp, "2026-06-29", "019f16bd-bbbb-7000-8000-bbbbbbbbbbbb", 2);
+
+    const cache = { version: 1, days: {} };
+    const firstStats = {};
+    const first = await countReaddir(() =>
+      listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats: firstStats }),
+    );
+    const secondStats = {};
+    const second = await countReaddir(() =>
+      listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats: secondStats }),
+    );
+
+    assert.deepEqual(second.value, first.value);
+    assert.ok(
+      second.count < first.count,
+      `expected fewer readdir calls on cache hit; first=${first.count}, second=${second.count}`,
+    );
+    assert.equal(secondStats.dayInventoryCacheHits, 2);
+    console.log(
+      `codex day inventory cache readdir counts: first=${first.count} second=${second.count}`,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("Codex day inventory cache invalidates when a day directory changes", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-cache-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    await writeCodexRollout(tmp, "2026-06-28", "019f16bd-cccc-7000-8000-cccccccccccc", 1);
+
+    const cache = { version: 1, days: {} };
+    await listRolloutFiles(sessionsDir, { dayInventoryCache: cache });
+
+    const added = await writeCodexRollout(
+      tmp,
+      "2026-06-28",
+      "019f16bd-dddd-7000-8000-dddddddddddd",
+      2,
+    );
+    const dayDir = path.dirname(added);
+    const future = new Date(Date.now() + 2000);
+    await fs.utimes(dayDir, future, future);
+
+    const stats = {};
+    const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats });
+    assert.ok(found.includes(added), "changed day directory must be re-read");
+    assert.equal(stats.dayInventoryCacheMisses, 1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("Codex day inventory cache falls back safely when cache data is corrupt", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-cache-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    const rolloutPath = await writeCodexRollout(
+      tmp,
+      "2026-06-28",
+      "019f16bd-eeee-7000-8000-eeeeeeeeeeee",
+      1,
+    );
+    const dayDir = path.dirname(rolloutPath);
+    const cache = { version: 1, days: { [dayDir]: { statKey: "corrupt", files: "not-an-array" } } };
+
+    const stats = {};
+    const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats });
+    assert.deepEqual(found, [rolloutPath]);
+    assert.equal(stats.dayInventoryCacheMisses, 1);
+    assert.ok(Array.isArray(cache.days[dayDir].files), "corrupt cache entry should be replaced");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("Codex day inventory cache rejects corrupt cached filenames", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-cache-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    const rolloutPath = await writeCodexRollout(
+      tmp,
+      "2026-06-28",
+      "019f16bd-abcd-7000-8000-abcdabcdabcd",
+      1,
+    );
+    const dayDir = path.dirname(rolloutPath);
+    const cache = { version: 1, days: {} };
+    await listRolloutFiles(sessionsDir, { dayInventoryCache: cache });
+    cache.days[dayDir].files = ["rollout-x/evil.jsonl"];
+
+    const stats = {};
+    const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats });
+    assert.deepEqual(found, [rolloutPath]);
+    assert.equal(stats.dayInventoryCacheMisses, 1);
+    assert.ok(cache.days[dayDir].files.includes(path.basename(rolloutPath)));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("Codex day inventory cache discards incompatible cache versions", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-cache-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    const rolloutPath = await writeCodexRollout(
+      tmp,
+      "2026-06-28",
+      "019f16bd-ffff-7000-8000-ffffffffffff",
+      1,
+    );
+    const dayDir = path.dirname(rolloutPath);
+    const cache = { version: 1, days: {} };
+    await listRolloutFiles(sessionsDir, { dayInventoryCache: cache });
+
+    cache.version = 0;
+    cache.days[dayDir].files = [];
+
+    const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache });
+    assert.deepEqual(found, [rolloutPath]);
+    assert.equal(cache.version, 1);
+    assert.ok(cache.days[dayDir].files.includes(path.basename(rolloutPath)));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -591,13 +591,15 @@ test("Codex day inventory cache rejects corrupt cached filenames", async () => {
     const dayDir = path.dirname(rolloutPath);
     const cache = { version: 1, days: {} };
     await listRolloutFiles(sessionsDir, { dayInventoryCache: cache });
-    cache.days[dayDir].files = ["rollout-x/evil.jsonl"];
+    for (const badName of ["rollout-x/evil.jsonl", "rollout-x\\evil.jsonl", "../rollout-x.jsonl"]) {
+      cache.days[dayDir].files = [badName];
 
-    const stats = {};
-    const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats });
-    assert.deepEqual(found, [rolloutPath]);
-    assert.equal(stats.dayInventoryCacheMisses, 1);
-    assert.ok(cache.days[dayDir].files.includes(path.basename(rolloutPath)));
+      const stats = {};
+      const found = await listRolloutFiles(sessionsDir, { dayInventoryCache: cache, stats });
+      assert.deepEqual(found, [rolloutPath]);
+      assert.equal(stats.dayInventoryCacheMisses, 1);
+      assert.ok(cache.days[dayDir].files.includes(path.basename(rolloutPath)));
+    }
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/openclaw-session-plugin.test.js
+++ b/test/openclaw-session-plugin.test.js
@@ -310,6 +310,11 @@ test("ensureOpenclawSessionPluginFiles includes agent/session lifecycle hooks", 
   assert.match(index, /api\.on\('gateway_start'/);
   assert.match(index, /api\.on\('gateway_stop'/);
   assert.match(index, /TOKENTRACKER_OPENCLAW_PREV_SESSION_ID/);
+  assert.equal(
+    (index.match(/args: \['sync', '--auto', '--from-openclaw'\]/g) || []).length,
+    3,
+    "agent and gateway lifecycle syncs must stay scoped to OpenClaw",
+  );
 
   await fs.rm(tmp, { recursive: true, force: true });
 });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -44,6 +44,7 @@ const {
   resolveKimiCodeWireFiles,
   resolveKimiCodeDefaultModel,
   listRolloutFilesDeep,
+  filterColdCodexRolloutFiles,
 } = require("../src/lib/rollout");
 
 const antigravityTestTokens = (text) => estimateAntigravityTokens(text || "");
@@ -941,6 +942,117 @@ test("parseRolloutIncremental keeps project EOF fast path scoped to codex source
     assert.equal(second.filesProcessed, 1);
     assert.equal(second.eventsAggregated, 0);
     assert.equal(cursors.files[rolloutPath].projectOffset, undefined);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("filterColdCodexRolloutFiles skips historical EOF Codex files without statting them", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  const realStat = fs.stat;
+  try {
+    const oldPath = path.join(
+      tmp,
+      ".codex",
+      "sessions",
+      "2026",
+      "01",
+      "01",
+      "rollout-2026-01-01T00-00-00-019f16bd-1111-7222-8333-444444444444.jsonl",
+    );
+    const recentPath = path.join(
+      tmp,
+      ".codex",
+      "sessions",
+      "2026",
+      "07",
+      "02",
+      "rollout-2026-07-02T00-00-00-019f16bd-2222-7333-8444-555555555555.jsonl",
+    );
+    const otherSourcePath = path.join(
+      tmp,
+      ".code",
+      "sessions",
+      "rollout-2026-01-01T00-00-00-019f16bd-3333-7444-8555-666666666666.jsonl",
+    );
+    let rolloutStats = 0;
+    fs.stat = async function countedStat(target, ...args) {
+      if (String(target).endsWith(".jsonl")) rolloutStats += 1;
+      return realStat.call(this, target, ...args);
+    };
+
+    const filtered = await filterColdCodexRolloutFiles({
+      rolloutFiles: [
+        { path: oldPath, source: "codex" },
+        { path: recentPath, source: "codex" },
+        { path: otherSourcePath, source: "every-code" },
+      ],
+      cursors: {
+        files: {
+          [oldPath]: { offset: 123, projectOffset: 123 },
+          [recentPath]: { offset: 123, projectOffset: 123 },
+          [otherSourcePath]: { offset: 123 },
+        },
+      },
+      projectEnabled: false,
+      nowMs: Date.UTC(2026, 6, 2),
+    });
+
+    assert.equal(filtered.skipped, 1);
+    assert.deepEqual(
+      filtered.rolloutFiles.map((entry) => entry.path),
+      [recentPath, otherSourcePath],
+    );
+    assert.equal(rolloutStats, 0);
+  } finally {
+    fs.stat = realStat;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("filterColdCodexRolloutFiles keeps project-stale historical files parseable", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    const configPath = path.join(repoRoot, ".git", "config");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `[remote "origin"]\n\turl = https://github.com/acme/changed.git\n`,
+      "utf8",
+    );
+    const configStat = await fs.stat(configPath);
+    const rolloutPath = path.join(
+      tmp,
+      ".codex",
+      "sessions",
+      "2026",
+      "01",
+      "01",
+      "rollout-2026-01-01T00-00-00-019f16bd-4444-7555-8666-777777777777.jsonl",
+    );
+
+    const filtered = await filterColdCodexRolloutFiles({
+      rolloutFiles: [{ path: rolloutPath, source: "codex" }],
+      cursors: {
+        files: {
+          [rolloutPath]: {
+            offset: 123,
+            projectOffset: 123,
+            projectFileContext: {
+              configPath,
+              configMtimeMs: configStat.mtimeMs - 1,
+              configSize: configStat.size,
+            },
+          },
+        },
+      },
+      projectEnabled: true,
+      nowMs: Date.UTC(2026, 6, 2),
+    });
+
+    assert.equal(filtered.skipped, 0);
+    assert.deepEqual(filtered.rolloutFiles, [{ path: rolloutPath, source: "codex" }]);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -762,7 +762,7 @@ test("parseRolloutIncremental does not skip unchanged project files with a custo
   }
 });
 
-test("parseRolloutIncremental keeps probing unchanged files after missing project context", async () => {
+test("parseRolloutIncremental throttles unchanged files after missing project context", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
     const repoRoot = path.join(tmp, "repo");
@@ -795,6 +795,7 @@ test("parseRolloutIncremental keeps probing unchanged files after missing projec
     });
     assert.equal(first.filesProcessed, 1);
     assert.equal(cursors.files[rolloutPath].projectFileContext.absent, true);
+    assert.equal(typeof cursors.files[rolloutPath].projectFileContext.checkedAtMs, "number");
 
     await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
     await fs.writeFile(
@@ -809,10 +810,85 @@ test("parseRolloutIncremental keeps probing unchanged files after missing projec
       queuePath,
       projectQueuePath,
     });
-    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.filesProcessed, 0);
     assert.equal(second.eventsAggregated, 0);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.absent, true);
+
+    cursors.files[rolloutPath].projectFileContext.checkedAtMs = 1;
+    const third = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(third.filesProcessed, 1);
+    assert.equal(third.eventsAggregated, 0);
     assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
   } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental memoizes project config freshness during idle scans", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  const realStat = fs.stat;
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    const configPath = path.join(repoRoot, ".git", "config");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionsDir = path.join(tmp, ".codex", "sessions", "2026", "01", "26");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    const rolloutFiles = [];
+    for (let i = 0; i < 3; i += 1) {
+      const rolloutPath = path.join(sessionsDir, `rollout-test-${i}.jsonl`);
+      rolloutFiles.push(rolloutPath);
+      await fs.writeFile(
+        rolloutPath,
+        [
+          buildTurnContextLine({ model: "gpt-4", cwd: repoRoot }),
+          buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+    }
+
+    await parseRolloutIncremental({
+      rolloutFiles,
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+
+    let configStats = 0;
+    fs.stat = async function countedStat(target, ...args) {
+      if (String(target) === configPath) configStats += 1;
+      return realStat.call(this, target, ...args);
+    };
+    const second = await parseRolloutIncremental({
+      rolloutFiles,
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 0);
+    assert.equal(configStats, 1);
+  } finally {
+    fs.stat = realStat;
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -443,10 +443,17 @@ test("parseRolloutIncremental skips unchanged files when project state is disabl
   }
 });
 
-test("parseRolloutIncremental still processes unchanged files when project state is enabled", async () => {
+test("parseRolloutIncremental skips unchanged project-enabled files after project EOF is recorded", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
-    const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const rolloutPath = path.join(repoRoot, "rollout-test.jsonl");
     const queuePath = path.join(tmp, "queue.jsonl");
     const projectQueuePath = path.join(tmp, "project.queue.jsonl");
     const cursors = { version: 1, files: {}, updatedAt: null };
@@ -473,6 +480,136 @@ test("parseRolloutIncremental still processes unchanged files when project state
       projectQueuePath,
     });
     assert.equal(first.filesProcessed, 1);
+    assert.equal(first.projectBucketsQueued, 1);
+    assert.equal(cursors.files[rolloutPath].projectOffset, cursors.files[rolloutPath].offset);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 0);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.equal(second.projectBucketsQueued, 0);
+
+    await fs.writeFile(path.join(repoRoot, ".git", "config"), "", "utf8");
+    const third = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(third.filesProcessed, 1);
+    assert.equal(third.eventsAggregated, 0);
+    assert.equal(third.bucketsQueued, 0);
+    assert.equal(cursors.projectHourly.projects["acme/alpha"].status, "blocked");
+    assert.equal(cursors.projectHourly.projects["acme/alpha"].purge_pending, true);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental skips unchanged codex sessions using turn_context cwd project freshness", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionsDir = path.join(tmp, ".codex", "sessions", "2026", "01", "26");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const rolloutPath = path.join(sessionsDir, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4", cwd: repoRoot }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(first.projectBucketsQueued, 1);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 0);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.projectBucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental recovers legacy Codex EOF cursor project freshness from turn_context cwd", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionsDir = path.join(tmp, ".codex", "sessions", "2026", "01", "26");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const rolloutPath = path.join(
+      sessionsDir,
+      "rollout-2026-01-26T00-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
+    );
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4", cwd: repoRoot }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(cursors.files[rolloutPath].projectOffset, undefined);
 
     const second = await parseRolloutIncremental({
       rolloutFiles: [rolloutPath],
@@ -483,6 +620,251 @@ test("parseRolloutIncremental still processes unchanged files when project state
     assert.equal(second.filesProcessed, 1);
     assert.equal(second.eventsAggregated, 0);
     assert.equal(second.bucketsQueued, 0);
+    assert.equal(second.projectBucketsQueued, 0);
+    assert.equal(cursors.files[rolloutPath].projectOffset, cursors.files[rolloutPath].offset);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
+
+    const third = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(third.filesProcessed, 0);
+    assert.equal(third.eventsAggregated, 0);
+    assert.equal(third.projectBucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental gives legacy project cursors one EOF pass before skipping", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const rolloutPath = path.join(repoRoot, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(cursors.files[rolloutPath].projectOffset, undefined);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+    assert.equal(cursors.files[rolloutPath].projectOffset, cursors.files[rolloutPath].offset);
+
+    const third = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(third.filesProcessed, 0);
+    assert.equal(third.eventsAggregated, 0);
+    assert.equal(third.bucketsQueued, 0);
+    assert.equal(third.projectBucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental does not skip unchanged project files with a custom resolver", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const rolloutPath = path.join(repoRoot, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    let resolverCalls = 0;
+    const publicRepoResolver = async ({ projectRef }) => {
+      resolverCalls += 1;
+      return { status: "public_verified", projectKey: "acme/alpha", projectRef };
+    };
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver,
+    });
+    assert.equal(first.filesProcessed, 1);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+      publicRepoResolver,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(resolverCalls, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental keeps probing unchanged files after missing project context", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(repoRoot, { recursive: true });
+    const rolloutPath = path.join(repoRoot, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.absent, true);
+
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental keeps project EOF fast path scoped to codex source", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const rolloutPath = path.join(repoRoot, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTurnContextLine({ model: "gpt-4" }),
+        buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [{ path: rolloutPath, source: "every-code" }],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(cursors.files[rolloutPath].projectOffset, undefined);
+
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [{ path: rolloutPath, source: "every-code" }],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(cursors.files[rolloutPath].projectOffset, undefined);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  cmdSync,
   repairCodexRescanInflation,
   CODEX_RESCAN_DEDUP_REPAIR_KEY,
 } = require("../src/commands/sync");
@@ -21,22 +22,35 @@ function tokenCountLine({ ts, last, total }) {
   });
 }
 
+function turnContextLine({ cwd, model = "gpt-4" }) {
+  return JSON.stringify({
+    type: "turn_context",
+    payload: { cwd, model },
+  });
+}
+
 // Two cumulative events in one half-hour: deltas 100 + 150 → true codex total 250.
 const U1 = { input_tokens: 60, cached_input_tokens: 0, output_tokens: 40, reasoning_output_tokens: 0, total_tokens: 100 };
 const T2 = { input_tokens: 150, cached_input_tokens: 0, output_tokens: 100, reasoning_output_tokens: 0, total_tokens: 250 };
 const U2 = { input_tokens: 90, cached_input_tokens: 0, output_tokens: 60, reasoning_output_tokens: 0, total_tokens: 150 };
 const TRUE_CODEX_TOTAL = 250;
 
-async function writeCodexFile(home, uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee") {
+async function writeCodexFile(
+  home,
+  uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  opts = {},
+) {
   const dir = path.join(home, ".codex", "sessions", "2025", "12", "17");
   await fs.mkdir(dir, { recursive: true });
   const fp = path.join(dir, `rollout-2025-12-17T00-00-00-${uuid}.jsonl`);
+  const lines = [
+    tokenCountLine({ ts: "2025-12-17T00:00:00.000Z", last: U1, total: U1 }),
+    tokenCountLine({ ts: "2025-12-17T00:00:01.000Z", last: U2, total: T2 }),
+  ];
+  if (opts.cwd) lines.unshift(turnContextLine({ cwd: opts.cwd, model: opts.model }));
   await fs.writeFile(
     fp,
-    [
-      tokenCountLine({ ts: "2025-12-17T00:00:00.000Z", last: U1, total: U1 }),
-      tokenCountLine({ ts: "2025-12-17T00:00:01.000Z", last: U2, total: T2 }),
-    ].join("\n") + "\n",
+    lines.join("\n") + "\n",
     "utf8",
   );
   return fp;
@@ -60,7 +74,103 @@ const queueRowsBySource = async (queuePath) => {
   return m;
 };
 
+const projectBucketTotal = (cursors, source = "codex") =>
+  Object.entries(cursors.projectHourly?.buckets || {})
+    .filter(([, v]) => v?.source === source)
+    .reduce((s, [, v]) => s + Number(v.totals?.total_tokens || 0), 0);
+
+async function withTempSyncEnv(fn) {
+  const home = await makeTempHome();
+  const saved = {
+    HOME: process.env.HOME,
+    CODEX_HOME: process.env.CODEX_HOME,
+    CODE_HOME: process.env.CODE_HOME,
+    GEMINI_HOME: process.env.GEMINI_HOME,
+    OPENCODE_HOME: process.env.OPENCODE_HOME,
+    TOKENTRACKER_DEVICE_TOKEN: process.env.TOKENTRACKER_DEVICE_TOKEN,
+    TOKENTRACKER_AUTO_RETRY_NO_SPAWN: process.env.TOKENTRACKER_AUTO_RETRY_NO_SPAWN,
+  };
+  try {
+    process.env.HOME = home;
+    process.env.CODEX_HOME = path.join(home, ".codex");
+    process.env.CODE_HOME = path.join(home, ".code");
+    process.env.GEMINI_HOME = path.join(home, ".gemini");
+    process.env.OPENCODE_HOME = path.join(home, ".opencode");
+    process.env.TOKENTRACKER_DEVICE_TOKEN = "test-device-token";
+    process.env.TOKENTRACKER_AUTO_RETRY_NO_SPAWN = "1";
+    return await fn(home);
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
 describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
+  it("does not treat project.queue.jsonl as cloud upload backlog", async () => {
+    await withTempSyncEnv(async (home) => {
+      const trackerDir = path.join(home, ".tokentracker", "tracker");
+      await fs.mkdir(trackerDir, { recursive: true });
+      await fs.writeFile(path.join(trackerDir, "queue.jsonl"), "", "utf8");
+      await fs.writeFile(path.join(trackerDir, "queue.state.json"), JSON.stringify({ offset: 0 }), "utf8");
+      await fs.writeFile(
+        path.join(trackerDir, "cursors.json"),
+        JSON.stringify({
+          version: 1,
+          files: {},
+          migrations: {
+            cloudConversationsBackfill_2026_06: { appliedAt: "2026-01-01T00:00:00.000Z" },
+            claudeGroundTruthRepair_2026_05_v4: { appliedAt: "2026-01-01T00:00:00.000Z" },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(trackerDir, "project.queue.jsonl"),
+        JSON.stringify({
+          project_ref: "https://github.com/acme/alpha",
+          project_key: "acme/alpha",
+          source: "codex",
+          hour_start: "2025-12-17T00:00:00.000Z",
+          total_tokens: 250,
+        }) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(trackerDir, "project.queue.state.json"),
+        JSON.stringify({ offset: 0 }),
+        "utf8",
+      );
+
+      let stdout = "";
+      const write = process.stdout.write;
+      process.stdout.write = function capture(chunk, ...args) {
+        stdout += String(chunk);
+        return true;
+      };
+      try {
+        await cmdSync([]);
+      } finally {
+        process.stdout.write = write;
+      }
+
+      assert.match(stdout, /Sync finished:/);
+      assert.doesNotMatch(stdout, /Remaining:/);
+      const retryPath = path.join(trackerDir, "auto.retry.json");
+      await assert.rejects(fs.stat(retryPath), { code: "ENOENT" });
+
+      await fs.writeFile(
+        path.join(trackerDir, "upload.throttle.json"),
+        JSON.stringify({ nextAllowedAtMs: Date.now() + 60_000 }),
+        "utf8",
+      );
+      await cmdSync(["--auto"]);
+      await assert.rejects(fs.stat(retryPath), { code: "ENOENT" });
+    });
+  });
+
   it("rebuilds inflated codex to the true value, preserves other sources, strips+rebuilds the queue, resets the offset", async () => {
     const home = await makeTempHome();
     try {
@@ -125,6 +235,461 @@ describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
         false,
       );
       assert.equal(codexBucketTotal(cursors), TRUE_CODEX_TOTAL);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rebuilds Codex project usage during rescan repair", async () => {
+    const home = await makeTempHome();
+    try {
+      const repoRoot = path.join(home, "work", "alpha");
+      await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+      await fs.writeFile(
+        path.join(repoRoot, ".git", "config"),
+        `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+        "utf8",
+      );
+      const codexFile = await writeCodexFile(home, undefined, { cwd: repoRoot, model: "gpt-4" });
+      const hour = "2025-12-17T00:00:00.000Z";
+      const projectRef = "https://github.com/acme/alpha";
+      const projectKey = "acme/alpha";
+      const projectBucketKey = `${projectKey}|codex|${hour}`;
+      const claudeProjectBucketKey = `${projectKey}|claude|${hour}`;
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+
+      await fs.writeFile(
+        queuePath,
+        [
+          JSON.stringify({ source: "codex", model: "gpt-4", hour_start: hour, total_tokens: 750 }),
+          JSON.stringify({ source: "claude", model: "opus", hour_start: hour, total_tokens: 5000 }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        projectQueuePath,
+        [
+          JSON.stringify({
+            project_ref: projectRef,
+            project_key: projectKey,
+            source: "codex",
+            hour_start: hour,
+            total_tokens: 750,
+          }),
+          JSON.stringify({
+            project_ref: projectRef,
+            project_key: projectKey,
+            source: "claude",
+            hour_start: hour,
+            total_tokens: 5000,
+          }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 99999 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 88888 }), "utf8");
+
+      const cursors = {
+        hourly: {
+          buckets: {
+            "codex|gpt-4|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 750 } },
+            "claude|opus|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 5000 } },
+          },
+          groupQueued: {},
+        },
+        projectHourly: {
+          version: 2,
+          buckets: {
+            [projectBucketKey]: {
+              project_ref: projectRef,
+              project_key: projectKey,
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: 750 },
+            },
+            [claudeProjectBucketKey]: {
+              project_ref: projectRef,
+              project_key: projectKey,
+              source: "claude",
+              hour_start: hour,
+              totals: { total_tokens: 5000 },
+            },
+          },
+          projects: {
+            [projectKey]: { projectRef, projectKey, status: "public_verified" },
+          },
+        },
+        files: { [codexFile]: { inode: 1, offset: 5, lastTotal: { total_tokens: 750 } } },
+        codexHashes: ["stale:key"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, true);
+
+      assert.equal(codexBucketTotal(cursors), TRUE_CODEX_TOTAL);
+      assert.equal(projectBucketTotal(cursors, "codex"), TRUE_CODEX_TOTAL);
+      assert.equal(projectBucketTotal(cursors, "claude"), 5000);
+
+      const q = await queueRowsBySource(queuePath);
+      const pq = await queueRowsBySource(projectQueuePath);
+      assert.equal(q.codex.total, TRUE_CODEX_TOTAL);
+      assert.equal(q.claude.total, 5000);
+      assert.equal(pq.codex.total, TRUE_CODEX_TOTAL);
+      assert.equal(pq.claude.total, 5000);
+
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 0);
+      assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 0);
+      assert.equal(cursors.files[codexFile].projectOffset, cursors.files[codexFile].offset);
+      assert.equal(
+        cursors.files[codexFile].projectFileContext.configPath.endsWith(".git/config"),
+        true,
+      );
+      assert.equal(cursors.projectHourly.projects[projectKey].status, "public_verified");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("GUARD: skips without mutation when existing Codex project usage cannot be rebuilt", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeCodexFile(home);
+      const hour = "2025-12-17T00:00:00.000Z";
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({ source: "codex", model: "unknown", hour_start: hour, total_tokens: 750 }) +
+          "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        projectQueuePath,
+        JSON.stringify({
+          project_ref: "https://github.com/acme/alpha",
+          project_key: "acme/alpha",
+          source: "codex",
+          hour_start: hour,
+          total_tokens: 750,
+        }) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 123 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 456 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: { "codex|unknown|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 750 } } },
+          groupQueued: {},
+        },
+        projectHourly: {
+          version: 2,
+          buckets: {
+            "acme/alpha|codex|2025-12-17T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/alpha",
+              project_key: "acme/alpha",
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: 750 },
+            },
+          },
+          projects: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 5 } },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 750);
+      assert.equal(projectBucketTotal(cursors, "codex"), 750);
+      assert.equal((await queueRowsBySource(queuePath)).codex.total, 750);
+      assert.equal((await queueRowsBySource(projectQueuePath)).codex.total, 750);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 123);
+      assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 456);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY], undefined);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("GUARD: skips without mutation when Codex project queue rows are malformed", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeCodexFile(home);
+      const hour = "2025-12-17T00:00:00.000Z";
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+      const malformedProjectRow =
+        JSON.stringify({
+          project_ref: "https://github.com/acme/alpha",
+          source: "codex",
+          hour_start: hour,
+          total_tokens: 750,
+        }) + "\n";
+
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({ source: "codex", model: "unknown", hour_start: hour, total_tokens: 750 }) +
+          "\n",
+        "utf8",
+      );
+      await fs.writeFile(projectQueuePath, malformedProjectRow, "utf8");
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 123 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 456 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: { "codex|unknown|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 750 } } },
+          groupQueued: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 5 } },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 750);
+      assert.equal(await fs.readFile(projectQueuePath, "utf8"), malformedProjectRow);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 123);
+      assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 456);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY], undefined);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("GUARD: skips without mutation when Codex project rebuild is partial", async () => {
+    const home = await makeTempHome();
+    try {
+      const repoRoot = path.join(home, "work", "alpha");
+      await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+      await fs.writeFile(
+        path.join(repoRoot, ".git", "config"),
+        `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+        "utf8",
+      );
+      const alphaFile = await writeCodexFile(
+        home,
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        { cwd: repoRoot, model: "gpt-4" },
+      );
+      const betaFile = await writeCodexFile(home, "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee");
+      const hour = "2025-12-17T00:00:00.000Z";
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({ source: "codex", model: "gpt-4", hour_start: hour, total_tokens: 1500 }) +
+          "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        projectQueuePath,
+        [
+          JSON.stringify({
+            project_ref: "https://github.com/acme/alpha",
+            project_key: "acme/alpha",
+            source: "codex",
+            hour_start: hour,
+            total_tokens: 750,
+          }),
+          JSON.stringify({
+            project_ref: "https://github.com/acme/beta",
+            project_key: "acme/beta",
+            source: "codex",
+            hour_start: hour,
+            total_tokens: 750,
+          }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 123 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 456 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: { "codex|gpt-4|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 1500 } } },
+          groupQueued: {},
+        },
+        projectHourly: {
+          version: 2,
+          buckets: {
+            "acme/alpha|codex|2025-12-17T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/alpha",
+              project_key: "acme/alpha",
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: 750 },
+            },
+            "acme/beta|codex|2025-12-17T00:00:00.000Z": {
+              project_ref: "https://github.com/acme/beta",
+              project_key: "acme/beta",
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: 750 },
+            },
+          },
+          projects: {},
+        },
+        files: {
+          [alphaFile]: { inode: 1, offset: 5 },
+          [betaFile]: { inode: 2, offset: 5 },
+        },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [
+          { path: alphaFile, source: "codex" },
+          { path: betaFile, source: "codex" },
+        ],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 1500);
+      assert.equal(projectBucketTotal(cursors, "codex"), 1500);
+      assert.equal((await queueRowsBySource(queuePath)).codex.total, 1500);
+      assert.equal((await queueRowsBySource(projectQueuePath)).codex.total, 1500);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 123);
+      assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 456);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY], undefined);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("GUARD: skips without mutation when Codex project rebuild lowers an existing key without main repair", async () => {
+    const home = await makeTempHome();
+    try {
+      const repoRoot = path.join(home, "work", "alpha");
+      await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+      await fs.writeFile(
+        path.join(repoRoot, ".git", "config"),
+        `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+        "utf8",
+      );
+      const alphaFile = await writeCodexFile(
+        home,
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        { cwd: repoRoot, model: "gpt-4" },
+      );
+      const betaFile = await writeCodexFile(
+        home,
+        "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+        { model: "gpt-4" },
+      );
+      const hour = "2025-12-17T00:00:00.000Z";
+      const projectRef = "https://github.com/acme/alpha";
+      const projectKey = "acme/alpha";
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({ source: "codex", model: "gpt-4", hour_start: hour, total_tokens: 500 }) +
+          "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        projectQueuePath,
+        JSON.stringify({
+          project_ref: projectRef,
+          project_key: projectKey,
+          source: "codex",
+          hour_start: hour,
+          total_tokens: 500,
+        }) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 123 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 456 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: { "codex|gpt-4|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 500 } } },
+          groupQueued: {},
+        },
+        projectHourly: {
+          version: 2,
+          buckets: {
+            "acme/alpha|codex|2025-12-17T00:00:00.000Z": {
+              project_ref: projectRef,
+              project_key: projectKey,
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: 500 },
+            },
+          },
+          projects: {},
+        },
+        files: {
+          [alphaFile]: { inode: 1, offset: 5 },
+          [betaFile]: { inode: 2, offset: 5 },
+        },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [
+          { path: alphaFile, source: "codex" },
+          { path: betaFile, source: "codex" },
+        ],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 500);
+      assert.equal(projectBucketTotal(cursors, "codex"), 500);
+      assert.equal((await queueRowsBySource(queuePath)).codex.total, 500);
+      assert.equal((await queueRowsBySource(projectQueuePath)).codex.total, 500);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 123);
+      assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 456);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY], undefined);
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }
@@ -291,6 +856,51 @@ describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
 
       assert.equal(ran, false, "an unreproducible deleted session must defer the repair");
       assert.equal(codexBucketTotal(cursors), 750, "nothing mutated");
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 88);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY].skipped, true);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("GUARD recognizes Windows-style stale Codex cursor paths", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeCodexFile(home);
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({
+          source: "codex",
+          model: "unknown",
+          hour_start: "2025-12-17T00:00:00.000Z",
+          total_tokens: 750,
+        }) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 88 }), "utf8");
+      const deletedWindowsPath =
+        "C:\\Users\\me\\.codex\\sessions\\2025\\12\\10\\rollout-2025-12-10T00-00-00-99999999-9999-9999-9999-999999999999.jsonl";
+      const cursors = {
+        hourly: {
+          buckets: { "codex|unknown|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 750 } } },
+          groupQueued: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 5 }, [deletedWindowsPath]: { inode: 2, offset: 5 } },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 750);
       assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 88);
       assert.deepEqual(cursors.codexHashes, ["keep:me"]);
       assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY].skipped, true);


### PR DESCRIPTION
## Problem

Auto sync could still do more work than needed in several background paths: known notify/retry/OpenClaw triggers could fall back to broader provider scans, and Codex session discovery could repeatedly walk unchanged historical day directories.

## Summary

- Scope known auto sync triggers so notify, retry, and OpenClaw paths only scan the relevant provider.
- Cache Codex day session inventory so unchanged historical session directories are not repeatedly walked.
- Keep Codex rollout parsing guarded by existing stat, inode, offset, truncation, and project freshness checks.
- Scope OpenClaw agent and gateway lifecycle syncs with `--from-openclaw` to avoid accidental full provider scans.
- Preserve full scans for manual sync, unknown sources, plain full auto sync, and legacy retries without `syncSource`.
- Keep Codex rescan repair guarded against partial or unsafe rebuilds.

## Compatibility / Safety

- Manual sync and unknown-source auto sync still run full provider scans.
- Legacy retries without `syncSource` still use the previous full-scan behavior.
- The Codex inventory cache only avoids repeated directory enumeration; individual rollout files still go through the incremental parser and freshness checks.
- Corrupt or path-like cached filenames are rejected and rebuilt from disk.

## Verification

- `git diff --check`
- `node --test test/openclaw-session-plugin.test.js test/codex-source-scoped-cache.test.js` — 23/23 passing
- `node --test test/rollout-parser.test.js test/sync-codex-rescan-repair.test.js test/codex-source-scoped-cache.test.js` — 209/209 passing
- `npm test` — 1091/1091 passing
- `codex-workflow` final convergence: `20260701-pr234-post-cache-coverage-convergence`, status `done`, final vote `7/7`, hard gaps `0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--source` option to run source-scoped auto syncs instead of scanning everything.
  * Rescan repairs now safely rebuild Codex project usage and update both queues/offset state consistently.
* **Bug Fixes**
  * Auto-retry backlog detection no longer misuses project queue data after cloud draining.
  * Improved handling of stale/missing project context so unchanged work is skipped without side effects.
  * Notify and OpenClaw lifecycle syncs now correctly preserve the originating sync scope.
* **Performance**
  * Enhanced rollout caching and Codex cold-scan skipping to reduce unnecessary file statting/parsing.
* **Tests**
  * Expanded coverage for source scoping, repairs, caching, and cold-scan behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->