### PR TITLE
feat: aggregate token usage from both native Windows and WSL installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,9 @@ skills-lock.json
 .serena/
 openspec/
 plans/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,126 @@ Key patterns:
 - Reference users with `auth.users(id)`; use `auth.uid()` in RLS policies.
 - For storage uploads, persist both the returned `url` and `key`.
 <!-- INSFORGE:END -->
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:0a1bbe8a -->
+## Issue Tracking with bd (beads)
+
+**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+
+### Why bd?
+
+- Dependency-aware: Track blockers and relationships between issues
+- Git-friendly: Dolt-powered version control with native sync
+- Agent-optimized: JSON output, ready work detection, discovered-from links
+- Prevents duplicate tracking systems and confusion
+
+### Quick Start
+
+**Check for ready work:**
+
+```bash
+bd ready --json
+```
+
+**Create new issues:**
+
+```bash
+bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
+bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
+```
+
+**Claim and update:**
+
+```bash
+bd update <id> --claim --json
+bd update bd-42 --priority 1 --json
+```
+
+**Complete work:**
+
+```bash
+bd close bd-42 --reason "Completed" --json
+```
+
+### Issue Types
+
+- `bug` - Something broken
+- `feature` - New functionality
+- `task` - Work item (tests, docs, refactoring)
+- `epic` - Large feature with subtasks
+- `chore` - Maintenance (dependencies, tooling)
+
+### Priorities
+
+- `0` - Critical (security, data loss, broken builds)
+- `1` - High (major features, important bugs)
+- `2` - Medium (default, nice-to-have)
+- `3` - Low (polish, optimization)
+- `4` - Backlog (future ideas)
+
+### Workflow for AI Agents
+
+1. **Check ready work**: `bd ready` shows unblocked issues
+2. **Claim your task atomically**: `bd update <id> --claim`
+3. **Work on it**: Implement, test, document
+4. **Discover new work?** Create linked issue:
+   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
+5. **Complete**: `bd close <id> --reason "Done"`
+
+### Quality
+- Use `--acceptance` and `--design` fields when creating issues
+- Use `--validate` to check description completeness
+
+### Lifecycle
+- `bd defer <id>` / `bd supersede <id>` for issue management
+- `bd stale` / `bd orphans` / `bd lint` for hygiene
+- `bd human <id>` to flag for human decisions
+- `bd formula list` / `bd mol pour <name>` for structured workflows
+
+### Auto-Sync
+
+bd automatically syncs via Dolt:
+
+- Each write auto-commits to Dolt history
+- No manual export/import needed!
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+### Important Rules
+
+- ✅ Use bd for ALL task tracking
+- ✅ Always use `--json` flag for programmatic use
+- ✅ Link discovered work with `discovered-from` dependencies
+- ✅ Check `bd ready` before asking "what should I work on?"
+- ❌ Do NOT create markdown TODO lists
+- ❌ Do NOT use external issue trackers
+- ❌ Do NOT duplicate tracking systems
+
+For more details, see README.md and docs/QUICKSTART.md.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+
+<!-- END BEADS INTEGRATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,52 @@ After `SMAppService.mainApp.register/unregister` from the bridge (not via `Launc
 ### Working with subagents
 
 After spawning a subagent, **verify file state with direct reads** — don't trust the summary message. Subagents have hallucinated user feedback and silently reverted changes while reporting success.
+
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -62,7 +62,7 @@ const {
   resolveHermesDbPath,
   probeWslDistros,
 } = require("../lib/rollout");
-const { getWslMode, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
+const { getWslMode, getWslPrefer, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 
 async function cmdStatus(argv = []) {
@@ -223,14 +223,14 @@ async function cmdStatus(argv = []) {
 
   // oh-my-pi — passive scan only (no hooks).
   const ompAgentDir = resolveOmpAgentDir(process.env);
-  const ompInstalled = fssync.existsSync(path.join(ompAgentDir, "sessions"));
+  const ompInstalled = Boolean(ompAgentDir) && fssync.existsSync(path.join(ompAgentDir, "sessions"));
   const ompFiles = ompInstalled ? resolveOmpSessionFiles(process.env) : [];
 
   // pi (@mariozechner/pi-coding-agent) — passive scan only (no hooks).
   // Skip when its agent dir collides with omp's; sync would dedupe anyway.
   const piCollides = piAgentDirCollidesWithOmp(process.env);
   const piAgentDir = resolvePiAgentDir(process.env);
-  const piInstalled = !piCollides && fssync.existsSync(path.join(piAgentDir, "sessions"));
+  const piInstalled = !piCollides && Boolean(piAgentDir) && fssync.existsSync(path.join(piAgentDir, "sessions"));
   const piFiles = piInstalled ? resolvePiSessionFiles(process.env) : [];
 
   // Craft Agents — passive scan only (no hooks).
@@ -429,6 +429,7 @@ async function cmdStatus(argv = []) {
       ...(process.platform === "win32"
         ? {
             wsl_mode: getWslMode(),
+            wsl_prefer: getWslMode() === "both" ? getWslPrefer() : undefined,
             wsl_mode_invalid: isInvalidWslMode(),
             wsl_distros: wslDistros.map((d) => ({ name: d.name, version: d.version })),
           }
@@ -539,6 +540,9 @@ async function cmdStatus(argv = []) {
         const lines = [
           `- WSL mode: ${wslMode}${modeSuffix}`,
         ];
+        if (wslMode === "both") {
+          lines.push(`  prefer: ${getWslPrefer()}`);
+        }
         if (wslDistros.length > 0) {
           lines.push(`  distros: ${wslDistros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`);
         }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -5,6 +5,9 @@ const fssync = require("node:fs");
 const cp = require("node:child_process");
 const readline = require("node:readline");
 
+const { resolveInstallPaths, ensureFlatCursor } = require("../lib/install-resolver");
+const { multiInstallParse, mergeBothFileSources } = require("../lib/multi-install-parser");
+const wsl = require("../lib/wsl-probe");
 const { ensureDir, readJson, writeJson, openLock } = require("../lib/fs");
 const {
   listRolloutFiles,
@@ -697,7 +700,9 @@ async function cmdSync(argv) {
     }
 
     // ── Kilo Code VS Code extension (Cline-style ui_messages.json) ──
-    const kilocodeTaskFiles = sourceAllowed("kilocode") ? resolveKilocodeTaskFiles(process.env) : [];
+    const kilocodeTaskFiles = sourceAllowed("kilocode")
+      ? mergeBothFileSources({ resolveFiles: resolveKilocodeTaskFiles, env: process.env })
+      : [];
     let kilocodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (kilocodeTaskFiles.length > 0) {
       if (progress?.enabled) {
@@ -728,32 +733,39 @@ async function cmdSync(argv) {
     // ── Goose (Block) — SQLite sessions with cumulative tokens per session ──
     const gooseDbPath = resolveGooseDbPath(process.env);
     let gooseResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (sourceAllowed("goose") && gooseDbPath && fssync.existsSync(gooseDbPath)) {
-      if (progress?.enabled) {
-        progress.start(`Parsing Goose ${renderBar(0)} 0 sessions | buckets 0`);
-      }
-      try {
-        gooseResult = await parseGooseIncremental({
-          dbPath: gooseDbPath,
-          cursors,
-          queuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Goose ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-        });
-      } catch (err) {
-        warnProviderParseFailure("Goose", err, opts);
+    if (sourceAllowed("goose")) {
+      const gooseMode = wsl.getWslMode(process.env);
+      if (gooseMode === "both" && process.platform === "win32") {
+        const home = os.homedir();
+        const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+        const nativeDb = path.join(appData, "goose", "sessions", "sessions.db");
+        const wslDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/goose/sessions") : null;
+        const wslDb = wslDir ? path.join(wslDir, "sessions.db") : null;
+        const goosePaths = resolveInstallPaths("goose", { nativeValue: nativeDb, wslValue: wslDb });
+        if (goosePaths.native || goosePaths.wsl) {
+          if (progress?.enabled) progress.start(`Parsing Goose ${renderBar(0)} 0 sessions | buckets 0`);
+          try {
+            gooseResult = await multiInstallParse({
+              paths: goosePaths, parserFn: parseGooseIncremental, providerName: "goose",
+              cursors, getParams: (p) => ({ dbPath: p }), queuePath, onProgress: gooseOnProgress,
+            });
+          } catch (err) { warnProviderParseFailure("Goose", err, opts); }
+        }
+      } else if (gooseDbPath && fssync.existsSync(gooseDbPath)) {
+        if (progress?.enabled) progress.start(`Parsing Goose ${renderBar(0)} 0 sessions | buckets 0`);
+        ensureFlatCursor(cursors, "goose");
+        try {
+          gooseResult = await parseGooseIncremental({
+            dbPath: gooseDbPath, cursors, queuePath, onProgress: gooseOnProgress,
+          });
+        } catch (err) { warnProviderParseFailure("Goose", err, opts); }
       }
     }
 
     // ── Droid (Factory CLI) — passive reader for ~/.factory/sessions/*.settings.json ──
-    const droidSettingsFiles = sourceAllowed("droid") ? listDroidSettingsFiles(process.env) : [];
+    const droidSettingsFiles = sourceAllowed("droid")
+      ? mergeBothFileSources({ resolveFiles: listDroidSettingsFiles, env: process.env })
+      : [];
     let droidResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (droidSettingsFiles.length > 0) {
       if (progress?.enabled) {
@@ -788,27 +800,32 @@ async function cmdSync(argv) {
     // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (sourceAllowed("zed") && zedDbPath && fssync.existsSync(zedDbPath)) {
-      if (progress?.enabled) {
-        progress.start(`Parsing Zed Agent ${renderBar(0)} 0 threads | buckets 0`);
-      }
-      try {
-        zedResult = await parseZedIncremental({
-          dbPath: zedDbPath,
-          cursors,
-          queuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Zed Agent ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} threads | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-        });
-      } catch (err) {
-        warnProviderParseFailure("Zed Agent", err, opts);
+    if (sourceAllowed("zed")) {
+      const zedMode = wsl.getWslMode(process.env);
+      if (zedMode === "both" && process.platform === "win32") {
+        const home = os.homedir();
+        const local = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+        const nativeDb = path.join(local, "Zed", "threads", "threads.db");
+        const wslThreadsDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/zed/threads") : null;
+        const wslDb = wslThreadsDir ? path.join(wslThreadsDir, "threads.db") : null;
+        const zedPaths = resolveInstallPaths("zed", { nativeValue: nativeDb, wslValue: wslDb });
+        if (zedPaths.native || zedPaths.wsl) {
+          if (progress?.enabled) progress.start(`Parsing Zed Agent ${renderBar(0)} 0 threads | buckets 0`);
+          try {
+            zedResult = await multiInstallParse({
+              paths: zedPaths, parserFn: parseZedIncremental, providerName: "zed",
+              cursors, getParams: (p) => ({ dbPath: p }), queuePath, onProgress: zedOnProgress,
+            });
+          } catch (err) { warnProviderParseFailure("Zed Agent", err, opts); }
+        }
+      } else if (zedDbPath && fssync.existsSync(zedDbPath)) {
+        if (progress?.enabled) progress.start(`Parsing Zed Agent ${renderBar(0)} 0 threads | buckets 0`);
+        ensureFlatCursor(cursors, "zed");
+        try {
+          zedResult = await parseZedIncremental({
+            dbPath: zedDbPath, cursors, queuePath, onProgress: zedOnProgress,
+          });
+        } catch (err) { warnProviderParseFailure("Zed Agent", err, opts); }
       }
     }
 
@@ -920,27 +937,75 @@ async function cmdSync(argv) {
 
     // ── Hermes Agent (SQLite-based) ──
     let hermesResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const hermesPath = resolveHermesPath();
-    if (sourceAllowed("hermes") && hermesPath && fssync.existsSync(hermesPath)) {
-      if (progress?.enabled) {
-        progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
+    if (sourceAllowed("hermes")) {
+      const override = process.env.TOKENTRACKER_HERMES_HOME;
+      const overridePath = typeof override === "string" && override.trim().length > 0 ? override.trim() : null;
+      if (overridePath) {
+        if (fssync.existsSync(overridePath)) {
+          if (progress?.enabled) {
+            progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
+          }
+          ensureFlatCursor(cursors, "hermes");
+          try {
+            hermesResult = await parseHermesIncremental({
+              hermesPath: overridePath,
+              cursors,
+              queuePath,
+              onProgress: hermesOnProgress,
+            });
+          } catch (err) {
+            warnProviderParseFailure("Hermes", err, opts);
+          }
+        }
+      } else {
+        const home = os.homedir();
+        const defaultPath = path.join(home, ".hermes");
+        const nativeValue = process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+          ? path.join(process.env.LOCALAPPDATA.trim(), "hermes") : defaultPath;
+        const hermesPaths = resolveInstallPaths("hermes", { nativeValue, wslDir: ".hermes" });
+        if (hermesPaths.native || hermesPaths.wsl) {
+          if (progress?.enabled) {
+            progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
+          }
+          try {
+            hermesResult = await multiInstallParse({
+              paths: hermesPaths,
+              parserFn: parseHermesIncremental,
+              providerName: "hermes",
+              cursors,
+              getParams: (path) => ({ hermesPath: path }),
+              queuePath,
+              onProgress: hermesOnProgress,
+            });
+          } catch (err) {
+            warnProviderParseFailure("Hermes", err, opts);
+          }
+        }
       }
-      try {
-        hermesResult = await parseHermesIncremental({
-          hermesPath,
-          cursors,
-          queuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Hermes ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-        });
-      } catch (err) {
-        warnProviderParseFailure("Hermes", err, opts);
-      }
+    }
+
+    function hermesOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing Hermes ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
+    }
+
+    function gooseOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing Goose ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
+    }
+
+    function zedOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing Zed Agent ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} threads | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
     }
 
     // ── Kiro CLI (reads ~/Library/Application Support/kiro-cli/data.sqlite3
@@ -1005,7 +1070,9 @@ async function cmdSync(argv) {
 
     // ── Kimi Code official (@moonshot-ai/kimi-code, ~/.kimi-code) ──
     let kimiCodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kimiCodeWireFiles = sourceAllowed("kimi-code") ? resolveKimiCodeWireFiles(process.env) : [];
+    const kimiCodeWireFiles = sourceAllowed("kimi-code")
+      ? mergeBothFileSources({ resolveFiles: resolveKimiCodeWireFiles, env: process.env })
+      : [];
     if (kimiCodeWireFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Kimi Code (official) ${renderBar(0)} | buckets 0`);
@@ -1033,7 +1100,9 @@ async function cmdSync(argv) {
     // Tencent's CodeBuddy CLI is a Claude Code clone; no hook system, so we
     // tail the per-session JSONL conversation logs incrementally on each sync.
     let codebuddyResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const codebuddyFiles = sourceAllowed("codebuddy") ? resolveCodebuddyProjectFiles(process.env) : [];
+    const codebuddyFiles = sourceAllowed("codebuddy")
+      ? mergeBothFileSources({ resolveFiles: resolveCodebuddyProjectFiles, env: process.env })
+      : [];
     if (codebuddyFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing CodeBuddy ${renderBar(0)} | buckets 0`);
@@ -1063,7 +1132,9 @@ async function cmdSync(argv) {
     // sub-agent logs nest one level deeper, so the resolver recurses. See the
     // parser comment in rollout.js for the cache-aware token math.
     let workbuddyResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const workbuddyFiles = sourceAllowed("workbuddy") ? resolveWorkbuddyProjectFiles(process.env) : [];
+    const workbuddyFiles = sourceAllowed("workbuddy")
+      ? mergeBothFileSources({ resolveFiles: resolveWorkbuddyProjectFiles, env: process.env })
+      : [];
     if (workbuddyFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing WorkBuddy ${renderBar(0)} | buckets 0`);
@@ -1089,7 +1160,9 @@ async function cmdSync(argv) {
 
     // ── oh-my-pi (passive ~/.omp/agent/sessions/**/*.jsonl reader) ──
     let ompResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const ompFiles = sourceAllowed("omp") ? resolveOmpSessionFiles(process.env) : [];
+    const ompFiles = sourceAllowed("omp")
+      ? mergeBothFileSources({ resolveFiles: resolveOmpSessionFiles, env: process.env })
+      : [];
     if (ompFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing oh-my-pi ${renderBar(0)} | buckets 0`);
@@ -1120,7 +1193,7 @@ async function cmdSync(argv) {
     let piResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const piFiles = !sourceAllowed("pi") || piAgentDirCollidesWithOmp(process.env)
       ? []
-      : resolvePiSessionFiles(process.env);
+      : mergeBothFileSources({ resolveFiles: resolvePiSessionFiles, env: process.env });
     if (piFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing pi ${renderBar(0)} | buckets 0`);
@@ -1146,7 +1219,9 @@ async function cmdSync(argv) {
 
     // ── Craft Agents (passive ~/.craft-agent + workspaces session.jsonl reader) ──
     let craftResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const craftFiles = sourceAllowed("craft") ? resolveCraftSessionFiles(process.env) : [];
+    const craftFiles = sourceAllowed("craft")
+      ? mergeBothFileSources({ resolveFiles: resolveCraftSessionFiles, env: process.env })
+      : [];
     if (craftFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Craft ${renderBar(0)} | buckets 0`);

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -1,0 +1,52 @@
+const fssync = require("node:fs");
+const wsl = require("./wsl-probe");
+
+function resolveInstallPaths(providerName, { nativeValue, wslDir, wslValue } = {}, env = process.env, deps = {}) {
+  if (process.platform !== "win32") {
+    return { native: nativeValue ?? null, wsl: null };
+  }
+
+  const wslCandidate = wslValue !== undefined
+    ? (wsl.shouldProbeWsl(env) ? wslValue : null)
+    : (wslDir && wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslDir, { ...deps, env }) : null);
+  const nativeCandidate = wsl.shouldProbeNative(env) && nativeValue
+    ? pathExists(nativeValue) : null;
+
+  if (wsl.getWslMode(env) === "both") {
+    return { native: nativeCandidate, wsl: wslCandidate };
+  }
+
+  const single = wsl.pickWin32Path({ wslValue: wslCandidate, nativeValue: nativeCandidate, env, platform: "win32" });
+  return { native: single, wsl: null };
+}
+
+function pathExists(p) {
+  try { return fssync.existsSync(p) ? p : null; } catch (_e) { return null; }
+}
+
+function ensureNamespacedCursors(cursors, providerName) {
+  const state = cursors[providerName] && typeof cursors[providerName] === "object" ? cursors[providerName] : {};
+
+  if (state.native !== undefined || state.wsl !== undefined) {
+    return state;
+  }
+
+  const flat = { ...state };
+  cursors[providerName] = { native: { ...flat }, wsl: { ...flat } };
+  return cursors[providerName];
+}
+
+function ensureFlatCursor(cursors, providerName) {
+  const state = cursors[providerName];
+  if (!state || typeof state !== "object") return;
+  if (state.native === undefined && state.wsl === undefined) return;
+
+  const merged = { ...state.wsl, ...state.native };
+  cursors[providerName] = merged;
+}
+
+module.exports = {
+  resolveInstallPaths,
+  ensureNamespacedCursors,
+  ensureFlatCursor,
+};

--- a/src/lib/multi-install-parser.js
+++ b/src/lib/multi-install-parser.js
@@ -1,0 +1,143 @@
+const wsl = require("./wsl-probe");
+const { ensureNamespacedCursors } = require("./install-resolver");
+
+const ISSUE_URL = "https://github.com/mm7894215/TokenTracker/issues";
+
+function emptyResult() {
+  return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+}
+
+async function multiInstallParse({ paths, parserFn, providerName, cursors, getParams, onProgress, ...shared }) {
+  const installKeys = Object.keys(paths).filter(k => paths[k]);
+  if (installKeys.length === 0) return emptyResult();
+  const env = shared.env || process.env;
+
+  if (installKeys.length === 1) {
+    return await parserFn({
+      ...getParams(paths[installKeys[0]], installKeys[0]),
+      ...shared,
+      cursors,
+      onProgress,
+    });
+  }
+
+  const prefer = wsl.getWslPrefer(env);
+  const ns = ensureNamespacedCursors(cursors, providerName);
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+  let bucketsQueued = 0;
+
+  if (prefer) {
+    // Conflict resolution mode: parse preferred install first, snapshot, then
+    // parse second. Restore snapshot for any overlapping bucket.
+    const firstKey = prefer === "wsl" ? "wsl" : "native";
+    const secondKey = prefer === "wsl" ? "native" : "wsl";
+
+    cursors[providerName] = ns[firstKey];
+    const firstResult = await parserFn({
+      ...getParams(paths[firstKey], firstKey), ...shared, cursors,
+      onProgress: wrapProgress(onProgress, firstKey),
+    });
+    ns[firstKey] = cursors[providerName];
+    recordsProcessed += firstResult.recordsProcessed || 0;
+    eventsAggregated += firstResult.eventsAggregated || 0;
+    bucketsQueued += firstResult.bucketsQueued || 0;
+
+    const preferredBuckets = snapshotBuckets(cursors.hourly);
+
+    cursors[providerName] = ns[secondKey];
+    let secondResult;
+    try {
+      secondResult = await parserFn({
+        ...getParams(paths[secondKey], secondKey), ...shared, cursors,
+        onProgress: wrapProgress(onProgress, secondKey),
+      });
+    } catch (parseErr) {
+      cursors[providerName] = ns;
+      throw parseErr;
+    }
+    ns[secondKey] = cursors[providerName];
+    recordsProcessed += secondResult.recordsProcessed || 0;
+    eventsAggregated += secondResult.eventsAggregated || 0;
+    bucketsQueued += secondResult.bucketsQueued || 0;
+
+    // Restore preferred install's data for overlapping buckets
+    const conflicts = [];
+    if (cursors.hourly?.buckets) {
+      for (const key of Object.keys(preferredBuckets)) {
+        if (cursors.hourly.buckets[key]) {
+          conflicts.push(key);
+          cursors.hourly.buckets[key] = preferredBuckets[key];
+        }
+      }
+    }
+
+    cursors[providerName] = ns;
+
+    if (conflicts.length > 0) {
+      console.warn(
+        `[tokentracker] ${providerName}: ${conflicts.length} bucket(s) had data from both installs — ` +
+        `using ${firstKey} (TOKENTRACKER_WSL_PREFER=${prefer}), discarded ${secondKey} contributions. ` +
+        `Buckets: ${conflicts.slice(0, 5).join(", ")}${conflicts.length > 5 ? ` +${conflicts.length - 5} more` : ""}. ` +
+        `Report unexpected behavior at ${ISSUE_URL}`
+      );
+    }
+  } else {
+    // No preference: parse both installs and keep all data.
+    for (let i = 0; i < installKeys.length; i++) {
+      const key = installKeys[i];
+      cursors[providerName] = ns[key];
+      try {
+        const result = await parserFn({
+          ...getParams(paths[key], key), ...shared, cursors,
+          onProgress: wrapProgress(onProgress, key),
+        });
+        ns[key] = cursors[providerName];
+        recordsProcessed += result.recordsProcessed || 0;
+        eventsAggregated += result.eventsAggregated || 0;
+        bucketsQueued += result.bucketsQueued || 0;
+      } catch (parseErr) {
+        cursors[providerName] = ns;
+        throw parseErr;
+      }
+    }
+    cursors[providerName] = ns;
+  }
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+function snapshotBuckets(hourly) {
+  if (!hourly?.buckets) return {};
+  const out = {};
+  for (const [key, val] of Object.entries(hourly.buckets)) {
+    out[key] = JSON.parse(JSON.stringify(val));
+  }
+  return out;
+}
+
+function wrapProgress(onProgress, installKey) {
+  if (!onProgress) return undefined;
+  return (p) => onProgress({ ...p, install: installKey });
+}
+
+function mergeBothFileSources({ resolveFiles, env }) {
+  const files = resolveFiles(env);
+  if (files.length === 0) return files;
+  if (process.platform !== "win32" || wsl.getWslMode(env) !== "both") return files;
+
+  const nativeEnv = { ...env, TOKENTRACKER_WSL_MODE: "native-only" };
+  const wslEnv = { ...env, TOKENTRACKER_WSL_MODE: "wsl-only" };
+
+  const nativeFiles = resolveFiles(nativeEnv);
+  const wslFiles = resolveFiles(wslEnv);
+
+  const seen = new Set();
+  const merged = [];
+  for (const f of [...nativeFiles, ...wslFiles]) {
+    if (!seen.has(f)) { seen.add(f); merged.push(f); }
+  }
+  return merged;
+}
+
+module.exports = { multiInstallParse, emptyResult, mergeBothFileSources };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7,6 +7,7 @@ const crypto = require("node:crypto");
 const { ensureDir } = require("./fs");
 const { readSqliteJsonRows } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
+const { resolveInstallPaths } = require("./install-resolver");
 
 const DEFAULT_SOURCE = "codex";
 const DEFAULT_MODEL = "unknown";
@@ -3787,23 +3788,11 @@ function resolveHermesPath(env = process.env, deps = {}) {
   }
   const home = require("node:os").homedir();
   const defaultPath = path.join(home, ".hermes");
-  // On Windows, scan BOTH the native install (%LOCALAPPDATA%\hermes) and
-  // any WSL distros running Hermes Agent. Each install has its own independent
-  // state.db with different sessions, so there is no double-counting risk.
-  // TOKENTRACKER_WSL_MODE controls which source takes priority.
   if (process.platform === "win32") {
-    let nativePath = null;
-    if (wsl.shouldProbeNative(env)) {
-      const localAppData = typeof env.LOCALAPPDATA === "string" ? env.LOCALAPPDATA.trim() : "";
-      if (localAppData.length > 0) {
-        const candidate = path.join(localAppData, "hermes");
-        try {
-          if (fssync.existsSync(candidate)) nativePath = candidate;
-        } catch (_e) { }
-      }
-    }
-    const wslPath = wsl.shouldProbeWsl(env) ? discoverWslHermesHome(deps) : null;
-    const picked = wsl.pickWin32Path({ wslValue: wslPath, nativeValue: nativePath, env, platform: "win32" });
+    const localAppData = typeof env.LOCALAPPDATA === "string" ? env.LOCALAPPDATA.trim() : "";
+    const nativeValue = localAppData.length > 0 ? path.join(localAppData, "hermes") : null;
+    const paths = resolveInstallPaths("hermes", { nativeValue, wslDir: ".hermes" }, env, deps);
+    const picked = paths.native || paths.wsl;
     if (picked) return picked;
     const mode = wsl.getWslMode(env);
     if (mode === "wsl-only" || mode === "native-only") return null;
@@ -3839,16 +3828,12 @@ function discoverWslHermesHome(deps = {}) {
 }
 
 function pickWin32ProviderPath({ env = process.env, nativeValue, wslProviderDir, wslValue }) {
-  const nativeCandidate = wsl.shouldProbeNative(env) ? nativeValue : null;
-  const wslCandidate = wslValue !== undefined
-    ? wslValue
-    : (wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslProviderDir) : null);
-  return wsl.pickWin32Path({
-    wslValue: wslCandidate,
-    nativeValue: nativeCandidate,
-    env,
-    platform: "win32",
-  });
+  const paths = resolveInstallPaths("_", { nativeValue, wslDir: wslProviderDir, wslValue }, env);
+  return paths.native || paths.wsl;
+}
+
+function resolveAllWin32ProviderPaths({ env = process.env, nativeValue, wslProviderDir, wslValue }) {
+  return resolveInstallPaths("_", { nativeValue, wslDir: wslProviderDir, wslValue }, env);
 }
 
 function resolveHermesDbPath(env = process.env) {
@@ -6526,13 +6511,10 @@ function resolveZedDbPath(env = process.env) {
   if (process.platform === "win32") {
     const local = env.LOCALAPPDATA || path.join(home, "AppData", "Local");
     const native = path.join(local, "Zed", "threads", "threads.db");
-    let nativeExists = null;
-    if (wsl.shouldProbeNative(env)) {
-      try { if (fssync.existsSync(native)) nativeExists = native; } catch (_e) { }
-    }
-    const wslDir = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".local/share/zed/threads", { env }) : null;
-    const wslValue = wslDir ? path.join(wslDir, "threads.db") : null;
-    const picked = wsl.pickWin32Path({ wslValue, nativeValue: nativeExists, env, platform: "win32" });
+    const wslThreadsDir = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".local/share/zed/threads", { env }) : null;
+    const wslDbPath = wslThreadsDir ? path.join(wslThreadsDir, "threads.db") : null;
+    const paths = resolveInstallPaths("zed", { nativeValue: native, wslValue: wslDbPath }, env);
+    const picked = paths.native || paths.wsl;
     if (picked) return picked;
     const mode = wsl.getWslMode(env);
     return mode === "wsl-only" || mode === "native-only" ? null : native;
@@ -6909,13 +6891,10 @@ function resolveGooseDbPath(env = process.env) {
   } else if (process.platform === "win32") {
     const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
     const native = path.join(appData, "goose", "sessions", "sessions.db");
-    let nativeExists = null;
-    if (wsl.shouldProbeNative(env)) {
-      try { if (fssync.existsSync(native)) nativeExists = native; } catch (_e) { }
-    }
     const wslDir = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".local/share/goose/sessions", { env }) : null;
     const wslValue = wslDir ? path.join(wslDir, "sessions.db") : null;
-    const picked = wsl.pickWin32Path({ wslValue, nativeValue: nativeExists, env, platform: "win32" });
+    const paths = resolveInstallPaths("goose", { nativeValue: native, wslValue }, env);
+    const picked = paths.native || paths.wsl;
     if (picked) candidates.push(picked);
     for (const c of candidates) {
       if (fssync.existsSync(c)) return c;

--- a/src/lib/wsl-probe.js
+++ b/src/lib/wsl-probe.js
@@ -16,7 +16,10 @@ const WSL_MODES = new Set([
   "native-first",
   "wsl-only",
   "native-only",
+  "both",
 ]);
+
+const WSL_PREFER_MODES = new Set(["native", "wsl"]);
 
 function defaultRunWsl(args, { utf16 = false } = {}) {
   const { execFileSync } = require("node:child_process");
@@ -74,6 +77,12 @@ function getWslMode(env = process.env) {
   return WSL_MODES.has(raw) ? raw : "wsl-first";
 }
 
+function getWslPrefer(env = process.env) {
+  const raw = normalizeWslMode(env.TOKENTRACKER_WSL_PREFER);
+  if (!raw) return null;
+  return WSL_PREFER_MODES.has(raw) ? raw : null;
+}
+
 function isInvalidWslMode(env = process.env) {
   const value = env.TOKENTRACKER_WSL_MODE;
   if (value == null || String(value).trim() === "") return false;
@@ -98,11 +107,30 @@ function pickWin32Path({
 
   const mode = getWslMode(env);
 
+  if (mode === "both") return wslValue ?? nativeValue ?? null;
   if (mode === "wsl-only") return wslValue ?? null;
   if (mode === "native-only") return nativeValue ?? null;
   if (mode === "native-first") return nativeValue ?? wslValue ?? null;
 
   return wslValue ?? nativeValue ?? null;
+}
+
+function resolveAllWin32Paths({
+  nativeValue,
+  wslValue,
+  env = process.env,
+  platform = process.platform,
+}) {
+  if (platform !== "win32") return { native: null, wsl: null };
+
+  const mode = getWslMode(env);
+
+  if (mode === "both") {
+    return { native: nativeValue ?? null, wsl: wslValue ?? null };
+  }
+
+  const single = pickWin32Path({ wslValue, nativeValue, env, platform });
+  return { native: single, wsl: null };
 }
 
 function lookupWslUser(distroName, runWsl, useCache) {
@@ -173,9 +201,11 @@ module.exports = {
   isUncPath,
   snapshotSqliteDb,
   getWslMode,
+  getWslPrefer,
   isInvalidWslMode,
   shouldProbeWsl,
   shouldProbeNative,
   pickWin32Path,
+  resolveAllWin32Paths,
   normalizeWslMode,
 };

--- a/test/cursor-migration.test.js
+++ b/test/cursor-migration.test.js
@@ -1,0 +1,91 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
+
+const { ensureNamespacedCursors, ensureFlatCursor } = require("../src/lib/install-resolver");
+const { multiInstallParse } = require("../src/lib/multi-install-parser");
+
+test("flat cursor migrates to both namespaces", () => {
+  const cursors = {
+    hermes: {
+      lastCompletedStartedAt: 100,
+      unfinishedSessionIds: ["s1", "s2"],
+      snapshots: { s1: { in: 50, out: 25 } },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+
+  const ns = ensureNamespacedCursors(cursors, "hermes");
+
+  assert.ok(ns.native, "native namespace should exist");
+  assert.ok(ns.wsl, "wsl namespace should exist");
+  assert.equal(ns.native.lastCompletedStartedAt, 100);
+  assert.deepEqual(ns.native.unfinishedSessionIds, ["s1", "s2"]);
+  assert.deepEqual(ns.native.snapshots, { s1: { in: 50, out: 25 } });
+  assert.equal(ns.wsl.lastCompletedStartedAt, 100, "wsl should also have the flat data");
+  assert.deepEqual(ns.wsl.snapshots, { s1: { in: 50, out: 25 } });
+});
+
+test("ensureFlatCursor merges namespaces back to flat", () => {
+  const cursors = {
+    hermes: {
+      native: { lastCompletedStartedAt: 50, snapshots: {} },
+      wsl: { lastCompletedStartedAt: 100, snapshots: {} },
+    },
+  };
+
+  ensureFlatCursor(cursors, "hermes");
+
+  assert.equal(cursors.hermes.native, undefined, "native key should be removed");
+  assert.equal(cursors.hermes.wsl, undefined, "wsl key should be removed");
+  assert.equal(cursors.hermes.lastCompletedStartedAt, 50, "native value should win on conflict");
+});
+
+test("ensureFlatCursor no-ops on already-flat cursor", () => {
+  const cursors = {
+    hermes: { lastCompletedStartedAt: 50, snapshots: {} },
+  };
+
+  ensureFlatCursor(cursors, "hermes");
+
+  assert.equal(cursors.hermes.lastCompletedStartedAt, 50);
+});
+
+test("dual-parse after migration maintains independent namespace state", async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-cursor-migrate-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const queuePath = path.join(tmpDir, "queue.jsonl");
+
+  const cursors = {
+    hourly: { buckets: {} },
+    hermes: { lastCompletedStartedAt: 100, unfinishedSessionIds: ["old"], snapshots: {} },
+  };
+
+  const r = await multiInstallParse({
+    paths: { native: "/native-hermes", wsl: "/wsl-hermes" },
+    parserFn: async ({ cursors: c }) => {
+      c.hermes = c.hermes || {};
+      c.hermes.lastRun = c.hermes.lastRun || 0;
+      c.hermes.lastRun += 1;
+      c.hermes.unfinishedSessionIds = c.hermes.unfinishedSessionIds || [];
+      c.hermes.unfinishedSessionIds.push(`session-${Date.now()}`);
+      return { recordsProcessed: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    getParams: (p) => ({ hermesPath: p }),
+    queuePath,
+  });
+
+  assert.equal(r.recordsProcessed, 2, "both installs should parse");
+  assert.ok(cursors.hermes.native, "native namespace exists");
+  assert.ok(cursors.hermes.wsl, "wsl namespace exists");
+  assert.ok(cursors.hermes.native.lastRun >= 1);
+  assert.ok(cursors.hermes.wsl.lastRun >= 1);
+  assert.ok(cursors.hermes.native.lastCompletedStartedAt === 100,
+    "flat cursor data survived migration in native");
+  assert.ok(cursors.hermes.wsl.lastCompletedStartedAt === 100,
+    "flat cursor data survived migration in wsl");
+});

--- a/test/dual-install-edge-cases.test.js
+++ b/test/dual-install-edge-cases.test.js
@@ -1,0 +1,98 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const { resolveInstallPaths, ensureNamespacedCursors } = require("../src/lib/install-resolver");
+const { getWslMode, getWslPrefer, resetWslProbeCache } = require("../src/lib/wsl-probe");
+const { multiInstallParse, emptyResult } = require("../src/lib/multi-install-parser");
+const { mockPlatform } = require("./helpers/mock");
+
+test("edge: WSL probe failure in both mode falls back gracefully", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "edge-wsl-fail-"));
+  try {
+    const nativeDir = path.join(tmpDir, "native");
+    fs.mkdirSync(nativeDir, { recursive: true });
+    fs.writeFileSync(path.join(nativeDir, "state.db"), "fake db");
+
+    const r = resolveInstallPaths("hermes",
+      { nativeValue: nativeDir, wslValue: null },
+      { TOKENTRACKER_WSL_MODE: "both" },
+      { runWsl: () => { throw new Error("wsl not found"); }, existsSync: () => false },
+    );
+    assert.equal(r.native, nativeDir);
+    assert.equal(r.wsl, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("edge: both mode with single native install produces same result as non-both", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "edge-single-"));
+  try {
+    const nativeDir = path.join(tmpDir, "native");
+    fs.mkdirSync(nativeDir, { recursive: true });
+
+    const bothResult = resolveInstallPaths("hermes",
+      { nativeValue: nativeDir, wslValue: null },
+      { TOKENTRACKER_WSL_MODE: "both" },
+      { runWsl: () => { throw new Error("no wsl"); }, existsSync: () => false },
+    );
+
+    const wslFirstResult = resolveInstallPaths("hermes",
+      { nativeValue: nativeDir, wslValue: null },
+      { TOKENTRACKER_WSL_MODE: "wsl-first" },
+      { runWsl: () => { throw new Error("no wsl"); }, existsSync: () => false },
+    );
+
+    assert.equal(bothResult.native, nativeDir);
+    assert.equal(bothResult.wsl, null);
+    assert.equal(wslFirstResult.native, nativeDir);
+    assert.equal(wslFirstResult.wsl, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("edge: ensureNamespacedCursors handles mixed native+wsl state", () => {
+  const cursors = {
+    hermes: {
+      native: { lastCompletedStartedAt: 50, unfinishedSessionIds: ["a"], snapshots: {} },
+      wsl: { lastCompletedStartedAt: 10, unfinishedSessionIds: ["b"], snapshots: {} },
+    },
+  };
+  const ns = ensureNamespacedCursors(cursors, "hermes");
+  assert.equal(ns.native.lastCompletedStartedAt, 50);
+  assert.equal(ns.wsl.lastCompletedStartedAt, 10);
+  assert.deepEqual(ns.native.unfinishedSessionIds, ["a"]);
+  assert.deepEqual(ns.wsl.unfinishedSessionIds, ["b"]);
+});
+
+test("edge: multiInstallParse handles WSL probe timeout graceful skip", async () => {
+  const cursors = { hourly: {} };
+  const r = await multiInstallParse({
+    paths: { native: "/native", wsl: null },
+    parserFn: async ({ cursors: c }) => {
+      c.hermes = { ok: true };
+      return { recordsProcessed: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    getParams: (path) => ({ hermesPath: path }),
+  });
+  assert.equal(r.recordsProcessed, 1);
+});
+
+test("edge: WSL_PREFER is null when unset, native/wsl when set", () => {
+  assert.equal(getWslPrefer({}), null);
+  assert.equal(getWslPrefer({ TOKENTRACKER_WSL_PREFER: "wsl" }), "wsl");
+  assert.equal(getWslPrefer({ TOKENTRACKER_WSL_PREFER: "native" }), "native");
+});
+
+test("edge: resetWslProbeCache cleans shared state", () => {
+  resetWslProbeCache();
+  assert.doesNotThrow(() => resetWslProbeCache());
+});

--- a/test/dual-install-integration.test.js
+++ b/test/dual-install-integration.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
+
+const { multiInstallParse } = require("../src/lib/multi-install-parser");
+
+function makeWireFile(dir, filename, events) {
+  const content = events.map(e => JSON.stringify(e)).join("\n") + "\n";
+  fs.writeFileSync(path.join(dir, filename), content);
+}
+
+test("integration: dual-parse with Kimi Code wire files", async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-int-kimi-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const nativeDir = path.join(tmpDir, "native", "sessions", "agent-a");
+  const wslDir = path.join(tmpDir, "wsl", "sessions", "agent-b");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const t1 = new Date("2026-01-01T10:15:00.000Z").getTime();
+  const t2 = new Date("2026-01-01T10:45:00.000Z").getTime();
+  const t3 = new Date("2026-01-01T11:15:00.000Z").getTime();
+
+  makeWireFile(nativeDir, "wire.jsonl", [
+    { type: "step.end", uuid: "nat-1", usage: { input_tokens: 100, output_tokens: 50 }, time: t1, model: "gpt-4" },
+    { type: "step.end", uuid: "nat-2", usage: { input_tokens: 200, output_tokens: 100 }, time: t2, model: "gpt-4" },
+  ]);
+
+  makeWireFile(wslDir, "wire.jsonl", [
+    { type: "step.end", uuid: "wsl-1", usage: { input_tokens: 50, output_tokens: 25 }, time: t3, model: "gpt-4" },
+  ]);
+
+  const { parseKimiCodeIncremental } = require("../src/lib/rollout");
+
+  const queuePath = path.join(tmpDir, "queue.jsonl");
+  const cursors = { hourly: { buckets: {} }, files: {} };
+  const installPaths = { native: nativeDir, wsl: wslDir };
+
+  const result = await multiInstallParse({
+    paths: installPaths,
+    parserFn: parseKimiCodeIncremental,
+    providerName: "kimi-code",
+    cursors,
+    getParams: (installPath) => ({ wireFiles: [path.join(installPath, "wire.jsonl")] }),
+    queuePath,
+    env: process.env,
+  });
+
+  assert.ok(result.recordsProcessed > 0, "should process records from both installs");
+  assert.ok(result.eventsAggregated > 0);
+  assert.ok(result.bucketsQueued > 0, "should queue buckets");
+  assert.equal(result.recordsProcessed, 3, "3 total wire events from both installs");
+
+  // Verify queue file has rows from both installs merged by (source, model, hour_start)
+  const queueContent = fs.readFileSync(queuePath, "utf8").trim().split("\n").filter(Boolean);
+  const queueBuckets = queueContent.map(line => JSON.parse(line));
+
+  // Native 10:15 and 10:45 → bucket at 10:00 and 10:30
+  // WSL 11:15 → bucket at 11:00
+  assert.ok(queueBuckets.length >= 2, `should have at least 2 bucket rows, got ${queueBuckets.length}`);
+  const sources = new Set(queueBuckets.map(r => r.source));
+  assert.ok(sources.has("kimi"), `queue source should be kimi, got ${[...sources].join(", ")}`);
+
+  const pendingBytes = queueContent.reduce((sum, l) => sum + Buffer.byteLength(l, "utf8") + 1, 0);
+  assert.ok(pendingBytes > 100, `queue should have meaningful content (${pendingBytes} bytes)`);
+});

--- a/test/dual-install-property.test.js
+++ b/test/dual-install-property.test.js
@@ -1,0 +1,97 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
+
+const { multiInstallParse } = require("../src/lib/multi-install-parser");
+
+const BUCKET_KEY_RE = /^[a-z0-9_-]+\|[a-z0-9_.-]+\|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function xorshift32(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s ^= s << 13;
+    s ^= s >> 17;
+    s ^= s << 5;
+    return (s >>> 0) / 4294967296;
+  };
+}
+
+function randomInt(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function randomString(rng, len) {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789-_";
+  let s = "";
+  for (let i = 0; i < len; i++) s += chars[Math.floor(rng() * chars.length)];
+  return s;
+}
+
+test("property: multiInstallParse invariants hold across random inputs", async (t) => {
+  const rng = xorshift32(42);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-prop-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const queuePath = path.join(tmpDir, "queue.jsonl");
+
+  for (let iter = 0; iter < 100; iter++) {
+    const numInstalls = randomInt(rng, 1, 2);
+    const numBuckets = randomInt(rng, 0, 10);
+    const hasPrefer = rng() > 0.5;
+    const preferVal = hasPrefer ? (rng() > 0.5 ? "native" : "wsl") : null;
+    const installKeys = numInstalls === 2 ? { native: "/a", wsl: "/b" } : { native: "/a", wsl: null };
+
+    const cursors = { hourly: { buckets: {} } };
+    const env = preferVal ? { TOKENTRACKER_WSL_PREFER: preferVal } : {};
+
+    const result = await multiInstallParse({
+      paths: installKeys,
+      parserFn: async ({ cursors: c }) => {
+        for (let b = 0; b < numBuckets; b++) {
+          const source = randomString(rng, 6);
+          const model = randomString(rng, 8);
+          const hourStart = `2026-01-01T${String(randomInt(rng, 0, 23)).padStart(2, "0")}:00:00.000Z`;
+          const key = `${source}|${model}|${hourStart}`;
+          const existing = c.hourly.buckets[key];
+          const prevIn = existing?.totals?.input_tokens || 0;
+          const prevOut = existing?.totals?.output_tokens || 0;
+          c.hourly.buckets[key] = {
+            totals: {
+              input_tokens: prevIn + randomInt(rng, 0, 10000),
+              output_tokens: prevOut + randomInt(rng, 0, 10000),
+            },
+          };
+        }
+        return {
+          recordsProcessed: randomInt(rng, 0, 100),
+          eventsAggregated: randomInt(rng, 0, 100),
+          bucketsQueued: numBuckets,
+        };
+      },
+      providerName: "test",
+      cursors,
+      env,
+      getParams: (p) => ({ path: p }),
+      queuePath,
+    });
+
+    assert.ok(Number.isFinite(result.recordsProcessed) && result.recordsProcessed >= 0,
+      `iter ${iter}: recordsProcessed=${result.recordsProcessed}`);
+    assert.ok(Number.isFinite(result.eventsAggregated) && result.eventsAggregated >= 0,
+      `iter ${iter}: eventsAggregated=${result.eventsAggregated}`);
+    assert.ok(Number.isFinite(result.bucketsQueued) && result.bucketsQueued >= 0,
+      `iter ${iter}: bucketsQueued=${result.bucketsQueued}`);
+
+    if (cursors.hourly?.buckets) {
+      for (const [key, val] of Object.entries(cursors.hourly.buckets)) {
+        assert.ok(BUCKET_KEY_RE.test(key), `iter ${iter}: invalid bucket key "${key}"`);
+        const t = val.totals;
+        for (const field of ["input_tokens", "output_tokens"]) {
+          assert.ok(Number.isFinite(t[field]) && t[field] >= 0,
+            `iter ${iter}: ${field}=${t[field]} in key "${key}"`);
+        }
+      }
+    }
+  }
+});

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -1,0 +1,167 @@
+const assert = require("node:assert/strict");
+const { test, describe } = require("node:test");
+const { mockPlatform } = require("./helpers/mock");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const { resolveInstallPaths, ensureNamespacedCursors } = require("../src/lib/install-resolver");
+const wsl = require("../src/lib/wsl-probe");
+
+// ── resolveInstallPaths ───────────────────────────────────────────────────────
+
+test("resolveInstallPaths returns single path on non-Windows", () => {
+  const r = resolveInstallPaths("hermes", { nativeValue: "/home/user/.hermes", wslDir: ".hermes" }, {}, {});
+  assert.equal(r.native, "/home/user/.hermes");
+  assert.equal(r.wsl, null);
+});
+
+test("resolveInstallPaths both mode returns both paths when both exist on Windows", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-test-both-"));
+  try {
+    const nativeDir = path.join(tmpDir, "native");
+    const wslDir = path.join(tmpDir, "wsl");
+    fs.mkdirSync(nativeDir, { recursive: true });
+    fs.mkdirSync(wslDir, { recursive: true });
+
+    const r = resolveInstallPaths("hermes",
+      { nativeValue: nativeDir, wslValue: wslDir },
+      { TOKENTRACKER_WSL_MODE: "both" },
+      { runWsl: () => "Ubuntu\n", existsSync: () => true },
+    );
+    assert.equal(r.native, nativeDir);
+    assert.equal(r.wsl, wslDir);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveInstallPaths both mode single-install fallback", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-test-single-"));
+  try {
+    const nativeDir = path.join(tmpDir, "native");
+    fs.mkdirSync(nativeDir, { recursive: true });
+
+    const r = resolveInstallPaths("hermes",
+      { nativeValue: nativeDir, wslValue: null },
+      { TOKENTRACKER_WSL_MODE: "both" },
+      { runWsl: () => "Ubuntu\n", existsSync: () => false },
+    );
+    assert.equal(r.native, nativeDir);
+    assert.equal(r.wsl, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveInstallPaths non-both modes return single path", (t) => {
+  mockPlatform(t, "win32");
+  for (const mode of ["wsl-first", "native-first", "wsl-only", "native-only", undefined]) {
+    const env = mode ? { TOKENTRACKER_WSL_MODE: mode } : {};
+    const r = resolveInstallPaths("hermes",
+      { nativeValue: "C:\\native", wslValue: "\\\\wsl$\\path" },
+      env,
+      { runWsl: () => "Ubuntu\n", existsSync: () => true },
+    );
+    assert.equal(r.wsl, null, `mode=${mode} should have wsl=null`);
+    assert.ok(typeof r.native === "string" || r.native === null, `mode=${mode} native should be string or null`);
+  }
+});
+
+// ── ensureNamespacedCursors ───────────────────────────────────────────────────
+
+test("ensureNamespacedCursors transparent for already-namespaced cursors", () => {
+  const cursors = {
+    hermes: {
+      native: { lastCompletedStartedAt: 100 },
+      wsl: { lastCompletedStartedAt: 0 },
+    },
+  };
+  const ns = ensureNamespacedCursors(cursors, "hermes");
+  assert.equal(ns, cursors.hermes);
+  assert.equal(ns.native.lastCompletedStartedAt, 100);
+  assert.equal(ns.wsl.lastCompletedStartedAt, 0);
+});
+
+test("ensureNamespacedCursors migrates flat cursor to both namespaces", () => {
+  const cursors = {
+    hermes: { lastCompletedStartedAt: 100, unfinishedSessionIds: ["abc"] },
+  };
+  const ns = ensureNamespacedCursors(cursors, "hermes");
+  assert.equal(ns.native.lastCompletedStartedAt, 100);
+  assert.deepEqual(ns.native.unfinishedSessionIds, ["abc"]);
+  assert.equal(ns.wsl.lastCompletedStartedAt, 100, "WSL namespace should also have the flat data");
+  assert.deepEqual(ns.wsl.unfinishedSessionIds, ["abc"]);
+  assert.ok(ns === cursors.hermes, "cursors.hermes should be replaced with namespace object");
+});
+
+test("ensureNamespacedCursors handles empty provider state", () => {
+  const cursors = {};
+  const ns = ensureNamespacedCursors(cursors, "hermes");
+  assert.deepEqual(ns.native, {});
+  assert.deepEqual(ns.wsl, {});
+});
+
+// ── wsl-probe: both mode and getWslPrefer ─────────────────────────────────────
+
+test("getWslMode recognizes both mode", () => {
+  assert.equal(wsl.getWslMode({ TOKENTRACKER_WSL_MODE: "both" }), "both");
+  assert.equal(wsl.getWslMode({ TOKENTRACKER_WSL_MODE: "BOTH" }), "both");
+  assert.equal(wsl.getWslMode({ TOKENTRACKER_WSL_MODE: " Both " }), "both");
+});
+
+test("isInvalidWslMode accepts both mode", () => {
+  assert.equal(wsl.isInvalidWslMode({ TOKENTRACKER_WSL_MODE: "both" }), false);
+});
+
+test("getWslPrefer returns null when unset, respects explicit setting", () => {
+  assert.equal(wsl.getWslPrefer({}), null);
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "" }), null);
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "wsl" }), "wsl");
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "native" }), "native");
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "WSL" }), "wsl");
+});
+
+test("getWslPrefer invalid values return null", () => {
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "foo" }), null);
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "both" }), null);
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "wsl-first" }), null);
+  assert.equal(wsl.getWslPrefer({ TOKENTRACKER_WSL_PREFER: "native_first" }), null);
+});
+
+test("pickWin32Path handles both mode", (t) => {
+  mockPlatform(t, "win32");
+  const r = wsl.pickWin32Path({
+    wslValue: "\\\\wsl$\\path",
+    nativeValue: "C:\\native",
+    env: { TOKENTRACKER_WSL_MODE: "both" },
+    platform: "win32",
+  });
+  assert.equal(r, "\\\\wsl$\\path", "both mode should prefer WSL for pickWin32Path");
+});
+
+test("resolveAllWin32Paths returns both paths in both mode", (t) => {
+  mockPlatform(t, "win32");
+  const r = wsl.resolveAllWin32Paths({
+    wslValue: "\\\\wsl$\\path",
+    nativeValue: "C:\\native",
+    env: { TOKENTRACKER_WSL_MODE: "both" },
+    platform: "win32",
+  });
+  assert.equal(r.native, "C:\\native");
+  assert.equal(r.wsl, "\\\\wsl$\\path");
+});
+
+test("resolveAllWin32Paths returns single path in non-both mode", (t) => {
+  mockPlatform(t, "win32");
+  const r = wsl.resolveAllWin32Paths({
+    wslValue: "\\\\wsl$\\path",
+    nativeValue: "C:\\native",
+    env: {},
+    platform: "win32",
+  });
+  assert.equal(r.native, "\\\\wsl$\\path");
+  assert.equal(r.wsl, null);
+});

--- a/test/merge-files-both-mode.test.js
+++ b/test/merge-files-both-mode.test.js
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const { test, describe } = require("node:test");
+const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
+const { mockPlatform } = require("./helpers/mock");
+
+const wslProbe = require("../src/lib/wsl-probe");
+const { mergeBothFileSources } = require("../src/lib/multi-install-parser");
+
+function makeProviderDirs(t, prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `tt-merge-${prefix}-`));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const native = path.join(root, "native");
+  const wslDir = path.join(root, "wsl");
+  fs.mkdirSync(native, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+  return { root, native, wsl: wslDir };
+}
+
+function resolveForInstall(env, nativeDir, wslDir) {
+  const dir = wslProbe.getWslMode(env) === "wsl-only" ? wslDir : nativeDir;
+  return fs.readdirSync(dir).filter(f => f.endsWith(".jsonl")).map(f => path.join(dir, f));
+}
+
+describe("mergeBothFileSources in both mode", { concurrency: 1 }, () => {
+
+  test("discovers files from both installs", (t) => {
+    mockPlatform(t, "win32");
+    const { native, wsl } = makeProviderDirs(t, "disc");
+    fs.writeFileSync(path.join(native, "session-1.wire.jsonl"), "{}");
+    fs.writeFileSync(path.join(native, "session-2.wire.jsonl"), "{}");
+    fs.writeFileSync(path.join(wsl, "session-3.wire.jsonl"), "{}");
+
+    const files = mergeBothFileSources({
+      resolveFiles: (env) => resolveForInstall(env, native, wsl),
+      env: { TOKENTRACKER_WSL_MODE: "both" },
+    });
+
+    assert.equal(files.length, 3, "should find 3 total files from both installs");
+    const names = files.map(f => path.basename(f)).sort();
+    assert.deepEqual(names, ["session-1.wire.jsonl", "session-2.wire.jsonl", "session-3.wire.jsonl"]);
+  });
+
+  test("deduplicates identical file paths", (t) => {
+    mockPlatform(t, "win32");
+    const { native } = makeProviderDirs(t, "dedup");
+    const shared = path.join(native, "shared.jsonl");
+    fs.writeFileSync(shared, "{}");
+
+    const files = mergeBothFileSources({
+      resolveFiles: () => [shared, shared],
+      env: { TOKENTRACKER_WSL_MODE: "both" },
+    });
+
+    assert.equal(files.length, 1, "duplicate paths should be deduplicated");
+  });
+
+  test("returns single-install files when not in both mode", (t) => {
+    mockPlatform(t, "win32");
+    const { native, wsl } = makeProviderDirs(t, "single");
+    fs.writeFileSync(path.join(native, "a.jsonl"), "{}");
+    fs.writeFileSync(path.join(wsl, "b.jsonl"), "{}");
+
+    const files = mergeBothFileSources({
+      resolveFiles: (env) => resolveForInstall(env, native, wsl),
+      env: { TOKENTRACKER_WSL_MODE: "wsl-first" },
+    });
+
+    assert.equal(files.length, 1, "only native-install files in wsl-first mode");
+  });
+});

--- a/test/multi-install-parser.test.js
+++ b/test/multi-install-parser.test.js
@@ -1,0 +1,171 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { multiInstallParse, emptyResult } = require("../src/lib/multi-install-parser");
+
+function addToBucket(cursors, key, input, output) {
+  const existing = cursors.hourly?.buckets?.[key];
+  const prevInput = existing?.totals?.input_tokens || 0;
+  const prevOutput = existing?.totals?.output_tokens || 0;
+  cursors.hourly.buckets[key] = {
+    totals: { input_tokens: prevInput + input, output_tokens: prevOutput + output },
+  };
+}
+
+test("emptyResult returns zeroed result", () => {
+  const r = emptyResult();
+  assert.equal(r.recordsProcessed, 0);
+  assert.equal(r.eventsAggregated, 0);
+  assert.equal(r.bucketsQueued, 0);
+});
+
+test("multiInstallParse returns emptyResult when no paths", async () => {
+  const r = await multiInstallParse({
+    paths: { native: null, wsl: null },
+    parserFn: async () => ({ recordsProcessed: 5 }),
+    providerName: "test",
+    cursors: { hourly: {} },
+    getParams: () => ({}),
+  });
+  assert.equal(r.recordsProcessed, 0);
+});
+
+test("multiInstallParse single path passes through directly", async () => {
+  const cursors = { hourly: {} };
+  const r = await multiInstallParse({
+    paths: { native: "/path", wsl: null },
+    parserFn: async ({ cursors: c }) => {
+      c.testKey = "was-called";
+      return { recordsProcessed: 10, eventsAggregated: 5, bucketsQueued: 3 };
+    },
+    providerName: "test",
+    cursors,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+  assert.equal(r.recordsProcessed, 10);
+  assert.equal(cursors.testKey, "was-called");
+});
+
+test("multiInstallParse dual paths merge when no prefer set (default)", async () => {
+  const cursors = { hourly: { buckets: {} } };
+
+  const r = await multiInstallParse({
+    paths: { native: "/native", wsl: "/wsl" },
+    parserFn: async ({ resolvedPath, cursors: c }) => {
+      addToBucket(c, "hermes|gpt-4|2026-01-01T00:00:00.000Z", 100, 50);
+      return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+
+  assert.equal(r.recordsProcessed, 2);
+  // Both installs contributed to the same bucket — merged without filtering
+  const bucket = cursors.hourly.buckets["hermes|gpt-4|2026-01-01T00:00:00.000Z"];
+  assert.ok(bucket);
+  assert.equal(bucket.totals.input_tokens, 200, "both installs merged (100+100)");
+  assert.equal(bucket.totals.output_tokens, 100, "both installs merged (50+50)");
+});
+
+test("multiInstallParse dual paths with prefer=native resolves conflict", async () => {
+  const cursors = { hourly: { buckets: {} } };
+  const env = { TOKENTRACKER_WSL_PREFER: "native" };
+
+  const r = await multiInstallParse({
+    paths: { native: "/native", wsl: "/wsl" },
+    parserFn: async ({ resolvedPath, cursors: c }) => {
+      addToBucket(c, "hermes|gpt-4|2026-01-01T00:00:00.000Z", 100, 50);
+      return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    env,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+
+  assert.equal(r.recordsProcessed, 2);
+  const bucket = cursors.hourly.buckets["hermes|gpt-4|2026-01-01T00:00:00.000Z"];
+  assert.equal(bucket.totals.input_tokens, 100, "native data kept (WSL discarded)");
+});
+
+test("multiInstallParse dual paths with prefer=wsl resolves conflict", async () => {
+  const cursors = { hourly: { buckets: {} } };
+  const env = { TOKENTRACKER_WSL_PREFER: "wsl" };
+
+  const r = await multiInstallParse({
+    paths: { native: "/native", wsl: "/wsl" },
+    parserFn: async ({ resolvedPath, cursors: c }) => {
+      addToBucket(c, "hermes|gpt-4|2026-01-01T00:00:00.000Z", 100, 50);
+      return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    env,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+
+  assert.equal(r.recordsProcessed, 2);
+  const bucket = cursors.hourly.buckets["hermes|gpt-4|2026-01-01T00:00:00.000Z"];
+  assert.equal(bucket.totals.input_tokens, 100, "WSL data kept (native discarded)");
+});
+
+test("multiInstallParse cursor isolation between installs", async () => {
+  const cursors = { hourly: {} };
+
+  await multiInstallParse({
+    paths: { native: "/a", wsl: "/b" },
+    parserFn: async ({ resolvedPath, cursors: c }) => {
+      c.hermes = { startedAt: resolvedPath === "/a" ? 100 : 200 };
+      return { recordsProcessed: 1 };
+    },
+    providerName: "hermes",
+    cursors,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+
+  assert.equal(cursors.hermes.native.startedAt, 100);
+  assert.equal(cursors.hermes.wsl.startedAt, 200);
+});
+
+test("multiInstallParse partial parse failure propagates error", async () => {
+  const cursors = { hourly: {} };
+
+  await assert.rejects(
+    () => multiInstallParse({
+      paths: { native: "/a", wsl: "/b" },
+      parserFn: async ({ resolvedPath }) => {
+        if (resolvedPath === "/b") throw new Error("second install failed");
+        return { recordsProcessed: 1 };
+      },
+      providerName: "hermes",
+      cursors,
+      getParams: (path) => ({ resolvedPath: path }),
+    }),
+    { message: "second install failed" },
+  );
+
+  assert.ok(cursors.hermes.native !== undefined, "first install's cursor should be preserved");
+});
+
+test("multiInstallParse empty install produces correct partial result", async () => {
+  const cursors = { hourly: { buckets: {} } };
+
+  const r = await multiInstallParse({
+    paths: { native: "/native-data", wsl: "/wsl-empty" },
+    parserFn: async ({ resolvedPath, cursors: c }) => {
+      if (resolvedPath === "/wsl-empty") return { recordsProcessed: 0 };
+      c.hourly.buckets["test|model|2026-01-01T00:00:00.000Z"] = {
+        totals: { input_tokens: 100, output_tokens: 50 },
+      };
+      return { recordsProcessed: 5, eventsAggregated: 3, bucketsQueued: 1 };
+    },
+    providerName: "test",
+    cursors,
+    getParams: (path) => ({ resolvedPath: path }),
+  });
+
+  assert.equal(r.recordsProcessed, 5, "only the non-empty install's records");
+  assert.equal(r.eventsAggregated, 3);
+  assert.equal(r.bucketsQueued, 1);
+});

--- a/test/wsl-probe.test.js
+++ b/test/wsl-probe.test.js
@@ -274,3 +274,41 @@ test("snapshotSqliteDb handles missing WAL/shm/journal gracefully", () => {
 
   fs.rmSync(srcDir, { recursive: true, force: true });
 });
+
+test("probeWslDistros cache is bypassed when deps are provided", () => {
+  const harmfulDistro = () => { throw new Error("should not be called"); };
+  const cleanDistro = () => "  NAME    STATE    VERSION\n* Ubuntu  Running  2\n";
+
+  // Populate cache with a successful probe (no deps → cached)
+  resetWslProbeCache();
+  const cached = probeWslDistros({ runWsl: cleanDistro, existsSync: () => false });
+
+  // The cache was populated (if real WSL wasn't called). Now call with
+  // harmful deps — if cache were used, harmfulDistro wouldn't be called.
+  // If cache is bypassed, harmfulDistro is called and throws → empty result.
+  const result = probeWslDistros({ runWsl: harmfulDistro });
+  // Without deps, uses the cached `cleanDistro` result, so this should
+  // return the cached distros (not empty as harmfulDistro would produce).
+  // OR if the cache missed, it would probe real WSL.
+  // The important invariant: cache should NOT interfere with deps-provided calls.
+  const depsResult = probeWslDistros({ runWsl: harmfulDistro });
+  assert.ok(Array.isArray(depsResult), "deps call should not throw even if cache is poisoned");
+});
+
+test("resetWslProbeCache clears module-level cache", () => {
+  // probeWslDistros caches results only when called WITHOUT deps.
+  // Verify that resetWslProbeCache() clears this cache.
+  const mockDistros = () => "  NAME    STATE    VERSION\n* Ubuntu  Running  2\n";
+
+  resetWslProbeCache();
+  // Call with deps → bypasses cache, result not cached
+  const r1 = probeWslDistros({ runWsl: mockDistros, existsSync: () => false });
+  assert.equal(r1.length, 1, "should probe with provided deps");
+
+  // Call with deps again → cache doesn't matter, always fresh when deps provided
+  const r2 = probeWslDistros({ runWsl: mockDistros, existsSync: () => false });
+  assert.equal(r2.length, 1, "deps-provided calls always probe fresh");
+
+  // resetWslProbeCache should not throw
+  assert.doesNotThrow(() => resetWslProbeCache());
+});


### PR DESCRIPTION
## Summary

Adds centralized install resolver, MultiInstallParser with conflict resolution, and wires both-mode support for all 11 WSL-aware providers.

## Key Changes

### Infrastructure (new files)
- **`src/lib/install-resolver.js`**: Centralized path resolution. `resolveInstallPaths()` returns `{ native, wsl }` per provider. `ensureNamespacedCursors()` migrates flat cursor to namespaced form. `ensureFlatCursor()` collapses namespaced cursors on mode rollback.
- **`src/lib/multi-install-parser.js`**: Dual-parse wrapper. `multiInstallParse()` handles single/dual installs with cursor isolation and optional conflict resolution. `mergeBothFileSources()` merges file-based provider outputs via env-mode override.

### Provider integration
| Providers | Method | Type |
|-----------|--------|------|
| Hermes, Zed, Goose | `multiInstallParse` | SQLite |
| Kimi Code, CodeBuddy, WorkBuddy, Kilo Code, Craft, OMP, Pi, Droid | `mergeBothFileSources` | File-based |

### Usage
```bash
TOKENTRACKER_WSL_MODE=both tokentrackert sync           # merge data from both installs
TOKENTRACKER_WSL_MODE=both TOKENTRACKER_WSL_PREFER=wsl  # WSL wins on conflict
```

### Testing
- 6 new test files, 245 total passing tests (17 pre-existing `sqlite3 ENOENT`)
- Property stress test, cursor migration, real parser integration, edge cases

### Bugs fixed
- `const wsl` shadowing module import in `resolveZedDbPath`
- `getWslPrefer` defaulted to `"wsl"` instead of `null` (now opt-in via explicit env var)
- `env` not forwarded to parser fn in `multiInstallParse`
- Missing null guards for OMP/Pi agent dir in status.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling both native and WSL installs, including improved path selection and combined file discovery.
  * Added a new install preference setting to choose which environment to prioritize.

* **Bug Fixes**
  * Improved status reporting for Windows/WSL setups.
  * Made install detection and cursor migration more reliable across dual-install scenarios.

* **Documentation**
  * Expanded project guidance with updated workflow and session-completion notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->