### PR TITLE
Improve native menu bar catch-up after wake

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
@@ -3,6 +3,7 @@ import Foundation
 enum BackgroundRefreshPolicy {
     static let defaultRefreshInterval: TimeInterval = 300
     static let defaultSyncInterval: TimeInterval = 1_800
+    static let defaultCatchUpStaleInterval: TimeInterval = 300
 
     static func shouldRunSync(
         now: Date,
@@ -12,5 +13,15 @@ enum BackgroundRefreshPolicy {
         guard syncInterval > 0 else { return false }
         guard let lastSyncAt else { return true }
         return now.timeIntervalSince(lastSyncAt) >= syncInterval
+    }
+
+    static func shouldRunCatchUpSync(
+        now: Date,
+        lastSyncAt: Date?,
+        staleInterval: TimeInterval = defaultCatchUpStaleInterval
+    ) -> Bool {
+        guard staleInterval > 0 else { return false }
+        guard let lastSyncAt else { return true }
+        return now.timeIntervalSince(lastSyncAt) >= staleInterval
     }
 }

--- a/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
+++ b/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
@@ -13,11 +13,13 @@ struct TokenTrackerBarApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusBarController: StatusBarController?
+    private var lastWakeCatchUpAttemptAt: Date?
     private let viewModel = DashboardViewModel()
     private let serverManager = ServerManager()
     private let launchAtLoginManager = LaunchAtLoginManager()
     private lazy var desktopPetController = DesktopPetWindowController(viewModel: viewModel)
     private static var userInitiatedQuit = false
+    private static let wakeCatchUpDebounceInterval: TimeInterval = 60
 
     /// Real quit path: popover/Footer Quit buttons, NativeBridge "quit", UpdateChecker relaunch.
     /// Cmd+Q from the dashboard window goes through `applicationShouldTerminate` and is downgraded
@@ -53,6 +55,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             viewModel: viewModel,
             launchAtLoginManager: launchAtLoginManager
         )
+        registerWakeCatchUpObservers()
 
         Task { @MainActor in
             await serverManager.ensureServerRunning()
@@ -68,7 +71,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
         serverManager.stopServer()
+    }
+
+    private func registerWakeCatchUpObservers() {
+        let notificationCenter = NSWorkspace.shared.notificationCenter
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(scheduleWakeCatchUp(_:)),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(scheduleWakeCatchUp(_:)),
+            name: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    @objc private func scheduleWakeCatchUp(_ notification: Notification) {
+        let now = Date()
+        if let lastWakeCatchUpAttemptAt,
+           now.timeIntervalSince(lastWakeCatchUpAttemptAt) < Self.wakeCatchUpDebounceInterval {
+            return
+        }
+        lastWakeCatchUpAttemptAt = now
+
+        Task { @MainActor in
+            await serverManager.ensureServerRunning()
+            await viewModel.catchUpAfterWakeOrSessionActive(now: now)
+        }
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -258,6 +258,18 @@ class DashboardViewModel: ObservableObject {
         await loadAll()
     }
 
+    func catchUpAfterWakeOrSessionActive(now: Date = Date()) async {
+        let shouldSync = BackgroundRefreshPolicy.shouldRunCatchUpSync(
+            now: now,
+            lastSyncAt: lastBackgroundSyncAt
+        )
+        if shouldSync {
+            await syncThenLoad()
+        } else {
+            await loadAll()
+        }
+    }
+
     func triggerSync() async {
         guard !isSyncing else { return }
         isSyncing = true

--- a/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
@@ -33,4 +33,56 @@ final class BackgroundRefreshPolicyTests: XCTestCase {
             true
         )
     }
+
+    func testRunsCatchUpSyncWhenNoPreviousSyncExists() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunCatchUpSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: nil,
+                staleInterval: 300
+            ),
+            true
+        )
+    }
+
+    func testSkipsCatchUpSyncWhenPreviousSyncIsFresh() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunCatchUpSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: Date(timeIntervalSince1970: 800),
+                staleInterval: 300
+            ),
+            false
+        )
+    }
+
+    func testRunsCatchUpSyncAtStaleBoundary() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunCatchUpSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: Date(timeIntervalSince1970: 700),
+                staleInterval: 300
+            ),
+            true
+        )
+    }
+
+    func testSkipsCatchUpSyncForNonPositiveInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunCatchUpSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: nil,
+                staleInterval: 0
+            ),
+            false
+        )
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunCatchUpSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastSyncAt: nil,
+                staleInterval: -1
+            ),
+            false
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add wake and session-active observers for the macOS menu bar app
- debounce wake/session catch-up attempts for 60 seconds
- run a real sync only when the last successful background sync is stale; otherwise only reload local data

## Why
When macOS sleeps or locks, scheduled refresh work can be delayed. This keeps the existing 5-minute UI refresh and 30-minute regular sync cadence unchanged, while making the app catch up promptly after wake/unlock without repeatedly syncing when data is already fresh.

## Verification
- xcodegen generate
- xcodebuild test -project TokenTrackerBar/TokenTrackerBar.xcodeproj -scheme TokenTrackerBarTests -destination 'platform=macOS' -derivedDataPath /tmp/TokenTrackerBarDerivedData
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic catch-up behavior when the app becomes active or the Mac wakes from sleep.
  * Introduced smarter sync timing so the app can decide whether to refresh data or just reload what’s already available.

* **Bug Fixes**
  * Improved handling of repeated wake/active events to avoid triggering duplicate refreshes.
  * Ensured catch-up sync logic behaves consistently when no prior sync exists or when data is already fresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->