### PR TITLE
ci: install sqlite3 for test fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
             package-lock.json
             dashboard/package-lock.json
 
+      - name: Install sqlite3 (defensive — preinstalled on GH runners but explicit dep hygiene)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y sqlite3
+
       - name: Install root dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Installs `sqlite3` CLI on the Ubuntu CI runner as an explicit dependency. The test suite uses `sqlite3` to create fixture databases for Zed, Goose, Kiro CLI, and Go migration parsers.

## Background

GitHub-hosted Ubuntu runners include `sqlite3` preinstalled today, so this is **not** fixing a current CI failure. The purpose is defensive dependency hygiene — guarding against a future runner image dropping `sqlite3`, and documenting that this is a test dependency.

Uses `--no-install-recommends` to minimize image bloat.

## Impact

- Adds ~2s per CI run (apt-get update + install)
- Ensures test suite doesn't silently break if the runner image changes