### PR TITLE
fix: let transparent Windows pet areas pass clicks through

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,16 @@ jobs:
           xcodebuild test \
             -scheme TokenTrackerBarTests \
             -destination 'platform=macOS'
+
+  windows-build:
+    name: Windows build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build TokenTrackerWin
+        run: dotnet build TokenTrackerWin/TokenTrackerWin.csproj --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@v5
         with:

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -126,6 +126,55 @@ internal sealed class PetWindow : Window
     {
         base.OnSourceInitialized(e);
         _hwnd = new WindowInteropHelper(this).Handle;
+        HwndSource.FromHwnd(_hwnd)?.AddHook(WndProc);
+    }
+
+    private nint WndProc(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)
+    {
+        if (msg == WM_NCHITTEST && !IsPointOnPet(HitTestScreenPointFromLParam(lParam)))
+        {
+            handled = true;
+            return (nint)HTTRANSPARENT;
+        }
+
+        return nint.Zero;
+    }
+
+    private bool IsPointOnPet(System.Windows.Point screenPoint)
+    {
+        try
+        {
+            if (ActualWidth <= 0 || ActualHeight <= 0) return true;
+
+            var p = PointFromScreen(screenPoint);
+            if (p.X < 0 || p.Y < 0 || p.X >= ActualWidth || p.Y >= ActualHeight) return false;
+
+            // The WebView2 surface is rectangular even though most of it is transparent.
+            // Keep only the lower centered sprite square mouse-active; clicks on the
+            // bubble band or horizontal padding should pass through to whatever is behind.
+            double spriteSize = Math.Max(40, Math.Min(ActualWidth, ActualHeight - BubbleBand) - 8);
+            double pad = Math.Max(8, spriteSize * 0.08);
+            double left = (ActualWidth - spriteSize) / 2 - pad;
+            double right = left + spriteSize + (pad * 2);
+            double top = BubbleBand - pad;
+            double bottom = Math.Min(ActualHeight, BubbleBand + spriteSize + pad);
+
+            return p.X >= left && p.X <= right && p.Y >= top && p.Y <= bottom;
+        }
+        catch
+        {
+            // If layout or DPI transforms are temporarily unavailable, prefer the old
+            // behaviour over making the pet impossible to interact with.
+            return true;
+        }
+    }
+
+    private static System.Windows.Point HitTestScreenPointFromLParam(nint lParam)
+    {
+        int raw = unchecked((int)lParam);
+        short x = unchecked((short)(raw & 0xFFFF));
+        short y = unchecked((short)((raw >> 16) & 0xFFFF));
+        return new System.Windows.Point(x, y);
     }
 
     private async Task InitializeWebViewAsync()
@@ -568,6 +617,8 @@ internal sealed class PetWindow : Window
     // little roomier than the sprite needs so longer lines have horizontal space. The
     // sprite tracks (height − band), so these heights keep it the same visual size as
     // before the taller band.
