### PR TITLE
fix: build dashboard before source-tree pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "graph:auto-index": "node scripts/graph/auto-index.cjs",
     "graph:scip": "node scripts/graph/generate-scip.cjs",
     "pricing:build-seed": "node scripts/build-pricing-seed.cjs",
+    "prepack": "npm run dashboard:build && npm run pricing:build-seed",
     "prepublishOnly": "node scripts/build-pricing-seed.cjs",
     "test": "node --test test/*.test.js",
     "validate:copy": "node scripts/validate-copy-registry.cjs",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "graph:scip": "node scripts/graph/generate-scip.cjs",
     "pricing:build-seed": "node scripts/build-pricing-seed.cjs",
     "prepack": "npm run dashboard:build && npm run pricing:build-seed",
-    "prepublishOnly": "node scripts/build-pricing-seed.cjs",
     "test": "node --test test/*.test.js",
     "validate:copy": "node scripts/validate-copy-registry.cjs",
     "validate:guardrails": "node scripts/validate-architecture-guardrails.cjs",

--- a/scripts/acceptance/npm-install-smoke.cjs
+++ b/scripts/acceptance/npm-install-smoke.cjs
@@ -33,7 +33,12 @@ try {
 }
 
 const files = new Set((data[0]?.files || []).map((file) => file.path));
-const required = ["package.json", "bin/tracker.js", "src/cli.js"];
+const required = [
+  "package.json",
+  "bin/tracker.js",
+  "src/cli.js",
+  "dashboard/dist/index.html",
+];
 const missing = required.filter((file) => !files.has(file));
 
 if (missing.length > 0) {

--- a/scripts/build-pricing-seed.cjs
+++ b/scripts/build-pricing-seed.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Fetch the live LiteLLM pricing JSON and write a slimmed snapshot used as the
-// day-1 offline fallback. Runs from `npm prepublishOnly`; can also be invoked
+// day-1 offline fallback. Runs from `npm prepack`; can also be invoked
 // manually: `node scripts/build-pricing-seed.cjs`.
 
 const fs = require("node:fs");

--- a/test/npm-publish-workflow.test.js
+++ b/test/npm-publish-workflow.test.js
@@ -132,3 +132,25 @@ test("package.json files array includes dashboard/dist", () => {
     "published package must include dashboard/dist/"
   );
 });
+
+test("package.json prepack builds dashboard before packing from a source tree", () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8")
+  );
+  assert.equal(
+    pkg.scripts.prepack,
+    "npm run dashboard:build && npm run pricing:build-seed",
+    "prepack should build dashboard/dist and refresh the pricing seed before pack/publish"
+  );
+});
+
+test("npm install smoke requires dashboard/dist/index.html in the packed artifact", () => {
+  const smoke = fs.readFileSync(
+    path.join(__dirname, "..", "scripts", "acceptance", "npm-install-smoke.cjs"),
+    "utf8"
+  );
+  assert.ok(
+    smoke.includes('"dashboard/dist/index.html"'),
+    "pack smoke should fail when dashboard/dist/index.html is missing from the tarball"
+  );
+});

--- a/test/npm-publish-workflow.test.js
+++ b/test/npm-publish-workflow.test.js
@@ -142,6 +142,11 @@ test("package.json prepack builds dashboard before packing from a source tree", 
     "npm run dashboard:build && npm run pricing:build-seed",
     "prepack should build dashboard/dist and refresh the pricing seed before pack/publish"
   );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(pkg.scripts, "prepublishOnly"),
+    false,
+    "prepublishOnly should be removed once prepack is the single packaging entry point"
+  );
 });
 
 test("npm install smoke requires dashboard/dist/index.html in the packed artifact", () => {


### PR DESCRIPTION
## Title: fix: build dashboard before source-tree pack

### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** `dashboard/dist/` is declared as a published file, but a source-tree `npm pack` path can still emit a tarball without it because `prepublishOnly` refreshes pricing data only. That leaves a silent release footgun: the package contract says the dashboard bundle ships, but local pack/publish does not enforce it.
- **Trade-offs:** This fix enforces the package contract at pack time instead of relying on workflow discipline. It slightly increases pack/publish work by rebuilding the dashboard before packaging, but it converts a latent broken-artifact risk into a deterministic build requirement.

### 2. Implementation Details (Implementation)
- Added a `prepack` script in `package.json` that builds `dashboard/dist` and refreshes the pricing seed before `npm pack` / `npm publish` package assembly.
- Hardened `scripts/acceptance/npm-install-smoke.cjs` so the packed artifact must contain `dashboard/dist/index.html`, not just the CLI entrypoints.
- Added regression coverage in `test/npm-publish-workflow.test.js` for the new `prepack` contract and the strengthened smoke requirement.
- **Note:** This PR does not introduce Linux release artifacts yet. It only makes the existing npm distribution path honor the package's declared contents.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for npm publish/packaging guardrails (covering `prepack` contract and required `dashboard/dist/index.html` smoke validation)
- [x] Ran targeted Node test suite: `node --test test/npm-publish-workflow.test.js`
- [x] Verified backward compatibility with the current npm publish workflow contract: Node 20 publish path and `dashboard/dist` inclusion assertions remain intact
- **Benchmark:** Not applicable. The cost is one dashboard build before pack; no runtime hot path changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Packaging now runs required build steps before the package is created, ensuring the published tarball includes the latest dashboard and pricing content.
  * Release verification now fails if the dashboard build output (dashboard/dist/index.html) is missing from the npm package.

* **Tests**
  * Added test coverage to confirm the npm prepack script wiring and to validate expected tarball contents, including the dashboard build file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->