### PR TITLE
fix: harden macOS dashboard asset loading against stale chunk requests

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/ServerManager.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/ServerManager.swift
@@ -177,7 +177,7 @@ final class ServerManager: ObservableObject {
     private func launchServer(nodePath: String, entryPath: String) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: nodePath)
-        process.arguments = [entryPath, "serve", "--no-sync", "--no-open"]
+        process.arguments = [entryPath, "serve", "--port", "\(Constants.serverPort)", "--no-sync", "--no-open"]
         process.currentDirectoryURL = FileManager.default.temporaryDirectory
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
@@ -209,7 +209,7 @@ final class ServerManager: ObservableObject {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         // Use login shell so Node.js/npm PATH is available
-        process.arguments = ["-lc", "\(binaryPath) serve --no-sync"]
+        process.arguments = ["-lc", "\(binaryPath) serve --port \(Constants.serverPort) --no-sync"]
         process.currentDirectoryURL = FileManager.default.temporaryDirectory
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -14,6 +14,26 @@ const DEFAULT_PORT = 7680;
 const DEFAULT_MAX_PORT_ATTEMPTS = 20;
 const NPM_PACKAGE_NAME = "tokentracker-cli";
 const LOCAL_BIND_HOST = "127.0.0.1";
+const STATIC_ASSET_EXTENSIONS = new Set([
+  ".css",
+  ".gif",
+  ".html",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".js",
+  ".json",
+  ".mjs",
+  ".png",
+  ".svg",
+  ".ttf",
+  ".txt",
+  ".webmanifest",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".xml",
+]);
 
 function buildPortInUseHint(port) {
   return `Port ${port} is still in use after cleanup. Try: npx ${NPM_PACKAGE_NAME} serve --port ${port + 1}\n`;
@@ -123,7 +143,12 @@ async function cmdServe(argv) {
       if (served) return;
 
       // SPA fallback
-      await serveStaticFile(dashboardDir, "/index.html", res);
+      if (shouldServeSpaFallback(req, url)) {
+        await serveStaticFile(dashboardDir, "/index.html", res);
+        return;
+      }
+
+      sendNotFound(res);
     } catch (e) {
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "text/plain" });
@@ -230,6 +255,38 @@ async function ensurePortFree(port) {
     } catch (_e) {}
   }
   await new Promise((r) => setTimeout(r, 500));
+}
+
+function isApiPath(pathname) {
+  return (
+    pathname.startsWith("/api/")
+    || pathname.startsWith("/functions/")
+    || pathname.startsWith("/proxy/")
+  );
+}
+
+function isStaticAssetPath(pathname) {
+  if (pathname.startsWith("/assets/")) return true;
+  return STATIC_ASSET_EXTENSIONS.has(path.posix.extname(pathname).toLowerCase());
+}
+
+function shouldServeSpaFallback(req, url) {
+  const method = String(req.method || "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return false;
+
+  const pathname = url.pathname || "/";
+  if (isApiPath(pathname) || isStaticAssetPath(pathname)) return false;
+
+  const accept = String(req.headers?.accept || "");
+  return !accept || accept.includes("text/html") || accept.includes("*/*");
+}
+
+function sendNotFound(res) {
+  res.writeHead(404, {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end("Not Found");
 }
 
 function listenOnce(server, port, host) {
@@ -346,4 +403,5 @@ module.exports = {
   listenOnAvailablePort,
   getLocalServerUrl,
   parseArgs,
+  shouldServeSpaFallback,
 };

--- a/test/macos-server-manager-port.test.js
+++ b/test/macos-server-manager-port.test.js
@@ -1,0 +1,32 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const serverManagerPath = path.join(
+  __dirname,
+  "..",
+  "TokenTrackerBar",
+  "TokenTrackerBar",
+  "Services",
+  "ServerManager.swift",
+);
+
+function readServerManager() {
+  return fs.readFileSync(serverManagerPath, "utf8");
+}
+
+test("macOS app launches local CLI on the same fixed port that WKWebView loads", () => {
+  const source = readServerManager();
+
+  assert.match(
+    source,
+    /process\.arguments\s*=\s*\[entryPath,\s*"serve",\s*"--port",\s*"\\\(Constants\.serverPort\)",\s*"--no-sync",\s*"--no-open"\]/,
+    "embedded server launch should explicitly bind Constants.serverPort",
+  );
+  assert.match(
+    source,
+    /serve --port \\\(Constants\.serverPort\) --no-sync/,
+    "system CLI fallback should explicitly bind Constants.serverPort",
+  );
+});

--- a/test/serve-spa-fallback.test.js
+++ b/test/serve-spa-fallback.test.js
@@ -1,0 +1,30 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { shouldServeSpaFallback } = require("../src/commands/serve");
+
+function request({ method = "GET", accept = "text/html" } = {}) {
+  return { method, headers: { accept } };
+}
+
+function localUrl(pathname) {
+  return new URL(pathname, "http://127.0.0.1:7680");
+}
+
+test("serve only falls back to the SPA document for page navigations", () => {
+  assert.equal(shouldServeSpaFallback(request(), localUrl("/settings?app=1")), true);
+  assert.equal(shouldServeSpaFallback(request(), localUrl("/u/user-without-static-extension")), true);
+});
+
+test("serve does not return index.html for missing Vite chunks or static assets", () => {
+  assert.equal(shouldServeSpaFallback(request({ accept: "*/*" }), localUrl("/assets/SettingsPage-old.js")), false);
+  assert.equal(shouldServeSpaFallback(request({ accept: "*/*" }), localUrl("/assets/main-old.css")), false);
+  assert.equal(shouldServeSpaFallback(request({ accept: "image/svg+xml" }), localUrl("/icon.svg")), false);
+  assert.equal(shouldServeSpaFallback(request({ accept: "application/json" }), localUrl("/manifest.webmanifest")), false);
+});
+
+test("serve does not fall back to index.html for unknown API routes or mutations", () => {
+  assert.equal(shouldServeSpaFallback(request({ accept: "*/*" }), localUrl("/functions/missing")), false);
+  assert.equal(shouldServeSpaFallback(request({ accept: "application/json" }), localUrl("/api/missing")), false);
+  assert.equal(shouldServeSpaFallback(request({ method: "POST", accept: "text/html" }), localUrl("/settings")), false);
+});


### PR DESCRIPTION
## Summary

Prevent the macOS app dashboard from failing with `text/html is not a valid JavaScript MIME type` when WKWebView requests a stale or missing Vite chunk, by returning a real 404 for missing static assets and forcing the embedded/system CLI server to bind the fixed macOS app port.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

### Rules / invariants

- Missing static assets under the local CLI server must not fall back to `index.html`.
- SPA fallback should apply only to real page navigations, not `assets/*.js`, CSS, or API-like paths.
- The macOS app must launch and load the same fixed local port (`:7680`) because Swift-side URLs are hardcoded to that port.

### Boundary matrix (list at least 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup to consistently use the configured port in both embedded and fallback launch paths.
  * Made app routing more precise so non-page requests return a 404 instead of loading the main app shell.
* **Tests**
  * Added coverage for server port handling on macOS.
  * Added coverage for SPA fallback behavior across page, API, and static asset requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->