+    private const double BubbleBand = 46;
+
     private static (double Width, double Height) SizeDimensions(string size) => size switch
     {
         SizeSmall => (150, 138),
@@ -724,7 +775,9 @@ internal sealed class PetWindow : Window
     // ── P/Invoke + constants ───────────────────────────────────────────
 
     private const int WM_NCLBUTTONDOWN = 0xA1;
+    private const int WM_NCHITTEST = 0x84;
     private const int HTCAPTION = 2;
+    private const int HTTRANSPARENT = -1;
 
     [DllImport("user32.dll")]
     private static extern bool ReleaseCapture();

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -22,8 +22,9 @@ namespace TokenTrackerWin;
 /// the sprite's opaque pixels show and everything around it is fully see-through to
 /// the desktop — no frame, no frosted box.
 ///
-/// There is no chrome: the whole surface is the hit area. The page decides what a
-/// press means (<c>pet:drag</c> → native window move, tap → animation, right-click →
+/// There is no chrome: only the pet sprite is mouse-active, while transparent padding
+/// passes clicks to the desktop or app underneath. The page decides what a press on the
+/// pet means (<c>pet:drag</c> → native window move, tap → animation, right-click →
 /// <c>pet:open-dashboard</c>). Closing hides the window; the app exits via the tray
 /// "Quit" → <see cref="Shutdown"/>.
 /// </summary>
@@ -36,7 +37,9 @@ internal sealed class PetWindow : Window
     private readonly ServerManager _server;
     private readonly System.Windows.Threading.DispatcherTimer _saveTimer;
     private readonly System.Windows.Threading.DispatcherTimer _hoverTimer;
+    private readonly System.Windows.Threading.DispatcherTimer _clickThroughTimer;
     private bool _lastHover;
+    private bool _clickThrough;
     private bool _typing;
     private long _lastKeyTick;
     private long _typingStreakStart;  // when the current unbroken typing streak began (0 = not typing)
@@ -118,6 +121,15 @@ internal sealed class PetWindow : Window
         };
         _hoverTimer.Tick += (_, _) => { HoverTick(); TypingTick(); };
 
+        // WS_EX_TRANSPARENT is window-wide, so poll the OS cursor and apply it only
+        // while the pointer is over transparent padding. This preserves interaction
+        // with the pet while allowing padding clicks to reach other processes.
+        _clickThroughTimer = new System.Windows.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(50),
+        };
+        _clickThroughTimer.Tick += (_, _) => ClickThroughTick();
+
         Loaded += async (_, _) => await InitializeWebViewAsync();
         _server.StatusChanged += OnServerStatusChanged;
     }
@@ -126,18 +138,8 @@ internal sealed class PetWindow : Window
     {
         base.OnSourceInitialized(e);
         _hwnd = new WindowInteropHelper(this).Handle;
-        HwndSource.FromHwnd(_hwnd)?.AddHook(WndProc);
-    }
-
-    private nint WndProc(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)
-    {
-        if (msg == WM_NCHITTEST && !IsPointOnPet(HitTestScreenPointFromLParam(lParam)))
-        {
-            handled = true;
-            return (nint)HTTRANSPARENT;
-        }
-
-        return nint.Zero;
+        _clickThrough = (GetWindowExStyle(_hwnd).ToInt64() & WS_EX_TRANSPARENT) != 0;
+        ClickThroughTick();
     }
 
     private bool IsPointOnPet(System.Windows.Point screenPoint)
@@ -169,12 +171,34 @@ internal sealed class PetWindow : Window
         }
     }
 
-    private static System.Windows.Point HitTestScreenPointFromLParam(nint lParam)
+    private void ClickThroughTick()
     {
-        int raw = unchecked((int)lParam);
-        short x = unchecked((short)(raw & 0xFFFF));
-        short y = unchecked((short)((raw >> 16) & 0xFFFF));
-        return new System.Windows.Point(x, y);
+        if (!IsVisible || _hwnd == nint.Zero || !GetCursorPos(out var cursor)) return;
+        SetClickThrough(!IsPointOnPet(new System.Windows.Point(cursor.X, cursor.Y)));
+    }
+
+    private void SetClickThrough(bool enabled)
+    {
+        if (_hwnd == nint.Zero || enabled == _clickThrough) return;
+
+        long style = GetWindowExStyle(_hwnd).ToInt64();
+        long updatedStyle = enabled
+            ? style | WS_EX_TRANSPARENT
+            : style & ~WS_EX_TRANSPARENT;
+        SetWindowExStyle(_hwnd, (nint)updatedStyle);
+
+        long appliedStyle = GetWindowExStyle(_hwnd).ToInt64();
+        if (((appliedStyle & WS_EX_TRANSPARENT) != 0) != enabled) return;
+
+        _clickThrough = enabled;
+        SetWindowPos(
+            _hwnd,
+            nint.Zero,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
     }
 
     private async Task InitializeWebViewAsync()
@@ -255,10 +279,14 @@ internal sealed class PetWindow : Window
         if (!IsVisible) Show();
         Topmost = true;
         _hoverTimer.Start();
+        _clickThroughTimer.Start();
+        ClickThroughTick();
     }
 
     public void HidePet()
     {
+        _clickThroughTimer.Stop();
+        SetClickThrough(false);
         Hide();
         _hoverTimer.Stop();
         _lastHover = false;
@@ -565,6 +593,7 @@ internal sealed class PetWindow : Window
         SavePlacement();
         _saveTimer.Stop();
         _hoverTimer.Stop();
+        _clickThroughTimer.Stop();
         _server.StatusChanged -= OnServerStatusChanged;
         base.OnClosing(e);
     }
