### PR TITLE
Mint relayed cloud tokens for background sync

### DIFF
--- a/src/lib/cloud-account.js
+++ b/src/lib/cloud-account.js
@@ -68,12 +68,13 @@ function decodeJwtExpMs(token) {
   return 0;
 }
 
-// Module-level access-token cache, keyed by the refresh token that produced it.
+// Module-level access-token cache, keyed by the cloud base URL and refresh token
+// that produced it.
 // The popover polls frequently, so caching avoids hammering /api/auth/refresh.
-let tokenCache = { refreshToken: null, accessToken: null, expMs: 0 };
+let tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
 
 function __resetCloudAccountCacheForTests() {
-  tokenCache = { refreshToken: null, accessToken: null, expMs: 0 };
+  tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
 }
 
 function csrfTokenFromRefreshPayload(data) {
@@ -100,15 +101,16 @@ async function mintAccessToken({
   timeoutMs,
 } = {}) {
   if (!refreshToken) return null;
+  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+  const cacheKey = `${root}\0${refreshToken}`;
   if (
-    tokenCache.refreshToken === refreshToken &&
+    tokenCache.cacheKey === cacheKey &&
     tokenCache.accessToken &&
     tokenCache.expMs - skewMs > now()
   ) {
     return { accessToken: tokenCache.accessToken, refreshToken: null, csrfToken: null };
   }
 
-  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
   const headers = { "Content-Type": "application/json", Accept: "application/json" };
   if (anonKey) headers.apikey = anonKey;
 
@@ -150,7 +152,7 @@ async function mintAccessToken({
   if (!accessToken) return null;
 
   const expMs = decodeJwtExpMs(accessToken) || now() + 10 * 60_000;
-  tokenCache = { refreshToken, accessToken, expMs };
+  tokenCache = { cacheKey, accessToken, expMs };
 
   const rotated = refreshTokenFromRefreshPayload(data);
   return {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1470,13 +1470,16 @@ function createLocalApiHandler({ queuePath }) {
           }
           extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = allowedBaseUrl;
         }
-        if (drain && !extraEnv.TOKENTRACKER_DEVICE_TOKEN && getCloudSyncPref() && getRefreshTokenForCloud()) {
+        if (!extraEnv.TOKENTRACKER_DEVICE_TOKEN && getCloudSyncPref() && getRefreshTokenForCloud()) {
           const issuedToken = await issueDeviceTokenForDrainSync(qp).catch(() => null);
           if (!issuedToken) {
-            json(res, { ok: false, error: "Unable to issue cloud device token for drain sync" }, 502);
-            return true;
+            if (drain) {
+              json(res, { ok: false, error: "Unable to issue cloud device token for drain sync" }, 502);
+              return true;
+            }
+          } else {
+            extraEnv.TOKENTRACKER_DEVICE_TOKEN = issuedToken;
           }
-          extraEnv.TOKENTRACKER_DEVICE_TOKEN = issuedToken;
         }
         const result = await runSyncCommand(extraEnv, { drain });
         try {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -768,6 +768,8 @@ function createLocalApiHandler({ queuePath }) {
   const localAuthToken = crypto.randomBytes(24).toString("hex");
   const trackerDataDir = path.join(os.homedir(), ".tokentracker", "tracker");
   const cookiePath = path.join(trackerDataDir, "relay-cookies.json");
+  const localSyncDeviceTokenCache = new Map();
+  const localSyncDeviceTokenInflight = new Map();
 
   // Load persisted cookies on startup
   try {
@@ -941,65 +943,93 @@ function createLocalApiHandler({ queuePath }) {
     }
   }
 
-  async function issueDeviceTokenForDrainSync(queuePathForMachineId) {
+  function localSyncDeviceTokenCacheKey(refreshToken, machineId, baseUrl) {
+    return `${baseUrl}\0${refreshToken}\0${machineId}`;
+  }
+
+  async function issueDeviceTokenForLocalSync(queuePathForMachineId, options = {}) {
     if (!getCloudSyncPref()) return null;
     const refreshToken = getRefreshTokenForCloud();
     if (!refreshToken) return null;
-
-    const runtime = resolveRuntimeConfig();
-    const baseUrl = runtime.baseUrl || DEFAULT_BASE_URL;
-    const minted = await mintAccessToken({
-      baseUrl,
-      anonKey: runtime.anonKey,
-      refreshToken,
-      timeoutMs: runtime.httpTimeoutMs,
-    });
-    if (!minted?.accessToken) return null;
-    if (minted.refreshToken) setRelayRefreshToken(minted.refreshToken);
-    if (minted.csrfToken) setRelayCsrfToken(minted.csrfToken);
-
     const machineId = getOrCreateMachineId(queuePathForMachineId);
     if (!machineId) return null;
 
-    const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
-    const headers = {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Authorization: `Bearer ${minted.accessToken}`,
-    };
-    if (runtime.anonKey) headers.apikey = runtime.anonKey;
+    const runtime = resolveRuntimeConfig();
+    const baseUrl =
+      normalizeRemoteHttpBaseUrl(options.baseUrl) ||
+      normalizeRemoteHttpBaseUrl(runtime.baseUrl) ||
+      normalizeRemoteHttpBaseUrl(DEFAULT_BASE_URL);
+    const cacheKey = localSyncDeviceTokenCacheKey(refreshToken, machineId, baseUrl);
+    const cachedToken = localSyncDeviceTokenCache.get(cacheKey);
+    if (cachedToken) return cachedToken;
+    const inflightToken = localSyncDeviceTokenInflight.get(cacheKey);
+    if (inflightToken) return inflightToken;
 
-    let timeoutId;
-    const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
-    if (controller && runtime.httpTimeoutMs > 0) {
-      timeoutId = setTimeout(() => controller.abort(), runtime.httpTimeoutMs);
+    const issuePromise = (async () => {
+      const minted = await mintAccessToken({
+        baseUrl,
+        anonKey: runtime.anonKey,
+        refreshToken,
+        timeoutMs: runtime.httpTimeoutMs,
+      });
+      if (!minted?.accessToken) return null;
+      const rotatedRefreshToken =
+        typeof minted.refreshToken === "string" && minted.refreshToken.trim()
+          ? minted.refreshToken.trim()
+          : "";
+      if (rotatedRefreshToken) setRelayRefreshToken(rotatedRefreshToken);
+      if (minted.csrfToken) setRelayCsrfToken(minted.csrfToken);
+
+      const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+      const headers = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${minted.accessToken}`,
+      };
+      if (runtime.anonKey) headers.apikey = runtime.anonKey;
+
+      let timeoutId;
+      const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+      if (controller && runtime.httpTimeoutMs > 0) {
+        timeoutId = setTimeout(() => controller.abort(), runtime.httpTimeoutMs);
+      }
+
+      const dashboardPlatform =
+        process.platform === "darwin" ? "MacIntel" :
+          process.platform === "win32" ? "Win32" :
+            process.platform === "linux" ? "Linux x86_64" :
+              "web";
+
+      const res = await fetch(`${root}/functions/tokentracker-device-token-issue`, {
+        method: "POST",
+        headers,
+        signal: controller ? controller.signal : undefined,
+        body: JSON.stringify({
+          // 必须和 dashboard/src/lib/cloud-sync.ts 使用同一个设备身份。
+          // 旧云端设备按 (platform, device_name) 认领；如果这里发明
+          // local-sync 身份，会多出一个 active device，账户视图会把历史求和两次。
+          device_name: `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
+          platform: dashboardPlatform,
+          machine_id: machineId,
+        }),
+      }).finally(() => {
+        if (timeoutId) clearTimeout(timeoutId);
+      });
+      if (!res.ok) return null;
+      const data = await res.json().catch(() => null);
+      const token = typeof data?.token === "string" ? data.token.trim() : "";
+      if (token) {
+        const activeRefreshToken = rotatedRefreshToken || refreshToken;
+        localSyncDeviceTokenCache.set(localSyncDeviceTokenCacheKey(activeRefreshToken, machineId, baseUrl), token);
+      }
+      return token || null;
+    })();
+    localSyncDeviceTokenInflight.set(cacheKey, issuePromise);
+    try {
+      return await issuePromise;
+    } finally {
+      localSyncDeviceTokenInflight.delete(cacheKey);
     }
-
-    const dashboardPlatform =
-      process.platform === "darwin" ? "MacIntel" :
-        process.platform === "win32" ? "Win32" :
-          process.platform === "linux" ? "Linux x86_64" :
-            "web";
-
-    const res = await fetch(`${root}/functions/tokentracker-device-token-issue`, {
-      method: "POST",
-      headers,
-      signal: controller ? controller.signal : undefined,
-      body: JSON.stringify({
-        // 必须和 dashboard/src/lib/cloud-sync.ts 使用同一个设备身份。
-        // 旧云端设备按 (platform, device_name) 认领；如果这里发明
-        // local-sync 身份，会多出一个 active device，账户视图会把历史求和两次。
-        device_name: `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
-        platform: dashboardPlatform,
-        machine_id: machineId,
-      }),
-    }).finally(() => {
-      if (timeoutId) clearTimeout(timeoutId);
-    });
-    if (!res.ok) return null;
-    const data = await res.json().catch(() => null);
-    const token = typeof data?.token === "string" ? data.token.trim() : "";
-    return token || null;
   }
 
   // Returns "served" when the cross-device aggregate was written to `res`, or
@@ -1462,6 +1492,7 @@ function createLocalApiHandler({ queuePath }) {
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
         }
+        let localSyncBaseUrl = null;
         if (body.insforgeBaseUrl != null) {
           const allowedBaseUrl = resolveAllowedInsforgeBaseUrl(body.insforgeBaseUrl);
           if (!allowedBaseUrl) {
@@ -1469,12 +1500,20 @@ function createLocalApiHandler({ queuePath }) {
             return true;
           }
           extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = allowedBaseUrl;
+          localSyncBaseUrl = allowedBaseUrl;
         }
         if (!extraEnv.TOKENTRACKER_DEVICE_TOKEN && getCloudSyncPref() && getRefreshTokenForCloud()) {
-          const issuedToken = await issueDeviceTokenForDrainSync(qp).catch(() => null);
+          let issuedToken = null;
+          try {
+            issuedToken = await issueDeviceTokenForLocalSync(qp, { baseUrl: localSyncBaseUrl });
+          } catch (e) {
+            if (resolveRuntimeConfig().debug) {
+              console.warn("[LocalAPI] local sync device token issue failed:", e?.message || e);
+            }
+          }
           if (!issuedToken) {
             if (drain) {
-              json(res, { ok: false, error: "Unable to issue cloud device token for drain sync" }, 502);
+              json(res, { ok: false, error: "Unable to issue cloud device token for local sync" }, 502);
               return true;
             }
           } else {

--- a/test/cloud-account.test.js
+++ b/test/cloud-account.test.js
@@ -102,6 +102,35 @@ test("mintAccessToken caches by refresh token and skips re-fetch until near expi
   assert.equal(fetchCount, 2);
 });
 
+test("mintAccessToken scopes cache by base URL", async () => {
+  __resetCloudAccountCacheForTests();
+  const calls = [];
+  const accessA = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const accessB = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const fetchImpl = async (urlStr) => {
+    calls.push(String(urlStr));
+    return jsonResponse({ accessToken: calls.length === 1 ? accessA : accessB });
+  };
+
+  const first = await mintAccessToken({
+    baseUrl: "https://cloud-a.example",
+    refreshToken: "refresh-cache",
+    fetchImpl,
+  });
+  const second = await mintAccessToken({
+    baseUrl: "https://cloud-b.example",
+    refreshToken: "refresh-cache",
+    fetchImpl,
+  });
+
+  assert.equal(first.accessToken, accessA);
+  assert.equal(second.accessToken, accessB);
+  assert.deepEqual(calls, [
+    "https://cloud-a.example/api/auth/refresh?client_type=mobile",
+    "https://cloud-b.example/api/auth/refresh?client_type=mobile",
+  ]);
+});
+
 test("mintAccessToken returns null on non-ok refresh and on network error", async () => {
   __resetCloudAccountCacheForTests();
   assert.equal(

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
+const { DEFAULT_BASE_URL } = require("../src/lib/runtime-config");
 
 function createRequest({ method = "GET", headers = {}, body } = {}) {
   const req = new EventEmitter();
@@ -77,6 +78,16 @@ function createSuccessfulSpawn(calls) {
     });
     return child;
   };
+}
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function createRelayedLoginFixture(prefix, { cloudSyncEnabled = true, includeRefreshToken = true } = {}) {
@@ -318,6 +329,398 @@ test("local sync non-drain request mints a device token from relayed login when 
     assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
     assert.ok(fetchCalls.some((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")));
     assert.ok(fetchCalls.some((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")));
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync reuses relayed device token cache across repeated requests", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-cache-");
+  const prevFetch = global.fetch;
+  const fetchCalls = [];
+
+  global.fetch = async (urlStr, opts) => {
+    fetchCalls.push({ url: String(urlStr), opts });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      assert.equal(JSON.parse(String(opts.body || "{}")).refresh_token, "refresh-xyz");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: "access-token", refreshToken: "refresh-rotated" }),
+      };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      assert.equal(opts.headers.Authorization, "Bearer access-token");
+      const body = JSON.parse(String(opts.body || "{}"));
+      assert.equal(body.machine_id, "machine-abcdef12");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "issued-device-token", device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+
+    for (let i = 0; i < 2; i += 1) {
+      const req = createRequest({
+        method: "POST",
+        headers: { "x-tokentracker-local-auth": localAuthToken },
+        body: JSON.stringify({}),
+      });
+      const res = createResponse();
+      const handled = await handler(
+        req,
+        res,
+        new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+      );
+      assert.equal(handled, true);
+      assert.equal(res.statusCode, 200);
+    }
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(calls[1].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).length, 1);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 1);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync reuses relayed device token cache without refresh rotation", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-cache-stable-");
+  const prevFetch = global.fetch;
+  const fetchCalls = [];
+
+  global.fetch = async (urlStr, opts) => {
+    fetchCalls.push({ url: String(urlStr), opts });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      assert.equal(JSON.parse(String(opts.body || "{}")).refresh_token, "refresh-xyz");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: "access-token" }),
+      };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      assert.equal(opts.headers.Authorization, "Bearer access-token");
+      const body = JSON.parse(String(opts.body || "{}"));
+      assert.equal(body.machine_id, "machine-abcdef12");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "issued-device-token", device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+
+    for (let i = 0; i < 2; i += 1) {
+      const req = createRequest({
+        method: "POST",
+        headers: { "x-tokentracker-local-auth": localAuthToken },
+        body: JSON.stringify({}),
+      });
+      const res = createResponse();
+      const handled = await handler(
+        req,
+        res,
+        new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+      );
+      assert.equal(handled, true);
+      assert.equal(res.statusCode, 200);
+    }
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(calls[1].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).length, 1);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 1);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync dedupes concurrent relayed device token minting", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-cache-inflight-");
+  const prevFetch = global.fetch;
+  const fetchCalls = [];
+  const issueStarted = createDeferred();
+  const issueGate = createDeferred();
+
+  global.fetch = async (urlStr, opts) => {
+    fetchCalls.push({ url: String(urlStr), opts });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: "access-token" }),
+      };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      issueStarted.resolve();
+      await issueGate.promise;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "issued-device-token", device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+
+    const firstReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const firstRes = createResponse();
+    const firstSync = handler(firstReq, firstRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync"));
+    await issueStarted.promise;
+
+    const secondReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const secondRes = createResponse();
+    const secondSync = handler(secondReq, secondRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync"));
+    await new Promise((resolve) => setImmediate(resolve));
+    issueGate.resolve();
+
+    assert.equal(await firstSync, true);
+    assert.equal(await secondSync, true);
+    assert.equal(firstRes.statusCode, 200);
+    assert.equal(secondRes.statusCode, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(calls[1].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).length, 1);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 1);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync scopes relayed device token cache by InsForge base URL", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-cache-base-url-");
+  const prevFetch = global.fetch;
+  const fetchCalls = [];
+  const defaultRoot = DEFAULT_BASE_URL.replace(/\/$/, "");
+  const tokensByRoot = new Map([
+    ["https://cloud.example", "cloud-device-token"],
+    [defaultRoot, "default-device-token"],
+  ]);
+
+  global.fetch = async (urlStr, opts) => {
+    const url = String(urlStr);
+    fetchCalls.push({ url, opts });
+    if (url === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: "cloud-access-token" }),
+      };
+    }
+    if (url === `${defaultRoot}/api/auth/refresh?client_type=mobile`) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: "default-access-token" }),
+      };
+    }
+    if (url.endsWith("/functions/tokentracker-device-token-issue")) {
+      const root = url.slice(0, -"/functions/tokentracker-device-token-issue".length);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: tokensByRoot.get(root), device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+
+    const firstReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const firstRes = createResponse();
+    assert.equal(
+      await handler(firstReq, firstRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync")),
+      true,
+    );
+    assert.equal(firstRes.statusCode, 200);
+
+    const secondReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({ insforgeBaseUrl: DEFAULT_BASE_URL }),
+    });
+    const secondRes = createResponse();
+    assert.equal(
+      await handler(secondReq, secondRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync")),
+      true,
+    );
+    assert.equal(secondRes.statusCode, 200);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "cloud-device-token");
+    assert.equal(calls[1].options.env.TOKENTRACKER_DEVICE_TOKEN, "default-device-token");
+    assert.equal(calls[1].options.env.TOKENTRACKER_INSFORGE_BASE_URL, defaultRoot);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).length, 2);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 2);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync remints relayed device token after active refresh token changes", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-cache-split-");
+  const prevFetch = global.fetch;
+  const fetchCalls = [];
+  const issueTokens = ["issued-device-token-1", "issued-device-token-2"];
+
+  function jsonProxyResponse(data) {
+    const body = Buffer.from(JSON.stringify(data));
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        entries: () => [["content-type", "application/json"]],
+        get: (name) => (String(name).toLowerCase() === "content-type" ? "application/json" : null),
+      },
+      arrayBuffer: async () => body,
+    };
+  }
+
+  global.fetch = async (urlStr, opts) => {
+    const parsedBody = JSON.parse(String(opts.body || "{}"));
+    fetchCalls.push({ url: String(urlStr), body: parsedBody });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      if (parsedBody.refresh_token === "refresh-xyz" && opts.credentials === "include") {
+        return jsonProxyResponse({ accessToken: "proxy-access-token", refreshToken: "refresh-new" });
+      }
+      const suffix = parsedBody.refresh_token === "refresh-new" ? "2" : "1";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: `access-token-${suffix}` }),
+      };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      const token = issueTokens.shift();
+      assert.ok(token, "unexpected extra device-token issue request");
+      assert.match(opts.headers.Authorization, /^Bearer access-token-[12]$/);
+      const body = JSON.parse(String(opts.body || "{}"));
+      assert.equal(body.machine_id, "machine-abcdef12");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token, device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+
+    const firstSyncReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const firstSyncRes = createResponse();
+    assert.equal(
+      await handler(firstSyncReq, firstSyncRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync")),
+      true,
+    );
+    assert.equal(firstSyncRes.statusCode, 200);
+
+    const refreshReq = createRequest({ method: "POST" });
+    refreshReq[Symbol.asyncIterator] = async function* () {};
+    const refreshRes = createResponse();
+    assert.equal(
+      await handler(refreshReq, refreshRes, new URL("http://127.0.0.1/api/auth/refresh")),
+      true,
+    );
+    assert.equal(refreshRes.statusCode, 200, refreshRes.body.toString("utf8"));
+
+    const secondSyncReq = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const secondSyncRes = createResponse();
+    assert.equal(
+      await handler(secondSyncReq, secondSyncRes, new URL("http://127.0.0.1/functions/tokentracker-local-sync")),
+      true,
+    );
+    assert.equal(secondSyncRes.statusCode, 200);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token-1");
+    assert.equal(calls[1].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token-2");
+    assert.deepEqual(
+      fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).map((c) => c.body.refresh_token),
+      ["refresh-xyz", "refresh-xyz", "refresh-new"],
+    );
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 2);
+    assert.equal(issueTokens.length, 0);
   } finally {
     restore();
     global.fetch = prevFetch;
@@ -640,7 +1043,7 @@ test("local sync drain request fails when relayed device token cannot be issued"
     assert.equal(res.statusCode, 502);
     assert.deepEqual(JSON.parse(res.body.toString("utf8")), {
       ok: false,
-      error: "Unable to issue cloud device token for drain sync",
+      error: "Unable to issue cloud device token for local sync",
     });
     assert.equal(calls.length, 0);
   } finally {

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -48,7 +48,9 @@ async function getLocalAuthToken(handler) {
 
 function loadLocalApiWithSpawn(fakeSpawn) {
   const childProcess = require("node:child_process");
+  const cloudAccount = require("../src/lib/cloud-account");
   const originalSpawn = childProcess.spawn;
+  cloudAccount.__resetCloudAccountCacheForTests();
   childProcess.spawn = fakeSpawn;
   delete require.cache[require.resolve("../src/lib/local-api")];
   const mod = require("../src/lib/local-api");
@@ -56,6 +58,7 @@ function loadLocalApiWithSpawn(fakeSpawn) {
     mod,
     restore() {
       childProcess.spawn = originalSpawn;
+      cloudAccount.__resetCloudAccountCacheForTests();
       delete require.cache[require.resolve("../src/lib/local-api")];
     },
   };
@@ -73,6 +76,42 @@ function createSuccessfulSpawn(calls) {
       child.emit("close", 0);
     });
     return child;
+  };
+}
+
+function createRelayedLoginFixture(prefix, { cloudSyncEnabled = true, includeRefreshToken = true } = {}) {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: cloudSyncEnabled }));
+  fs.writeFileSync(path.join(trackerDir, "config.json"), JSON.stringify({ machineId: "machine-abcdef12" }));
+  if (includeRefreshToken) {
+    fs.writeFileSync(
+      path.join(trackerDir, "relay-cookies.json"),
+      JSON.stringify({
+        insforge_refresh_token: "insforge_refresh_token=refresh-xyz; Path=/; HttpOnly; SameSite=Lax",
+      }),
+    );
+  }
+
+  return {
+    trackerDir,
+    restore() {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+      else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    },
   };
 }
 
@@ -225,6 +264,234 @@ test("local sync only treats boolean true as drain", async () => {
     } finally {
       restore();
     }
+  }
+});
+
+test("local sync non-drain request mints a device token from relayed login when none is provided", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-");
+  const prevFetch = global.fetch;
+
+  const fetchCalls = [];
+  global.fetch = async (urlStr, opts = {}) => {
+    fetchCalls.push({ url: String(urlStr), opts });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return { ok: true, status: 200, json: async () => ({ accessToken: "access-token" }) };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      assert.equal(opts.headers.Authorization, "Bearer access-token");
+      const body = JSON.parse(String(opts.body || "{}"));
+      assert.equal(body.machine_id, "machine-abcdef12");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "issued-device-token", device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.ok(fetchCalls.some((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")));
+    assert.ok(fetchCalls.some((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")));
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync non-drain request keeps explicit device token without relayed minting", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-explicit-token-");
+  const prevFetch = global.fetch;
+
+  global.fetch = async (urlStr) => {
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({ deviceToken: "explicit-device-token" }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "explicit-device-token");
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync non-drain request falls back to local sync when relayed device token cannot be issued", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-auto-fail-");
+  const prevFetch = global.fetch;
+
+  global.fetch = async (urlStr) => {
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return { ok: true, status: 200, json: async () => ({ accessToken: "access-token" }) };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      return { ok: false, status: 502, json: async () => ({ error: "upstream unavailable" }) };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, undefined);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync non-drain request skips relayed minting when cloud sync is disabled", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-cloud-off-", { cloudSyncEnabled: false });
+  const prevFetch = global.fetch;
+
+  global.fetch = async (urlStr) => {
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, undefined);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
+  }
+});
+
+test("local sync non-drain request skips relayed minting when refresh token is absent", async () => {
+  const calls = [];
+  const fixture = createRelayedLoginFixture("tt-local-sync-no-refresh-", { includeRefreshToken: false });
+  const prevFetch = global.fetch;
+
+  global.fetch = async (urlStr) => {
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({}),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, undefined);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    fixture.restore();
   }
 });
 


### PR DESCRIPTION
## Summary
- allow non-drain local sync requests to best-effort mint a temporary cloud device token from the relayed login session
- keep explicit device tokens as the highest-precedence path
- preserve strict drain behavior: drain sync still returns 502 and does not spawn sync if token minting fails
- add success, fallback, and no-fetch guard tests for the background mint path

## Why
Background auto sync can run without a provided device token even when the dashboard already has a relayed cloud login. Best-effort token minting lets eligible background sync upload normally, while avoiding extra network work when cloud sync is off, no refresh token exists, or a device token was explicitly supplied.

## Performance notes
The new mint attempt is gated by all of these conditions: no explicit device token, cloud sync enabled, and relayed refresh token present. There are no retry loops; non-drain failures fall back to local sync.

## Verification
- node --test test/local-api-security.test.js
- npm --prefix dashboard run build
- npm test
- git diff --check
- codex-dynamic-workflow review: .codex-workflow/runs/20260703-175807/report.md (Final vote 3/3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-drain local sync when cloud sync is enabled: a device token is now automatically minted and applied if it’s missing.
  * If token minting/issuance fails, non-drain local sync continues without a device token (only drain behavior remains erroring).
  * Non-drain local sync now reuses a cached relayed device token and correctly handles refresh rotation and CSRF token persistence.
* **Tests**
  * Expanded local API security tests with isolated relayed-login fixtures, covering device-token minting, caching, reuse across repeated requests, explicit token overrides, and failure/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->