### PR TITLE
feat: add Linux x64 release tarball workflow

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
@@ -32,10 +33,12 @@ jobs:
           node-version: 20
 
       - name: Verify version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" != "${{ inputs.version }}" ]]; then
-            echo "::error::package.json version ($PKG_VERSION) does not match input (${{ inputs.version }})"
+          if [[ "$PKG_VERSION" != "$VERSION" ]]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match input ($VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,84 @@
+name: release Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.68.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+concurrency:
+  group: release-linux-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Verify version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PKG_VERSION" != "${{ inputs.version }}" ]]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match input (${{ inputs.version }})"
+            exit 1
+          fi
+
+      - name: Install dashboard dependencies
+        run: npm ci --prefix dashboard
+
+      - name: Build dashboard
+        env:
+          VITE_INSFORGE_BASE_URL: https://srctyff5.us-east.insforge.app
+          VITE_INSFORGE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3OC0xMjM0LTU2NzgtOTBhYi1jZGVmMTIzNDU2NzgiLCJlbWFpbCI6ImFub25AaW5zZm9yZ2UuY29tIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODExNDU5NDd9.T0auta_IrVIh0uXW1bob5QSnzvsnJmN28r5XkSGEuQY
+        run: npm run dashboard:build
+
+      - name: Bundle Linux runtime
+        run: bash scripts/release/bundle-node-linux.sh
+
+      - name: Verify package contents
+        run: |
+          required=(
+            "build/linux-x64/tokentracker"
+            "build/linux-x64/EmbeddedServer/node"
+            "build/linux-x64/EmbeddedServer/tokentracker/bin/tracker.js"
+            "build/linux-x64/EmbeddedServer/tokentracker/dashboard/dist/index.html"
+          )
+          for file in "${required[@]}"; do
+            if [[ ! -e "$file" ]]; then
+              echo "::error::missing required file: $file"
+              exit 1
+            fi
+          done
+
+      - name: Package tarball
+        run: |
+          tar -C build/linux-x64 -czf TokenTracker-linux-x64.tar.gz .
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          tag="v$VERSION"
+          asset="TokenTracker-linux-x64.tar.gz"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "$asset" --clobber
+          else
+            gh release create "$tag" "$asset" --title "$tag" --generate-notes
+          fi

--- a/scripts/release/bundle-node-linux.sh
+++ b/scripts/release/bundle-node-linux.sh
@@ -35,9 +35,24 @@ mkdir -p "$TT_DIR/bin"
 
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
 NODE_TAR="node-v${NODE_VERSION}-linux-x64.tar.xz"
+NODE_SHA_FILE="SHASUMS256.txt"
 
 echo "Downloading Node.js v${NODE_VERSION} (${TARGET_ARCH})..."
 curl -fSL --progress-bar -o "$TMPDIR_BUNDLE/$NODE_TAR" "$NODE_BASE_URL/$NODE_TAR"
+curl -fSL --progress-bar -o "$TMPDIR_BUNDLE/$NODE_SHA_FILE" "$NODE_BASE_URL/$NODE_SHA_FILE"
+
+EXPECTED_HASH="$(awk -v file="$NODE_TAR" '$2 == file { print $1 }' "$TMPDIR_BUNDLE/$NODE_SHA_FILE")"
+if [[ -z "$EXPECTED_HASH" ]]; then
+  echo "Unable to find checksum for $NODE_TAR in $NODE_SHA_FILE" >&2
+  exit 1
+fi
+
+ACTUAL_HASH="$(sha256sum "$TMPDIR_BUNDLE/$NODE_TAR" | awk '{print $1}')"
+if [[ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]]; then
+  echo "Checksum mismatch for $NODE_TAR: expected $EXPECTED_HASH, got $ACTUAL_HASH" >&2
+  exit 1
+fi
+
 tar -xJf "$TMPDIR_BUNDLE/$NODE_TAR" -C "$TMPDIR_BUNDLE" "node-v${NODE_VERSION}-linux-x64/bin/node"
 cp "$TMPDIR_BUNDLE/node-v${NODE_VERSION}-linux-x64/bin/node" "$EMBED_DIR/node"
 chmod +x "$EMBED_DIR/node"
@@ -51,6 +66,7 @@ fi
 cp "$REPO_ROOT/bin/tracker.js" "$TT_DIR/bin/"
 cp -R "$REPO_ROOT/src" "$TT_DIR/src"
 cp "$REPO_ROOT/package.json" "$TT_DIR/"
+cp "$REPO_ROOT/package-lock.json" "$TT_DIR/"
 
 if [[ ! -d "$REPO_ROOT/dashboard/dist" ]]; then
   echo "dashboard/dist not found. Run 'npm run dashboard:build' first." >&2
@@ -62,36 +78,8 @@ cp -R "$REPO_ROOT/dashboard/dist" "$TT_DIR/dashboard/dist"
 
 (
   cd "$TT_DIR"
-  npm install --omit=dev --no-optional --ignore-scripts
+  npm ci --omit=dev --no-optional --ignore-scripts
 )
-
-find "$TT_DIR/node_modules" -type f \( \
-  -name "*.md" -o \
-  -name "*.txt" -o \
-  -name "*.map" -o \
-  -name "*.ts" -o \
-  -name "*.d.ts" -o \
-  -iname "LICENSE*" -o \
-  -iname "LICENCE*" -o \
-  -iname "CHANGELOG*" -o \
-  -iname "CHANGES*" -o \
-  -iname "HISTORY*" -o \
-  -name ".npmignore" -o \
-  -name ".eslintrc*" -o \
-  -name ".prettierrc*" -o \
-  -name "tsconfig.json" -o \
-  -name ".editorconfig" \
-\) -delete 2>/dev/null || true
-
-find "$TT_DIR/node_modules" -type d \( \
-  -name "test" -o \
-  -name "tests" -o \
-  -name "__tests__" -o \
-  -name "examples" -o \
-  -name "example" -o \
-  -name "docs" -o \
-  -name ".github" \
-\) -exec rm -rf {} + 2>/dev/null || true
 
 cat > "$BUILD_ROOT/tokentracker" <<'EOF'
 #!/bin/sh

--- a/scripts/release/bundle-node-linux.sh
+++ b/scripts/release/bundle-node-linux.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds a self-contained Linux x64 bundle:
+#   build/linux-x64/
+#     tokentracker
+#     EmbeddedServer/node
+#     EmbeddedServer/tokentracker/{bin,src,node_modules,dashboard/dist}
+
+EXPECTED_NODE_VERSION="22.22.2"
+NODE_VERSION="${NODE_VERSION:-$EXPECTED_NODE_VERSION}"
+TARGET_ARCH="${TARGET_ARCH:-x64}"
+
+if [[ "$NODE_VERSION" != "$EXPECTED_NODE_VERSION" ]]; then
+  echo "Refusing to bundle Node.js v${NODE_VERSION}; expected pinned v${EXPECTED_NODE_VERSION}." >&2
+  echo "Update EXPECTED_NODE_VERSION after validating npm test against the new Node runtime." >&2
+  exit 1
+fi
+
+if [[ "$TARGET_ARCH" != "x64" ]]; then
+  echo "Unsupported TARGET_ARCH: ${TARGET_ARCH}. This workflow currently ships linux-x64 only." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_ROOT="$REPO_ROOT/build/linux-x64"
+EMBED_DIR="$BUILD_ROOT/EmbeddedServer"
+TT_DIR="$EMBED_DIR/tokentracker"
+TMPDIR_BUNDLE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BUNDLE"' EXIT
+
+rm -rf "$BUILD_ROOT"
+mkdir -p "$TT_DIR/bin"
+
+NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
+NODE_TAR="node-v${NODE_VERSION}-linux-x64.tar.xz"
+
+echo "Downloading Node.js v${NODE_VERSION} (${TARGET_ARCH})..."
+curl -fSL --progress-bar -o "$TMPDIR_BUNDLE/$NODE_TAR" "$NODE_BASE_URL/$NODE_TAR"
+tar -xJf "$TMPDIR_BUNDLE/$NODE_TAR" -C "$TMPDIR_BUNDLE" "node-v${NODE_VERSION}-linux-x64/bin/node"
+cp "$TMPDIR_BUNDLE/node-v${NODE_VERSION}-linux-x64/bin/node" "$EMBED_DIR/node"
+chmod +x "$EMBED_DIR/node"
+
+BUNDLED_NODE_VERSION="$("$EMBED_DIR/node" -p 'process.versions.node' 2>/dev/null || echo unknown)"
+if [[ "$BUNDLED_NODE_VERSION" != "$EXPECTED_NODE_VERSION" ]]; then
+  echo "Bundled Node drifted: expected v${EXPECTED_NODE_VERSION}, got v${BUNDLED_NODE_VERSION}" >&2
+  exit 1
+fi
+
+cp "$REPO_ROOT/bin/tracker.js" "$TT_DIR/bin/"
+cp -R "$REPO_ROOT/src" "$TT_DIR/src"
+cp "$REPO_ROOT/package.json" "$TT_DIR/"
+
+if [[ ! -d "$REPO_ROOT/dashboard/dist" ]]; then
+  echo "dashboard/dist not found. Run 'npm run dashboard:build' first." >&2
+  exit 1
+fi
+
+mkdir -p "$TT_DIR/dashboard"
+cp -R "$REPO_ROOT/dashboard/dist" "$TT_DIR/dashboard/dist"
+
+(
+  cd "$TT_DIR"
+  npm install --omit=dev --no-optional --ignore-scripts
+)
+
+find "$TT_DIR/node_modules" -type f \( \
+  -name "*.md" -o \
+  -name "*.txt" -o \
+  -name "*.map" -o \
+  -name "*.ts" -o \
+  -name "*.d.ts" -o \
+  -iname "LICENSE*" -o \
+  -iname "LICENCE*" -o \
+  -iname "CHANGELOG*" -o \
+  -iname "CHANGES*" -o \
+  -iname "HISTORY*" -o \
+  -name ".npmignore" -o \
+  -name ".eslintrc*" -o \
+  -name ".prettierrc*" -o \
+  -name "tsconfig.json" -o \
+  -name ".editorconfig" \
+\) -delete 2>/dev/null || true
+
+find "$TT_DIR/node_modules" -type d \( \
+  -name "test" -o \
+  -name "tests" -o \
+  -name "__tests__" -o \
+  -name "examples" -o \
+  -name "example" -o \
+  -name "docs" -o \
+  -name ".github" \
+\) -exec rm -rf {} + 2>/dev/null || true
+
+cat > "$BUILD_ROOT/tokentracker" <<'EOF'
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/EmbeddedServer/node" "$SCRIPT_DIR/EmbeddedServer/tokentracker/bin/tracker.js" "$@"
+EOF
+chmod +x "$BUILD_ROOT/tokentracker"
+
+echo "Linux bundle complete: $BUILD_ROOT"

--- a/test/release-linux-workflow.test.js
+++ b/test/release-linux-workflow.test.js
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
 const { test } = require("node:test");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -27,26 +28,39 @@ function loadScript() {
   return fs.readFileSync(SCRIPT_PATH, "utf8");
 }
 
+function parseWorkflow() {
+  const script = [
+    "import json, sys, yaml",
+    `with open(${JSON.stringify(WORKFLOW_PATH)}, 'r', encoding='utf-8') as f:`,
+    "    print(json.dumps(yaml.load(f, Loader=yaml.BaseLoader)))",
+  ].join("\n");
+  return JSON.parse(execFileSync("python3", ["-c", script], { encoding: "utf8" }));
+}
+
 test("release-linux workflow file exists", () => {
   assert.ok(fs.existsSync(WORKFLOW_PATH));
 });
 
 test("workflow supports manual and reusable invocation", () => {
-  const content = loadWorkflow();
-  assert.ok(content.includes("workflow_dispatch:"));
-  assert.ok(content.includes("workflow_call:"));
-  assert.ok(content.includes("version:"));
+  const workflow = parseWorkflow();
+  assert.ok(workflow.on.workflow_dispatch);
+  assert.ok(workflow.on.workflow_call);
+  assert.equal(workflow.on.workflow_dispatch.inputs.version.required, "true");
+  assert.equal(workflow.on.workflow_call.inputs.version.required, "true");
 });
 
 test("workflow uses an Ubuntu runner", () => {
-  const content = loadWorkflow();
-  assert.ok(/runs-on:\s*ubuntu-latest/.test(content));
+  const workflow = parseWorkflow();
+  assert.equal(workflow.jobs.build["runs-on"], "ubuntu-latest");
 });
 
 test("workflow verifies the requested version against package.json", () => {
+  const workflow = parseWorkflow();
   const content = loadWorkflow();
+  assert.equal(workflow.jobs.build["timeout-minutes"], "30");
   assert.ok(content.includes("Verify version"));
   assert.ok(content.includes("package.json version"));
+  assert.ok(content.includes("VERSION: ${{ inputs.version }}"));
 });
 
 test("workflow builds dashboard before bundling the Linux runtime", () => {
@@ -79,9 +93,9 @@ test("workflow uploads the tarball to the GitHub release", () => {
 });
 
 test("workflow has a per-version concurrency guard", () => {
-  const content = loadWorkflow();
-  assert.ok(content.includes("concurrency:"));
-  assert.ok(content.includes("release-linux-${{ inputs.version }}"));
+  const workflow = parseWorkflow();
+  assert.equal(workflow.concurrency.group, "release-linux-${{ inputs.version }}");
+  assert.equal(workflow.concurrency["cancel-in-progress"], "false");
 });
 
 test("linux bundle script exists", () => {
@@ -92,11 +106,14 @@ test("linux bundle script pins the Node runtime and downloads the linux-x64 arch
   const script = loadScript();
   assert.ok(script.includes('EXPECTED_NODE_VERSION="22.22.2"'));
   assert.ok(script.includes('node-v${NODE_VERSION}-linux-x64.tar.xz'));
+  assert.ok(script.includes("SHASUMS256.txt"));
+  assert.ok(script.includes("sha256sum"));
 });
 
 test("linux bundle script installs production dependencies only", () => {
   const script = loadScript();
-  assert.ok(script.includes("npm install --omit=dev --no-optional --ignore-scripts"));
+  assert.ok(script.includes("npm ci --omit=dev --no-optional --ignore-scripts"));
+  assert.ok(script.includes('cp "$REPO_ROOT/package-lock.json" "$TT_DIR/"'));
 });
 
 test("linux bundle script fails when dashboard/dist is missing", () => {
@@ -110,4 +127,10 @@ test("linux bundle script emits a launcher that execs the bundled tracker", () =
   assert.ok(script.includes('cat > "$BUILD_ROOT/tokentracker"'));
   assert.ok(script.includes('EmbeddedServer/node'));
   assert.ok(script.includes('EmbeddedServer/tokentracker/bin/tracker.js'));
+});
+
+test("linux bundle script has valid shell syntax", () => {
+  assert.doesNotThrow(() => {
+    execFileSync("bash", ["-n", SCRIPT_PATH], { stdio: "pipe" });
+  });
 });

--- a/test/release-linux-workflow.test.js
+++ b/test/release-linux-workflow.test.js
@@ -1,0 +1,113 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const WORKFLOW_PATH = path.join(
+  __dirname,
+  "..",
+  ".github",
+  "workflows",
+  "release-linux.yml"
+);
+
+const SCRIPT_PATH = path.join(
+  __dirname,
+  "..",
+  "scripts",
+  "release",
+  "bundle-node-linux.sh"
+);
+
+function loadWorkflow() {
+  return fs.readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+function loadScript() {
+  return fs.readFileSync(SCRIPT_PATH, "utf8");
+}
+
+test("release-linux workflow file exists", () => {
+  assert.ok(fs.existsSync(WORKFLOW_PATH));
+});
+
+test("workflow supports manual and reusable invocation", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("workflow_dispatch:"));
+  assert.ok(content.includes("workflow_call:"));
+  assert.ok(content.includes("version:"));
+});
+
+test("workflow uses an Ubuntu runner", () => {
+  const content = loadWorkflow();
+  assert.ok(/runs-on:\s*ubuntu-latest/.test(content));
+});
+
+test("workflow verifies the requested version against package.json", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("Verify version"));
+  assert.ok(content.includes("package.json version"));
+});
+
+test("workflow builds dashboard before bundling the Linux runtime", () => {
+  const content = loadWorkflow();
+  const dashBuild = content.indexOf("dashboard:build");
+  const bundle = content.indexOf("bundle-node-linux.sh");
+  assert.ok(dashBuild > 0, "should build dashboard");
+  assert.ok(bundle > 0, "should bundle Linux runtime");
+  assert.ok(dashBuild < bundle, "dashboard build must come before Linux bundle");
+});
+
+test("workflow verifies the packaged Linux bundle contains the dashboard and launcher", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("build/linux-x64/tokentracker"));
+  assert.ok(content.includes("EmbeddedServer/node"));
+  assert.ok(content.includes("dashboard/dist/index.html"));
+});
+
+test("workflow packages a stable linux-x64 tarball asset", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("TokenTracker-linux-x64.tar.gz"));
+  assert.ok(content.includes("tar -C build/linux-x64 -czf"));
+});
+
+test("workflow uploads the tarball to the GitHub release", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("gh release upload"));
+  assert.ok(content.includes("gh release create"));
+  assert.ok(content.includes("--clobber"));
+});
+
+test("workflow has a per-version concurrency guard", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("concurrency:"));
+  assert.ok(content.includes("release-linux-${{ inputs.version }}"));
+});
+
+test("linux bundle script exists", () => {
+  assert.ok(fs.existsSync(SCRIPT_PATH));
+});
+
+test("linux bundle script pins the Node runtime and downloads the linux-x64 archive", () => {
+  const script = loadScript();
+  assert.ok(script.includes('EXPECTED_NODE_VERSION="22.22.2"'));
+  assert.ok(script.includes('node-v${NODE_VERSION}-linux-x64.tar.xz'));
+});
+
+test("linux bundle script installs production dependencies only", () => {
+  const script = loadScript();
+  assert.ok(script.includes("npm install --omit=dev --no-optional --ignore-scripts"));
+});
+
+test("linux bundle script fails when dashboard/dist is missing", () => {
+  const script = loadScript();
+  assert.ok(script.includes("dashboard/dist not found"));
+  assert.ok(script.includes("exit 1"));
+});
+
+test("linux bundle script emits a launcher that execs the bundled tracker", () => {
+  const script = loadScript();
+  assert.ok(script.includes('cat > "$BUILD_ROOT/tokentracker"'));
+  assert.ok(script.includes('EmbeddedServer/node'));
+  assert.ok(script.includes('EmbeddedServer/tokentracker/bin/tracker.js'));
+});


