### PR TITLE
feat(openrouter): add OpenRouter Analytics API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 | **Claude Code** | ✅ Auto | SessionEnd hook in `settings.json` |
 | **Codex CLI** | ✅ Auto | TOML notify hook in `config.toml` |
 | **Cursor** | ✅ Auto | API + SQLite auth token |
+| **OpenRouter** | ✅ Auto | OpenRouter Analytics API (`OPENROUTER_API_KEY`) |
 | **Kiro** | ✅ Auto | SQLite + JSONL hybrid |
 | **Gemini CLI** | ✅ Auto | SessionEnd hook |
 | **OpenCode** | ✅ Auto | Plugin system + SQLite |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 | **Claude Code** | ✅ Auto | SessionEnd hook in `settings.json` |
 | **Codex CLI** | ✅ Auto | TOML notify hook in `config.toml` |
 | **Cursor** | ✅ Auto | API + SQLite auth token |
-| **OpenRouter** | ✅ Auto | OpenRouter Analytics API (`OPENROUTER_API_KEY`) |
+| **OpenRouter** | ✅ Auto | OpenRouter Analytics API (Settings, `tokentracker config openrouter set`, or `OPENROUTER_API_KEY`) |
 | **Kiro** | ✅ Auto | SQLite + JSONL hybrid |
 | **Gemini CLI** | ✅ Auto | SessionEnd hook |
 | **OpenCode** | ✅ Auto | Plugin system + SQLite |

--- a/dashboard/src/components/settings/OpenRouterSection.jsx
+++ b/dashboard/src/components/settings/OpenRouterSection.jsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { ExternalLink, KeyRound, Loader2 } from "lucide-react";
+import { copy } from "../../lib/copy";
+import { isLocalDashboardHost } from "../../lib/cloud-sync-prefs";
+import { useOpenRouterConfig } from "../../hooks/use-openrouter-config";
+import { SectionCard, SettingsRow } from "./Controls.jsx";
+
+export function OpenRouterSection() {
+  if (!isLocalDashboardHost()) return null;
+
+  const config = useOpenRouterConfig(true);
+  const [draftKey, setDraftKey] = React.useState("");
+  const [message, setMessage] = React.useState(null);
+
+  const configured = config.snapshot?.configured === true;
+  const envOverrides = config.snapshot?.env_overrides_config === true;
+
+  const handleSave = async () => {
+    setMessage(null);
+    try {
+      await config.save(draftKey, { sync: true });
+      setDraftKey("");
+      setMessage(copy("settings.openrouter.saved"));
+    } catch {
+      /* error surfaced via config.error */
+    }
+  };
+
+  const handleTest = async () => {
+    setMessage(null);
+    const key = draftKey.trim() || "";
+    if (!key) {
+      setMessage(copy("settings.openrouter.testNeedsKey"));
+      return;
+    }
+    try {
+      await config.test(key);
+      setMessage(copy("settings.openrouter.verified"));
+    } catch {
+      /* error surfaced via config.error */
+    }
+  };
+
+  const handleClear = async () => {
+    setMessage(null);
+    try {
+      await config.clear();
+      setDraftKey("");
+      setMessage(copy("settings.openrouter.cleared"));
+    } catch {
+      /* error surfaced via config.error */
+    }
+  };
+
+  return (
+    <SectionCard
+      title={copy("settings.section.providers")}
+      subtitle={copy("settings.openrouter.subtitle")}
+    >
+      <SettingsRow
+        label={copy("settings.openrouter.status")}
+        hint={
+          config.loading
+            ? copy("settings.openrouter.loading")
+            : configured
+              ? envOverrides
+                ? copy("settings.openrouter.statusEnv")
+                : copy("settings.openrouter.statusConfigured", {
+                    key: config.snapshot?.masked_key || "••••",
+                  })
+              : copy("settings.openrouter.statusUnset")
+        }
+        control={
+          configured ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+              <KeyRound className="h-3 w-3" aria-hidden />
+              {copy("settings.openrouter.badgeConfigured")}
+            </span>
+          ) : (
+            <span className="inline-flex items-center rounded-full bg-oai-gray-100 px-2 py-0.5 text-xs font-medium text-oai-gray-600 dark:bg-oai-gray-800 dark:text-oai-gray-300">
+              {copy("settings.openrouter.badgeUnset")}
+            </span>
+          )
+        }
+      />
+
+      <div className="py-3">
+        <label htmlFor="openrouter-api-key" className="text-sm text-oai-gray-900 dark:text-oai-gray-200">
+          {copy("settings.openrouter.apiKeyLabel")}
+        </label>
+        <p className="mt-0.5 text-xs text-oai-gray-500 dark:text-oai-gray-400">
+          {copy("settings.openrouter.apiKeyHint")}{" "}
+          <a
+            href="https://openrouter.ai/keys"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-0.5 text-oai-brand-600 hover:underline dark:text-oai-brand-400"
+          >
+            openrouter.ai/keys
+            <ExternalLink className="h-3 w-3" aria-hidden />
+          </a>
+        </p>
+        <input
+          id="openrouter-api-key"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          value={draftKey}
+          onChange={(event) => setDraftKey(event.target.value)}
+          placeholder={copy("settings.openrouter.apiKeyPlaceholder")}
+          disabled={envOverrides || config.saving || config.testing}
+          className="mt-2 w-full rounded-lg border border-oai-gray-200 bg-white px-3 py-2 font-mono text-sm text-oai-gray-900 outline-none ring-oai-brand-500 focus:border-oai-brand-500 focus:ring-1 disabled:cursor-not-allowed disabled:opacity-60 dark:border-oai-gray-800 dark:bg-oai-gray-900 dark:text-oai-white"
+        />
+        {envOverrides ? (
+          <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+            {copy("settings.openrouter.envOverride")}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 py-3">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={!draftKey.trim() || envOverrides || config.saving || config.testing}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md bg-oai-brand-600 px-3 text-xs font-medium text-white transition-colors hover:bg-oai-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {config.saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : null}
+          {config.saving ? copy("settings.openrouter.saving") : copy("settings.openrouter.save")}
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleTest()}
+          disabled={!draftKey.trim() || envOverrides || config.saving || config.testing}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-oai-gray-200 px-3 text-xs font-medium text-oai-gray-700 transition-colors hover:bg-oai-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-oai-gray-800 dark:text-oai-gray-300 dark:hover:bg-oai-gray-800"
+        >
+          {config.testing ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : null}
+          {config.testing ? copy("settings.openrouter.testing") : copy("settings.openrouter.test")}
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleClear()}
+          disabled={!configured || envOverrides || config.clearing || config.saving}
+          className="inline-flex h-8 items-center rounded-md px-3 text-xs font-medium text-oai-gray-500 transition-colors hover:bg-oai-gray-100 hover:text-oai-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-oai-gray-800 dark:hover:text-oai-gray-300"
+        >
+          {config.clearing ? copy("settings.openrouter.clearing") : copy("settings.openrouter.clear")}
+        </button>
+      </div>
+
+      {config.error ? (
+        <p className="pb-3 text-xs text-red-600 dark:text-red-400">{config.error}</p>
+      ) : null}
+      {message ? (
+        <p className="pb-3 text-xs text-emerald-700 dark:text-emerald-300">{message}</p>
+      ) : null}
+    </SectionCard>
+  );
+}

