### PR TITLE
feat: WSL auto-discovery + TOKENTRACKER_WSL_MODE config for all Windows providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ skills-lock.json
 .roo
 .trae
 .windsurf
+.opencode/
+.serena/
+openspec/
+plans/

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -429,6 +429,7 @@ async function cmdStatus(argv = []) {
       ...(process.platform === "win32"
         ? {
             wsl_mode: getWslMode(),
+            wsl_mode_invalid: isInvalidWslMode(),
             wsl_distros: wslDistros.map((d) => ({ name: d.name, version: d.version })),
           }
         : {}),

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -62,6 +62,7 @@ const {
   resolveHermesDbPath,
   probeWslDistros,
 } = require("../lib/rollout");
+const { getWslMode, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 
 async function cmdStatus(argv = []) {
@@ -268,7 +269,7 @@ async function cmdStatus(argv = []) {
   // per thread we've surfaced usage for, so its size distinguishes "DB present
   // with usage" from "DB present but nothing counted yet" (fresh/undecodable).
   const zedDbPath = resolveZedDbPath(process.env);
-  const zedInstalled = fssync.existsSync(zedDbPath);
+  const zedInstalled = Boolean(zedDbPath && fssync.existsSync(zedDbPath));
   const zedThreadsCounted =
     cursors?.zed?.threadTotals && typeof cursors.zed.threadTotals === "object"
       ? Object.keys(cursors.zed.threadTotals).length
@@ -276,7 +277,7 @@ async function cmdStatus(argv = []) {
 
   // Goose (Block) — passive cumulative-delta read of sessions.db.
   const gooseDbPath = resolveGooseDbPath(process.env);
-  const gooseInstalled = fssync.existsSync(gooseDbPath);
+  const gooseInstalled = Boolean(gooseDbPath && fssync.existsSync(gooseDbPath));
 
   // Droid (Factory CLI) — passive cumulative-delta read of *.settings.json.
   const droidSessionsDir = resolveDroidSessionsDir(process.env);
@@ -296,8 +297,8 @@ async function cmdStatus(argv = []) {
   // without guessing the right UNC alias (#87).
   const hermesPath = resolveHermesPath();
   const hermesDbPath = resolveHermesDbPath();
-  const hermesInstalled = fssync.existsSync(hermesDbPath);
-  const hermesWslDistros = process.platform === "win32" ? probeWslDistros() : [];
+  const hermesInstalled = Boolean(hermesDbPath && fssync.existsSync(hermesDbPath));
+  const wslDistros = process.platform === "win32" && shouldProbeWsl(process.env) ? probeWslDistros() : [];
 
   const copilotToken = readCopilotOauthToken({ home });
   const copilotOtel = describeCopilotOtelStatus({ home, env: process.env });
@@ -413,9 +414,6 @@ async function cmdStatus(argv = []) {
         hermes: {
           installed: hermesInstalled,
           detail: hermesPath,
-          ...(hermesWslDistros.length
-            ? { wsl_distros: hermesWslDistros.map((d) => ({ name: d.name, version: d.version })) }
-            : {}),
         },
       },
       copilot: {
@@ -428,6 +426,12 @@ async function cmdStatus(argv = []) {
         active: isPassiveModeActive(passiveProviders),
         providers: passiveProviders,
       },
+      ...(process.platform === "win32"
+        ? {
+            wsl_mode: getWslMode(),
+            wsl_distros: wslDistros.map((d) => ({ name: d.name, version: d.version })),
+          }
+        : {}),
       subscriptions,
     };
 
@@ -513,16 +517,8 @@ async function cmdStatus(argv = []) {
         ? `- Droid (Factory): passive reader (${droidSettingsFiles.length} session${droidSettingsFiles.length !== 1 ? "s" : ""} in ${droidSessionsDir}, cumulative-delta)`
         : null,
       ...(() => {
-        // Always surface Hermes when its state.db resolves; on Windows also show
-        // it when WSL distros are discovered so users can debug UNC resolution.
-        if (!hermesInstalled && hermesWslDistros.length === 0) return [];
-        const wslSuffix = hermesWslDistros.length
-          ? `; WSL distros: ${hermesWslDistros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`
-          : "";
-        const head = hermesInstalled
-          ? `- Hermes Agent: state.db found (${hermesPath})`
-          : `- Hermes Agent: state.db not found (resolved ${hermesPath})`;
-        return [`${head}${wslSuffix}`];
+        if (!hermesInstalled) return [];
+        return [`- Hermes Agent: state.db found (${hermesPath})`];
       })(),
       ...(() => {
         const passive = passiveProviders.filter((p) => p.passive);
@@ -535,6 +531,18 @@ async function cmdStatus(argv = []) {
         ? `- Grok Build (xAI): ${grokHookState.configured ? "hook installed" : "detected"} (${grokSessions.length} session${grokSessions.length !== 1 ? "s" : ""} found, hook: ${grokHookState.configured ? "yes" : "no"})`
         : null,
       ...copilotLines,
+      ...(process.platform === "win32" ? (() => {
+        const wslMode = getWslMode();
+        const modeInvalid = isInvalidWslMode();
+        const modeSuffix = modeInvalid ? ` (invalid TOKENTRACKER_WSL_MODE ignored)` : "";
+        const lines = [
+          `- WSL mode: ${wslMode}${modeSuffix}`,
+        ];
+        if (wslDistros.length > 0) {
+          lines.push(`  distros: ${wslDistros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`);
+        }
+        return lines;
+      })() : []),
       ...subscriptionLines,
       "",
     ]

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -728,7 +728,7 @@ async function cmdSync(argv) {
     // ── Goose (Block) — SQLite sessions with cumulative tokens per session ──
     const gooseDbPath = resolveGooseDbPath(process.env);
     let gooseResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (sourceAllowed("goose") && fssync.existsSync(gooseDbPath)) {
+    if (sourceAllowed("goose") && gooseDbPath && fssync.existsSync(gooseDbPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Goose ${renderBar(0)} 0 sessions | buckets 0`);
       }
@@ -788,7 +788,7 @@ async function cmdSync(argv) {
     // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (sourceAllowed("zed") && fssync.existsSync(zedDbPath)) {
+    if (sourceAllowed("zed") && zedDbPath && fssync.existsSync(zedDbPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Zed Agent ${renderBar(0)} 0 threads | buckets 0`);
       }
@@ -921,7 +921,7 @@ async function cmdSync(argv) {
     // ── Hermes Agent (SQLite-based) ──
     let hermesResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const hermesPath = resolveHermesPath();
-    if (sourceAllowed("hermes") && fssync.existsSync(hermesPath)) {
+    if (sourceAllowed("hermes") && hermesPath && fssync.existsSync(hermesPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
       }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6,6 +6,7 @@ const readline = require("node:readline");
 const crypto = require("node:crypto");
 const { ensureDir } = require("./fs");
 const { readSqliteJsonRows } = require("./sqlite-reader");
+const wsl = require("./wsl-probe");
 
 const DEFAULT_SOURCE = "codex";
 const DEFAULT_MODEL = "unknown";
@@ -3789,115 +3790,75 @@ function resolveHermesPath(env = process.env, deps = {}) {
   // On Windows, scan BOTH the native install (%LOCALAPPDATA%\hermes) and
   // any WSL distros running Hermes Agent. Each install has its own independent
   // state.db with different sessions, so there is no double-counting risk.
-  // WSL is preferred when both exist because development happens in WSL (#87).
+  // TOKENTRACKER_WSL_MODE controls which source takes priority.
   if (process.platform === "win32") {
     let nativePath = null;
-    const localAppData = typeof env.LOCALAPPDATA === "string" ? env.LOCALAPPDATA.trim() : "";
-    if (localAppData.length > 0) {
-      const candidate = path.join(localAppData, "hermes");
-      try {
-        if (fssync.existsSync(candidate)) nativePath = candidate;
-      } catch (_e) { }
+    if (wsl.shouldProbeNative(env)) {
+      const localAppData = typeof env.LOCALAPPDATA === "string" ? env.LOCALAPPDATA.trim() : "";
+      if (localAppData.length > 0) {
+        const candidate = path.join(localAppData, "hermes");
+        try {
+          if (fssync.existsSync(candidate)) nativePath = candidate;
+        } catch (_e) { }
+      }
     }
-    const wslPath = discoverWslHermesHome(deps);
-    if (wslPath) return wslPath;
-    if (nativePath) return nativePath;
+    const wslPath = wsl.shouldProbeWsl(env) ? discoverWslHermesHome(deps) : null;
+    const picked = wsl.pickWin32Path({ wslValue: wslPath, nativeValue: nativePath, env, platform: "win32" });
+    if (picked) return picked;
+    const mode = wsl.getWslMode(env);
+    if (mode === "wsl-only" || mode === "native-only") return null;
   }
   return defaultPath;
 }
 
-// ── WSL auto-discovery (Windows host, Hermes installed inside a distro) ──────
+// ── WSL auto-discovery (Windows host, tools inside a distro) ──────────────────
 // `wsl.exe -l -v` prints UTF-16LE; the per-distro `whoami` runs a Linux process
 // so its stdout is UTF-8. We capture buffers and decode per-call.
 function defaultRunWsl(args, { utf16 = false } = {}) {
-  const { execFileSync } = require("node:child_process");
-  const buf = execFileSync("wsl.exe", args, {
-    timeout: 5000,
-    windowsHide: true,
-    maxBuffer: 1024 * 1024,
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  return utf16 ? buf.toString("utf16le") : buf.toString("utf8");
+  return wsl.defaultRunWsl(args, { utf16 });
 }
 
 // Parse `wsl.exe -l -v` output into [{ name, version, isDefault }]. The default
 // distro is prefixed with `*`; the VERSION column (1 or 2) decides which UNC
 // alias to try first (simonlpaige, #87).
 function parseWslListVerbose(raw) {
-  if (typeof raw !== "string") return [];
-  const distros = [];
-  for (const line of raw.split(/\r?\n/)) {
-    const clean = line.replace(/ /g, "").replace(/﻿/g, "").trim();
-    if (!clean) continue;
-    const cells = clean.split(/\s+/);
-    let isDefault = false;
-    let idx = 0;
-    if (cells[0] === "*") {
-      isDefault = true;
-      idx = 1;
-    }
-    const name = cells[idx];
-    if (!name || name === "NAME") continue; // skip header row
-    const version = parseInt(cells[cells.length - 1], 10);
-    distros.push({
-      name,
-      version: Number.isFinite(version) ? version : null,
-      isDefault,
-    });
-  }
-  return distros;
+  return wsl.parseWslListVerbose(raw);
 }
 
 // Default distro first, then listed order — matches what a user expects when
 // they have one primary distro plus extras.
 function probeWslDistros(deps = {}) {
-  const runWsl = deps.runWsl || defaultRunWsl;
-  let raw;
-  try {
-    raw = runWsl(["-l", "-v"], { utf16: true });
-  } catch (_e) {
-    return [];
-  }
-  const distros = parseWslListVerbose(raw);
-  return distros.sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+  return wsl.probeWslDistros(deps);
 }
 
 // Probe each WSL distro for ~/.hermes via UNC. The Linux username rarely equals
 // %USERNAME%, so we ask the distro directly with `whoami` rather than guessing
 // (simonlpaige, #87).
 function discoverWslHermesHome(deps = {}) {
-  const runWsl = deps.runWsl || defaultRunWsl;
-  const existsSync = deps.existsSync || fssync.existsSync;
-  const distros = probeWslDistros(deps);
-  for (const distro of distros) {
-    let user;
-    try {
-      user = String(runWsl(["-d", distro.name, "-e", "whoami"], { utf16: false }) || "").trim();
-    } catch (_e) {
-      user = "";
-    }
-    if (!user) continue;
-    // \\wsl$\ is the legacy alias, \\wsl.localhost\ the newer one. WSL1 distros
-    // sometimes only resolve via \\wsl.localhost\, so order by version.
-    const roots = distro.version === 1
-      ? ["\\\\wsl.localhost\\", "\\\\wsl$\\"]
-      : ["\\\\wsl$\\", "\\\\wsl.localhost\\"];
-    for (const root of roots) {
-      const candidate = `${root}${distro.name}\\home\\${user}\\.hermes`;
-      try {
-        if (existsSync(candidate)) return candidate;
-      } catch (_e) { }
-    }
-  }
-  return null;
+  return wsl.discoverWslHome(".hermes", deps);
+}
+
+function pickWin32ProviderPath({ env = process.env, nativeValue, wslProviderDir, wslValue }) {
+  const nativeCandidate = wsl.shouldProbeNative(env) ? nativeValue : null;
+  const wslCandidate = wslValue !== undefined
+    ? wslValue
+    : (wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslProviderDir, { env }) : null);
+  return wsl.pickWin32Path({
+    wslValue: wslCandidate,
+    nativeValue: nativeCandidate,
+    env,
+    platform: "win32",
+  });
 }
 
 function resolveHermesDbPath(env = process.env) {
-  return path.join(resolveHermesPath(env), "state.db");
+  const hermesPath = resolveHermesPath(env);
+  return hermesPath ? path.join(hermesPath, "state.db") : null;
 }
 
 function resolveAllHermesDBPaths({ hermesPath, dbPath } = {}) {
   const hermesDir = hermesPath ?? (dbPath ? path.dirname(dbPath) : resolveHermesPath());
+  if (!hermesDir) return { default: null, profiles: {} };
   const defaultDbPath = dbPath ?? path.join(hermesDir, "state.db");
   const profilePaths = {};
   try {
@@ -3929,28 +3890,11 @@ function sqliteStringLiteral(value) {
 // / SMB bridge can't grant the locks SQLite asks for — even after `wsl
 // --shutdown`. Detect those paths so we can snapshot the DB locally first.
 function isUncPath(p) {
-  return typeof p === "string" && (p.startsWith("\\\\") || p.startsWith("//"));
+  return wsl.isUncPath(p);
 }
 
 function snapshotSqliteDb(dbPath) {
-  const tmpRoot = fssync.mkdtempSync(
-    path.join(require("node:os").tmpdir(), "tokentracker-hermes-snap-"),
-  );
-  const target = path.join(tmpRoot, path.basename(dbPath));
-  fssync.copyFileSync(dbPath, target);
-  // Best-effort copy of SQLite sidecars; missing -wal/-shm/-journal is fine.
-  for (const suffix of ["-wal", "-shm", "-journal"]) {
-    const src = dbPath + suffix;
-    try {
-      if (fssync.existsSync(src)) fssync.copyFileSync(src, target + suffix);
-    } catch (_e) { }
-  }
-  return {
-    path: target,
-    cleanup() {
-      try { fssync.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_e) { }
-    },
-  };
+  return wsl.snapshotSqliteDb(dbPath);
 }
 
 function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = [], sqliteOptions = {}) {
@@ -5251,11 +5195,21 @@ async function parseKimiIncremental({ wireFiles, cursors, queuePath, onProgress,
 function resolveKimiCodeHome(env = process.env) {
   const home = require("node:os").homedir();
   const explicit = typeof env?.KIMI_CODE_HOME === "string" ? env.KIMI_CODE_HOME.trim() : "";
-  return explicit ? path.resolve(explicit) : path.join(home, ".kimi-code");
+  if (explicit) return path.resolve(explicit);
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".kimi-code"),
+      wslProviderDir: ".kimi-code",
+    });
+  }
+  return path.join(home, ".kimi-code");
 }
 
 function resolveKimiCodeWireFiles(env = process.env) {
-  const sessionsDir = path.join(resolveKimiCodeHome(env), "sessions");
+  const kimiHome = resolveKimiCodeHome(env);
+  if (!kimiHome) return [];
+  const sessionsDir = path.join(kimiHome, "sessions");
   if (!fssync.existsSync(sessionsDir)) return [];
   const files = [];
   const walk = (dir, depth) => {
@@ -5275,7 +5229,9 @@ function resolveKimiCodeWireFiles(env = process.env) {
 function resolveKimiCodeDefaultModel(env = process.env) {
   const fallback = "kimi-for-coding";
   try {
-    const cfgPath = path.join(resolveKimiCodeHome(env), "config.toml");
+    const kimiHome = resolveKimiCodeHome(env);
+    if (!kimiHome) return fallback;
+    const cfgPath = path.join(kimiHome, "config.toml");
     const raw = fssync.readFileSync(cfgPath, "utf8");
     const m = raw.match(/^\s*default_model\s*=\s*"([^"]+)"/m);
     if (!m) return fallback;
@@ -5479,13 +5435,23 @@ async function parseKimiCodeIncremental({ wireFiles, cursors, queuePath, onProgr
 
 function resolveCodebuddyHome(env = process.env) {
   const home = env.HOME || require("node:os").homedir();
-  return env.CODEBUDDY_HOME || path.join(home, ".codebuddy");
+  if (env.CODEBUDDY_HOME) return env.CODEBUDDY_HOME;
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".codebuddy"),
+      wslProviderDir: ".codebuddy",
+    });
+  }
+  return path.join(home, ".codebuddy");
 }
 
 function resolveCodebuddyDefaultModel(env = process.env) {
   const fallback = "codebuddy-unknown";
   try {
-    const settingsPath = path.join(resolveCodebuddyHome(env), "settings.json");
+    const codebuddyHome = resolveCodebuddyHome(env);
+    if (!codebuddyHome) return fallback;
+    const settingsPath = path.join(codebuddyHome, "settings.json");
     const raw = fssync.readFileSync(settingsPath, "utf8");
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && typeof parsed.model === "string" && parsed.model.trim()) {
@@ -5498,7 +5464,9 @@ function resolveCodebuddyDefaultModel(env = process.env) {
 }
 
 function resolveCodebuddyProjectFiles(env = process.env) {
-  const projectsDir = path.join(resolveCodebuddyHome(env), "projects");
+  const codebuddyHome = resolveCodebuddyHome(env);
+  if (!codebuddyHome) return [];
+  const projectsDir = path.join(codebuddyHome, "projects");
   if (!fssync.existsSync(projectsDir)) return [];
   const files = [];
   try {
@@ -5773,13 +5741,23 @@ async function parseCodebuddyIncremental({
 
 function resolveWorkbuddyHome(env = process.env) {
   const home = env.HOME || require("node:os").homedir();
-  return env.WORKBUDDY_HOME || path.join(home, ".workbuddy");
+  if (env.WORKBUDDY_HOME) return env.WORKBUDDY_HOME;
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".workbuddy"),
+      wslProviderDir: ".workbuddy",
+    });
+  }
+  return path.join(home, ".workbuddy");
 }
 
 function resolveWorkbuddyDefaultModel(env = process.env) {
   const fallback = "auto";
   try {
-    const settingsPath = path.join(resolveWorkbuddyHome(env), "settings.json");
+    const workbuddyHome = resolveWorkbuddyHome(env);
+    if (!workbuddyHome) return fallback;
+    const settingsPath = path.join(workbuddyHome, "settings.json");
     const raw = fssync.readFileSync(settingsPath, "utf8");
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && typeof parsed.model === "string" && parsed.model.trim()) {
@@ -5795,7 +5773,9 @@ function resolveWorkbuddyDefaultModel(env = process.env) {
 // per-session conversation logs AND their nested subagents/agent-*.jsonl files
 // are both discovered. Non-.jsonl artefacts (tool-results/*.txt) are ignored.
 function resolveWorkbuddyProjectFiles(env = process.env) {
-  const projectsDir = path.join(resolveWorkbuddyHome(env), "projects");
+  const workbuddyHome = resolveWorkbuddyHome(env);
+  if (!workbuddyHome) return [];
+  const projectsDir = path.join(workbuddyHome, "projects");
   if (!fssync.existsSync(projectsDir)) return [];
   const files = [];
   const walk = (dir) => {
@@ -6069,6 +6049,13 @@ function resolveOmpHome(env = process.env) {
   // Honor TokenTracker override first, then oh-my-pi upstream env vars.
   if (env.OMP_HOME) return env.OMP_HOME;
   if (env.PI_CONFIG_DIR) return path.join(home, env.PI_CONFIG_DIR);
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".omp"),
+      wslProviderDir: ".omp",
+    });
+  }
   return path.join(home, ".omp");
 }
 
@@ -6106,11 +6093,14 @@ function resolveOmpAgentDir(env = process.env) {
   if (env.PI_CODING_AGENT_DIR && decidePiCodingAgentDirOwner(env) === "omp") {
     return expandHomePath(env.PI_CODING_AGENT_DIR, env);
   }
-  return path.join(resolveOmpHome(env), "agent");
+  const ompHome = resolveOmpHome(env);
+  return ompHome ? path.join(ompHome, "agent") : null;
 }
 
 function resolveOmpSessionFiles(env = process.env) {
-  const sessionsDir = path.join(resolveOmpAgentDir(env), "sessions");
+  const agentDir = resolveOmpAgentDir(env);
+  if (!agentDir) return [];
+  const sessionsDir = path.join(agentDir, "sessions");
   if (!fssync.existsSync(sessionsDir)) return [];
   const files = [];
   try {
@@ -6186,14 +6176,28 @@ function resolveKilocodeRoots(env = process.env) {
     );
   } else if (process.platform === "win32") {
     const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
-    candidates.push(
+    const nativeRoots = [
       path.join(appData, "Code"),
       path.join(appData, "Code - Insiders"),
       path.join(appData, "Cursor"),
       path.join(appData, "CodeBuddy"),
       path.join(appData, "Windsurf"),
       path.join(appData, "VSCodium"),
-    );
+    ];
+    const wslRoots = [];
+    if (wsl.shouldProbeWsl(env)) {
+      for (const ide of ["Code", "Code - Insiders", "Cursor", "CodeBuddy", "Windsurf", "VSCodium"]) {
+        const wslDir = wsl.discoverWslHome(`.config/${ide}`, { env });
+        if (wslDir) wslRoots.push(wslDir);
+      }
+    }
+    const nativeCandidates = wsl.shouldProbeNative(env) ? nativeRoots : [];
+    const mode = wsl.getWslMode(env);
+    if (mode === "native-first" || mode === "native-only") {
+      candidates.push(...nativeCandidates, ...wslRoots);
+    } else {
+      candidates.push(...wslRoots, ...nativeCandidates);
+    }
   } else {
     const xdg = env.XDG_CONFIG_HOME || path.join(home, ".config");
     candidates.push(
@@ -6521,7 +6525,17 @@ function resolveZedDbPath(env = process.env) {
   }
   if (process.platform === "win32") {
     const local = env.LOCALAPPDATA || path.join(home, "AppData", "Local");
-    return path.join(local, "Zed", "threads", "threads.db");
+    const native = path.join(local, "Zed", "threads", "threads.db");
+    let nativeExists = null;
+    if (wsl.shouldProbeNative(env)) {
+      try { if (fssync.existsSync(native)) nativeExists = native; } catch (_e) { }
+    }
+    const wslDir = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".local/share/zed/threads", { env }) : null;
+    const wslValue = wslDir ? path.join(wslDir, "threads.db") : null;
+    const picked = wsl.pickWin32Path({ wslValue, nativeValue: nativeExists, env, platform: "win32" });
+    if (picked) return picked;
+    const mode = wsl.getWslMode(env);
+    return mode === "wsl-only" || mode === "native-only" ? null : native;
   }
   const xdg = env.XDG_DATA_HOME || path.join(home, ".local", "share");
   return path.join(xdg, "zed", "threads", "threads.db");
@@ -6673,6 +6687,10 @@ async function parseZedIncremental({
 } = {}) {
   await ensureDir(path.dirname(queuePath));
   const resolvedDb = dbPath || resolveZedDbPath(env || process.env);
+  if (!resolvedDb) {
+    cursors.zed = { ...cursors.zed, updatedAt: new Date().toISOString() };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
   const zedState =
     cursors.zed && typeof cursors.zed === "object" ? cursors.zed : {};
   const threadTotals =
@@ -6890,7 +6908,20 @@ function resolveGooseDbPath(env = process.env) {
     );
   } else if (process.platform === "win32") {
     const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
-    candidates.push(path.join(appData, "goose", "sessions", "sessions.db"));
+    const native = path.join(appData, "goose", "sessions", "sessions.db");
+    let nativeExists = null;
+    if (wsl.shouldProbeNative(env)) {
+      try { if (fssync.existsSync(native)) nativeExists = native; } catch (_e) { }
+    }
+    const wslDir = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".local/share/goose/sessions", { env }) : null;
+    const wslValue = wslDir ? path.join(wslDir, "sessions.db") : null;
+    const picked = wsl.pickWin32Path({ wslValue, nativeValue: nativeExists, env, platform: "win32" });
+    if (picked) candidates.push(picked);
+    for (const c of candidates) {
+      if (fssync.existsSync(c)) return c;
+    }
+    const mode = wsl.getWslMode(env);
+    return mode === "wsl-only" || mode === "native-only" ? null : native;
   }
   const xdg = env.XDG_DATA_HOME || path.join(home, ".local", "share");
   candidates.push(
@@ -6902,7 +6933,7 @@ function resolveGooseDbPath(env = process.env) {
   for (const c of candidates) {
     if (fssync.existsSync(c)) return c;
   }
-  return candidates[0];
+  return candidates[0] || null;
 }
 
 function parseGooseModelName(modelConfigJson) {
@@ -6996,6 +7027,11 @@ async function parseGooseIncremental({
     gooseState.sessionTotals && typeof gooseState.sessionTotals === "object"
       ? { ...gooseState.sessionTotals }
       : {};
+
+  if (!resolvedDb) {
+    cursors.goose = { ...gooseState, sessionTotals, updatedAt: new Date().toISOString() };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
 
   const cursorDbMtime = Number.isFinite(gooseState.lastDbMtimeMs) ? gooseState.lastDbMtimeMs : 0;
   let currentMtime = 0;
@@ -7178,6 +7214,14 @@ function resolveDroidSessionsDirs(env = process.env) {
     return [path.join(expandHomePath(env.FACTORY_DIR.trim(), env), "sessions")];
   }
   const home = env.HOME || require("node:os").homedir();
+  if (process.platform === "win32") {
+    const picked = pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".factory", "sessions"),
+      wslProviderDir: ".factory/sessions",
+    });
+    return picked ? [picked] : [];
+  }
   return [path.join(home, ".factory", "sessions")];
 }
 
@@ -8035,6 +8079,13 @@ async function parseOmpIncremental({
 
 function resolvePiHome(env = process.env) {
   const home = env.HOME || require("node:os").homedir();
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".pi"),
+      wslProviderDir: ".pi",
+    });
+  }
   return path.join(home, ".pi");
 }
 
@@ -8045,7 +8096,8 @@ function resolvePiAgentDir(env = process.env) {
   if (env.PI_CODING_AGENT_DIR && decidePiCodingAgentDirOwner(env) === "pi") {
     return expandHomePath(env.PI_CODING_AGENT_DIR, env);
   }
-  return path.join(resolvePiHome(env), "agent");
+  const piHome = resolvePiHome(env);
+  return piHome ? path.join(piHome, "agent") : null;
 }
 
 // Defense in depth for invariant 2 (no double-count). Two explicit overrides
@@ -8054,11 +8106,16 @@ function resolvePiAgentDir(env = process.env) {
 // the install-signal disambiguator and would otherwise have both providers scan
 // the same sessions directory under different `source` tags.
 function piAgentDirCollidesWithOmp(env = process.env) {
-  return path.resolve(resolvePiAgentDir(env)) === path.resolve(resolveOmpAgentDir(env));
+  const piAgentDir = resolvePiAgentDir(env);
+  const ompAgentDir = resolveOmpAgentDir(env);
+  if (!piAgentDir || !ompAgentDir) return false;
+  return path.resolve(piAgentDir) === path.resolve(ompAgentDir);
 }
 
 function resolvePiSessionFiles(env = process.env) {
-  const sessionsDir = path.join(resolvePiAgentDir(env), "sessions");
+  const agentDir = resolvePiAgentDir(env);
+  if (!agentDir) return [];
+  const sessionsDir = path.join(agentDir, "sessions");
   if (!fssync.existsSync(sessionsDir)) return [];
   const files = [];
   try {
@@ -8306,11 +8363,19 @@ async function parsePiIncremental({
 function resolveCraftConfigDir(env = process.env) {
   if (env.CRAFT_CONFIG_DIR) return env.CRAFT_CONFIG_DIR;
   const home = env.HOME || require("node:os").homedir();
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".craft-agent"),
+      wslProviderDir: ".craft-agent",
+    });
+  }
   return path.join(home, ".craft-agent");
 }
 
 function resolveCraftWorkspaceRoots(env = process.env) {
   const configDir = resolveCraftConfigDir(env);
+  if (!configDir) return [];
   const roots = new Set();
   // Always include the default workspaces directory so a fresh install (no
   // config.json yet) still gets discovered.
@@ -8604,13 +8669,22 @@ async function parseCraftIncremental({
 function resolveCopilotOtelPaths(env = process.env) {
   const home = env.HOME || require("node:os").homedir();
   const paths = new Set();
-  const defaultDir = path.join(home, ".copilot", "otel");
-  if (fssync.existsSync(defaultDir)) {
+  const scanDir = (dir) => {
+    if (!fssync.existsSync(dir)) return;
     try {
-      for (const entry of fssync.readdirSync(defaultDir)) {
-        if (entry.endsWith(".jsonl")) paths.add(path.join(defaultDir, entry));
+      for (const entry of fssync.readdirSync(dir)) {
+        if (entry.endsWith(".jsonl")) paths.add(path.join(dir, entry));
       }
     } catch (_e) {}
+  };
+  if (process.platform !== "win32" || wsl.shouldProbeNative(env)) {
+    scanDir(path.join(home, ".copilot", "otel"));
+  }
+  if (process.platform === "win32") {
+    if (wsl.shouldProbeWsl(env)) {
+      const wslDir = wsl.discoverWslHome(".copilot/otel", { env });
+      if (wslDir) scanDir(wslDir);
+    }
   }
   const explicit = env.COPILOT_OTEL_FILE_EXPORTER_PATH;
   if (typeof explicit === "string" && explicit.trim() && fssync.existsSync(explicit)) {
@@ -8933,15 +9007,21 @@ const GROK_ESTIMATED_INPUT_RATIO = 0.8;
 const GROK_CURSOR_VERSION = 3;
 
 function resolveGrokBuildHome(env = process.env) {
-  return (
-    env.TOKENTRACKER_GROK_HOME ||
-    env.GROK_HOME ||
-    path.join(require("node:os").homedir(), ".grok")
-  );
+  if (env.TOKENTRACKER_GROK_HOME) return env.TOKENTRACKER_GROK_HOME;
+  if (env.GROK_HOME) return env.GROK_HOME;
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(require("node:os").homedir(), ".grok"),
+      wslProviderDir: ".grok",
+    });
+  }
+  return path.join(require("node:os").homedir(), ".grok");
 }
 
 function resolveGrokBuildSessions(env = process.env) {
   const home = resolveGrokBuildHome(env);
+  if (!home) return [];
   const sessionsRoot = path.join(home, "sessions");
   if (!fssync.existsSync(sessionsRoot)) return [];
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3842,7 +3842,7 @@ function pickWin32ProviderPath({ env = process.env, nativeValue, wslProviderDir,
   const nativeCandidate = wsl.shouldProbeNative(env) ? nativeValue : null;
   const wslCandidate = wslValue !== undefined
     ? wslValue
-    : (wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslProviderDir, { env }) : null);
+    : (wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslProviderDir) : null);
   return wsl.pickWin32Path({
     wslValue: wslCandidate,
     nativeValue: nativeCandidate,

--- a/src/lib/wsl-probe.js
+++ b/src/lib/wsl-probe.js
@@ -1,7 +1,7 @@
 const fssync = require("node:fs");
 const path = require("node:path");
 
-const DEFAULT_EXEC_OPTS = { timeout: 5000, windowsHide: true, maxBuffer: 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] };
+const DEFAULT_EXEC_OPTS = { timeout: 15000, windowsHide: true, maxBuffer: 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] };
 
 const WSL_MODES = new Set([
   "wsl-first",

--- a/src/lib/wsl-probe.js
+++ b/src/lib/wsl-probe.js
@@ -3,6 +3,12 @@ const path = require("node:path");
 
 const DEFAULT_EXEC_OPTS = { timeout: 15000, windowsHide: true, maxBuffer: 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] };
 
+let _cachedDistros = null;
+
+function resetWslProbeCache() {
+  _cachedDistros = null;
+}
+
 const WSL_MODES = new Set([
   "wsl-first",
   "native-first",
@@ -38,6 +44,8 @@ function parseWslListVerbose(raw) {
 }
 
 function probeWslDistros(deps = {}) {
+  const hasDeps = Object.keys(deps).length > 0;
+  if (!hasDeps && _cachedDistros) return _cachedDistros;
   const runWsl = deps.runWsl || defaultRunWsl;
   let raw;
   try {
@@ -46,7 +54,9 @@ function probeWslDistros(deps = {}) {
     return [];
   }
   const distros = parseWslListVerbose(raw);
-  return distros.sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+  const sorted = distros.sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+  if (!hasDeps) _cachedDistros = sorted;
+  return sorted;
 }
 
 function normalizeWslMode(value) {
@@ -97,7 +107,7 @@ function discoverWslHome(providerDir, deps = {}) {
 
   const runWsl = deps.runWsl || defaultRunWsl;
   const existsSync = deps.existsSync || fssync.existsSync;
-  const distros = probeWslDistros(deps);
+  const distros = deps.runWsl ? probeWslDistros({ runWsl: deps.runWsl }) : probeWslDistros();
   for (const distro of distros) {
     let user;
     try {
@@ -147,6 +157,7 @@ module.exports = {
   defaultRunWsl,
   parseWslListVerbose,
   probeWslDistros,
+  resetWslProbeCache,
   discoverWslHome,
   isUncPath,
   snapshotSqliteDb,

--- a/src/lib/wsl-probe.js
+++ b/src/lib/wsl-probe.js
@@ -4,9 +4,11 @@ const path = require("node:path");
 const DEFAULT_EXEC_OPTS = { timeout: 15000, windowsHide: true, maxBuffer: 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] };
 
 let _cachedDistros = null;
+const _cachedWslUsers = new Map();
 
 function resetWslProbeCache() {
   _cachedDistros = null;
+  _cachedWslUsers.clear();
 }
 
 const WSL_MODES = new Set([
@@ -51,6 +53,7 @@ function probeWslDistros(deps = {}) {
   try {
     raw = runWsl(["-l", "-v"], { utf16: true });
   } catch (_e) {
+    if (!hasDeps) _cachedDistros = [];
     return [];
   }
   const distros = parseWslListVerbose(raw);
@@ -102,19 +105,27 @@ function pickWin32Path({
   return wslValue ?? nativeValue ?? null;
 }
 
+function lookupWslUser(distroName, runWsl, useCache) {
+  if (useCache && _cachedWslUsers.has(distroName)) {
+    return _cachedWslUsers.get(distroName);
+  }
+  let user = "";
+  try {
+    user = String(runWsl(["-d", distroName, "-e", "whoami"], { utf16: false }) || "").trim();
+  } catch (_e) { }
+  if (useCache) _cachedWslUsers.set(distroName, user);
+  return user;
+}
+
 function discoverWslHome(providerDir, deps = {}) {
   if (!shouldProbeWsl(deps.env)) return null;
 
   const runWsl = deps.runWsl || defaultRunWsl;
   const existsSync = deps.existsSync || fssync.existsSync;
   const distros = deps.runWsl ? probeWslDistros({ runWsl: deps.runWsl }) : probeWslDistros();
+  const useCache = !deps.runWsl;
   for (const distro of distros) {
-    let user;
-    try {
-      user = String(runWsl(["-d", distro.name, "-e", "whoami"], { utf16: false }) || "").trim();
-    } catch (_e) {
-      user = "";
-    }
+    const user = lookupWslUser(distro.name, runWsl, useCache);
     if (!user) continue;
     const roots = distro.version === 1
       ? ["\\\\wsl.localhost\\", "\\\\wsl$\\"]

--- a/src/lib/wsl-probe.js
+++ b/src/lib/wsl-probe.js
@@ -1,0 +1,159 @@
+const fssync = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_EXEC_OPTS = { timeout: 5000, windowsHide: true, maxBuffer: 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] };
+
+const WSL_MODES = new Set([
+  "wsl-first",
+  "native-first",
+  "wsl-only",
+  "native-only",
+]);
+
+function defaultRunWsl(args, { utf16 = false } = {}) {
+  const { execFileSync } = require("node:child_process");
+  const buf = execFileSync("wsl.exe", args, DEFAULT_EXEC_OPTS);
+  return utf16 ? buf.toString("utf16le") : buf.toString("utf8");
+}
+
+function parseWslListVerbose(raw) {
+  if (typeof raw !== "string") return [];
+  const distros = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const clean = line.replace(/\0/g, "").replace(/\uFEFF/g, "").trim();
+    if (!clean) continue;
+    const cells = clean.split(/\s+/);
+    let isDefault = false;
+    let idx = 0;
+    if (cells[0] === "*") {
+      isDefault = true;
+      idx = 1;
+    }
+    const name = cells[idx];
+    if (!name || name === "NAME") continue;
+    const version = parseInt(cells[cells.length - 1], 10);
+    distros.push({ name, version: Number.isFinite(version) ? version : null, isDefault });
+  }
+  return distros;
+}
+
+function probeWslDistros(deps = {}) {
+  const runWsl = deps.runWsl || defaultRunWsl;
+  let raw;
+  try {
+    raw = runWsl(["-l", "-v"], { utf16: true });
+  } catch (_e) {
+    return [];
+  }
+  const distros = parseWslListVerbose(raw);
+  return distros.sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+}
+
+function normalizeWslMode(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll("_", "-");
+}
+
+function getWslMode(env = process.env) {
+  const raw = normalizeWslMode(env.TOKENTRACKER_WSL_MODE);
+  return WSL_MODES.has(raw) ? raw : "wsl-first";
+}
+
+function isInvalidWslMode(env = process.env) {
+  const value = env.TOKENTRACKER_WSL_MODE;
+  if (value == null || String(value).trim() === "") return false;
+  return !WSL_MODES.has(normalizeWslMode(value));
+}
+
+function shouldProbeWsl(env = process.env) {
+  return getWslMode(env) !== "native-only";
+}
+
+function shouldProbeNative(env = process.env) {
+  return getWslMode(env) !== "wsl-only";
+}
+
+function pickWin32Path({
+  wslValue,
+  nativeValue,
+  env = process.env,
+  platform = process.platform,
+}) {
+  if (platform !== "win32") return null;
+
+  const mode = getWslMode(env);
+
+  if (mode === "wsl-only") return wslValue ?? null;
+  if (mode === "native-only") return nativeValue ?? null;
+  if (mode === "native-first") return nativeValue ?? wslValue ?? null;
+
+  return wslValue ?? nativeValue ?? null;
+}
+
+function discoverWslHome(providerDir, deps = {}) {
+  if (!shouldProbeWsl(deps.env)) return null;
+
+  const runWsl = deps.runWsl || defaultRunWsl;
+  const existsSync = deps.existsSync || fssync.existsSync;
+  const distros = probeWslDistros(deps);
+  for (const distro of distros) {
+    let user;
+    try {
+      user = String(runWsl(["-d", distro.name, "-e", "whoami"], { utf16: false }) || "").trim();
+    } catch (_e) {
+      user = "";
+    }
+    if (!user) continue;
+    const roots = distro.version === 1
+      ? ["\\\\wsl.localhost\\", "\\\\wsl$\\"]
+      : ["\\\\wsl$\\", "\\\\wsl.localhost\\"];
+    for (const root of roots) {
+      const candidate = `${root}${distro.name}\\home\\${user}\\${providerDir}`;
+      try {
+        if (existsSync(candidate)) return candidate;
+      } catch (_e) { }
+    }
+  }
+  return null;
+}
+
+function isUncPath(p) {
+  return typeof p === "string" && (p.startsWith("\\\\") || p.startsWith("//"));
+}
+
+function snapshotSqliteDb(dbPath) {
+  const tmpRoot = fssync.mkdtempSync(
+    path.join(require("node:os").tmpdir(), "tokentracker-wsl-snap-"),
+  );
+  const target = path.join(tmpRoot, path.basename(dbPath));
+  fssync.copyFileSync(dbPath, target);
+  for (const suffix of ["-wal", "-shm", "-journal"]) {
+    const src = dbPath + suffix;
+    try {
+      if (fssync.existsSync(src)) fssync.copyFileSync(src, target + suffix);
+    } catch (_e) { }
+  }
+  return {
+    path: target,
+    cleanup() {
+      try { fssync.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_e) { }
+    },
+  };
+}
+
+module.exports = {
+  defaultRunWsl,
+  parseWslListVerbose,
+  probeWslDistros,
+  discoverWslHome,
+  isUncPath,
+  snapshotSqliteDb,
+  getWslMode,
+  isInvalidWslMode,
+  shouldProbeWsl,
+  shouldProbeNative,
+  pickWin32Path,
+  normalizeWslMode,
+};

--- a/test/helpers/mock.js
+++ b/test/helpers/mock.js
@@ -1,0 +1,21 @@
+function mockPlatform(t, value) {
+  if (t.mock && typeof t.mock.property === "function") {
+    t.mock.property(process, "platform", value);
+    return;
+  }
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  t.after(() => Object.defineProperty(process, "platform", original));
+}
+
+function mockMethod(t, obj, name, impl) {
+  if (t.mock && typeof t.mock.method === "function") {
+    t.mock.method(obj, name, impl);
+    return;
+  }
+  const original = obj[name];
+  obj[name] = impl;
+  t.after(() => { obj[name] = original; });
+}
+
+module.exports = { mockPlatform, mockMethod };

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs/promises");
+const fssync = require("node:fs");
 const { test } = require("node:test");
 
 const cp = require("node:child_process");
@@ -44,14 +45,50 @@ const {
   listAntigravitySessionFiles,
   estimateAntigravityTokens,
   parseKimiCodeIncremental,
+  resolveKimiCodeHome,
   resolveKimiCodeWireFiles,
   resolveKimiCodeDefaultModel,
+  resolveKilocodeRoots,
+  resolveZedDbPath,
+  resolveGooseDbPath,
   listRolloutFilesDeep,
   filterColdCodexRolloutFiles,
 } = require("../src/lib/rollout");
 const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
 const antigravityTestTokens = (text) => estimateAntigravityTokens(text || "");
+
+function mockPlatform(t, value) {
+  if (t.mock && typeof t.mock.property === "function") {
+    t.mock.property(process, "platform", value);
+    return;
+  }
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  t.after(() => Object.defineProperty(process, "platform", original));
+}
+
+function mockMethod(t, obj, name, impl) {
+  if (t.mock && typeof t.mock.method === "function") {
+    t.mock.method(obj, name, impl);
+    return;
+  }
+  const original = obj[name];
+  obj[name] = impl;
+  t.after(() => { obj[name] = original; });
+}
+
+function mockWsl(t, { distro = "Ubuntu", user = "dev" } = {}) {
+  mockMethod(t, cp, "execFileSync", (_cmd, args) => {
+    if (args[0] === "-l" && args[1] === "-v") {
+      return Buffer.from(`  NAME    STATE    VERSION\n* ${distro}  Running  2\n`, "utf16le");
+    }
+    if (args[0] === "-d" && args[1] === distro && args.includes("whoami")) {
+      return Buffer.from(`${user}\n`, "utf8");
+    }
+    throw new Error(`unexpected wsl args: ${args.join(" ")}`);
+  });
+}
 
 test("parseRolloutIncremental ignores repeated token_count records with unchanged totals", async () => {
   // Codex can repeat the same token_count record in a rollout. The cumulative
@@ -4730,6 +4767,86 @@ test("resolveHermesPath prefers %LOCALAPPDATA%\\hermes on Windows when present",
     resolveHermesPath({ LOCALAPPDATA: tmp, TOKENTRACKER_HERMES_HOME: "/custom/hermes" }),
     "/custom/hermes",
   );
+});
+
+test("Zed wsl-only does not return or stat native Windows DB", (t) => {
+  mockPlatform(t, "win32");
+  mockMethod(t, cp, "execFileSync", () => { throw new Error("wsl unavailable"); });
+  mockMethod(t, fssync, "existsSync", (candidate) => {
+    assert.ok(!String(candidate).includes("AppData"), `native path was probed: ${candidate}`);
+    return false;
+  });
+
+  const dbPath = resolveZedDbPath({
+    HOME: "C:\\Users\\me",
+    LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local",
+    TOKENTRACKER_WSL_MODE: "wsl-only",
+  });
+
+  assert.equal(dbPath, null);
+});
+
+test("Goose wsl-only does not return or stat native Windows candidates", (t) => {
+  mockPlatform(t, "win32");
+  mockMethod(t, cp, "execFileSync", () => { throw new Error("wsl unavailable"); });
+  mockMethod(t, fssync, "existsSync", (candidate) => {
+    assert.ok(!String(candidate).includes("AppData"), `native path was probed: ${candidate}`);
+    return false;
+  });
+
+  const dbPath = resolveGooseDbPath({
+    HOME: "C:\\Users\\me",
+    APPDATA: "C:\\Users\\me\\AppData\\Roaming",
+    XDG_DATA_HOME: "C:\\Users\\me\\AppData\\Roaming",
+    TOKENTRACKER_WSL_MODE: "wsl-only",
+  });
+
+  assert.equal(dbPath, null);
+});
+
+test("Kimi Code native-first prefers native home when WSL also exists", (t) => {
+  mockPlatform(t, "win32");
+  mockWsl(t);
+  mockMethod(t, fssync, "existsSync", (candidate) => (
+    candidate === "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi-code" ||
+    candidate === path.join(os.homedir(), ".kimi-code")
+  ));
+
+  const home = resolveKimiCodeHome({
+    HOME: "C:\\Users\\me",
+    TOKENTRACKER_WSL_MODE: "native-first",
+  });
+
+  assert.equal(home, path.join(os.homedir(), ".kimi-code"));
+});
+
+test("Kimi Code wsl-first prefers WSL home when both sides exist", (t) => {
+  mockPlatform(t, "win32");
+  mockWsl(t);
+  mockMethod(t, fssync, "existsSync", (candidate) => (
+    candidate === "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi-code" ||
+    candidate === path.join("C:\\Users\\me", ".kimi-code")
+  ));
+
+  const home = resolveKimiCodeHome({
+    HOME: "C:\\Users\\me",
+    TOKENTRACKER_WSL_MODE: "wsl-first",
+  });
+
+  assert.equal(home, "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi-code");
+});
+
+test("Kilocode roots pass resolver env to WSL discovery", (t) => {
+  mockPlatform(t, "win32");
+  mockMethod(t, cp, "execFileSync", () => { throw new Error("WSL discovery should not be called"); });
+
+  const roots = resolveKilocodeRoots({
+    HOME: "C:\\Users\\me",
+    APPDATA: "C:\\Users\\me\\AppData\\Roaming",
+    TOKENTRACKER_WSL_MODE: "native-only",
+  });
+
+  assert.ok(roots.some((root) => root.includes("AppData")));
 });
 
 test("parseWslListVerbose parses distros, default marker and version column", () => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -56,27 +56,9 @@ const {
 } = require("../src/lib/rollout");
 const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
+const { mockPlatform, mockMethod } = require("./helpers/mock");
+
 const antigravityTestTokens = (text) => estimateAntigravityTokens(text || "");
-
-function mockPlatform(t, value) {
-  if (t.mock && typeof t.mock.property === "function") {
-    t.mock.property(process, "platform", value);
-    return;
-  }
-  const original = Object.getOwnPropertyDescriptor(process, "platform");
-  Object.defineProperty(process, "platform", { value, configurable: true });
-  t.after(() => Object.defineProperty(process, "platform", original));
-}
-
-function mockMethod(t, obj, name, impl) {
-  if (t.mock && typeof t.mock.method === "function") {
-    t.mock.method(obj, name, impl);
-    return;
-  }
-  const original = obj[name];
-  obj[name] = impl;
-  t.after(() => { obj[name] = original; });
-}
 
 function mockWsl(t, { distro = "Ubuntu", user = "dev" } = {}) {
   mockMethod(t, cp, "execFileSync", (_cmd, args) => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -57,6 +57,7 @@ const {
 const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
 const { mockPlatform, mockMethod } = require("./helpers/mock");
+const { resetWslProbeCache } = require("../src/lib/wsl-probe");
 
 const antigravityTestTokens = (text) => estimateAntigravityTokens(text || "");
 
@@ -4769,6 +4770,7 @@ test("Zed wsl-only does not return or stat native Windows DB", (t) => {
 });
 
 test("Goose wsl-only does not return or stat native Windows candidates", (t) => {
+  resetWslProbeCache();
   mockPlatform(t, "win32");
   mockMethod(t, cp, "execFileSync", () => { throw new Error("wsl unavailable"); });
   mockMethod(t, fssync, "existsSync", (candidate) => {
@@ -4787,6 +4789,7 @@ test("Goose wsl-only does not return or stat native Windows candidates", (t) => 
 });
 
 test("Kimi Code native-first prefers native home when WSL also exists", (t) => {
+  resetWslProbeCache();
   mockPlatform(t, "win32");
   mockWsl(t);
   mockMethod(t, fssync, "existsSync", (candidate) => (
@@ -4803,6 +4806,7 @@ test("Kimi Code native-first prefers native home when WSL also exists", (t) => {
 });
 
 test("Kimi Code wsl-first prefers WSL home when both sides exist", (t) => {
+  resetWslProbeCache();
   mockPlatform(t, "win32");
   mockWsl(t);
   mockMethod(t, fssync, "existsSync", (candidate) => (

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -6,26 +6,7 @@ const cp = require("node:child_process");
 const { test } = require("node:test");
 
 const { cmdStatus } = require("../src/commands/status");
-
-function mockPlatform(t, value) {
-  if (t.mock && typeof t.mock.property === "function") {
-    t.mock.property(process, "platform", value);
-    return;
-  }
-  const original = Object.getOwnPropertyDescriptor(process, "platform");
-  Object.defineProperty(process, "platform", { value, configurable: true });
-  t.after(() => Object.defineProperty(process, "platform", original));
-}
-
-function mockMethod(t, obj, name, impl) {
-  if (t.mock && typeof t.mock.method === "function") {
-    t.mock.method(obj, name, impl);
-    return;
-  }
-  const original = obj[name];
-  obj[name] = impl;
-  t.after(() => { obj[name] = original; });
-}
+const { mockPlatform, mockMethod } = require("./helpers/mock");
 
 test("status prints last upload timestamps from upload.throttle.json", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-"));

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -2,9 +2,30 @@ const assert = require("node:assert/strict");
 const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs/promises");
+const cp = require("node:child_process");
 const { test } = require("node:test");
 
 const { cmdStatus } = require("../src/commands/status");
+
+function mockPlatform(t, value) {
+  if (t.mock && typeof t.mock.property === "function") {
+    t.mock.property(process, "platform", value);
+    return;
+  }
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  t.after(() => Object.defineProperty(process, "platform", original));
+}
+
+function mockMethod(t, obj, name, impl) {
+  if (t.mock && typeof t.mock.method === "function") {
+    t.mock.method(obj, name, impl);
+    return;
+  }
+  const original = obj[name];
+  obj[name] = impl;
+  t.after(() => { obj[name] = original; });
+}
 
 test("status prints last upload timestamps from upload.throttle.json", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-"));
@@ -83,6 +104,52 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
     else process.env.HOME = prevHome;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("status native-only mode does not probe WSL distros", async (t) => {
+  mockPlatform(t, "win32");
+  let wslCalls = 0;
+  mockMethod(t, cp, "execFileSync", (cmd) => {
+    if (cmd === "wsl.exe") wslCalls++;
+    throw new Error("unexpected child process call");
+  });
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-wsl-mode-"));
+  const prevEnv = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    LOCALAPPDATA: process.env.LOCALAPPDATA,
+    APPDATA: process.env.APPDATA,
+    TOKENTRACKER_WSL_MODE: process.env.TOKENTRACKER_WSL_MODE,
+  };
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    process.env.LOCALAPPDATA = path.join(tmp, "AppData", "Local");
+    process.env.APPDATA = path.join(tmp, "AppData", "Roaming");
+    process.env.TOKENTRACKER_WSL_MODE = "native-only";
+
+    let out = "";
+    process.stdout.write = (chunk, enc, cb) => {
+      out += typeof chunk === "string" ? chunk : chunk.toString(enc || "utf8");
+      if (typeof cb === "function") cb();
+      return true;
+    };
+
+    await cmdStatus();
+
+    assert.equal(wslCalls, 0);
+    assert.match(out, /- WSL mode: native-only/);
+  } finally {
+    for (const [key, value] of Object.entries(prevEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    process.stdout.write = prevWrite;
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/wsl-probe.test.js
+++ b/test/wsl-probe.test.js
@@ -15,6 +15,7 @@ const {
   shouldProbeNative,
   pickWin32Path,
   normalizeWslMode,
+  resetWslProbeCache,
 } = require("../src/lib/wsl-probe");
 
 test("parseWslListVerbose parses distros, default marker and version column", () => {
@@ -69,12 +70,14 @@ test("discoverWslHome resolves provider dir via the right UNC alias per distro",
     runWsl,
     existsSync: (p) => {
       tried1.push(p);
-      return p === "\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp";
+      return false;
     },
   });
-  assert.equal(hit1, "\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp");
-  assert.ok(tried1.indexOf("\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp") <
-    tried1.indexOf("\\\\wsl$\\Legacy\\home\\bob\\.myapp") || !tried1.includes("\\\\wsl$\\Legacy\\home\\bob\\.myapp"));
+  assert.equal(hit1, null);
+  const legacyCandidates = tried1.filter((p) => p.includes("Legacy"));
+  assert.ok(legacyCandidates.length >= 2);
+  assert.ok(legacyCandidates[0].includes("wsl.localhost"));
+  assert.ok(legacyCandidates[1].includes("wsl$"));
 
   assert.equal(discoverWslHome(".myapp", { runWsl, existsSync: () => false }), null);
   assert.equal(

--- a/test/wsl-probe.test.js
+++ b/test/wsl-probe.test.js
@@ -1,0 +1,273 @@
+const assert = require("node:assert/strict");
+const { test, describe, before } = require("node:test");
+const cp = require("node:child_process");
+
+const {
+  defaultRunWsl,
+  parseWslListVerbose,
+  probeWslDistros,
+  discoverWslHome,
+  isUncPath,
+  snapshotSqliteDb,
+  getWslMode,
+  isInvalidWslMode,
+  shouldProbeWsl,
+  shouldProbeNative,
+  pickWin32Path,
+  normalizeWslMode,
+} = require("../src/lib/wsl-probe");
+
+test("parseWslListVerbose parses distros, default marker and version column", () => {
+  const raw = "  NAME            STATE           VERSION\n" +
+    "* Ubuntu          Running         2\n" +
+    "  Debian-22.04    Stopped         1\n";
+  assert.deepEqual(parseWslListVerbose(raw), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+    { name: "Debian-22.04", version: 1, isDefault: false },
+  ]);
+});
+
+test("parseWslListVerbose tolerates UTF-16 NUL/BOM noise and skips the header", () => {
+  const raw = "\uFEFF  NAME   STATE   VERSION\n* Ub\u0000untu Running 2\n";
+  assert.deepEqual(parseWslListVerbose(raw), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+  ]);
+  assert.deepEqual(parseWslListVerbose(""), []);
+  assert.deepEqual(parseWslListVerbose(undefined), []);
+});
+
+test("probeWslDistros sorts the default distro first and is fail-safe", () => {
+  const raw = "  NAME    STATE    VERSION\n  Debian  Stopped  1\n* Ubuntu  Running  2\n";
+  assert.deepEqual(probeWslDistros({ runWsl: () => raw }), [
+    { name: "Ubuntu", version: 2, isDefault: true },
+    { name: "Debian", version: 1, isDefault: false },
+  ]);
+  assert.deepEqual(
+    probeWslDistros({ runWsl: () => { throw new Error("wsl not found"); } }),
+    [],
+  );
+});
+
+test("discoverWslHome resolves provider dir via the right UNC alias per distro", () => {
+  const list = "  NAME    STATE    VERSION\n* Ubuntu  Running  2\n  Legacy  Running  1\n";
+  const users = { Ubuntu: "alice\n", Legacy: "bob\n" };
+  const runWsl = (args) => (args[0] === "-l" ? list : users[args[1]]);
+
+  const tried = [];
+  const hit = discoverWslHome(".myapp", {
+    runWsl,
+    existsSync: (p) => {
+      tried.push(p);
+      return p === "\\\\wsl$\\Ubuntu\\home\\alice\\.myapp";
+    },
+  });
+  assert.equal(hit, "\\\\wsl$\\Ubuntu\\home\\alice\\.myapp");
+  assert.equal(tried[0], "\\\\wsl$\\Ubuntu\\home\\alice\\.myapp");
+
+  const tried1 = [];
+  const hit1 = discoverWslHome(".myapp", {
+    runWsl,
+    existsSync: (p) => {
+      tried1.push(p);
+      return p === "\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp";
+    },
+  });
+  assert.equal(hit1, "\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp");
+  assert.ok(tried1.indexOf("\\\\wsl.localhost\\Legacy\\home\\bob\\.myapp") <
+    tried1.indexOf("\\\\wsl$\\Legacy\\home\\bob\\.myapp") || !tried1.includes("\\\\wsl$\\Legacy\\home\\bob\\.myapp"));
+
+  assert.equal(discoverWslHome(".myapp", { runWsl, existsSync: () => false }), null);
+  assert.equal(
+    discoverWslHome(".myapp", {
+      runWsl: (args) => { if (args[0] === "-l") return list; throw new Error("whoami failed"); },
+      existsSync: () => true,
+    }),
+    null,
+  );
+});
+
+test("isUncPath detects WSL and network UNC paths", () => {
+  assert.equal(isUncPath("\\\\wsl$\\Ubuntu\\home\\user"), true);
+  assert.equal(isUncPath("\\\\wsl.localhost\\Ubuntu\\home\\user"), true);
+  assert.equal(isUncPath("\\\\server\\share\\path"), true);
+  assert.equal(isUncPath("//wsl$/Ubuntu/path"), true);
+  assert.equal(isUncPath("/home/user/.myapp"), false);
+  assert.equal(isUncPath("C:\\Users\\user"), false);
+  assert.equal(isUncPath(null), false);
+  assert.equal(isUncPath(undefined), false);
+});
+
+test("snapshotSqliteDb copies a file and its WAL/shm/journal siblings", () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const os = require("node:os");
+  const srcDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsl-test-src-"));
+  const dbPath = path.join(srcDir, "test.db");
+  fs.writeFileSync(dbPath, "db content");
+  fs.writeFileSync(dbPath + "-wal", "wal content");
+  fs.writeFileSync(dbPath + "-shm", "shm content");
+
+  const snap = snapshotSqliteDb(dbPath);
+  assert.equal(fs.readFileSync(snap.path, "utf8"), "db content");
+  assert.equal(fs.readFileSync(snap.path + "-wal", "utf8"), "wal content");
+  assert.equal(fs.readFileSync(snap.path + "-shm", "utf8"), "shm content");
+  assert.equal(fs.existsSync(dbPath), true, "original should still exist");
+
+  snap.cleanup();
+  assert.equal(fs.existsSync(snap.path), false, "snapshot should be removed after cleanup");
+  assert.equal(fs.existsSync(path.dirname(snap.path)), false, "tmp dir should be removed");
+
+  fs.rmSync(srcDir, { recursive: true, force: true });
+});
+
+// ── WSL mode helpers ─────────────────────────────────────────────────────────
+
+test("getWslMode returns default wsl-first for unset env", () => {
+  assert.equal(getWslMode({}), "wsl-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "" }), "wsl-first");
+});
+
+test("normalizeWslMode normalizes whitespace, case, and underscores", () => {
+  assert.equal(normalizeWslMode(" NATIVE_FIRST "), "native-first");
+  assert.equal(normalizeWslMode("WSL_ONLY"), "wsl-only");
+  assert.equal(normalizeWslMode(null), "");
+});
+
+test("getWslMode normalizes case, whitespace, and underscores", () => {
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "native-first" }), "native-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "Native-First" }), "native-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "NATIVE_FIRST" }), "native-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "  native-first  " }), "native-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "WSL_ONLY" }), "wsl-only");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "native_only" }), "native-only");
+});
+
+test("getWslMode returns default for invalid values", () => {
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "foo" }), "wsl-first");
+  assert.equal(getWslMode({ TOKENTRACKER_WSL_MODE: "wsl" }), "wsl-first");
+});
+
+test("isInvalidWslMode detects invalid values", () => {
+  assert.equal(isInvalidWslMode({}), false);
+  assert.equal(isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "" }), false);
+  assert.equal(isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "wsl-first" }), false);
+  assert.equal(isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "native-only" }), false);
+  assert.equal(isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "foo" }), true);
+  assert.equal(isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "wsl" }), true);
+});
+
+test("shouldProbeWsl is false only for native-only mode", () => {
+  assert.equal(shouldProbeWsl({}), true);
+  assert.equal(shouldProbeWsl({ TOKENTRACKER_WSL_MODE: "wsl-first" }), true);
+  assert.equal(shouldProbeWsl({ TOKENTRACKER_WSL_MODE: "native-first" }), true);
+  assert.equal(shouldProbeWsl({ TOKENTRACKER_WSL_MODE: "wsl-only" }), true);
+  assert.equal(shouldProbeWsl({ TOKENTRACKER_WSL_MODE: "native-only" }), false);
+});
+
+test("shouldProbeNative is false only for wsl-only mode", () => {
+  assert.equal(shouldProbeNative({}), true);
+  assert.equal(shouldProbeNative({ TOKENTRACKER_WSL_MODE: "wsl-first" }), true);
+  assert.equal(shouldProbeNative({ TOKENTRACKER_WSL_MODE: "native-first" }), true);
+  assert.equal(shouldProbeNative({ TOKENTRACKER_WSL_MODE: "wsl-only" }), false);
+  assert.equal(shouldProbeNative({ TOKENTRACKER_WSL_MODE: "native-only" }), true);
+});
+
+test("pickWin32Path returns null on non-Windows platforms", () => {
+  for (const mode of [undefined, "wsl-first", "native-first", "wsl-only", "native-only"]) {
+    const env = mode ? { TOKENTRACKER_WSL_MODE: mode } : {};
+    assert.equal(pickWin32Path({ wslValue: "/wsl", nativeValue: "/native", env, platform: "linux" }), null);
+    assert.equal(pickWin32Path({ wslValue: "/wsl", nativeValue: "/native", env, platform: "darwin" }), null);
+  }
+});
+
+test("pickWin32Path matrix", () => {
+  const cases = [
+    // mode                    wsl      native   expected
+    [undefined,                "wsl",   "native", "wsl"],
+    ["wsl-first",              "wsl",   "native", "wsl"],
+    ["native-first",           "wsl",   "native", "native"],
+    ["native-first",           "wsl",   null,     "wsl"],
+    ["wsl-first",              null,    "native", "native"],
+    ["wsl-only",               null,    "native", null],
+    ["native-only",            "wsl",   null,     null],
+    ["native-only",            "wsl",   "native", "native"],
+    [" native-first ",         "wsl",   "native", "native"],
+    ["NATIVE-FIRST",           "wsl",   "native", "native"],
+    ["bad-value",              "wsl",   "native", "wsl"],
+  ];
+  for (const [mode, wsl, native, expected] of cases) {
+    const env = mode ? { TOKENTRACKER_WSL_MODE: mode } : {};
+    assert.equal(
+      pickWin32Path({ wslValue: wsl ?? null, nativeValue: native ?? null, env, platform: "win32" }),
+      expected ?? null,
+      `mode=${JSON.stringify(mode)} wsl=${JSON.stringify(wsl)} native=${JSON.stringify(native)}`,
+    );
+  }
+});
+
+test("discoverWslHome respects shouldProbeWsl (native-only)", () => {
+  // Even with a working runWsl, native-only mode should skip the probe.
+  const runWsl = () => { throw new Error("should not be called"); };
+  assert.equal(
+    discoverWslHome(".myapp", { runWsl, env: { TOKENTRACKER_WSL_MODE: "native-only" } }),
+    null,
+  );
+});
+
+// ── Real WSL integration test (skipped when wsl.exe is unavailable) ──────────
+// Only runs on Windows with WSL installed. This validates that our parsing
+// logic matches real `wsl.exe -l -v` output format, and that UNC paths to WSL
+// distros are reachable. Without actual WSL, we skip silently.
+describe("real WSL integration", { skip: process.platform !== "win32" }, () => {
+  let wslAvailable = false;
+  before(() => {
+    try {
+      cp.execFileSync("wsl.exe", ["--version"], { stdio: "ignore", timeout: 5000 });
+      wslAvailable = true;
+    } catch {
+      wslAvailable = false;
+    }
+  });
+
+  test("defaultRunWsl parses distro list successfully", { skip: !wslAvailable }, () => {
+    const raw = defaultRunWsl(["-l", "-v"], { utf16: true });
+    assert.ok(typeof raw === "string", `expected string, got ${typeof raw}`);
+    assert.ok(raw.length > 0, "wsl.exe -l -v output should not be empty");
+    const distros = parseWslListVerbose(raw);
+    assert.ok(Array.isArray(distros), "parsed distros should be an array");
+    assert.ok(distros.length > 0, "expected at least one WSL distro");
+    for (const d of distros) {
+      assert.ok(typeof d.name === "string" && d.name.length > 0, `distro name should be non-empty, got ${d.name}`);
+      assert.ok(d.version === 1 || d.version === 2, `version should be 1 or 2, got ${d.version}`);
+      assert.ok(typeof d.isDefault === "boolean", `isDefault should be boolean, got ${d.isDefault}`);
+    }
+    // The default distro marker should place it first.
+    const defaults = distros.filter((d) => d.isDefault);
+    assert.equal(defaults.length, 1, "exactly one default distro expected");
+    assert.equal(distros[0].name, defaults[0].name, "default distro should be first");
+  });
+
+  test("probeWslDistros returns real distros via defaultRunWsl", { skip: !wslAvailable }, () => {
+    const distros = probeWslDistros();
+    assert.ok(Array.isArray(distros));
+    assert.ok(distros.length > 0);
+    const defaults = distros.filter((d) => d.isDefault);
+    assert.equal(defaults.length, 1);
+    assert.equal(distros[0].name, defaults[0].name);
+  });
+});
+
+test("snapshotSqliteDb handles missing WAL/shm/journal gracefully", () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const os = require("node:os");
+  const srcDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsl-test-src2-"));
+  const dbPath = path.join(srcDir, "clean.db");
+  fs.writeFileSync(dbPath, "clean content");
+
+  const snap = snapshotSqliteDb(dbPath);
+  assert.equal(fs.readFileSync(snap.path, "utf8"), "clean content");
+  snap.cleanup();
+
+  fs.rmSync(srcDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

Completes WSL auto-discovery and priority configuration for all Windows provider resolvers, replacing  with the more expressive  environment variable.

## Changes

### Core module: `src/lib/wsl-probe.js`
- 12 exported helpers: 6 WSL core utilities + 6 mode arbitration functions
- `normalizeWslMode` — case/whitespace/underscore tolerant (`WSL_ONLY`, `wsl-first` both work)
- `pickWin32Path` — sole arbitration point; returns native or WSL path based on mode
- `shouldProbeWsl` / `shouldProbeNative` — prevent probing excluded sources in `wsl-only` / `native-only`
- All helpers are O(1) function-level compositions with injectable `platform`/`env` for testing

### Provider resolvers (`src/lib/rollout.js`)
Every Windows provider now routes through mode-aware arbitration:
- **New resolvers**: KimiCode, CodeBuddy, WorkBuddy, OMP, Pi, Craft, Grok Build, Droid, Copilot OTel, KiloCode/RooCode
- **Existing**: Hermes, Zed, Goose — updated to use the shared `pickWin32Path` pattern
- `pickWin32ProviderPath` internal helper centralizes repeated native/WSL arbitration
- All resolvers return `null`/no-candidate in exclusive modes when the excluded side has no candidate

### Null safety
- `status` and `sync` commands guard against `existsSync(null)` with short-circuit
- `resolveHermesDbPath` returns `null` when resolver returns `null`
- `resolveAllHermesDBPaths` returns `{ default: null, profiles: {} }` when `hermesDir` is null
- All downstream file-listing/default-model consumers null-guarded

### Status reporting
- JSON output: top-level `wsl_mode` + `wsl_distros` fields
- Human-readable: shows active mode, invalid-value warning, and distro list
- `TOKENTRACKER_SKIP_WSL_PROBE` fully removed (use `TOKENTRACKER_WSL_MODE=native-only`)

### Tests
- `test/wsl-probe.test.js`: 17 unit tests (all 6 mode helpers, `normalizeWslMode`, `pickWin32Path` matrix, exclusive-mode skip) + 2 real-WSL integration (skip on non-Win32)
- `test/rollout-parser.test.js`: 5 resolver regression tests (Zed, Goose, Kimi Code ×2, Kilocode)
- `test/status.test.js`: `native-only` does not invoke `wsl.exe`
- Full suite: 1113 pass, 0 fail, 1 skip

## Breaking Changes
- `TOKENTRACKER_SKIP_WSL_PROBE` removed — use `TOKENTRACKER_WSL_MODE=native-only`

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `status` reporting with Windows/WSL-aware output, including `WSL mode` and (when available) discovered WSL distros in both human-readable and structured formats.
  * Updated Hermes status display to reflect actual installation more accurately.
* **Bug Fixes**
  * Avoided unnecessary filesystem existence checks when provider DB path values are missing.
* **Tests**
  * Added/expanded coverage for WSL probing, resolver behavior across WSL modes (including `native-only`), UNC detection, and SQLite snapshotting.
* **Chores**
  * Updated local ignore rules for new development directories/files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->