### PR DESCRIPTION
## Title: feat: add Linux x64 release tarball workflow

### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** The project currently ships native release artifacts for macOS and Windows, but Linux users have no first-party release output. The CLI works on Linux, yet there is no reproducible upstream workflow that assembles a self-contained Linux bundle and attaches it to a GitHub release.
- **Trade-offs:** This PR starts with a self-contained `linux-x64` tarball instead of a Linux tray host or distro-native packages. That keeps the artifact small in scope and reviewable, at the cost of deferring `arm64`, `.deb/.rpm`, and desktop-shell integration to follow-up work.

### 2. Implementation Details (Implementation)
- Added `scripts/release/bundle-node-linux.sh` to assemble a self-contained `build/linux-x64` bundle with a pinned Node runtime, packaged tracker sources, production dependencies, dashboard assets, and a top-level `tokentracker` launcher.
- Added `.github/workflows/release-linux.yml` as a manual/reusable Ubuntu workflow that verifies the requested version, builds the dashboard, bundles the Linux runtime, verifies required files, packages `TokenTracker-linux-x64.tar.gz`, and uploads it to the target GitHub release.
- Added `test/release-linux-workflow.test.js` to lock the workflow contract and bundle-script invariants in CI.
- **Note:** This PR intentionally does not wire Linux into the existing macOS/Windows fan-out workflow yet. That integration is follow-up work once the standalone Linux artifact path lands.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `release-linux.yml` and `bundle-node-linux.sh` contract checks (runner, step order, asset naming, required files, launcher generation)
- [x] Ran targeted test suite: `node --test test/release-linux-workflow.test.js`
- [x] Verified backward compatibility with the current release model by keeping the existing macOS/Windows workflows untouched
- **Benchmark:** Not applicable. This adds a release-time bundle path only; no runtime hot path changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linux release workflow that can be run manually or called from other workflows.
  * Packages the app into a standalone Linux x64 tarball and publishes it as a GitHub release asset.
  * Includes a self-contained Linux bundle with the app, dashboard build, and embedded Node runtime.

* **Bug Fixes**
  * Prevents overlapping release jobs for the same version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->