--- a/dashboard/src/components/settings/OpenRouterSection.jsx
+++ b/dashboard/src/components/settings/OpenRouterSection.jsx
@@ -91,12 +91,12 @@ export function OpenRouterSection() {
         <p className="mt-0.5 text-xs text-oai-gray-500 dark:text-oai-gray-400">
           {copy("settings.openrouter.apiKeyHint")}{" "}
           <a
-            href="https://openrouter.ai/keys"
+            href="https://openrouter.ai/settings/management-keys"
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-0.5 text-oai-brand-600 hover:underline dark:text-oai-brand-400"
           >
-            openrouter.ai/keys
+            openrouter.ai/settings/management-keys
             <ExternalLink className="h-3 w-3" aria-hidden />
           </a>
         </p>

--- a/dashboard/src/components/settings/OpenRouterSection.jsx
+++ b/dashboard/src/components/settings/OpenRouterSection.jsx
@@ -91,12 +91,12 @@ export function OpenRouterSection() {
         <p className="mt-0.5 text-xs text-oai-gray-500 dark:text-oai-gray-400">
           {copy("settings.openrouter.apiKeyHint")}{" "}
           <a
-            href="https://openrouter.ai/settings/management-keys"
+            href={copy("settings.openrouter.managementKeysUrl")}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-0.5 text-oai-brand-600 hover:underline dark:text-oai-brand-400"
           >
-            openrouter.ai/settings/management-keys
+            {copy("settings.openrouter.managementKeysLink")}
             <ExternalLink className="h-3 w-3" aria-hidden />
           </a>
         </p>

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -369,7 +369,7 @@ settings.openrouter.statusEnv,ui,SettingsPage,OpenRouterSection,status_env,"OPEN
 settings.openrouter.badgeConfigured,ui,SettingsPage,OpenRouterSection,badge_configured,"Configured",,active
 settings.openrouter.badgeUnset,ui,SettingsPage,OpenRouterSection,badge_unset,"Not set",,active
 settings.openrouter.apiKeyLabel,ui,SettingsPage,OpenRouterSection,api_key_label,"API key",,active
-settings.openrouter.apiKeyHint,ui,SettingsPage,OpenRouterSection,api_key_hint,"Create a management key at",,active
+settings.openrouter.apiKeyHint,ui,SettingsPage,OpenRouterSection,api_key_hint,"Requires a management key (not inference key). Create one at",,active
 settings.openrouter.apiKeyPlaceholder,ui,SettingsPage,OpenRouterSection,api_key_placeholder,"sk-or-v1-…",,active
 settings.openrouter.envOverride,ui,SettingsPage,OpenRouterSection,env_override,"Unset OPENROUTER_API_KEY in your shell to manage the key from Settings.",,active
 settings.openrouter.save,ui,SettingsPage,OpenRouterSection,save,"Save & sync",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -370,6 +370,8 @@ settings.openrouter.badgeConfigured,ui,SettingsPage,OpenRouterSection,badge_conf
 settings.openrouter.badgeUnset,ui,SettingsPage,OpenRouterSection,badge_unset,"Not set",,active
 settings.openrouter.apiKeyLabel,ui,SettingsPage,OpenRouterSection,api_key_label,"API key",,active
 settings.openrouter.apiKeyHint,ui,SettingsPage,OpenRouterSection,api_key_hint,"Requires a management key (not inference key). Create one at",,active
+settings.openrouter.managementKeysLink,ui,SettingsPage,OpenRouterSection,management_keys_link,"openrouter.ai/settings/management-keys",,active
+settings.openrouter.managementKeysUrl,ui,SettingsPage,OpenRouterSection,management_keys_url,"https://openrouter.ai/settings/management-keys",,active
 settings.openrouter.apiKeyPlaceholder,ui,SettingsPage,OpenRouterSection,api_key_placeholder,"sk-or-v1-…",,active
 settings.openrouter.envOverride,ui,SettingsPage,OpenRouterSection,env_override,"Unset OPENROUTER_API_KEY in your shell to manage the key from Settings.",,active
 settings.openrouter.save,ui,SettingsPage,OpenRouterSection,save,"Save & sync",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -359,6 +359,29 @@ settings.page.subtitle,ui,SettingsPage,SettingsPage,subtitle,"Manage your accoun
 settings.section.appearance,ui,SettingsPage,SettingsPage,sec_appearance,"Appearance",,active
 settings.section.account,ui,SettingsPage,SettingsPage,sec_account,"Account",,active
 settings.section.limits,ui,SettingsPage,SettingsPage,sec_limits,"Limits Display",,active
+settings.section.providers,ui,SettingsPage,OpenRouterSection,sec_providers,"API Providers",,active
+settings.openrouter.subtitle,ui,SettingsPage,OpenRouterSection,subtitle,"Connect OpenRouter to sync usage from the Analytics API.",,active
+settings.openrouter.status,ui,SettingsPage,OpenRouterSection,status,"OpenRouter",,active
+settings.openrouter.loading,ui,SettingsPage,OpenRouterSection,loading,"Checking configuration…",,active
+settings.openrouter.statusConfigured,ui,SettingsPage,OpenRouterSection,status_configured,"Saved key {{key}}",,active
+settings.openrouter.statusUnset,ui,SettingsPage,OpenRouterSection,status_unset,"No API key saved on this machine.",,active
+settings.openrouter.statusEnv,ui,SettingsPage,OpenRouterSection,status_env,"OPENROUTER_API_KEY env var is active and overrides saved config.",,active
+settings.openrouter.badgeConfigured,ui,SettingsPage,OpenRouterSection,badge_configured,"Configured",,active
+settings.openrouter.badgeUnset,ui,SettingsPage,OpenRouterSection,badge_unset,"Not set",,active
+settings.openrouter.apiKeyLabel,ui,SettingsPage,OpenRouterSection,api_key_label,"API key",,active
+settings.openrouter.apiKeyHint,ui,SettingsPage,OpenRouterSection,api_key_hint,"Create a management key at",,active
+settings.openrouter.apiKeyPlaceholder,ui,SettingsPage,OpenRouterSection,api_key_placeholder,"sk-or-v1-…",,active
+settings.openrouter.envOverride,ui,SettingsPage,OpenRouterSection,env_override,"Unset OPENROUTER_API_KEY in your shell to manage the key from Settings.",,active
+settings.openrouter.save,ui,SettingsPage,OpenRouterSection,save,"Save & sync",,active
+settings.openrouter.saving,ui,SettingsPage,OpenRouterSection,saving,"Saving…",,active
+settings.openrouter.test,ui,SettingsPage,OpenRouterSection,test,"Test key",,active
+settings.openrouter.testing,ui,SettingsPage,OpenRouterSection,testing,"Testing…",,active
+settings.openrouter.clear,ui,SettingsPage,OpenRouterSection,clear,"Clear saved key",,active
+settings.openrouter.clearing,ui,SettingsPage,OpenRouterSection,clearing,"Clearing…",,active
+settings.openrouter.saved,ui,SettingsPage,OpenRouterSection,saved,"OpenRouter key saved and sync started.",,active
+settings.openrouter.verified,ui,SettingsPage,OpenRouterSection,verified,"OpenRouter key verified.",,active
+settings.openrouter.cleared,ui,SettingsPage,OpenRouterSection,cleared,"Saved OpenRouter key removed.",,active
+settings.openrouter.testNeedsKey,ui,SettingsPage,OpenRouterSection,test_needs_key,"Enter an API key to test.",,active
 settings.labs.qpd.label,ui,SettingsPage,LabsSection,qpd_label,"Analyze PR cost-efficiency",,active
 settings.labs.qpd.hint,ui,SettingsPage,LabsSection,qpd_hint,"Link GitHub PR history to analyze average delivery costs and effective Tokens per model.",,active
 settings.labs.qpd.aria,ui,SettingsPage,LabsSection,qpd_aria,"Toggle PR cost-efficiency analysis",,active

--- a/dashboard/src/hooks/use-openrouter-config.ts
+++ b/dashboard/src/hooks/use-openrouter-config.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  clearOpenRouterConfig,
+  getOpenRouterConfig,
+  probeOpenRouterConfig,
+  saveOpenRouterConfig,
+  type OpenRouterConfigSnapshot,
+} from "../lib/api";
+
+type OpenRouterConfigState = {
+  loading: boolean;
+  saving: boolean;
+  testing: boolean;
+  clearing: boolean;
+  error: string | null;
+  snapshot: OpenRouterConfigSnapshot | null;
+  refresh: () => Promise<void>;
+  save: (apiKey: string, options?: { sync?: boolean }) => Promise<void>;
+  clear: () => Promise<void>;
+  test: (apiKey: string) => Promise<void>;
+};
+
+export function useOpenRouterConfig(enabled = true): OpenRouterConfigState {
+  const [loading, setLoading] = useState(enabled);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<OpenRouterConfigSnapshot | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getOpenRouterConfig();
+      setSnapshot(next);
+    } catch (err: any) {
+      setError(err?.message || String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const save = useCallback(
+    async (apiKey: string, options: { sync?: boolean } = {}) => {
+      setSaving(true);
+      setError(null);
+      try {
+        const next = await saveOpenRouterConfig({
+          apiKey,
+          verify: true,
+          sync: options.sync === true,
+        });
+        setSnapshot(next);
+      } catch (err: any) {
+        setError(err?.message || String(err));
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [],
+  );
+
+  const test = useCallback(async (apiKey: string) => {
+    setTesting(true);
+    setError(null);
+    try {
+      await probeOpenRouterConfig({ apiKey });
+    } catch (err: any) {
+      setError(err?.message || String(err));
+      throw err;
+    } finally {
+      setTesting(false);
+    }
+  }, []);
+
+  const clear = useCallback(async () => {
+    setClearing(true);
+    setError(null);
+    try {
+      const next = await clearOpenRouterConfig();
+      setSnapshot(next);
+    } catch (err: any) {
+      setError(err?.message || String(err));
+      throw err;
+    } finally {
+      setClearing(false);
+    }
+  }, []);
+
+  return {
+    loading,
+    saving,
+    testing,
+    clearing,
+    error,
+    snapshot,
+    refresh,
+    save,
+    clear,
+    test,
+  };
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -766,3 +766,107 @@ export async function renameAccountDevice({ deviceId, name, accessToken }: AnyRe
     body: { device_id: deviceId, device_name: name },
   });
 }
+
+export type OpenRouterConfigSnapshot = {
+  ok?: boolean;
+  configured: boolean;
+  source: "env" | "config" | "none";
+  masked_key: string | null;
+  configured_at: string | null;
+  last_verified_at: string | null;
+  env_overrides_config: boolean;
+};
+
+export async function getOpenRouterConfig({ signal }: { signal?: AbortSignal } = {}) {
+  const response = await fetch("/functions/tokentracker-openrouter-config", {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+    signal,
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.ok === false) {
+    throw new Error(payload?.error || `OpenRouter config request failed with HTTP ${response.status}`);
+  }
+  return payload as OpenRouterConfigSnapshot;
+}
+
+export async function saveOpenRouterConfig({
+  apiKey,
+  verify = true,
+  sync = false,
+  signal,
+}: {
+  apiKey: string;
+  verify?: boolean;
+  sync?: boolean;
+  signal?: AbortSignal;
+}) {
+  const authHeaders = await getLocalApiAuthHeaders();
+  const response = await fetch("/functions/tokentracker-openrouter-config", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...authHeaders,
+    },
+    cache: "no-store",
+    signal,
+    body: JSON.stringify({ apiKey, verify, sync }),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.ok === false) {
+    throw new Error(payload?.error || `OpenRouter save failed with HTTP ${response.status}`);
+  }
+  return payload as OpenRouterConfigSnapshot & { sync?: unknown };
+}
+
+export async function clearOpenRouterConfig({ signal }: { signal?: AbortSignal } = {}) {
+  const authHeaders = await getLocalApiAuthHeaders();
+  const response = await fetch("/functions/tokentracker-openrouter-config", {
+    method: "DELETE",
+    headers: { Accept: "application/json", ...authHeaders },
+    cache: "no-store",
+    signal,
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.ok === false) {
+    throw new Error(payload?.error || `OpenRouter clear failed with HTTP ${response.status}`);
+  }
+  return payload as OpenRouterConfigSnapshot;
+}
+
+export async function probeOpenRouterConfig({
+  apiKey,
+  signal,
+}: {
+  apiKey: string;
+  signal?: AbortSignal;
+}) {
+  const authHeaders = await getLocalApiAuthHeaders();
+  const response = await fetch("/functions/tokentracker-openrouter-config", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...authHeaders,
+    },
+    cache: "no-store",
+    signal,
+    body: JSON.stringify({ apiKey, probe: true, save: false, verify: true }),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.ok === false) {
+    throw new Error(payload?.error || `OpenRouter test failed with HTTP ${response.status}`);
+  }
+  return payload;
+}
+
+export async function testOpenRouterConfig({
+  apiKey,
+  signal,
+}: {
+  apiKey: string;
+  signal?: AbortSignal;
+}) {
+  return probeOpenRouterConfig({ apiKey, signal });
+}

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -5,6 +5,7 @@ import { AppearanceSection } from "../components/settings/AppearanceSection.jsx"
 import { SectionCard, SegmentedControl } from "../components/settings/Controls.jsx";
 import { MenuBarSection, NativeAppFooter } from "../components/settings/MenuBarSection.jsx";
 import { LIMIT_DISPLAY_MODES, useLimitsDisplayPrefs } from "../hooks/use-limits-display-prefs.js";
+import { OpenRouterSection } from "../components/settings/OpenRouterSection.jsx";
 import { copy } from "../lib/copy";
 
 function LimitsDisplayModeControl({ prefs }) {
@@ -40,6 +41,7 @@ export function SettingsPage() {
             <AppearanceSection />
             <MenuBarSection />
             <AccountSection />
+            <OpenRouterSection />
             <SectionCard
               title={copy("settings.section.limits")}
               action={<LimitsDisplayModeControl prefs={limitsPrefs} />}

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -58,6 +58,7 @@ const PROVIDER_COLORS = {
   "KILO-CODE": "#facc15",
   MIMO: "#ff6900",         // Xiaomi MiMo brand orange
   DROID: "#ef4444",        // red-500 (Factory brand)
+  ZCODE: "#14b8a6",        // teal-500 (Z.ai / GLM — distinct from the blues)
   OPENROUTER: "#6366f1",  // indigo-500
 };
 

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -58,7 +58,7 @@ const PROVIDER_COLORS = {
   "KILO-CODE": "#facc15",
   MIMO: "#ff6900",         // Xiaomi MiMo brand orange
   DROID: "#ef4444",        // red-500 (Factory brand)
-  ZCODE: "#14b8a6",        // teal-500 (Z.ai / GLM — distinct from the blues)
+  OPENROUTER: "#6366f1",  // indigo-500
 };
 
 function getProviderColor(label, index) {

--- a/scripts/ops/ui-hardcode-baseline.json
+++ b/scripts/ops/ui-hardcode-baseline.json
@@ -1,12 +1,12 @@
 {
-  "generatedAt": "2026-07-04T09:28:02.390Z",
+  "generatedAt": "2026-07-05T19:37:10.032Z",
   "root": "dashboard/src",
   "rules": {
     "colors": "hex/rgb(a) literals",
     "rawText": "JSX text nodes containing letters or digits"
   },
   "totals": {
-    "colors": 276,
+    "colors": 277,
     "rawText": 167
   },
   "files": {
@@ -339,7 +339,7 @@
       ]
     },
     "dashboard/src/ui/dashboard/components/UsageOverview.jsx": {
-      "colors": 13,
+      "colors": 14,
       "rawText": 3,
       "rawTextTokens": [
         "0 && (",

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ const { cmdUninstall } = require("./commands/uninstall");
 const { cmdServe } = require("./commands/serve");
 const { cmdDeviceLogin } = require("./commands/device-login");
 const { cmdWrapped } = require("./commands/wrapped");
+const { cmdConfig } = require("./commands/config");
 
 async function run(argv) {
   const [command, ...rest] = argv;
@@ -56,6 +57,9 @@ async function run(argv) {
     case "wrapped":
       await cmdWrapped(rest);
       return;
+    case "config":
+      await cmdConfig(rest);
+      return;
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -79,6 +83,7 @@ function printHelp() {
       "  npx tokentracker [--debug] uninstall [--purge]",
       "  npx tokentracker [--debug] device-login [--json] [--base-url <url>]",
       "  npx tokentracker [--debug] wrapped [--year 2026] [--json]",
+      "  npx tokentracker [--debug] config openrouter status|set|clear|test [--json] [--key <key>] [--no-verify]",
       "",
       "Notes:",
       "  - init: consent first, local setup next, browser sign-in last.",

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,0 +1,145 @@
+const os = require("node:os");
+
+const { promptHidden } = require("../lib/prompt");
+const { resolveTrackerPaths } = require("../lib/tracker-paths");
+const {
+  getOpenRouterConfigSnapshot,
+  saveOpenRouterApiKey,
+  clearOpenRouterApiKey,
+  probeOpenRouterApiKey,
+  readTrackerConfig,
+  resolveOpenRouterApiKey,
+} = require("../lib/openrouter-config");
+
+async function cmdConfig(argv = []) {
+  const [scope, action, ...rest] = argv;
+  if (scope === "openrouter") {
+    await cmdConfigOpenRouter(action, rest);
+    return;
+  }
+  throw new Error(`Unknown config scope: ${scope || "(missing)"}. Try: config openrouter`);
+}
+
+async function cmdConfigOpenRouter(action, argv = []) {
+  const opts = parseArgs(argv);
+  const home = os.homedir();
+  const { trackerDir } = await resolveTrackerPaths({ home });
+  const { config } = await readTrackerConfig({ home, trackerDir });
+
+  switch (action) {
+    case "status":
+      await printOpenRouterStatus({ config, opts });
+      return;
+    case "set":
+      await setOpenRouterKey({ config, trackerDir, home, opts });
+      return;
+    case "clear":
+      await clearOpenRouterKey({ trackerDir, home, opts });
+      return;
+    case "test": {
+      const apiKey = resolveOpenRouterApiKey({ config, env: process.env });
+      if (!apiKey) {
+        const message = "OpenRouter API key not configured";
+        if (opts.json) {
+          process.stdout.write(JSON.stringify({ ok: false, error: message }, null, 2) + "\n");
+        } else {
+          process.stderr.write(`${message}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+      const probe = await probeOpenRouterApiKey(apiKey);
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(probe, null, 2) + "\n");
+      } else if (probe.ok) {
+        process.stdout.write("OpenRouter API key verified\n");
+      } else {
+        process.stderr.write(`${probe.error || "OpenRouter API key test failed"}\n`);
+      }
+      if (!probe.ok) process.exitCode = 1;
+      return;
+    }
+    default:
+      throw new Error(
+        `Unknown config openrouter action: ${action || "(missing)"}. Try: status | set | clear | test`,
+      );
+  }
+}
+
+async function printOpenRouterStatus({ config, opts }) {
+  const snapshot = getOpenRouterConfigSnapshot({ config, env: process.env });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(snapshot, null, 2) + "\n");
+    return;
+  }
+
+  if (!snapshot.configured) {
+    process.stdout.write("OpenRouter: not configured\n");
+    process.stdout.write("Set with: tokentracker config openrouter set\n");
+    return;
+  }
+
+  process.stdout.write(`OpenRouter: configured (${snapshot.source})\n`);
+  if (snapshot.masked_key) {
+    process.stdout.write(`Key: ${snapshot.masked_key}\n`);
+  }
+  if (snapshot.env_overrides_config) {
+    process.stdout.write("Note: OPENROUTER_API_KEY env overrides saved config key\n");
+  }
+  if (snapshot.configured_at) {
+    process.stdout.write(`Saved at: ${snapshot.configured_at}\n`);
+  }
+}
+
+async function setOpenRouterKey({ trackerDir, home, opts }) {
+  let apiKey = typeof opts.key === "string" ? opts.key.trim() : "";
+  if (!apiKey) {
+    apiKey = (await promptHidden("OpenRouter API key: ")).trim();
+  }
+  if (!apiKey) {
+    throw new Error("OpenRouter API key is required");
+  }
+
+  const result = await saveOpenRouterApiKey({
+    apiKey,
+    home,
+    trackerDir,
+    verify: opts.verify !== false,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(`OpenRouter API key saved (${result.masked_key})\n`);
+  if (result.verified) {
+    process.stdout.write("OpenRouter API key verified\n");
+  } else if (result.verify_error) {
+    process.stderr.write(`Warning: verification failed — ${result.verify_error}\n`);
+  }
+}
+
+async function clearOpenRouterKey({ trackerDir, home, opts }) {
+  const result = await clearOpenRouterApiKey({ home, trackerDir });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(result.cleared ? "OpenRouter API key cleared\n" : "OpenRouter API key already unset\n");
+}
+
+function parseArgs(argv) {
+  const opts = { json: false, verify: true };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") opts.json = true;
+    else if (arg === "--no-verify") opts.verify = false;
+    else if (arg === "--key") opts.key = argv[++i];
+    else if (arg === "--verify") opts.verify = true;
+    else throw new Error(`Unknown flag: ${arg}`);
+  }
+  return opts;
+}
+
+module.exports = { cmdConfig, cmdConfigOpenRouter };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -38,7 +38,7 @@ const {
   isOpencodePluginInstalled,
 } = require("../lib/opencode-config");
 const { isCursorInstalled, extractCursorSessionToken } = require("../lib/cursor-config");
-const { isOpenRouterConfigured, saveOpenRouterApiKey } = require("../lib/openrouter-config");
+const { isOpenRouterConfigured, saveOpenRouterApiKey, readTrackerConfig } = require("../lib/openrouter-config");
 const { removeOpenclawHookConfig, probeOpenclawHookState } = require("../lib/openclaw-hook");
 const {
   installOpenclawSessionPlugin,
@@ -1098,7 +1098,8 @@ function isRunnableCommand(command) {
 }
 
 async function maybePromptOpenRouterKey({ home, trackerDir }) {
-  if (isOpenRouterConfigured({ env: process.env })) return;
+  const { config } = await readTrackerConfig({ home, trackerDir });
+  if (isOpenRouterConfigured({ config, env: process.env })) return;
 
   const choice = await prompt(
     "Configure OpenRouter API key now? (y/N) ",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -38,6 +38,7 @@ const {
   isOpencodePluginInstalled,
 } = require("../lib/opencode-config");
 const { isCursorInstalled, extractCursorSessionToken } = require("../lib/cursor-config");
+const { isOpenRouterConfigured } = require("../lib/openrouter-config");
 const { removeOpenclawHookConfig, probeOpenclawHookState } = require("../lib/openclaw-hook");
 const {
   installOpenclawSessionPlugin,
@@ -94,6 +95,7 @@ const SUPPORTED_PROVIDERS = [
   "Claude Code",
   "Codex CLI",
   "Cursor",
+  "OpenRouter",
   "Gemini CLI",
   "Antigravity",
   "Kiro",
@@ -420,6 +422,7 @@ function buildIntegrationTargets({ home, trackerDir, notifyPath }) {
 async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOriginalPath }) {
   const context = buildIntegrationTargets({ home, trackerDir, notifyPath });
   context.notifyOriginalPath = notifyOriginalPath;
+  const config = await readJson(path.join(trackerDir, "config.json"));
 
   const summary = [];
 
@@ -493,6 +496,21 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
     }
   } else {
     summary.push({ label: "Cursor", status: "skipped", detail: "Not installed" });
+  }
+
+  // OpenRouter (Analytics API, optional API key)
+  if (isOpenRouterConfigured({ config, env: process.env })) {
+    summary.push({
+      label: "OpenRouter",
+      status: "detected",
+      detail: "Usage synced via OpenRouter Analytics API",
+    });
+  } else {
+    summary.push({
+      label: "OpenRouter",
+      status: "skipped",
+      detail: "Set OPENROUTER_API_KEY to enable",
+    });
   }
 
   // Kimi: passive reader — no hook installation needed.

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -38,7 +38,7 @@ const {
   isOpencodePluginInstalled,
 } = require("../lib/opencode-config");
 const { isCursorInstalled, extractCursorSessionToken } = require("../lib/cursor-config");
-const { isOpenRouterConfigured } = require("../lib/openrouter-config");
+const { isOpenRouterConfigured, saveOpenRouterApiKey } = require("../lib/openrouter-config");
 const { removeOpenclawHookConfig, probeOpenclawHookState } = require("../lib/openclaw-hook");
 const {
   installOpenclawSessionPlugin,
@@ -199,6 +199,10 @@ async function cmdInit(argv) {
   spinner.stop();
 
   renderLocalReport({ summary: setup.summary, isDryRun: false });
+
+  if (isInteractive() && !opts.yes) {
+    await maybePromptOpenRouterKey({ home, trackerDir });
+  }
 
   // Run first sync inline (with a generous timeout) so we can render the
   // *actual* token total in the success message — the aha moment. If the
@@ -509,7 +513,7 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
     summary.push({
       label: "OpenRouter",
       status: "skipped",
-      detail: "Set OPENROUTER_API_KEY to enable",
+      detail: "Set OPENROUTER_API_KEY or run: tokentracker config openrouter set",
     });
   }
 
@@ -1091,6 +1095,39 @@ function isRunnableCommand(command) {
   }
 }
 `;
+}
+
+async function maybePromptOpenRouterKey({ home, trackerDir }) {
+  if (isOpenRouterConfigured({ env: process.env })) return;
+
+  const choice = await prompt(
+    "Configure OpenRouter API key now? (y/N) ",
+  );
+  const normalized = String(choice || "")
+    .trim()
+    .toLowerCase();
+  if (!normalized.startsWith("y")) return;
+
+  const apiKey = (await promptHidden("OpenRouter API key: ")).trim();
+  if (!apiKey) {
+    process.stdout.write("OpenRouter setup skipped (empty key).\n");
+    return;
+  }
+
+  try {
+    const result = await saveOpenRouterApiKey({
+      apiKey,
+      home,
+      trackerDir,
+      verify: true,
+    });
+    process.stdout.write(`OpenRouter API key saved (${result.masked_key}).\n`);
+    if (!result.verified && result.verify_error) {
+      process.stderr.write(`Warning: verification failed — ${result.verify_error}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`OpenRouter setup failed: ${err?.message || err}\n`);
+  }
 }
 
 module.exports = { cmdInit, buildNotifyHandler, installLocalTrackerApp };

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -64,6 +64,7 @@ const {
 } = require("../lib/rollout");
 const { getWslMode, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
+const { isOpenRouterConfigured } = require("../lib/openrouter-config");
 
 async function cmdStatus(argv = []) {
   const opts = parseArgs(argv);
@@ -415,6 +416,9 @@ async function cmdStatus(argv = []) {
           installed: hermesInstalled,
           detail: hermesPath,
         },
+        openrouter: isOpenRouterConfigured({ config, env: process.env })
+          ? { installed: true, detail: "analytics api" }
+          : { installed: false },
       },
       copilot: {
         token_set: Boolean(copilotToken),
@@ -521,6 +525,9 @@ async function cmdStatus(argv = []) {
         if (!hermesInstalled) return [];
         return [`- Hermes Agent: state.db found (${hermesPath})`];
       })(),
+      isOpenRouterConfigured({ config, env: process.env })
+        ? "- OpenRouter: Analytics API key configured"
+        : "- OpenRouter: unset (set OPENROUTER_API_KEY to enable)",
       ...(() => {
         const passive = passiveProviders.filter((p) => p.passive);
         if (passive.length === 0) return [];

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -527,7 +527,7 @@ async function cmdStatus(argv = []) {
       })(),
       isOpenRouterConfigured({ config, env: process.env })
         ? "- OpenRouter: Analytics API key configured"
-        : "- OpenRouter: unset (set OPENROUTER_API_KEY to enable)",
+        : "- OpenRouter: unset (Settings → API Providers, or: tokentracker config openrouter set)",
       ...(() => {
         const passive = passiveProviders.filter((p) => p.passive);
         if (passive.length === 0) return [];

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -31,6 +31,7 @@ const {
   parseOpencodeDbIncremental,
   parseOpenclawIncremental,
   parseCursorApiIncremental,
+  parseOpenRouterApiIncremental,
   parseKiroIncremental,
   parseHermesIncremental,
   gooseInstallOwnsCursor,
@@ -91,6 +92,11 @@ const {
   fetchCursorUsageCsv,
   parseCursorCsv,
 } = require("../lib/cursor-config");
+const {
+  resolveOpenRouterApiKey,
+  isOpenRouterConfigured,
+  fetchOpenRouterDailyUsage,
+} = require("../lib/openrouter-config");
 const { purgeProjectUsage } = require("../lib/project-usage-purge");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const { resolveRuntimeConfig } = require("../lib/runtime-config");
@@ -197,6 +203,7 @@ const AUTO_SYNC_SOURCES = new Set([
   "omp",
   "opencode",
   "openclaw",
+  "openrouter",
   "pi",
   "roocode",
   "workbuddy",
@@ -913,6 +920,46 @@ async function cmdSync(argv) {
       }
     }
 
+    // ── OpenRouter (Analytics API) ──
+    let openrouterResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (sourceAllowed("openrouter") && isOpenRouterConfigured({ config, env: process.env })) {
+      const openrouterApiKey = resolveOpenRouterApiKey({ config, env: process.env });
+      if (openrouterApiKey) {
+        try {
+          if (progress?.enabled) {
+            progress.start("Fetching OpenRouter usage...");
+          }
+          const records = await fetchOpenRouterDailyUsage({ apiKey: openrouterApiKey });
+          if (records.length > 0) {
+            if (progress?.enabled) {
+              progress.start(
+                `Parsing OpenRouter ${renderBar(0)} 0/${formatNumber(records.length)} records | buckets 0`,
+              );
+            }
+            openrouterResult = await parseOpenRouterApiIncremental({
+              records,
+              cursors,
+              queuePath,
+              onProgress: (p) => {
+                if (!progress?.enabled) return;
+                const pct = p.total > 0 ? p.index / p.total : 1;
+                progress.update(
+                  `Parsing OpenRouter ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
+                    p.total,
+                  )} records | buckets ${formatNumber(p.bucketsQueued)}`,
+                );
+              },
+              source: "openrouter",
+            });
+          }
+        } catch (err) {
+          if (!opts.auto) {
+            process.stderr.write(`OpenRouter sync: ${err.message}\n`);
+          }
+        }
+      }
+    }
+
     // ── Kiro (SQLite-based, with JSONL fallback) ──
     let kiroResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const kiroDbPath = resolveKiroDbPath();
@@ -1461,6 +1508,7 @@ async function cmdSync(argv) {
         antigravityResult.filesProcessed +
         opencodeResult.filesProcessed +
         cursorResult.recordsProcessed +
+        openrouterResult.recordsProcessed +
         kiroResult.recordsProcessed +
         kiroCliResult.recordsProcessed +
         hermesResult.recordsProcessed +
@@ -1489,6 +1537,7 @@ async function cmdSync(argv) {
         antigravityResult.bucketsQueued +
         opencodeResult.bucketsQueued +
         cursorResult.bucketsQueued +
+        openrouterResult.bucketsQueued +
         kiroResult.bucketsQueued +
         kiroCliResult.bucketsQueued +
         hermesResult.bucketsQueued +

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1966,18 +1966,16 @@ function createLocalApiHandler({ queuePath }) {
         }
         const verify = body.verify !== false;
         try {
-          if (verify || probeOnly) {
+          if (probeOnly) {
             const probe = await probeOpenRouterApiKey(apiKey);
             if (!probe.ok) {
               json(res, { ok: false, error: probe.error || "OpenRouter API key verification failed" }, 400);
               return true;
             }
-          }
-          if (probeOnly) {
             json(res, { ok: true, verified: true });
             return true;
           }
-          const saved = await saveOpenRouterApiKey({ apiKey, verify: false });
+          const saved = await saveOpenRouterApiKey({ apiKey, verify });
           const snapshot = saved.snapshot || getOpenRouterConfigSnapshot({ config: {} });
           let sync = null;
           if (body.sync === true) {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -43,6 +43,13 @@ const {
 } = require("./claude-categorizer");
 
 const { computeCodexContextBreakdown } = require("./codex-context-breakdown");
+const {
+  getOpenRouterConfigSnapshot,
+  saveOpenRouterApiKey,
+  clearOpenRouterApiKey,
+  probeOpenRouterApiKey,
+  readTrackerConfig,
+} = require("./openrouter-config");
 
 // ---------------------------------------------------------------------------
 // Queue data helpers
@@ -1921,6 +1928,79 @@ function createLocalApiHandler({ queuePath }) {
         }
         setCloudSyncPref(body.enabled);
         json(res, { ok: true, enabled: getCloudSyncPref() });
+        return true;
+      }
+      json(res, { error: "Method Not Allowed" }, 405);
+      return true;
+    }
+
+    // --- openrouter-config (API key management for OpenRouter analytics) ---
+    if (p === "/functions/tokentracker-openrouter-config") {
+      const method = String(req.method || "GET").toUpperCase();
+      if (method === "GET") {
+        try {
+          const { config } = await readTrackerConfig();
+          const snapshot = getOpenRouterConfigSnapshot({ config, env: process.env });
+          json(res, { ok: true, ...snapshot });
+        } catch (e) {
+          json(res, { ok: false, error: e?.message || String(e) }, 500);
+        }
+        return true;
+      }
+      if (method === "POST" || method === "PUT") {
+        if (!isAuthorizedLocalMutation(req)) {
+          json(res, { ok: false, error: "Unauthorized" }, 401);
+          return true;
+        }
+        let body = {};
+        try {
+          body = await readJsonBody(req);
+        } catch {
+          body = {};
+        }
+        const apiKey = typeof body?.apiKey === "string" ? body.apiKey.trim() : "";
+        const probeOnly = body.probe === true && body.save !== true;
+        if (!apiKey) {
+          json(res, { ok: false, error: "apiKey is required" }, 400);
+          return true;
+        }
+        const verify = body.verify !== false;
+        try {
+          if (verify || probeOnly) {
+            const probe = await probeOpenRouterApiKey(apiKey);
+            if (!probe.ok) {
+              json(res, { ok: false, error: probe.error || "OpenRouter API key verification failed" }, 400);
+              return true;
+            }
+          }
+          if (probeOnly) {
+            json(res, { ok: true, verified: true });
+            return true;
+          }
+          const saved = await saveOpenRouterApiKey({ apiKey, verify: false });
+          const snapshot = saved.snapshot || getOpenRouterConfigSnapshot({ config: {} });
+          let sync = null;
+          if (body.sync === true) {
+            sync = await runSyncCommand({}, { timeoutMs: SYNC_TIMEOUT_MS });
+          }
+          json(res, { ok: true, ...snapshot, sync });
+        } catch (e) {
+          json(res, { ok: false, error: e?.message || String(e) }, 500);
+        }
+        return true;
+      }
+      if (method === "DELETE") {
+        if (!isAuthorizedLocalMutation(req)) {
+          json(res, { ok: false, error: "Unauthorized" }, 401);
+          return true;
+        }
+        try {
+          const result = await clearOpenRouterApiKey();
+          const snapshot = result.snapshot || getOpenRouterConfigSnapshot({ config: {} });
+          json(res, { ok: true, ...snapshot });
+        } catch (e) {
+          json(res, { ok: false, error: e?.message || String(e) }, 500);
+        }
         return true;
       }
       json(res, { error: "Method Not Allowed" }, 405);

--- a/src/lib/openrouter-config.js
+++ b/src/lib/openrouter-config.js
@@ -1,0 +1,164 @@
+const OPENROUTER_ANALYTICS_QUERY_URL = "https://openrouter.ai/api/v1/analytics/query";
+
+function toInt(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}
+
+function openrouterDebugLog(message, env = process.env) {
+  const dbg = String((env && env.TOKENTRACKER_DEBUG) || "").toLowerCase();
+  if (dbg === "1" || dbg === "true") {
+    process.stderr.write(`[openrouter] ${message}\n`);
+  }
+}
+
+function resolveOpenRouterApiKey({ config, env = process.env } = {}) {
+  const fromEnv = typeof env.OPENROUTER_API_KEY === "string" ? env.OPENROUTER_API_KEY.trim() : "";
+  if (fromEnv) return fromEnv;
+  const fromConfig =
+    typeof config?.openrouter?.apiKey === "string" ? config.openrouter.apiKey.trim() : "";
+  return fromConfig || null;
+}
+
+function isOpenRouterConfigured({ config, env = process.env } = {}) {
+  return Boolean(resolveOpenRouterApiKey({ config, env }));
+}
+
+function resolveOpenRouterDayKey(row) {
+  if (!row || typeof row !== "object") return null;
+  const candidates = [
+    row.date__day,
+    row.created_at__day,
+    row.date__,
+    row.created_at__,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string" || !candidate.trim()) continue;
+    const trimmed = candidate.trim();
+    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
+      return trimmed.slice(0, 10);
+    }
+  }
+  return null;
+}
+
+function dayKeyToIsoDate(dayKey) {
+  if (!dayKey) return null;
+  return `${dayKey}T12:00:00.000Z`;
+}
+
+/**
+ * Parse OpenRouter analytics query rows into Cursor-like records for rollout.
+ */
+function parseOpenRouterAnalyticsRows(payload) {
+  const rows = payload?.data?.data;
+  if (!Array.isArray(rows)) return [];
+
+  const records = [];
+  for (const row of rows) {
+    const dayKey = resolveOpenRouterDayKey(row);
+    if (!dayKey) continue;
+
+    const model = typeof row.model === "string" && row.model.trim() ? row.model.trim() : "unknown";
+    const inputTokens = toInt(row.tokens_input);
+    const outputTokens = toInt(row.tokens_output);
+    const totalTokens = toInt(row.tokens_total) || inputTokens + outputTokens;
+    if (totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0) continue;
+
+    records.push({
+      date: dayKeyToIsoDate(dayKey),
+      model,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    });
+  }
+
+  return records;
+}
+
+/**
+ * Fetch daily OpenRouter usage via the official Analytics API.
+ * Requires a management-capable API key.
+ */
+async function fetchOpenRouterDailyUsage({
+  apiKey,
+  daysBack = 90,
+  timeoutMs = 30000,
+  fetchImpl = fetch,
+  now = new Date(),
+} = {}) {
+  if (!apiKey || typeof apiKey !== "string") {
+    throw new Error("OpenRouter API key is required");
+  }
+
+  const end = now instanceof Date ? now : new Date(now);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - Math.max(1, Number(daysBack) || 90));
+
+  const body = {
+    metrics: ["tokens_total", "tokens_input", "tokens_output", "request_count"],
+    dimensions: ["model"],
+    granularity: "day",
+    time_range: {
+      start: start.toISOString(),
+      end: end.toISOString(),
+    },
+    limit: 500,
+  };
+
+  const res = await fetchImpl(OPENROUTER_ANALYTICS_QUERY_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error("OpenRouter API key invalid or lacks analytics access");
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `OpenRouter API returned ${res.status}${text ? `: ${text.slice(0, 200)}` : ""}`,
+    );
+  }
+
+  const payload = await res.json();
+  openrouterDebugLog(`Fetched ${Array.isArray(payload?.data?.data) ? payload.data.data.length : 0} rows`);
+  return parseOpenRouterAnalyticsRows(payload);
+}
+
+function normalizeOpenRouterUsage(record) {
+  const inputTokens = Math.max(0, Math.floor(record.inputTokens || 0));
+  const outputTokens = Math.max(0, Math.floor(record.outputTokens || 0));
+  const totalTokens = Math.max(
+    0,
+    Math.floor(record.totalTokens || inputTokens + outputTokens),
+  );
+  return {
+    input_tokens: inputTokens,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: outputTokens,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+    billable_total_tokens: totalTokens,
+  };
+}
+
+module.exports = {
+  OPENROUTER_ANALYTICS_QUERY_URL,
+  resolveOpenRouterApiKey,
+  isOpenRouterConfigured,
+  resolveOpenRouterDayKey,
+  dayKeyToIsoDate,
+  parseOpenRouterAnalyticsRows,
+  fetchOpenRouterDailyUsage,
+  normalizeOpenRouterUsage,
+};

--- a/src/lib/openrouter-config.js
+++ b/src/lib/openrouter-config.js
@@ -205,6 +205,13 @@ function dayKeyToIsoDate(dayKey) {
   return `${dayKey}T18:30:00.000Z`;
 }
 
+function isOpenRouterAnalyticsTruncated(payload) {
+  if (!payload || typeof payload !== "object") return false;
+  if (payload.metadata?.truncated === true) return true;
+  if (payload.data?.metadata?.truncated === true) return true;
+  return false;
+}
+
 /**
  * Parse OpenRouter analytics query rows into Cursor-like records for rollout.
  */
@@ -218,9 +225,16 @@ function parseOpenRouterAnalyticsRows(payload) {
     if (!dayKey) continue;
 
     const model = typeof row.model === "string" && row.model.trim() ? row.model.trim() : "unknown";
-    const inputTokens = toInt(row.tokens_prompt ?? row.tokens_input);
+    const promptTotal = toInt(row.tokens_prompt ?? row.tokens_input);
+    const cacheReadTokens = toInt(row.cached_tokens);
+    const cacheWriteTokens = toInt(row.cache_write_tokens);
+    const inputTokens =
+      cacheReadTokens > 0 && cacheReadTokens <= promptTotal
+        ? promptTotal - cacheReadTokens
+        : promptTotal;
     const outputTokens = toInt(row.tokens_completion ?? row.tokens_output);
-    const totalTokens = toInt(row.tokens_total) || inputTokens + outputTokens;
+    const totalTokens =
+      toInt(row.tokens_total) || inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
     if (totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0) continue;
 
     records.push({
@@ -229,8 +243,8 @@ function parseOpenRouterAnalyticsRows(payload) {
       inputTokens,
       outputTokens,
       totalTokens,
-      cacheWriteTokens: 0,
-      cacheReadTokens: 0,
+      cacheWriteTokens,
+      cacheReadTokens,
     });
   }
 
@@ -257,14 +271,20 @@ async function fetchOpenRouterDailyUsage({
   start.setUTCDate(start.getUTCDate() - Math.max(1, Number(daysBack) || 90));
 
   const body = {
-    metrics: ["tokens_total", "tokens_prompt", "tokens_completion", "request_count"],
+    metrics: [
+      "tokens_total",
+      "tokens_prompt",
+      "tokens_completion",
+      "cached_tokens",
+      "request_count",
+    ],
     dimensions: ["model"],
     granularity: "day",
     time_range: {
       start: start.toISOString(),
       end: end.toISOString(),
     },
-    limit: 500,
+    limit: 10000,
   };
 
   const res = await fetchImpl(OPENROUTER_ANALYTICS_QUERY_URL, {
@@ -289,21 +309,28 @@ async function fetchOpenRouterDailyUsage({
   }
 
   const payload = await res.json();
+  if (isOpenRouterAnalyticsTruncated(payload)) {
+    throw new Error(
+      "OpenRouter analytics response was truncated; reduce the sync window or narrow filters",
+    );
+  }
   openrouterDebugLog(`Fetched ${Array.isArray(payload?.data?.data) ? payload.data.data.length : 0} rows`);
   return parseOpenRouterAnalyticsRows(payload);
 }
 
 function normalizeOpenRouterUsage(record) {
   const inputTokens = Math.max(0, Math.floor(record.inputTokens || 0));
+  const cacheWrite = Math.max(0, Math.floor(record.cacheWriteTokens || 0));
+  const cacheRead = Math.max(0, Math.floor(record.cacheReadTokens || 0));
   const outputTokens = Math.max(0, Math.floor(record.outputTokens || 0));
   const totalTokens = Math.max(
     0,
-    Math.floor(record.totalTokens || inputTokens + outputTokens),
+    Math.floor(record.totalTokens || inputTokens + outputTokens + cacheWrite + cacheRead),
   );
   return {
     input_tokens: inputTokens,
-    cached_input_tokens: 0,
-    cache_creation_input_tokens: 0,
+    cached_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheWrite,
     output_tokens: outputTokens,
     reasoning_output_tokens: 0,
     total_tokens: totalTokens,
@@ -327,6 +354,7 @@ module.exports = {
   resolveOpenRouterDayKey,
   dayKeyToIsoDate,
   parseOpenRouterAnalyticsRows,
+  isOpenRouterAnalyticsTruncated,
   fetchOpenRouterDailyUsage,
   normalizeOpenRouterUsage,
 };

--- a/src/lib/openrouter-config.js
+++ b/src/lib/openrouter-config.js
@@ -1,4 +1,9 @@
 const OPENROUTER_ANALYTICS_QUERY_URL = "https://openrouter.ai/api/v1/analytics/query";
+const OPENROUTER_ANALYTICS_META_URL = "https://openrouter.ai/api/v1/analytics/meta";
+
+const path = require("node:path");
+const { readJson, writeJson, chmod600IfPossible } = require("./fs");
+const { resolveTrackerPaths } = require("./tracker-paths");
 
 function toInt(value) {
   const n = Number(value);
@@ -22,6 +27,138 @@ function resolveOpenRouterApiKey({ config, env = process.env } = {}) {
 
 function isOpenRouterConfigured({ config, env = process.env } = {}) {
   return Boolean(resolveOpenRouterApiKey({ config, env }));
+}
+
+function isValidOpenRouterApiKey(key) {
+  if (typeof key !== "string") return false;
+  const trimmed = key.trim();
+  return /^sk-or-v1-[A-Za-z0-9_-]{8,}$/.test(trimmed);
+}
+
+function maskOpenRouterApiKey(key) {
+  if (typeof key !== "string" || !key.trim()) return null;
+  const trimmed = key.trim();
+  if (trimmed.length <= 12) return "sk-or-v1-••••";
+  return `${trimmed.slice(0, 10)}••••${trimmed.slice(-4)}`;
+}
+
+function resolveOpenRouterKeySource({ config, env = process.env } = {}) {
+  const fromEnv = typeof env.OPENROUTER_API_KEY === "string" ? env.OPENROUTER_API_KEY.trim() : "";
+  if (fromEnv) return "env";
+  const fromConfig =
+    typeof config?.openrouter?.apiKey === "string" ? config.openrouter.apiKey.trim() : "";
+  if (fromConfig) return "config";
+  return "none";
+}
+
+function getOpenRouterConfigSnapshot({ config, env = process.env } = {}) {
+  const source = resolveOpenRouterKeySource({ config, env });
+  const apiKey = resolveOpenRouterApiKey({ config, env });
+  const envKey = typeof env.OPENROUTER_API_KEY === "string" ? env.OPENROUTER_API_KEY.trim() : "";
+  const configKey =
+    typeof config?.openrouter?.apiKey === "string" ? config.openrouter.apiKey.trim() : "";
+  return {
+    configured: source !== "none",
+    source,
+    masked_key: apiKey ? maskOpenRouterApiKey(apiKey) : null,
+    configured_at:
+      typeof config?.openrouter?.configuredAt === "string" ? config.openrouter.configuredAt : null,
+    last_verified_at:
+      typeof config?.openrouter?.lastVerifiedAt === "string" ? config.openrouter.lastVerifiedAt : null,
+    env_overrides_config: Boolean(envKey && configKey),
+  };
+}
+
+async function readTrackerConfig({ home, trackerDir } = {}) {
+  const dir = trackerDir || (await resolveTrackerPaths({ home })).trackerDir;
+  const configPath = path.join(dir, "config.json");
+  const config = (await readJson(configPath)) || {};
+  return { configPath, config };
+}
+
+async function saveOpenRouterApiKey({ apiKey, home, trackerDir, verify = false, fetchImpl = fetch } = {}) {
+  const trimmed = typeof apiKey === "string" ? apiKey.trim() : "";
+  if (!isValidOpenRouterApiKey(trimmed)) {
+    throw new Error("Invalid OpenRouter API key format (expected sk-or-v1-...)");
+  }
+
+  const { configPath, config } = await readTrackerConfig({ home, trackerDir });
+  const now = new Date().toISOString();
+  let verified = false;
+  let verifyError = null;
+
+  if (verify) {
+    const probe = await probeOpenRouterApiKey(trimmed, { fetchImpl });
+    verified = probe.ok;
+    verifyError = probe.error || null;
+  }
+
+  const next = {
+    ...config,
+    openrouter: {
+      ...(config.openrouter && typeof config.openrouter === "object" ? config.openrouter : {}),
+      apiKey: trimmed,
+      configuredAt: now,
+      ...(verified ? { lastVerifiedAt: now } : {}),
+    },
+  };
+
+  await writeJson(configPath, next);
+  await chmod600IfPossible(configPath);
+
+  return {
+    ok: true,
+    masked_key: maskOpenRouterApiKey(trimmed),
+    verified,
+    verify_error: verifyError,
+    snapshot: getOpenRouterConfigSnapshot({ config: next }),
+  };
+}
+
+async function clearOpenRouterApiKey({ home, trackerDir } = {}) {
+  const { configPath, config } = await readTrackerConfig({ home, trackerDir });
+  if (!config.openrouter) {
+    return { ok: true, cleared: false, snapshot: getOpenRouterConfigSnapshot({ config }) };
+  }
+
+  const next = { ...config };
+  delete next.openrouter;
+  await writeJson(configPath, next);
+  await chmod600IfPossible(configPath);
+
+  return { ok: true, cleared: true, snapshot: getOpenRouterConfigSnapshot({ config: next }) };
+}
+
+async function probeOpenRouterApiKey(apiKey, { timeoutMs = 15000, fetchImpl = fetch } = {}) {
+  if (!isValidOpenRouterApiKey(apiKey)) {
+    return { ok: false, error: "Invalid OpenRouter API key format" };
+  }
+
+  try {
+    const res = await fetchImpl(OPENROUTER_ANALYTICS_META_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey.trim()}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, error: "OpenRouter API key invalid or lacks analytics access" };
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return {
+        ok: false,
+        error: `OpenRouter API returned ${res.status}${text ? `: ${text.slice(0, 120)}` : ""}`,
+      };
+    }
+
+    return { ok: true, error: null };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
 }
 
 function resolveOpenRouterDayKey(row) {
@@ -154,8 +291,17 @@ function normalizeOpenRouterUsage(record) {
 
 module.exports = {
   OPENROUTER_ANALYTICS_QUERY_URL,
+  OPENROUTER_ANALYTICS_META_URL,
   resolveOpenRouterApiKey,
   isOpenRouterConfigured,
+  isValidOpenRouterApiKey,
+  maskOpenRouterApiKey,
+  resolveOpenRouterKeySource,
+  getOpenRouterConfigSnapshot,
+  saveOpenRouterApiKey,
+  clearOpenRouterApiKey,
+  probeOpenRouterApiKey,
+  readTrackerConfig,
   resolveOpenRouterDayKey,
   dayKeyToIsoDate,
   parseOpenRouterAnalyticsRows,

--- a/src/lib/openrouter-config.js
+++ b/src/lib/openrouter-config.js
@@ -199,7 +199,10 @@ function resolveOpenRouterDayKey(row) {
 
 function dayKeyToIsoDate(dayKey) {
   if (!dayKey) return null;
-  return `${dayKey}T12:00:00.000Z`;
+  // OpenRouter analytics is daily-granularity only. Use 18:30 UTC so positive-offset
+  // timezones (e.g. IST) map the usage day to the same local calendar day as live
+  // CLI session buckets — matching Cursor/Claude week/month visibility.
+  return `${dayKey}T18:30:00.000Z`;
 }
 
 /**

--- a/src/lib/openrouter-config.js
+++ b/src/lib/openrouter-config.js
@@ -145,7 +145,25 @@ async function probeOpenRouterApiKey(apiKey, { timeoutMs = 15000, fetchImpl = fe
     });
 
     if (res.status === 401 || res.status === 403) {
-      return { ok: false, error: "OpenRouter API key invalid or lacks analytics access" };
+      const text = await res.text().catch(() => "");
+      let detail = "";
+      try {
+        const payload = JSON.parse(text);
+        detail = payload?.error?.message || payload?.message || "";
+      } catch {
+        detail = text.slice(0, 200);
+      }
+      if (/management key/i.test(detail)) {
+        return {
+          ok: false,
+          error:
+            "OpenRouter analytics requires a management key (not a regular inference key). Create one at openrouter.ai/settings/management-keys",
+        };
+      }
+      return {
+        ok: false,
+        error: detail || "OpenRouter API key invalid or lacks analytics access",
+      };
     }
     if (!res.ok) {
       const text = await res.text().catch(() => "");
@@ -197,8 +215,8 @@ function parseOpenRouterAnalyticsRows(payload) {
     if (!dayKey) continue;
 
     const model = typeof row.model === "string" && row.model.trim() ? row.model.trim() : "unknown";
-    const inputTokens = toInt(row.tokens_input);
-    const outputTokens = toInt(row.tokens_output);
+    const inputTokens = toInt(row.tokens_prompt ?? row.tokens_input);
+    const outputTokens = toInt(row.tokens_completion ?? row.tokens_output);
     const totalTokens = toInt(row.tokens_total) || inputTokens + outputTokens;
     if (totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0) continue;
 
@@ -236,7 +254,7 @@ async function fetchOpenRouterDailyUsage({
   start.setUTCDate(start.getUTCDate() - Math.max(1, Number(daysBack) || 90));
 
   const body = {
-    metrics: ["tokens_total", "tokens_input", "tokens_output", "request_count"],
+    metrics: ["tokens_total", "tokens_prompt", "tokens_completion", "request_count"],
     dimensions: ["model"],
     granularity: "day",
     time_range: {
@@ -253,6 +271,7 @@ async function fetchOpenRouterDailyUsage({
       "Content-Type": "application/json",
       Accept: "application/json",
     },
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(timeoutMs),
   });
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -8,6 +8,7 @@ const { ensureDir } = require("./fs");
 const { readSqliteJsonRows } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
 const { resolveInstallPaths } = require("./install-resolver");
+const { normalizeOpenRouterUsage } = require("./openrouter-config");
 
 const DEFAULT_SOURCE = "codex";
 const DEFAULT_MODEL = "unknown";
@@ -3526,7 +3527,6 @@ async function parseOpenRouterApiIncremental({
     const recordDate = record.date;
     if (!recordDate) continue;
 
-    const { normalizeOpenRouterUsage } = require("./openrouter-config");
     const delta = normalizeOpenRouterUsage(record);
     if (isAllZeroUsage(delta)) continue;
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3480,6 +3480,95 @@ async function parseCursorApiIncremental({
   return { recordsProcessed: total, eventsAggregated, bucketsQueued };
 }
 
+/**
+ * Incremental state is tracked in `cursors.openrouterApi.lastRecordTimestamp`.
+ */
+async function parseOpenRouterApiIncremental({
+  records,
+  cursors,
+  queuePath,
+  onProgress,
+  source,
+}) {
+  await ensureDir(path.dirname(queuePath));
+  const defaultSource = normalizeSourceInput(source) || "openrouter";
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+
+  const lastTs = cursors?.openrouterApi?.lastRecordTimestamp || null;
+  let latestTs = lastTs;
+  let eventsAggregated = 0;
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  const total = records.length;
+
+  if (records.length > 0) {
+    let earliestBucketStart = null;
+    for (const record of records) {
+      if (!record?.date) continue;
+      const b = toUtcHalfHourStart(record.date);
+      if (b && (!earliestBucketStart || b < earliestBucketStart)) earliestBucketStart = b;
+    }
+    if (earliestBucketStart) {
+      for (const [key, bucket] of Object.entries(hourlyState.buckets || {})) {
+        const parsed = parseBucketKey(key);
+        const sourceKey = normalizeSourceInput(parsed.source) || DEFAULT_SOURCE;
+        if (sourceKey !== defaultSource) continue;
+        if (!bucket?.totals) continue;
+        if (parsed.hourStart && parsed.hourStart < earliestBucketStart) continue;
+        bucket.totals = initTotals();
+        touchedBuckets.add(key);
+      }
+    }
+  }
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    const recordDate = record.date;
+    if (!recordDate) continue;
+
+    const { normalizeOpenRouterUsage } = require("./openrouter-config");
+    const delta = normalizeOpenRouterUsage(record);
+    if (isAllZeroUsage(delta)) continue;
+
+    delta.conversation_count = 1;
+
+    const bucketStart = toUtcHalfHourStart(recordDate);
+    if (!bucketStart) continue;
+
+    const model = normalizeModelInput(record.model) || DEFAULT_MODEL;
+    const bucket = getHourlyBucket(hourlyState, defaultSource, model, bucketStart);
+    addTotals(bucket.totals, delta);
+    touchedBuckets.add(bucketKey(defaultSource, model, bucketStart));
+
+    eventsAggregated += 1;
+
+    if (!latestTs || recordDate > latestTs) {
+      latestTs = recordDate;
+    }
+
+    if (cb && (i % 200 === 0 || i === records.length - 1)) {
+      cb({
+        index: i + 1,
+        total,
+        eventsAggregated,
+        bucketsQueued: touchedBuckets.size,
+      });
+    }
+  }
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  hourlyState.updatedAt = new Date().toISOString();
+  cursors.hourly = hourlyState;
+
+  if (!cursors.openrouterApi) cursors.openrouterApi = {};
+  if (latestTs && latestTs !== lastTs) {
+    cursors.openrouterApi.lastRecordTimestamp = latestTs;
+  }
+  cursors.openrouterApi.updatedAt = new Date().toISOString();
+
+  return { recordsProcessed: total, eventsAggregated, bucketsQueued };
+}
+
 // ---------------------------------------------------------------------------
 // Kiro token tracking (reads from devdata.sqlite or tokens_generated.jsonl)
 // ---------------------------------------------------------------------------
@@ -9978,6 +10067,7 @@ module.exports = {
   parseOpencodeDbIncremental,
   parseOpenclawIncremental,
   parseCursorApiIncremental,
+  parseOpenRouterApiIncremental,
   parseKiroIncremental,
   parseHermesIncremental,
   gooseInstallOwnsCursor,

--- a/test/config-openrouter.test.js
+++ b/test/config-openrouter.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { cmdConfigOpenRouter } = require("../src/commands/config");
+
+const VALID_KEY = "sk-or-v1-abcdefghijklmnopqrst";
+
+test("config openrouter status --json reports unset by default", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-config-cli-"));
+  const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+  await fs.mkdir(trackerDir, { recursive: true });
+
+  const originalHome = process.env.HOME;
+  process.env.HOME = tmp;
+  delete process.env.OPENROUTER_API_KEY;
+
+  const chunks = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+
+  try {
+    await cmdConfigOpenRouter("status", ["--json"]);
+    const payload = JSON.parse(chunks.join("").trim());
+    assert.equal(payload.configured, false);
+    assert.equal(payload.source, "none");
+  } finally {
+    process.stdout.write = originalWrite;
+    process.env.HOME = originalHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("config openrouter set --key persists key", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-config-set-"));
+  const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+  await fs.mkdir(trackerDir, { recursive: true });
+
+  const originalHome = process.env.HOME;
+  process.env.HOME = tmp;
+  delete process.env.OPENROUTER_API_KEY;
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => "",
+  });
+
+  try {
+    await cmdConfigOpenRouter("set", ["--key", VALID_KEY, "--json"]);
+    const config = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "config.json"), "utf8"),
+    );
+    assert.equal(config.openrouter.apiKey, VALID_KEY);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.HOME = originalHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("config openrouter clear removes saved key", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-config-clear-"));
+  const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+  await fs.mkdir(trackerDir, { recursive: true });
+  const configPath = path.join(trackerDir, "config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({ openrouter: { apiKey: VALID_KEY } }, null, 2),
+    "utf8",
+  );
+
+  const originalHome = process.env.HOME;
+  process.env.HOME = tmp;
+  delete process.env.OPENROUTER_API_KEY;
+
+  try {
+    await cmdConfigOpenRouter("clear", ["--json"]);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+    assert.equal(config.openrouter, undefined);
+  } finally {
+    process.env.HOME = originalHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/local-api-openrouter-config.test.js
+++ b/test/local-api-openrouter-config.test.js
@@ -154,6 +154,10 @@ describe("/functions/tokentracker-openrouter-config", () => {
       });
       assert.equal(save.status, 200);
       assert.equal(save.body.configured, true);
+      assert.equal(typeof save.body.last_verified_at, "string");
+
+      const savedConfig = JSON.parse(fs.readFileSync(path.join(trackerDir, "config.json"), "utf8"));
+      assert.equal(typeof savedConfig.openrouter.lastVerifiedAt, "string");
 
       const cleared = await call({
         method: "DELETE",

--- a/test/local-api-openrouter-config.test.js
+++ b/test/local-api-openrouter-config.test.js
@@ -1,0 +1,171 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { before, describe, it } = require("node:test");
+
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "tt-localapi-openrouter-"));
+process.env.HOME = sandboxHome;
+process.env.USERPROFILE = sandboxHome;
+delete process.env.OPENROUTER_API_KEY;
+
+const { createLocalApiHandler } = require("../src/lib/local-api");
+
+const VALID_KEY = "sk-or-v1-abcdefghijklmnopqrst";
+const trackerDir = path.join(sandboxHome, ".tokentracker", "tracker");
+fs.mkdirSync(trackerDir, { recursive: true });
+const queuePath = path.join(trackerDir, "queue.jsonl");
+fs.writeFileSync(queuePath, "");
+const handler = createLocalApiHandler({ queuePath });
+
+function makeReq({ method = "GET", pathname = "/functions/tokentracker-openrouter-config", headers = {}, body }) {
+  const url = new URL(`http://localhost${pathname}`);
+  let listeners = {};
+  const req = {
+    method,
+    url: url.pathname,
+    headers: { host: "localhost", ...headers },
+    on(event, fn) {
+      listeners[event] = fn;
+      return req;
+    },
+  };
+  if (body !== undefined) {
+    process.nextTick(() => {
+      listeners.data?.(Buffer.from(typeof body === "string" ? body : JSON.stringify(body)));
+      listeners.end?.();
+    });
+  } else {
+    process.nextTick(() => listeners.end?.());
+  }
+  return { req, url };
+}
+
+function makeRes() {
+  const chunks = [];
+  let statusCode = 200;
+  return {
+    get body() {
+      return chunks.join("");
+    },
+    get status() {
+      return statusCode;
+    },
+    setHeader() {},
+    writeHead(code) {
+      statusCode = code;
+    },
+    write(chunk) {
+      chunks.push(chunk);
+    },
+    end(chunk) {
+      if (chunk) chunks.push(chunk);
+    },
+  };
+}
+
+async function call({ method, pathname = "/functions/tokentracker-openrouter-config", headers = {}, body } = {}) {
+  const { req, url } = makeReq({ method, pathname, headers, body });
+  const res = makeRes();
+  const handled = await handler(req, res, url);
+  return {
+    handled,
+    status: res.status,
+    body: res.body ? JSON.parse(res.body) : null,
+  };
+}
+
+describe("/functions/tokentracker-openrouter-config", () => {
+  let token;
+
+  before(async () => {
+    const result = await call({ method: "GET", pathname: "/api/local-auth" });
+    token = result.body.token;
+    assert.ok(token);
+  });
+
+  it("GET returns masked snapshot without full key", async () => {
+    fs.writeFileSync(
+      path.join(trackerDir, "config.json"),
+      JSON.stringify({ openrouter: { apiKey: VALID_KEY } }, null, 2),
+    );
+    const { status, body } = await call({ method: "GET" });
+    assert.equal(status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.configured, true);
+    assert.ok(body.masked_key);
+    assert.notEqual(body.masked_key, VALID_KEY);
+    assert.equal(body.apiKey, undefined);
+  });
+
+  it("POST without auth returns 401", async () => {
+    const { status } = await call({
+      method: "POST",
+      body: { apiKey: VALID_KEY },
+    });
+    assert.equal(status, 401);
+  });
+
+  it("POST probe-only verifies without saving", async () => {
+    fs.writeFileSync(path.join(trackerDir, "config.json"), JSON.stringify({}, null, 2));
+
+    const originalFetch = global.fetch;
+    global.fetch = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    });
+
+    try {
+      const { status, body } = await call({
+        method: "POST",
+        headers: {
+          origin: "http://localhost:7680",
+          "x-tokentracker-local-auth": token,
+        },
+        body: { apiKey: VALID_KEY, probe: true, save: false },
+      });
+      assert.equal(status, 200);
+      assert.equal(body.ok, true);
+      assert.equal(body.verified, true);
+      const config = JSON.parse(fs.readFileSync(path.join(trackerDir, "config.json"), "utf8"));
+      assert.equal(config.openrouter, undefined);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it("POST saves key and DELETE clears it", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    });
+
+    try {
+      const save = await call({
+        method: "POST",
+        headers: {
+          origin: "http://localhost:7680",
+          "x-tokentracker-local-auth": token,
+        },
+        body: { apiKey: VALID_KEY, verify: true },
+      });
+      assert.equal(save.status, 200);
+      assert.equal(save.body.configured, true);
+
+      const cleared = await call({
+        method: "DELETE",
+        headers: {
+          origin: "http://localhost:7680",
+          "x-tokentracker-local-auth": token,
+        },
+      });
+      assert.equal(cleared.status, 200);
+      assert.equal(cleared.body.configured, false);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -10,8 +10,16 @@ const {
   resolveOpenRouterApiKey,
   isOpenRouterConfigured,
   resolveOpenRouterDayKey,
+  maskOpenRouterApiKey,
+  isValidOpenRouterApiKey,
+  getOpenRouterConfigSnapshot,
+  saveOpenRouterApiKey,
+  clearOpenRouterApiKey,
+  probeOpenRouterApiKey,
 } = require("../src/lib/openrouter-config");
 const { parseOpenRouterApiIncremental } = require("../src/lib/rollout");
+
+const VALID_KEY = "sk-or-v1-abcdefghijklmnopqrst";
 
 test("parseOpenRouterAnalyticsRows maps daily analytics rows to records", () => {
   const records = parseOpenRouterAnalyticsRows({
@@ -120,4 +128,92 @@ test("parseOpenRouterApiIncremental queues openrouter buckets", async () => {
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
+});
+
+test("maskOpenRouterApiKey never returns full key", () => {
+  const masked = maskOpenRouterApiKey(VALID_KEY);
+  assert.ok(masked);
+  assert.notEqual(masked, VALID_KEY);
+  assert.match(masked, /^sk-or-v1-/);
+  assert.doesNotMatch(masked, /abcdefghijklmnopqrst$/);
+});
+
+test("isValidOpenRouterApiKey accepts sk-or-v1 format", () => {
+  assert.equal(isValidOpenRouterApiKey(VALID_KEY), true);
+  assert.equal(isValidOpenRouterApiKey("sk-or-v1-short"), false);
+  assert.equal(isValidOpenRouterApiKey("sk-ant-abc"), false);
+});
+
+test("getOpenRouterConfigSnapshot reports env override", () => {
+  const snapshot = getOpenRouterConfigSnapshot({
+    env: { OPENROUTER_API_KEY: VALID_KEY },
+    config: { openrouter: { apiKey: "sk-or-v1-configkey123456" } },
+  });
+  assert.equal(snapshot.configured, true);
+  assert.equal(snapshot.source, "env");
+  assert.equal(snapshot.env_overrides_config, true);
+});
+
+test("saveOpenRouterApiKey persists masked snapshot to config.json", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-or-save-"));
+  const trackerDir = path.join(tmp, "tracker");
+  await fs.mkdir(trackerDir, { recursive: true });
+
+  const fetchImpl = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => "",
+  });
+
+  try {
+    const result = await saveOpenRouterApiKey({
+      apiKey: VALID_KEY,
+      trackerDir,
+      verify: true,
+      fetchImpl,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.verified, true);
+    assert.equal(result.masked_key, maskOpenRouterApiKey(VALID_KEY));
+
+    const raw = await fs.readFile(path.join(trackerDir, "config.json"), "utf8");
+    const config = JSON.parse(raw);
+    assert.equal(config.openrouter.apiKey, VALID_KEY);
+    assert.equal(typeof config.openrouter.configuredAt, "string");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("clearOpenRouterApiKey removes openrouter block", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-or-clear-"));
+  const trackerDir = path.join(tmp, "tracker");
+  await fs.mkdir(trackerDir, { recursive: true });
+  const configPath = path.join(trackerDir, "config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({ openrouter: { apiKey: VALID_KEY } }, null, 2),
+    "utf8",
+  );
+
+  try {
+    const result = await clearOpenRouterApiKey({ trackerDir });
+    assert.equal(result.cleared, true);
+    assert.equal(result.snapshot.configured, false);
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+    assert.equal(config.openrouter, undefined);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("probeOpenRouterApiKey maps auth failures", async () => {
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 401,
+    text: async () => "unauthorized",
+  });
+  const result = await probeOpenRouterApiKey(VALID_KEY, { fetchImpl });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /invalid|analytics/i);
 });

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -28,15 +28,15 @@ test("parseOpenRouterAnalyticsRows maps daily analytics rows to records", () => 
         {
           date__day: "2026-07-01",
           model: "anthropic/claude-sonnet-4",
-          tokens_input: 1200,
-          tokens_output: 300,
+          tokens_prompt: 1200,
+          tokens_completion: 300,
           tokens_total: 1500,
         },
         {
           created_at__day: "2026-07-02",
           model: "openai/gpt-4.1",
-          tokens_input: 0,
-          tokens_output: 0,
+          tokens_prompt: 0,
+          tokens_completion: 0,
           tokens_total: 0,
         },
       ],
@@ -215,5 +215,5 @@ test("probeOpenRouterApiKey maps auth failures", async () => {
   });
   const result = await probeOpenRouterApiKey(VALID_KEY, { fetchImpl });
   assert.equal(result.ok, false);
-  assert.match(result.error, /invalid|analytics/i);
+  assert.match(result.error, /invalid|analytics|unauthorized/i);
 });

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -16,6 +16,7 @@ const {
   saveOpenRouterApiKey,
   clearOpenRouterApiKey,
   probeOpenRouterApiKey,
+  fetchOpenRouterDailyUsage,
 } = require("../src/lib/openrouter-config");
 const { parseOpenRouterApiIncremental } = require("../src/lib/rollout");
 
@@ -39,16 +40,26 @@ test("parseOpenRouterAnalyticsRows maps daily analytics rows to records", () => 
           tokens_completion: 0,
           tokens_total: 0,
         },
+        {
+          date__day: "2026-07-03",
+          model: "deepseek/deepseek-chat",
+          tokens_prompt: 500,
+          tokens_completion: 100,
+          cached_tokens: 200,
+          tokens_total: 600,
+        },
       ],
     },
   });
 
-  assert.equal(records.length, 1);
+  assert.equal(records.length, 2);
   assert.equal(records[0].date, "2026-07-01T18:30:00.000Z");
   assert.equal(records[0].model, "anthropic/claude-sonnet-4");
   assert.equal(records[0].inputTokens, 1200);
   assert.equal(records[0].outputTokens, 300);
   assert.equal(records[0].totalTokens, 1500);
+  assert.equal(records[1].inputTokens, 300);
+  assert.equal(records[1].cacheReadTokens, 200);
 });
 
 test("normalizeOpenRouterUsage returns canonical token shape", () => {
@@ -66,6 +77,24 @@ test("normalizeOpenRouterUsage returns canonical token shape", () => {
       reasoning_output_tokens: 0,
       total_tokens: 15,
       billable_total_tokens: 15,
+    },
+  );
+  assert.deepEqual(
+    normalizeOpenRouterUsage({
+      inputTokens: 8,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 1,
+      totalTokens: 16,
+    }),
+    {
+      input_tokens: 8,
+      cached_input_tokens: 2,
+      cache_creation_input_tokens: 1,
+      output_tokens: 5,
+      reasoning_output_tokens: 0,
+      total_tokens: 16,
+      billable_total_tokens: 16,
     },
   );
 });
@@ -216,4 +245,20 @@ test("probeOpenRouterApiKey maps auth failures", async () => {
   const result = await probeOpenRouterApiKey(VALID_KEY, { fetchImpl });
   assert.equal(result.ok, false);
   assert.match(result.error, /invalid|analytics|unauthorized/i);
+});
+
+test("fetchOpenRouterDailyUsage rejects truncated analytics payloads", async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      metadata: { truncated: true, row_count: 10000 },
+      data: { data: [] },
+    }),
+  });
+
+  await assert.rejects(
+    () => fetchOpenRouterDailyUsage({ apiKey: VALID_KEY, fetchImpl }),
+    /truncated/i,
+  );
 });

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -1,0 +1,123 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  parseOpenRouterAnalyticsRows,
+  normalizeOpenRouterUsage,
+  resolveOpenRouterApiKey,
+  isOpenRouterConfigured,
+  resolveOpenRouterDayKey,
+} = require("../src/lib/openrouter-config");
+const { parseOpenRouterApiIncremental } = require("../src/lib/rollout");
+
+test("parseOpenRouterAnalyticsRows maps daily analytics rows to records", () => {
+  const records = parseOpenRouterAnalyticsRows({
+    data: {
+      data: [
+        {
+          date__day: "2026-07-01",
+          model: "anthropic/claude-sonnet-4",
+          tokens_input: 1200,
+          tokens_output: 300,
+          tokens_total: 1500,
+        },
+        {
+          created_at__day: "2026-07-02",
+          model: "openai/gpt-4.1",
+          tokens_input: 0,
+          tokens_output: 0,
+          tokens_total: 0,
+        },
+      ],
+    },
+  });
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].date, "2026-07-01T12:00:00.000Z");
+  assert.equal(records[0].model, "anthropic/claude-sonnet-4");
+  assert.equal(records[0].inputTokens, 1200);
+  assert.equal(records[0].outputTokens, 300);
+  assert.equal(records[0].totalTokens, 1500);
+});
+
+test("normalizeOpenRouterUsage returns canonical token shape", () => {
+  assert.deepEqual(
+    normalizeOpenRouterUsage({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    }),
+    {
+      input_tokens: 10,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 5,
+      reasoning_output_tokens: 0,
+      total_tokens: 15,
+      billable_total_tokens: 15,
+    },
+  );
+});
+
+test("resolveOpenRouterApiKey prefers env over config", () => {
+  assert.equal(
+    resolveOpenRouterApiKey({
+      env: { OPENROUTER_API_KEY: "sk-or-env" },
+      config: { openrouter: { apiKey: "sk-or-config" } },
+    }),
+    "sk-or-env",
+  );
+  assert.equal(
+    resolveOpenRouterApiKey({
+      env: {},
+      config: { openrouter: { apiKey: "sk-or-config" } },
+    }),
+    "sk-or-config",
+  );
+  assert.equal(resolveOpenRouterApiKey({ env: {}, config: {} }), null);
+  assert.equal(isOpenRouterConfigured({ env: { OPENROUTER_API_KEY: "x" } }), true);
+});
+
+test("resolveOpenRouterDayKey accepts date__day and created_at__day", () => {
+  assert.equal(resolveOpenRouterDayKey({ date__day: "2026-07-03" }), "2026-07-03");
+  assert.equal(resolveOpenRouterDayKey({ created_at__day: "2026-07-04" }), "2026-07-04");
+  assert.equal(resolveOpenRouterDayKey({}), null);
+});
+
+test("parseOpenRouterApiIncremental queues openrouter buckets", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-openrouter-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const result = await parseOpenRouterApiIncremental({
+      records: [
+        {
+          date: "2026-07-01T12:00:00.000Z",
+          model: "anthropic/claude-sonnet-4",
+          inputTokens: 100,
+          outputTokens: 25,
+          totalTokens: 125,
+        },
+      ],
+      cursors,
+      queuePath,
+      source: "openrouter",
+    });
+
+    assert.equal(result.eventsAggregated, 1);
+    const raw = await fs.readFile(queuePath, "utf8");
+    assert.match(raw, /"source":"openrouter"/);
+    assert.match(raw, /"total_tokens":125/);
+    assert.equal(
+      cursors.hourly.buckets["openrouter|anthropic/claude-sonnet-4|2026-07-01T12:00:00.000Z"].totals
+        .total_tokens,
+      125,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -44,7 +44,7 @@ test("parseOpenRouterAnalyticsRows maps daily analytics rows to records", () => 
   });
 
   assert.equal(records.length, 1);
-  assert.equal(records[0].date, "2026-07-01T12:00:00.000Z");
+  assert.equal(records[0].date, "2026-07-01T18:30:00.000Z");
   assert.equal(records[0].model, "anthropic/claude-sonnet-4");
   assert.equal(records[0].inputTokens, 1200);
   assert.equal(records[0].outputTokens, 300);
@@ -104,7 +104,7 @@ test("parseOpenRouterApiIncremental queues openrouter buckets", async () => {
     const result = await parseOpenRouterApiIncremental({
       records: [
         {
-          date: "2026-07-01T12:00:00.000Z",
+          date: "2026-07-01T18:30:00.000Z",
           model: "anthropic/claude-sonnet-4",
           inputTokens: 100,
           outputTokens: 25,
@@ -121,7 +121,7 @@ test("parseOpenRouterApiIncremental queues openrouter buckets", async () => {
     assert.match(raw, /"source":"openrouter"/);
     assert.match(raw, /"total_tokens":125/);
     assert.equal(
-      cursors.hourly.buckets["openrouter|anthropic/claude-sonnet-4|2026-07-01T12:00:00.000Z"].totals
+      cursors.hourly.buckets["openrouter|anthropic/claude-sonnet-4|2026-07-01T18:30:00.000Z"].totals
         .total_tokens,
       125,
     );


### PR DESCRIPTION
## Summary
Adds OpenRouter as an API-based provider using the official Analytics API (`POST /api/v1/analytics/query`). Users set `OPENROUTER_API_KEY` or `config.openrouter.apiKey`; sync pulls daily token totals by model into local buckets with `source=openrouter`.

Closes #272

## Why
OpenRouter is a common routing layer for mixed-model workflows, but TokenTracker had no way to include that spend alongside Cursor/Claude/Codex usage in one dashboard.

## Changes
- `src/lib/openrouter-config.js` — analytics client + normalizer
- Wire `sync` / `init` / `status`
- `parseOpenRouterApiIncremental` in `rollout.js` (same authoritative refresh pattern as Cursor API)
- Tests: `test/openrouter-config.test.js`
- README supported-tools row

## Test plan
- [x] `node --test test/openrouter-config.test.js`
- [x] `node --test test/status.test.js test/status-json-light.test.js test/init-dry-run.test.js`
- [x] `node bin/tracker.js status` shows OpenRouter configured/unset line
- [x] `node bin/tracker.js sync` runs with other providers when key unset
- [ ] With valid `OPENROUTER_API_KEY`: sync → dashboard daily + model breakdown show `openrouter`

## Privacy
Only token counts and timestamps from the analytics API. No prompt or conversation content requested or stored.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter support across setup, status reporting, and sync, including automatic detection and daily usage analytics ingestion.
  * Added a new CLI `config openrouter` workflow (status, set, clear, test) and help text updates.
  * Added dashboard OpenRouter settings and a local API endpoint to manage the API key.
* **Bug Fixes**
  * Improved OpenRouter configuration reporting (human + JSON) and enhanced API key privacy via masking.
* **Documentation**
  * Updated the README to include OpenRouter in supported auto-detected providers.
* **Tests**
  * Added automated coverage for OpenRouter configuration, CLI behavior, sync queueing, and the local API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->