@@ -775,9 +804,44 @@ internal sealed class PetWindow : Window
     // ── P/Invoke + constants ───────────────────────────────────────────
 
     private const int WM_NCLBUTTONDOWN = 0xA1;
-    private const int WM_NCHITTEST = 0x84;
     private const int HTCAPTION = 2;
-    private const int HTTRANSPARENT = -1;
+    private const int GWL_EXSTYLE = -20;
+    private const long WS_EX_TRANSPARENT = 0x00000020L;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOZORDER = 0x0004;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint SWP_FRAMECHANGED = 0x0020;
+
+    private static nint GetWindowExStyle(nint hWnd) => IntPtr.Size == 8
+        ? GetWindowLongPtr64(hWnd, GWL_EXSTYLE)
+        : (nint)GetWindowLong32(hWnd, GWL_EXSTYLE);
+
+    private static nint SetWindowExStyle(nint hWnd, nint style) => IntPtr.Size == 8
+        ? SetWindowLongPtr64(hWnd, GWL_EXSTYLE, style)
+        : (nint)SetWindowLong32(hWnd, GWL_EXSTYLE, style.ToInt32());
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern nint GetWindowLongPtr64(nint hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static extern int GetWindowLong32(nint hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static extern nint SetWindowLongPtr64(nint hWnd, int nIndex, nint dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static extern int SetWindowLong32(nint hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(
+        nint hWnd,
+        nint hWndInsertAfter,
+        int x,
+        int y,
+        int cx,
+        int cy,
+        uint uFlags);
 
     [DllImport("user32.dll")]
     private static extern bool ReleaseCapture();

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -126,7 +126,7 @@ internal sealed class PetWindow : Window
         // with the pet while allowing padding clicks to reach other processes.
         _clickThroughTimer = new System.Windows.Threading.DispatcherTimer
         {
-            Interval = TimeSpan.FromMilliseconds(50),
+            Interval = TimeSpan.FromMilliseconds(16),
         };
         _clickThroughTimer.Tick += (_, _) => ClickThroughTick();
 


### PR DESCRIPTION
## Summary
- add native `WM_NCHITTEST` handling for the Windows desktop pet
- return `HTTRANSPARENT` for transparent padding around the visible pet sprite so clicks fall through to the desktop or apps underneath
- keep the visible sprite area interactive for tap, drag, and right-click behaviour

## Why
The Windows pet is hosted in a rectangular transparent WebView2/WPF surface. Even though most pixels are visually transparent, the whole window still receives mouse hit-tests, which can make TokenTracker feel like it is hijacking clicks over nearby desktop/app areas.

## Validation
- `git diff --check`
- `node --test test/release-windows-workflow.test.js`

Could not run `dotnet build TokenTrackerWin/TokenTrackerWin.csproj` locally because no .NET SDK/MSBuild is installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pet window click-through now applies only to the pet sprite’s opaque area, allowing clicks to pass through transparent padding while preserving interaction on the sprite.
  * A reserved top “bubble/hover” band is excluded from the interactive region to prevent accidental clicks.
* **Chores**
  * Added a Windows build job to CI to compile the Windows app in Release mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->