### PR TITLE
Add GitHub Copilot App usage tracking

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -162,7 +162,8 @@ Aktualisieren mit `brew upgrade --cask mm7894215/tokentracker/tokentracker`. Der
 | **OpenClaw** | ✅ Auto | Session-Plugin |
 | **Every Code** | ✅ Auto | TOML-Notify-Hook |
 | **Hermes Agent** | ✅ Auto | SQLite Sessions-Tabelle (`~/.hermes/state.db`) |
-| **GitHub Copilot** | ✅ Auto | OpenTelemetry-Datei-Exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
+| **GitHub Copilot App** | ✅ Auto | Passiver Session-Summary-Reader (`~/.copilot/data.db` oder `COPILOT_HOME/data.db`) |
+| **GitHub Copilot CLI / Chat-Erweiterung** | ✅ Auto | OpenTelemetry-Datei-Exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ Auto | Passiver `wire.jsonl`-Reader (`~/.kimi/sessions/**/wire.jsonl`) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ Auto | Passiver Reader (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ Auto | SessionEnd-Hook in `~/.codebuddy/settings.json` (Claude-Code-Fork) |
@@ -182,7 +183,7 @@ Aktualisieren mit `brew upgrade --cask mm7894215/tokentracker/tokentracker`. Der
 > **Muss ich Plugins oder Hooks manuell installieren?** Nein. `tokentracker` (oder `tokentracker init`) erledigt alles beim ersten Start:
 > - **Hook-basiert** (Claude Code, Codex, Gemini, Every Code, CodeBuddy, WorkBuddy, Grok Build) — wir schreiben einen SessionEnd-Hook oder TOML-Notify-Eintrag in die Konfiguration des Tools.
 > - **Plugin-basiert** (OpenCode, OpenClaw) — das Plugin ist im npm-Paket enthalten (`~/.tokentracker/app/openclaw-plugin/`). Wir verlinken es per CLI (`openclaw plugins install --link …` + `enable`). Kein Download, kein Drag-and-Drop.
-> - **Passive Reader** (Cursor, Kiro, Hermes, Kimi Code, Copilot, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Antigravity, Zed Agent, Goose, Mimo Code, ZCode) — wir installieren nichts in diesen Tools. Wir lesen nur Dateien, die sie bereits produzieren (SQLite-DB, JSONL, OTEL-Export, Session-Logs).
+> - **Passive Reader** (Cursor, Kiro, Hermes, Kimi Code, Copilot, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Antigravity, Zed Agent, Goose, Mimo Code, ZCode) — wir installieren nichts in diesen Tools. Wir lesen nur Dateien, die sie bereits produzieren (SQLite-DB, JSONL, OTEL-Export, Session-Logs). Die Copilot-App-Nutzung wird ausschließlich aus den `sessions.total_*`-Token-Zusammenfassungen in `~/.copilot/data.db` gelesen und fließt in die bestehende `copilot`-Gesamtstatistik ein (Summen, Trends, Modellaufschlüsselung, Kosten). Copilot CLI / Chat-Erweiterung bleibt OTEL-basiert; beide Pfade führen getrennte Sync-Cursor, um Doppelzählungen zu vermeiden.
 >
 > Führe `tokentracker status` aus, um den Status jeder Integration zu prüfen. Zeigt ein Tool `skipped`, erklärt die `detail`-Spalte warum.
 >

--- a/README.ja.md
+++ b/README.ja.md
@@ -163,7 +163,8 @@ brew install mm7894215/tokentracker/tokentracker
 | **OpenClaw** | ✅ 自動 | セッションプラグイン |
 | **Every Code** | ✅ 自動 | TOML notify hook |
 | **Hermes Agent** | ✅ 自動 | SQLite の sessions テーブル (`~/.hermes/state.db`) |
-| **GitHub Copilot** | ✅ 自動 | OpenTelemetry のファイルエクスポーター (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
+| **GitHub Copilot App** | ✅ 自動 | パッシブなセッションサマリー読み取り (`~/.copilot/data.db`、または `COPILOT_HOME/data.db`) |
+| **GitHub Copilot CLI / Chat 拡張** | ✅ 自動 | OpenTelemetry のファイルエクスポーター (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ 自動 | パッシブな `wire.jsonl` リーダー (`~/.kimi/sessions/**/wire.jsonl`) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 自動 | パッシブリーダー (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ 自動 | `~/.codebuddy/settings.json` 内の SessionEnd hook（Claude-Code fork） |
@@ -183,7 +184,7 @@ brew install mm7894215/tokentracker/tokentracker
 > **プラグインや hook を手動でインストールする必要はありますか?** いいえ。`tokentracker`（または `tokentracker init`）が初回実行ですべて処理します:
 > - **Hook ベース**のツール (Claude Code、Codex、Gemini、Every Code、**CodeBuddy**、**WorkBuddy**、**Grok Build**) — ツール自身の設定に SessionEnd hook または TOML notify エントリーを書き込みます。
 > - **プラグインベース**のツール (OpenCode、**OpenClaw**) — プラグインは npm パッケージ内に同梱されています。OpenClaw のセッションプラグインは `~/.tokentracker/tracker/openclaw-plugin/openclaw-session-sync/` にあり、OpenClaw 自身の CLI でリンクして有効化したうえで、同期を起動するセッション終了イベントを許可するために `hooks.allowConversationAccess=true` を設定します。ダウンロードもドラッグ＆ドロップも不要です。
-> - **パッシブリーダー** (Cursor、Kiro、Hermes、Kimi Code、Copilot、**Grok Build**、**oh-my-pi**、**pi**、**Craft Agents**、**Kilo CLI**、**Kilo Code**、**Roo Code**、**Antigravity**、**Zed Agent**、**Goose**、**Mimo Code**、**ZCode**) — これらのツールには何もインストールしません。ツールがすでに出力しているファイル (SQLite DB、JSONL、OTEL エクスポート、session logs) を読むだけです。
+> - **パッシブリーダー** (Cursor、Kiro、Hermes、Kimi Code、Copilot、**Grok Build**、**oh-my-pi**、**pi**、**Craft Agents**、**Kilo CLI**、**Kilo Code**、**Roo Code**、**Antigravity**、**Zed Agent**、**Goose**、**Mimo Code**、**ZCode**) — これらのツールには何もインストールしません。ツールがすでに出力しているファイル (SQLite DB、JSONL、OTEL エクスポート、session logs) を読むだけです。Copilot App の使用量は `~/.copilot/data.db` の `sessions.total_*` トークンサマリーのみを読み取り、既存の `copilot` 集計統計 (合計、トレンド、モデル別内訳、コスト) に反映されます。Copilot CLI / Chat 拡張は引き続き OTEL ベースで、両者は重複カウントを避けるため別々の同期カーソルを保持します。
 > - **Grok Build の推定** — 現在のローカルテレメトリは `updates.jsonl` の累積 `totalTokens` を公開していますが、安定したプロンプト/出力/キャッシュの内訳はありません。`signals.json` は `contextTokensUsed` のスナップショットを使ったフォールバックとして残っています。コールごとの利用詳細が利用可能になるまで、TokenTracker は Grok のコストを推定します。
 >
 > いつでも `tokentracker status` を実行すれば、各統合の状態を確認できます。`skipped` と表示されている場合、`detail` 列にその理由が示されます（例: ツール CLI が `PATH` にない、設定が読めない）。

--- a/README.ko.md
+++ b/README.ko.md
@@ -163,7 +163,8 @@ brew install mm7894215/tokentracker/tokentracker
 | **OpenClaw** | ✅ 자동 | 세션 플러그인 |
 | **Every Code** | ✅ 자동 | TOML notify hook |
 | **Hermes Agent** | ✅ 자동 | SQLite sessions 테이블 (`~/.hermes/state.db`) |
-| **GitHub Copilot** | ✅ 자동 | OpenTelemetry 파일 익스포터 (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
+| **GitHub Copilot App** | ✅ 자동 | 패시브 세션 요약 리더 (`~/.copilot/data.db`, 또는 `COPILOT_HOME/data.db`) |
+| **GitHub Copilot CLI / Chat 확장** | ✅ 자동 | OpenTelemetry 파일 익스포터 (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ 자동 | 패시브 `wire.jsonl` 리더 (`~/.kimi/sessions/**/wire.jsonl`) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 자동 | 패시브 리더 (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ 자동 | `~/.codebuddy/settings.json`의 SessionEnd hook (Claude-Code fork) |
@@ -183,7 +184,7 @@ brew install mm7894215/tokentracker/tokentracker
 > **플러그인이나 hook을 수동으로 설치해야 하나요?** 아니요. `tokentracker` (또는 `tokentracker init`)가 첫 실행에서 모든 것을 처리합니다:
 > - **Hook 기반** 도구 (Claude Code, Codex, Gemini, Every Code, **CodeBuddy**, **WorkBuddy**, **Grok Build**) — 도구 자체의 설정에 SessionEnd hook 또는 TOML notify 엔트리를 작성합니다.
 > - **플러그인 기반** 도구 (OpenCode, **OpenClaw**) — 플러그인은 npm 패키지 안에 포함되어 있습니다. OpenClaw 세션 플러그인은 `~/.tokentracker/tracker/openclaw-plugin/openclaw-session-sync/`에 있으며, OpenClaw 자체 CLI로 링크하고 활성화한 뒤 동기화를 트리거하는 세션 종료 이벤트를 허용하도록 `hooks.allowConversationAccess=true`를 설정합니다. 다운로드, 드래그 앤 드롭 불필요.
-> - **패시브 리더** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **oh-my-pi**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Mimo Code**, **ZCode**) — 이들 도구에는 아무것도 설치하지 않습니다. 도구가 이미 생성하는 파일 (SQLite DB, JSONL, OTEL export, session logs)만 읽습니다.
+> - **패시브 리더** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **oh-my-pi**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Mimo Code**, **ZCode**) — 이들 도구에는 아무것도 설치하지 않습니다. 도구가 이미 생성하는 파일 (SQLite DB, JSONL, OTEL export, session logs)만 읽습니다. Copilot App 사용량은 `~/.copilot/data.db`의 `sessions.total_*` 토큰 요약만 읽어 기존 `copilot` 집계 통계 (합계, 추이, 모델별 분석, 비용)에 반영됩니다. Copilot CLI / Chat 확장은 계속 OTEL 기반이며, 중복 집계를 피하기 위해 두 경로는 별도의 동기화 커서를 유지합니다.
 > - **Grok Build 추정** — 현재 로컬 텔레메트리는 `updates.jsonl`의 누적 `totalTokens`를 노출하지만, 안정적인 프롬프트/출력/캐시 분할은 제공하지 않습니다; `signals.json`은 `contextTokensUsed` 스냅샷을 사용한 폴백으로 남아 있습니다. 호출별 사용 상세 정보가 제공될 때까지 TokenTracker는 Grok 비용을 추정합니다.
 >
 > 언제든 `tokentracker status`로 각 통합의 상태를 확인할 수 있습니다. `skipped`로 표시되면 `detail` 컬럼이 이유를 설명합니다 (예: 도구 CLI가 `PATH`에 없음, 설정 읽기 불가).

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 | **OpenClaw** | ✅ Auto | Session plugin |
 | **Every Code** | ✅ Auto | TOML notify hook |
 | **Hermes Agent** | ✅ Auto | SQLite sessions table (`~/.hermes/state.db`) |
-| **GitHub Copilot** | ✅ Auto | OpenTelemetry file exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
+| **GitHub Copilot App** | ✅ Auto | Passive session-summary reader (`~/.copilot/data.db`, or `COPILOT_HOME/data.db`) |
+| **GitHub Copilot CLI / Chat extension** | ✅ Auto | OpenTelemetry file exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ Auto | Passive `wire.jsonl` reader (`~/.kimi/sessions/**/wire.jsonl`) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ Auto | Passive reader (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ Auto | SessionEnd hook in `~/.codebuddy/settings.json` (Claude-Code fork) |
@@ -187,7 +188,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 > **Do I need to install any plugin or hook manually?** No. `tokentracker` (or `tokentracker init`) handles everything on first run:
 > - **Hook-based** tools (Claude Code, Codex, Gemini, Every Code, **CodeBuddy**, **WorkBuddy**, **Grok Build**) — we write a SessionEnd hook or TOML notify entry into the tool's own config.
 > - **Plugin-based** tools (OpenCode, **OpenClaw**) — plugins ship inside the npm package. OpenClaw's session plugin lives at `~/.tokentracker/tracker/openclaw-plugin/openclaw-session-sync/`; we link and enable it via OpenClaw's own CLI, then set `hooks.allowConversationAccess=true` so OpenClaw permits the session-finished event that triggers sync. No download, no drag-and-drop.
-> - **Passive readers** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **oh-my-pi**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Mimo Code**, **ZCode**) — nothing is installed into those tools. We only read files they already produce (SQLite DB, JSONL, OTEL export, session logs).
+> - **Passive readers** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **oh-my-pi**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Mimo Code**, **ZCode**) — nothing is installed into those tools. We only read files they already produce (SQLite DB, JSONL, OTEL export, session logs). Copilot App usage is read from `~/.copilot/data.db` `sessions.total_*` token summaries only and feeds the existing `copilot` aggregate statistics (totals, trends, model breakdown, cost). Copilot CLI / Chat extension usage remains OTEL-based; both surfaces keep separate sync cursors to avoid duplicate counting.
 > - **Grok Build estimate** — current local telemetry exposes cumulative `updates.jsonl` `totalTokens`, but not a stable prompt/output/cache split; `signals.json` remains a fallback with `contextTokensUsed` snapshots. TokenTracker estimates Grok cost until per-call usage details are available.
 >
 > Run `tokentracker status` anytime to verify every integration's state. If something shows `skipped`, the `detail` column explains why (e.g. tool CLI not on `PATH`, config unreadable).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,8 @@ brew install mm7894215/tokentracker/tokentracker
 | **OpenClaw** | ✅ 自动 | Session 插件 |
 | **Every Code** | ✅ 自动 | TOML notify hook |
 | **Hermes Agent** | ✅ 自动 | SQLite sessions 表（`~/.hermes/state.db`） |
-| **GitHub Copilot** | ✅ 自动 | OpenTelemetry 文件导出（`COPILOT_OTEL_FILE_EXPORTER_PATH`） |
+| **GitHub Copilot App** | ✅ 自动 | 被动会话汇总读取（`~/.copilot/data.db`，或 `COPILOT_HOME/data.db`） |
+| **GitHub Copilot CLI / Chat 扩展** | ✅ 自动 | OpenTelemetry 文件导出（`COPILOT_OTEL_FILE_EXPORTER_PATH`） |
 | **Kimi Code** | ✅ 自动 | 被动读取 `wire.jsonl`（`~/.kimi/sessions/**/wire.jsonl`） |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 自动 | 被动读取（`~/.omp/agent/sessions/**/*.jsonl`） |
 | **CodeBuddy** (腾讯) | ✅ 自动 | 写入 `~/.codebuddy/settings.json` 的 SessionEnd hook（Claude-Code fork） |
@@ -185,7 +186,7 @@ brew install mm7894215/tokentracker/tokentracker
 > **需要手动装什么插件 / hook 吗？** 不需要。`tokentracker`（或 `tokentracker init`）第一次跑的时候会全部搞定：
 > - **基于 hook 的工具**（Claude Code、Codex、Gemini、Every Code、**CodeBuddy**、**WorkBuddy**、**Grok Build**）—— 我们把 SessionEnd hook 或 TOML notify 条目写入它们自己的配置文件
 > - **基于插件的工具**（OpenCode、**OpenClaw**）—— 插件随 npm 包一起分发。OpenClaw 的 session plugin 位于 `~/.tokentracker/tracker/openclaw-plugin/openclaw-session-sync/`；TokenTracker 会通过 OpenClaw 自己的 CLI 挂接并启用它，然后写入 `hooks.allowConversationAccess=true`，让 OpenClaw 放行触发同步的会话结束事件。无需下载、无需拖拽
-> - **被动读取类**（Cursor、Kiro、Hermes、Kimi Code、Copilot、**Grok Build**、**oh-my-pi**、**pi**、**Craft Agents**、**Kilo CLI**、**Kilo Code**、**Roo Code**、**Antigravity**、**Zed Agent**、**Goose**、**Mimo Code**、**ZCode**）—— 完全不往它们里面塞东西，只读取它们自己产生的文件（SQLite DB、JSONL、OTEL 导出、会话轨迹日志）
+> - **被动读取类**（Cursor、Kiro、Hermes、Kimi Code、Copilot、**Grok Build**、**oh-my-pi**、**pi**、**Craft Agents**、**Kilo CLI**、**Kilo Code**、**Roo Code**、**Antigravity**、**Zed Agent**、**Goose**、**Mimo Code**、**ZCode**）—— 完全不往它们里面塞东西，只读取它们自己产生的文件（SQLite DB、JSONL、OTEL 导出、会话轨迹日志）。Copilot App 的用量只读取 `~/.copilot/data.db` 中 `sessions.total_*` 的 token 汇总列，并入现有 `copilot` 聚合统计（总量、趋势、模型拆分、成本）；Copilot CLI / Chat 扩展仍走 OTEL，两条数据面各自维护独立的同步游标以避免重复计数
 > - **Grok Build 估算说明** —— Grok 当前本地遥测提供 `updates.jsonl` 里的累计 `totalTokens`，但还没有稳定的输入/输出/cache 拆分；`signals.json` 仍作为 `contextTokensUsed` 快照兜底。所以在 Grok 提供按调用粒度的用量明细之前，TokenTracker 对 Grok 成本仍是估算值
 >
 > 任何时候都可以用 `tokentracker status` 查看每个集成的状态。如果显示 `skipped`，`detail` 列会解释原因（例如某工具 CLI 不在 `PATH` 上、config 不可读等）。

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -60,6 +60,8 @@ const {
   resolveGrokBuildSessions,
   resolveHermesPath,
   resolveHermesDbPath,
+  resolveCopilotAppDbPath,
+  resolveCopilotAppDbPaths,
   probeWslDistros,
 } = require("../lib/rollout");
 const { getWslMode, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
@@ -305,9 +307,18 @@ async function cmdStatus(argv = []) {
 
   const copilotToken = readCopilotOauthToken({ home });
   const copilotOtel = describeCopilotOtelStatus({ home, env: process.env });
+  const copilotAppDbPaths = resolveCopilotAppDbPaths(process.env);
+  const copilotAppExistingPaths = copilotAppDbPaths.filter((p) => {
+    try { return fssync.existsSync(p); } catch (_e) { return false; }
+  });
   const copilotLines = formatCopilotLines({
     token: copilotToken,
     otel: copilotOtel,
+    appDb: {
+      app_db_path: resolveCopilotAppDbPath(process.env),
+      app_db_paths: copilotAppExistingPaths,
+      app_db_has_file: copilotAppExistingPaths.length > 0,
+    },
   });
 
   // Detect passive-mode providers exactly once — both the JSON/light path
@@ -424,6 +435,9 @@ async function cmdStatus(argv = []) {
         otel_has_files: Boolean(copilotOtel.otel_has_files),
         otel_path: copilotOtel.otel_path || null,
         otel_enabled: Boolean(copilotOtel.otel_enabled),
+        app_db_has_file: copilotAppExistingPaths.length > 0,
+        app_db_path: resolveCopilotAppDbPath(process.env),
+        app_db_paths: copilotAppExistingPaths,
       },
       passive_mode: {
         active: isPassiveModeActive(passiveProviders),
@@ -555,11 +569,14 @@ async function cmdStatus(argv = []) {
   );
 }
 
-function formatCopilotLines({ token, otel }) {
-  if (!token && !otel.otel_has_files) return [];
+function formatCopilotLines({ token, otel, appDb }) {
+  if (!token && !otel.otel_has_files && !appDb?.app_db_has_file) return [];
   const limitsState = token
     ? "set (via GitHub OAuth)"
     : "unset (no Copilot OAuth token found)";
+  const appDbState = appDb?.app_db_has_file
+    ? `set (${(appDb.app_db_paths || []).join(", ")})`
+    : `not found (${appDb?.app_db_path || "unknown"})`;
   const usageState = otel.otel_has_files
     ? `set (${otel.otel_path || otel.otel_default_dir})`
     : otel.otel_enabled
@@ -567,11 +584,12 @@ function formatCopilotLines({ token, otel }) {
       : "unset (OTEL export not enabled)";
   const lines = [
     `- GitHub Copilot limits: ${limitsState}`,
-    `- GitHub Copilot usage (OTEL): ${usageState}`,
+    `- GitHub Copilot usage (App DB): ${appDbState}`,
+    `- GitHub Copilot usage (OTEL CLI/Chat extension): ${usageState}`,
   ];
   if (!otel.otel_has_files) {
     lines.push(
-      "    To track Copilot token usage, add to your shell profile:",
+      "    To track Copilot CLI / Chat extension token usage, add to your shell profile:",
       "      export COPILOT_OTEL_ENABLED=true",
       "      export COPILOT_OTEL_EXPORTER_TYPE=file",
       `      export COPILOT_OTEL_FILE_EXPORTER_PATH="${otel.otel_default_dir}/copilot-otel-$(date +%Y%m%d).jsonl"`,
@@ -673,6 +691,23 @@ function renderLightTable(summary) {
       detail.push(`WSL: ${info.wsl_distros.map((d) => `${d.name} (v${d.version ?? "?"})`).join(", ")}`);
     }
     push(`Provider · ${name}`, detail.length ? detail.join(", ") : "—");
+  }
+
+  if (summary.copilot) {
+    push(
+      "Copilot App DB",
+      summary.copilot.app_db_has_file
+        ? (summary.copilot.app_db_paths || [summary.copilot.app_db_path]).filter(Boolean).join(", ")
+        : `not found (${summary.copilot.app_db_path || "unknown"})`,
+    );
+    push(
+      "Copilot OTEL",
+      summary.copilot.otel_has_files
+        ? summary.copilot.otel_path || "files found"
+        : summary.copilot.otel_enabled
+          ? "enabled, no files"
+          : "not enabled",
+    );
   }
 
   if (summary.passive_mode) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -693,7 +693,15 @@ function renderLightTable(summary) {
     push(`Provider · ${name}`, detail.length ? detail.join(", ") : "—");
   }
 
-  if (summary.copilot) {
+  // Mirror formatCopilotLines(): stay silent for machines with no Copilot
+  // signal at all instead of printing "not found" rows for everyone.
+  const copilotDetected =
+    summary.copilot &&
+    (summary.copilot.token_set ||
+      summary.copilot.otel_enabled ||
+      summary.copilot.otel_has_files ||
+      summary.copilot.app_db_has_file);
+  if (copilotDetected) {
     push(
       "Copilot App DB",
       summary.copilot.app_db_has_file

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -24,6 +24,7 @@ const {
   resolveKiroJsonlPath,
   resolveHermesPath,
   resolveCopilotOtelPaths,
+  resolveCopilotAppDbPaths,
   parseRolloutIncremental,
   parseClaudeIncremental,
   parseGeminiIncremental,
@@ -37,6 +38,7 @@ const {
   zedInstallOwnsCursor,
   hermesInstallOwnsCursor,
   parseCopilotIncremental,
+  parseCopilotAppDbIncremental,
   resolveKimiWireFiles,
   parseKimiIncremental,
   resolveKimiCodeWireFiles,
@@ -1342,7 +1344,7 @@ async function cmdSync(argv) {
       await repairGrokQueueFromSessionSnapshots({ cursors, queuePath, queueStatePath });
     }
 
-    // ── GitHub Copilot CLI (OTEL JSONL files) ──
+    // ── GitHub Copilot CLI / Chat extension (OTEL JSONL files) ──
     let copilotResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const copilotPaths = sourceAllowed("copilot") ? resolveCopilotOtelPaths(process.env) : [];
     if (copilotPaths.length > 0) {
@@ -1365,6 +1367,40 @@ async function cmdSync(argv) {
         });
       } catch (err) {
         warnProviderParseFailure("Copilot", err, opts);
+      }
+    }
+
+    // ── GitHub Copilot App (passive data.db session summaries) ──
+    const copilotAppDbPaths = sourceAllowed("copilot")
+      ? resolveCopilotAppDbPaths(process.env).filter((p) => {
+          try { return fssync.existsSync(p); } catch (_e) { return false; }
+        })
+      : [];
+    if (copilotAppDbPaths.length > 0) {
+      if (progress?.enabled) {
+        progress.start(`Parsing Copilot App ${renderBar(0)} | buckets 0`);
+      }
+      try {
+        const copilotAppResult = await parseCopilotAppDbIncremental({
+          dbPaths: copilotAppDbPaths,
+          cursors,
+          queuePath,
+          env: process.env,
+          onProgress: (p) => {
+            if (!progress?.enabled) return;
+            const pct = p.total > 0 ? p.index / p.total : 1;
+            progress.update(
+              `Parsing Copilot App ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
+            );
+          },
+        });
+        copilotResult = {
+          recordsProcessed: copilotResult.recordsProcessed + copilotAppResult.recordsProcessed,
+          eventsAggregated: copilotResult.eventsAggregated + copilotAppResult.eventsAggregated,
+          bucketsQueued: copilotResult.bucketsQueued + copilotAppResult.bucketsQueued,
+        };
+      } catch (err) {
+        warnProviderParseFailure("Copilot App", err, opts);
       }
     }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9707,6 +9707,7 @@ async function parseCopilotAppDbIncremental({
   let recordsProcessed = 0;
   let eventsAggregated = 0;
   let totalRows = 0;
+  let dbErrors = 0;
   const updatedAt = new Date().toISOString();
 
   for (const resolvedDb of uniquePaths) {
@@ -9731,12 +9732,22 @@ async function parseCopilotAppDbIncremental({
       continue;
     }
 
-    const snap = snapshotSqliteDb(resolvedDb);
+    let snap = null;
     let rows = [];
     try {
+      snap = snapshotSqliteDb(resolvedDb);
       rows = readCopilotAppSessionsFromSqlite(snap.path, sqliteOptions);
+    } catch (err) {
+      dbErrors++;
+      dbStates[resolvedDb] = {
+        ...dbState,
+        sessionTotals,
+        lastError: err && err.message ? err.message : String(err),
+        lastErrorAt: updatedAt,
+      };
+      continue;
     } finally {
-      snap.cleanup();
+      if (snap) snap.cleanup();
     }
     totalRows += rows.length;
 
@@ -9795,6 +9806,8 @@ async function parseCopilotAppDbIncremental({
       ...dbState,
       sessionTotals,
       lastDbFingerprint: currentFingerprint,
+      lastError: null,
+      lastErrorAt: null,
       updatedAt,
     };
   }
@@ -9809,7 +9822,7 @@ async function parseCopilotAppDbIncremental({
     updatedAt,
   };
 
-  return { recordsProcessed, eventsAggregated, bucketsQueued };
+  return { recordsProcessed, eventsAggregated, bucketsQueued, dbErrors };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9711,15 +9711,6 @@ async function parseCopilotAppDbIncremental({
   const updatedAt = new Date().toISOString();
 
   for (const resolvedDb of uniquePaths) {
-    let currentFingerprint = null;
-    try {
-      fssync.statSync(resolvedDb);
-      currentFingerprint = sqliteSidecarFingerprint(resolvedDb);
-    } catch (e) {
-      if (e && e.code === "ENOENT") continue;
-      throw e;
-    }
-
     const dbState = dbStates[resolvedDb] && typeof dbStates[resolvedDb] === "object"
       ? dbStates[resolvedDb]
       : {};
@@ -9727,6 +9718,22 @@ async function parseCopilotAppDbIncremental({
       dbState.sessionTotals && typeof dbState.sessionTotals === "object"
         ? { ...dbState.sessionTotals }
         : {};
+    let currentFingerprint = null;
+    try {
+      fssync.statSync(resolvedDb);
+      currentFingerprint = sqliteSidecarFingerprint(resolvedDb);
+    } catch (e) {
+      if (e && e.code === "ENOENT") continue;
+      dbErrors++;
+      dbStates[resolvedDb] = {
+        ...dbState,
+        sessionTotals,
+        lastError: e && e.message ? e.message : String(e),
+        lastErrorAt: updatedAt,
+      };
+      continue;
+    }
+
     if (dbState.lastDbFingerprint && sameSqliteFingerprint(currentFingerprint, dbState.lastDbFingerprint)) {
       dbStates[resolvedDb] = { ...dbState, sessionTotals, updatedAt };
       continue;

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9577,23 +9577,20 @@ function readCopilotAppSessionsFromSqlite(dbPath, sqliteOptions = {}) {
   const orderBy = orderTerms.length > 0
     ? `ORDER BY COALESCE(${orderTerms.join(", ")}, ''), id`
     : "ORDER BY id";
+  // Select only the columns the parser consumes. Content-ish columns like
+  // `title` must stay out of the query: token counts only, never user content.
   const sql = `
     SELECT
       id,
-      ${optional("title")},
       ${optional("session_type")},
-      ${optional("mode")},
       ${optional("model")},
       ${optional("provider_id")},
       ${optional("created_at")},
       ${optional("updated_at")},
-      ${optional("forked_from_session_id")},
-      ${optional("fork_original_history_event_count")},
       ${optional("total_input_tokens")},
       ${optional("total_output_tokens")},
       ${optional("total_cached_tokens")},
-      ${optional("total_reasoning_tokens")},
-      ${optional("total_nano_aiu")}
+      ${optional("total_reasoning_tokens")}
     FROM sessions
     ${orderBy}
   `.trim();

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9449,6 +9449,370 @@ async function parseCopilotIncremental({ otelPaths, cursors, queuePath, onProgre
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GitHub Copilot App — passive reader for ~/.copilot/data.db
+//
+// The Copilot App persists one row per local App session in `sessions`, with
+// cumulative `total_*` token summary columns. We intentionally do NOT read
+// session-state/<id>/events.jsonl: forked App sessions inherit parent events
+// there before the child has produced any tokens, so parsing event history would
+// double-count parent usage. The only accounting source here is positive deltas
+// from the `sessions.total_*` counters. Those deltas feed the same aggregate
+// `source="copilot"` pipeline as existing OTEL data (dashboard totals, trends,
+// model breakdown, cost), but the cursor is separate (`cursors.copilotApp`) so
+// Copilot CLI / Chat extension OTEL support keeps its existing behavior.
+// Project attribution and per-conversation detail are intentionally absent:
+// data.db's summary columns do not expose privacy-safe project/message metadata.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COPILOT_APP_CURSOR_VERSION = 1;
+const COPILOT_APP_DEFAULT_MODEL = "github-copilot";
+
+function normalizeCopilotAppDbPath(dbPath, env = process.env) {
+  if (typeof dbPath !== "string" || !dbPath.trim()) return null;
+  const expanded = expandHomePath(dbPath.trim(), env);
+  return path.isAbsolute(expanded) ? path.normalize(expanded) : path.resolve(expanded);
+}
+
+function resolveCopilotAppDbPaths(env = process.env) {
+  const home = env.HOME || require("node:os").homedir();
+  const paths = new Set();
+  const addDbPath = (dbPath) => {
+    const normalized = normalizeCopilotAppDbPath(dbPath, env);
+    if (normalized) paths.add(normalized);
+  };
+  const addHome = (homePath) => {
+    const normalizedHome = normalizeCopilotAppDbPath(homePath, env);
+    if (normalizedHome) addDbPath(path.join(normalizedHome, "data.db"));
+  };
+
+  if (typeof env.TOKENTRACKER_COPILOT_APP_DB === "string" && env.TOKENTRACKER_COPILOT_APP_DB.trim()) {
+    addDbPath(env.TOKENTRACKER_COPILOT_APP_DB);
+  }
+  if (typeof env.COPILOT_HOME === "string" && env.COPILOT_HOME.trim()) {
+    addHome(env.COPILOT_HOME);
+  }
+
+  const defaultDb = path.join(home, ".copilot", "data.db");
+  if (process.platform === "win32") {
+    const wslHome = wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(".copilot", { env }) : null;
+    const wslDb = wslHome ? path.join(wslHome, "data.db") : null;
+    const resolved = resolveInstallPaths({ nativeValue: defaultDb, wslValue: wslDb }, env);
+    if (resolved.native) addDbPath(resolved.native);
+    if (resolved.wsl) addDbPath(resolved.wsl);
+    if (paths.size === 0 && wsl.shouldProbeNative(env)) addDbPath(defaultDb);
+  } else {
+    addDbPath(defaultDb);
+  }
+
+  return Array.from(paths).sort();
+}
+
+function resolveCopilotAppDbPath(env = process.env) {
+  const paths = resolveCopilotAppDbPaths(env);
+  for (const candidate of paths) {
+    try {
+      if (fssync.existsSync(candidate)) return candidate;
+    } catch (_e) {}
+  }
+  return paths[0] || null;
+}
+
+function shouldCountCopilotAppSession(row) {
+  const sessionType = typeof row?.session_type === "string" ? row.session_type.trim().toLowerCase() : "";
+  const providerId = typeof row?.provider_id === "string" ? row.provider_id.trim().toLowerCase() : "";
+  // OTEL remains the owner for recognizable Copilot CLI / VS Code extension
+  // sessions. The App DB path is separately cursored, but skipping known
+  // OTEL-backed surfaces avoids duplicate source="copilot" buckets if GitHub
+  // mirrors those sessions into data.db in a future release.
+  const markers = [sessionType, providerId];
+  return !markers.some((value) =>
+    value === "cli" ||
+    value === "copilot-cli" ||
+    value.includes("vscode") ||
+    value.includes("extension") ||
+    value.includes("otel")
+  );
+}
+
+function parseCopilotAppTimestamp(value) {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "number") {
+    const ms = value > 10_000_000_000 ? value : value * 1000;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d+$/.test(trimmed)) {
+    return parseCopilotAppTimestamp(Number(trimmed));
+  }
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function normalizeCopilotAppModel(model) {
+  if (typeof model !== "string") return "";
+  const normalized = normalizeModelInput(model);
+  if (!normalized) return "";
+  if (/^claude-(sonnet|opus|haiku)-\d+\.\d+/.test(normalized)) {
+    return normalized.replace(/^(claude-(?:sonnet|opus|haiku)-\d+)\.(\d+)/, "$1-$2");
+  }
+  return normalized;
+}
+
+function readCopilotAppSessionsFromSqlite(dbPath, sqliteOptions = {}) {
+  const pragmaRows = readSqliteJsonRows(dbPath, "PRAGMA table_info(sessions)", {
+    label: "GitHub Copilot App",
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10_000,
+    readOnly: true,
+    throwOnReadFailure: true,
+    ...sqliteOptions,
+  });
+  const columns = new Set(pragmaRows.map((row) => row?.name).filter(Boolean));
+  if (!columns.has("id")) return [];
+  const optional = (col) => (columns.has(col) ? col : `NULL AS ${col}`);
+  const orderTerms = ["updated_at", "created_at"].filter((col) => columns.has(col));
+  const orderBy = orderTerms.length > 0
+    ? `ORDER BY COALESCE(${orderTerms.join(", ")}, ''), id`
+    : "ORDER BY id";
+  const sql = `
+    SELECT
+      id,
+      ${optional("title")},
+      ${optional("session_type")},
+      ${optional("mode")},
+      ${optional("model")},
+      ${optional("provider_id")},
+      ${optional("created_at")},
+      ${optional("updated_at")},
+      ${optional("forked_from_session_id")},
+      ${optional("fork_original_history_event_count")},
+      ${optional("total_input_tokens")},
+      ${optional("total_output_tokens")},
+      ${optional("total_cached_tokens")},
+      ${optional("total_reasoning_tokens")},
+      ${optional("total_nano_aiu")}
+    FROM sessions
+    ${orderBy}
+  `.trim();
+  return readSqliteJsonRows(dbPath, sql, {
+    label: "GitHub Copilot App",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 60_000,
+    readOnly: true,
+    throwOnReadFailure: true,
+    ...sqliteOptions,
+  });
+}
+
+function sqliteSidecarFingerprint(dbPath) {
+  const out = {};
+  for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+    const filePath = `${dbPath}${suffix}`;
+    try {
+      const stat = fssync.statSync(filePath);
+      out[suffix || "db"] = {
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        ino: stat.ino,
+      };
+    } catch (e) {
+      if (!e || e.code !== "ENOENT") throw e;
+    }
+  }
+  return out;
+}
+
+function sameSqliteFingerprint(a, b) {
+  return JSON.stringify(a || {}) === JSON.stringify(b || {});
+}
+
+function copilotAppBaselineTotal(value) {
+  if (!value || typeof value !== "object") return 0;
+  return (
+    Number(value.input || 0) +
+    Number(value.output || 0) +
+    Number(value.cached || 0) +
+    Number(value.reasoning || 0)
+  );
+}
+
+function capCopilotAppSessionTotals(sessionTotals, maxEntries = 10_000) {
+  const entries = Object.entries(sessionTotals);
+  if (entries.length <= maxEntries) return sessionTotals;
+
+  const nonzero = [];
+  const zero = [];
+  for (const entry of entries) {
+    if (copilotAppBaselineTotal(entry[1]) > 0) nonzero.push(entry);
+    else zero.push(entry);
+  }
+
+  zero.sort((a, b) => {
+    const ta = Date.parse(a[1]?.updatedAt || "") || 0;
+    const tb = Date.parse(b[1]?.updatedAt || "") || 0;
+    return tb - ta;
+  });
+  const zeroBudget = Math.max(0, maxEntries - nonzero.length);
+  const capped = Object.fromEntries([...nonzero, ...zero.slice(0, zeroBudget)]);
+  for (const key of Object.keys(sessionTotals)) delete sessionTotals[key];
+  Object.assign(sessionTotals, capped);
+  return sessionTotals;
+}
+
+function normalizeCopilotAppTokenDelta(curr, prev) {
+  const inputDelta = Math.max(0, Number(curr?.input || 0) - Number(prev?.input || 0));
+  const cachedDelta = Math.max(0, Number(curr?.cached || 0) - Number(prev?.cached || 0));
+  const cachedInputTokens = Math.min(cachedDelta, inputDelta);
+  const inputTokens = Math.max(0, inputDelta - cachedInputTokens);
+  const outputTokens = Math.max(0, Number(curr?.output || 0) - Number(prev?.output || 0));
+  const reasoningTokens = Math.max(0, Number(curr?.reasoning || 0) - Number(prev?.reasoning || 0));
+  const totalTokens = inputTokens + cachedInputTokens + outputTokens + reasoningTokens;
+  return {
+    input_tokens: inputTokens,
+    cached_input_tokens: cachedInputTokens,
+    cache_creation_input_tokens: 0,
+    output_tokens: outputTokens,
+    reasoning_output_tokens: reasoningTokens,
+    total_tokens: totalTokens,
+    conversation_count: copilotAppBaselineTotal(prev) === 0 && totalTokens > 0 ? 1 : 0,
+  };
+}
+
+async function parseCopilotAppDbIncremental({
+  dbPath,
+  dbPaths,
+  cursors,
+  queuePath,
+  onProgress,
+  env,
+  sqliteOptions,
+} = {}) {
+  await ensureDir(path.dirname(queuePath));
+  const paths = Array.isArray(dbPaths) && dbPaths.length > 0
+    ? dbPaths
+    : dbPath
+      ? [dbPath]
+      : resolveCopilotAppDbPaths(env || process.env);
+  const uniquePaths = [...new Set(paths.map((p) => normalizeCopilotAppDbPath(p, env || process.env)).filter(Boolean))];
+  const appState =
+    cursors.copilotApp && typeof cursors.copilotApp === "object" ? cursors.copilotApp : {};
+  const dbStates =
+    appState.dbs && typeof appState.dbs === "object" ? { ...appState.dbs } : {};
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+  let totalRows = 0;
+  const updatedAt = new Date().toISOString();
+
+  for (const resolvedDb of uniquePaths) {
+    let currentFingerprint = null;
+    try {
+      fssync.statSync(resolvedDb);
+      currentFingerprint = sqliteSidecarFingerprint(resolvedDb);
+    } catch (e) {
+      if (e && e.code === "ENOENT") continue;
+      throw e;
+    }
+
+    const dbState = dbStates[resolvedDb] && typeof dbStates[resolvedDb] === "object"
+      ? dbStates[resolvedDb]
+      : {};
+    const sessionTotals =
+      dbState.sessionTotals && typeof dbState.sessionTotals === "object"
+        ? { ...dbState.sessionTotals }
+        : {};
+    if (dbState.lastDbFingerprint && sameSqliteFingerprint(currentFingerprint, dbState.lastDbFingerprint)) {
+      dbStates[resolvedDb] = { ...dbState, sessionTotals, updatedAt };
+      continue;
+    }
+
+    const snap = snapshotSqliteDb(resolvedDb);
+    let rows = [];
+    try {
+      rows = readCopilotAppSessionsFromSqlite(snap.path, sqliteOptions);
+    } finally {
+      snap.cleanup();
+    }
+    totalRows += rows.length;
+
+    for (const row of rows) {
+      recordsProcessed++;
+      if (!row || typeof row.id !== "string" || !row.id.trim()) continue;
+      if (!shouldCountCopilotAppSession(row)) continue;
+
+      const sessionId = row.id.trim();
+      const curr = {
+        input: toNonNegativeInt(row.total_input_tokens),
+        output: toNonNegativeInt(row.total_output_tokens),
+        cached: toNonNegativeInt(row.total_cached_tokens),
+        reasoning: toNonNegativeInt(row.total_reasoning_tokens),
+      };
+      const prev = sessionTotals[sessionId] || { input: 0, output: 0, cached: 0, reasoning: 0 };
+      const bucketDelta = normalizeCopilotAppTokenDelta(curr, prev);
+      const totalDelta = bucketDelta.total_tokens;
+      const rowUpdatedAt =
+        parseCopilotAppTimestamp(row.updated_at) ||
+        parseCopilotAppTimestamp(row.created_at) ||
+        updatedAt;
+      const model = normalizeCopilotAppModel(row.model) || COPILOT_APP_DEFAULT_MODEL;
+
+      if (totalDelta <= 0) {
+        sessionTotals[sessionId] = { ...curr, model, updatedAt: rowUpdatedAt };
+        continue;
+      }
+
+      const bucketStart = toUtcHalfHourStart(rowUpdatedAt);
+      if (!bucketStart) {
+        sessionTotals[sessionId] = { ...curr, model, updatedAt: rowUpdatedAt };
+        continue;
+      }
+
+      const bucket = getHourlyBucket(hourlyState, "copilot", model, bucketStart);
+      addTotals(bucket.totals, bucketDelta);
+      touchedBuckets.add(bucketKey("copilot", model, bucketStart));
+      sessionTotals[sessionId] = { ...curr, model, updatedAt: rowUpdatedAt };
+      eventsAggregated++;
+
+      if (cb) {
+        cb({
+          index: recordsProcessed,
+          total: Math.max(totalRows, recordsProcessed),
+          recordsProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+    }
+
+    capCopilotAppSessionTotals(sessionTotals);
+
+    dbStates[resolvedDb] = {
+      ...dbState,
+      sessionTotals,
+      lastDbFingerprint: currentFingerprint,
+      updatedAt,
+    };
+  }
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  hourlyState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors.copilotApp = {
+    ...appState,
+    version: COPILOT_APP_CURSOR_VERSION,
+    dbs: dbStates,
+    updatedAt,
+  };
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Grok Build (xAI) — passive reader for ~/.grok/sessions/**/updates.jsonl + signals.json
 // Triggered either by full scan in sync or by the SessionEnd hook writing a signal.
 // updates.jsonl exposes cumulative totalTokens metadata. Grok still does not
@@ -10363,6 +10727,9 @@ module.exports = {
   probeWslDistros,
   discoverWslHermesHome,
   resolveCopilotOtelPaths,
+  resolveCopilotAppDbPath,
+  resolveCopilotAppDbPaths,
+  readCopilotAppSessionsFromSqlite,
   parseRolloutIncremental,
   parseClaudeIncremental,
   parseGeminiIncremental,
@@ -10376,6 +10743,7 @@ module.exports = {
   zedInstallOwnsCursor,
   hermesInstallOwnsCursor,
   parseCopilotIncremental,
+  parseCopilotAppDbIncremental,
   resolveKimiWireFiles,
   resolveKimiDefaultModel,
   parseKimiIncremental,

--- a/src/lib/sqlite-reader.js
+++ b/src/lib/sqlite-reader.js
@@ -30,8 +30,9 @@ function warnSqliteUnavailable({ dbPath, label, cliError, nodeSqliteError, env, 
   }
 }
 
-function readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer }) {
-  const raw = execFileSync("sqlite3", ["-json", dbPath, sql], {
+function readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer, readOnly }) {
+  const args = readOnly ? ["-readonly", "-json", dbPath, sql] : ["-json", dbPath, sql];
+  const raw = execFileSync("sqlite3", args, {
     encoding: "utf8",
     maxBuffer,
     timeout,
@@ -92,7 +93,7 @@ function readSqliteJsonRows(dbPath, sql, options = {}) {
 
   let cliError = null;
   try {
-    return readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer });
+    return readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer, readOnly: Boolean(options.readOnly) });
   } catch (err) {
     cliError = err;
   }
@@ -114,11 +115,20 @@ function readSqliteJsonRows(dbPath, sql, options = {}) {
       stderr: options.stderr,
     });
   }
+  if (options.throwOnReadFailure) {
+    const err = new Error(
+      `Cannot read ${label} SQLite database at ${dbPath}: ${formatError(cliError)}; ${formatError(nodeSqliteError)}`,
+    );
+    err.cliError = cliError;
+    err.nodeSqliteError = nodeSqliteError;
+    throw err;
+  }
   return [];
 }
 
-async function readSqliteRowsWithCliAsync(dbPath, sql, { execFile, timeout, maxBuffer }) {
-  const { stdout } = await execFile("sqlite3", ["-json", dbPath, sql], {
+async function readSqliteRowsWithCliAsync(dbPath, sql, { execFile, timeout, maxBuffer, readOnly }) {
+  const args = readOnly ? ["-readonly", "-json", dbPath, sql] : ["-json", dbPath, sql];
+  const { stdout } = await execFile("sqlite3", args, {
     encoding: "utf8",
     maxBuffer,
     timeout,
@@ -149,7 +159,7 @@ async function readSqliteJsonRowsAsync(dbPath, sql, options = {}) {
 
   let cliError = null;
   try {
-    return await readSqliteRowsWithCliAsync(dbPath, sql, { execFile, timeout, maxBuffer });
+    return await readSqliteRowsWithCliAsync(dbPath, sql, { execFile, timeout, maxBuffer, readOnly: Boolean(options.readOnly) });
   } catch (err) {
     cliError = err;
   }
@@ -170,6 +180,14 @@ async function readSqliteJsonRowsAsync(dbPath, sql, options = {}) {
       env,
       stderr: options.stderr,
     });
+  }
+  if (options.throwOnReadFailure) {
+    const err = new Error(
+      `Cannot read ${label} SQLite database at ${dbPath}: ${formatError(cliError)}; ${formatError(nodeSqliteError)}`,
+    );
+    err.cliError = cliError;
+    err.nodeSqliteError = nodeSqliteError;
+    throw err;
   }
   return [];
 }

--- a/test/copilot-app-parser.test.js
+++ b/test/copilot-app-parser.test.js
@@ -389,10 +389,10 @@ test("parseCopilotAppDbIncremental clamps cached input to raw input delta", asyn
   }
 });
 
-test("parseCopilotAppDbIncremental does not advance DB fingerprint after SQLite read failure", async () => {
+test("parseCopilotAppDbIncremental isolates one DB read failure without dropping healthy progress", async () => {
   const { dir, dbPath } = makeCopilotAppDb([
     {
-      id: "read-failure-retry",
+      id: "healthy-db-session",
       session_type: "project",
       model: "gpt-5.5",
       created_at: "2026-07-07T14:45:00Z",
@@ -404,32 +404,26 @@ test("parseCopilotAppDbIncremental does not advance DB fingerprint after SQLite 
     },
   ]);
   try {
+    const badDbPath = path.join(dir, "bad-copilot-data.db");
+    fs.writeFileSync(badDbPath, "not a sqlite database", "utf8");
     const queuePath = path.join(dir, "queue.jsonl");
     const cursors = {};
-    await assert.rejects(
-      parseCopilotAppDbIncremental({
-        dbPath,
-        cursors,
-        queuePath,
-        sqliteOptions: {
-          execFileSync() {
-            throw new Error("simulated sqlite cli read failure");
-          },
-          requireFn() {
-            throw new Error("node:sqlite DatabaseSync is unavailable");
-          },
-        },
-      }),
-      /Cannot read GitHub Copilot App SQLite database/,
-    );
-    assert.equal(cursors.copilotApp, undefined, "failed read must not mark DB fingerprint as consumed");
 
-    const retry = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
-    assert.equal(retry.eventsAggregated, 1);
+    const result = await parseCopilotAppDbIncremental({ dbPaths: [dbPath, badDbPath], cursors, queuePath });
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal(result.dbErrors, 1);
+
     const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
     assert.equal(rows.length, 1);
     assert.equal(rows[0].input_tokens, 90);
     assert.equal(rows[0].cached_input_tokens, 10);
+    assert.ok(cursors.copilotApp.dbs[dbPath].lastDbFingerprint, "healthy DB fingerprint should persist");
+    assert.equal(
+      cursors.copilotApp.dbs[badDbPath].lastDbFingerprint,
+      undefined,
+      "failed DB must not advance fingerprint so unchanged history is retried",
+    );
+    assert.match(cursors.copilotApp.dbs[badDbPath].lastError, /GitHub Copilot App SQLite database|file is not a database|database disk image is malformed/i);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/copilot-app-parser.test.js
+++ b/test/copilot-app-parser.test.js
@@ -429,6 +429,51 @@ test("parseCopilotAppDbIncremental isolates one DB read failure without dropping
   }
 });
 
+test("parseCopilotAppDbIncremental isolates one DB fingerprint failure without dropping healthy progress", async (t) => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "healthy-after-fingerprint-failure",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T14:47:00Z",
+      updated_at: "2026-07-07T14:48:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+      total_cached_tokens: 10,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const badDbPath = path.join(dir, "stat-fails.db");
+    const originalStatSync = fs.statSync;
+    mockMethod(t, fs, "statSync", (target, ...args) => {
+      if (target === badDbPath) {
+        const err = new Error("simulated fingerprint stat failure");
+        err.code = "EACCES";
+        throw err;
+      }
+      return originalStatSync.call(fs, target, ...args);
+    });
+
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+
+    const result = await parseCopilotAppDbIncremental({ dbPaths: [badDbPath, dbPath], cursors, queuePath });
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal(result.dbErrors, 1);
+
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].input_tokens, 90);
+    assert.equal(rows[0].cached_input_tokens, 10);
+    assert.ok(cursors.copilotApp.dbs[dbPath].lastDbFingerprint, "healthy DB fingerprint should persist");
+    assert.equal(cursors.copilotApp.dbs[badDbPath].lastDbFingerprint, undefined);
+    assert.match(cursors.copilotApp.dbs[badDbPath].lastError, /simulated fingerprint stat failure/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotAppDbIncremental normalizes dotted Claude App model ids for pricing", async () => {
   const { dir, dbPath } = makeCopilotAppDb([
     {

--- a/test/copilot-app-parser.test.js
+++ b/test/copilot-app-parser.test.js
@@ -1,0 +1,673 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+const { computeRowCost } = require("../src/lib/pricing");
+const { mockPlatform, mockMethod } = require("./helpers/mock");
+const {
+  parseCopilotIncremental,
+  parseCopilotAppDbIncremental,
+  resolveCopilotAppDbPaths,
+} = require("../src/lib/rollout");
+
+function sqlValue(value) {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "number") return String(value);
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function runSql(dbPath, sql) {
+  cp.execFileSync("sqlite3", [dbPath, sql], { stdio: ["ignore", "ignore", "pipe"] });
+}
+
+function makeCopilotAppDb(rows = []) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-app-test-"));
+  const copilotHome = path.join(dir, ".copilot");
+  fs.mkdirSync(copilotHome, { recursive: true });
+  const dbPath = path.join(copilotHome, "data.db");
+  runSql(dbPath, `
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      session_type TEXT,
+      mode TEXT,
+      model TEXT,
+      provider_id TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      forked_from_session_id TEXT,
+      fork_original_history_event_count INTEGER,
+      total_input_tokens INTEGER,
+      total_output_tokens INTEGER,
+      total_cached_tokens INTEGER,
+      total_reasoning_tokens INTEGER,
+      total_nano_aiu INTEGER,
+      context_current_tokens INTEGER,
+      context_conversation_tokens INTEGER
+    );
+  `);
+  for (const row of rows) insertSession(dbPath, row);
+  return { dir, dbPath, copilotHome };
+}
+
+function insertSession(dbPath, row) {
+  const columns = [
+    "id",
+    "title",
+    "session_type",
+    "mode",
+    "model",
+    "provider_id",
+    "created_at",
+    "updated_at",
+    "forked_from_session_id",
+    "fork_original_history_event_count",
+    "total_input_tokens",
+    "total_output_tokens",
+    "total_cached_tokens",
+    "total_reasoning_tokens",
+    "total_nano_aiu",
+    "context_current_tokens",
+    "context_conversation_tokens",
+  ];
+  const values = columns.map((column) => sqlValue(row[column]));
+  runSql(dbPath, `INSERT INTO sessions (${columns.join(", ")}) VALUES (${values.join(", ")});`);
+}
+
+function updateSession(dbPath, id, values) {
+  const setSql = Object.entries(values)
+    .map(([column, value]) => `${column}=${sqlValue(value)}`)
+    .join(", ");
+  runSql(dbPath, `UPDATE sessions SET ${setSql} WHERE id=${sqlValue(id)};`);
+  const future = new Date(Date.now() + 2000);
+  fs.utimesSync(dbPath, future, future);
+}
+
+function updateSessionPreserveDbMtimeWithWal(dbPath, id, values) {
+  const before = fs.statSync(dbPath);
+  const child = cp.spawn("sqlite3", [dbPath], { stdio: ["pipe", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+  const setSql = Object.entries(values)
+    .map(([column, value]) => `${column}=${sqlValue(value)}`)
+    .join(", ");
+  child.stdin.write("PRAGMA journal_mode=WAL;\n");
+  child.stdin.write("PRAGMA wal_autocheckpoint=0;\n");
+  child.stdin.write("BEGIN IMMEDIATE;\n");
+  child.stdin.write(`UPDATE sessions SET ${setSql} WHERE id=${sqlValue(id)};\n`);
+  child.stdin.write("COMMIT;\n");
+  child.stdin.write("SELECT 'ready';\n");
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("timed out waiting for sqlite WAL update"));
+    }, 5000);
+    child.stdout.on("data", () => {
+      if (!stdout.includes("ready")) return;
+      clearTimeout(timer);
+      try {
+        fs.utimesSync(dbPath, before.atime, before.mtime);
+        resolve({
+          close() {
+            child.stdin.write(".quit\n");
+            child.stdin.end();
+          },
+        });
+      } catch (err) {
+        child.kill();
+        reject(err);
+      }
+    });
+    child.on("exit", (code) => {
+      if (code !== 0 && !stdout.includes("ready")) {
+        clearTimeout(timer);
+        reject(new Error(`sqlite exited with ${code}: ${stderr}`));
+      }
+    });
+  });
+}
+
+function readQueue(queuePath) {
+  if (!fs.existsSync(queuePath)) return [];
+  return fs
+    .readFileSync(queuePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(JSON.parse);
+}
+
+function latestByBucket(rows) {
+  const latest = new Map();
+  for (const row of rows) {
+    latest.set(`${row.source}|${row.model}|${row.hour_start}`, row);
+  }
+  return Array.from(latest.values());
+}
+
+function writeCopilotOtelFile(filePath, records) {
+  fs.writeFileSync(filePath, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
+}
+
+function makeCopilotOtelSpan({
+  traceId = "trace-1",
+  spanId = "span-1",
+  endSeconds = 1778641000,
+  inputTokens = 100,
+  outputTokens = 20,
+  cacheRead = 10,
+  model = "gpt-4o",
+} = {}) {
+  return {
+    type: "span",
+    traceId,
+    spanId,
+    name: `chat ${model}`,
+    startTime: [endSeconds - 1, 0],
+    endTime: [endSeconds, 0],
+    attributes: {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.response.model": model,
+      "gen_ai.usage.input_tokens": inputTokens,
+      "gen_ai.usage.output_tokens": outputTokens,
+      "gen_ai.usage.cache_read.input_tokens": cacheRead,
+    },
+  };
+}
+
+test("parseCopilotAppDbIncremental reads sessions table summaries into copilot buckets", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "sess-1",
+      session_type: "project",
+      mode: "autopilot",
+      model: "claude-sonnet-4-6",
+      provider_id: "anthropic",
+      created_at: "2026-07-07T10:01:00Z",
+      updated_at: "2026-07-07T10:29:00Z",
+      total_input_tokens: 1000,
+      total_output_tokens: 200,
+      total_cached_tokens: 300,
+      total_reasoning_tokens: 40,
+      total_nano_aiu: 999999,
+      context_current_tokens: 888888,
+      context_conversation_tokens: 777777,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    const result = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(result.recordsProcessed, 1);
+    assert.equal(result.eventsAggregated, 1);
+
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].model, "claude-sonnet-4-6");
+    assert.equal(rows[0].input_tokens, 700);
+    assert.equal(rows[0].output_tokens, 200);
+    assert.equal(rows[0].cached_input_tokens, 300);
+    assert.equal(rows[0].reasoning_output_tokens, 40);
+    assert.equal(rows[0].cache_creation_input_tokens, 0);
+    assert.equal(rows[0].total_tokens, 1240);
+    assert.equal(rows[0].conversation_count, 1);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental counts zero for fork sessions with inherited history but zero totals", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "fork-child",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T11:00:00Z",
+      updated_at: "2026-07-07T11:00:00Z",
+      forked_from_session_id: "parent",
+      fork_original_history_event_count: 42,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const result = await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    assert.equal(result.recordsProcessed, 1);
+    assert.equal(result.eventsAggregated, 0);
+    assert.deepEqual(readQueue(queuePath), []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental emits only positive deltas on subsequent sync", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "growing",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T12:00:00Z",
+      updated_at: "2026-07-07T12:05:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+      total_cached_tokens: 10,
+      total_reasoning_tokens: 5,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+
+    updateSession(dbPath, "growing", {
+      updated_at: "2026-07-07T12:20:00Z",
+      total_input_tokens: 175,
+      total_output_tokens: 30,
+      total_cached_tokens: 25,
+      total_reasoning_tokens: 5,
+    });
+    const second = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 1);
+
+    const latest = latestByBucket(readQueue(queuePath).filter((row) => row.source === "copilot"));
+    assert.equal(latest.length, 1);
+    assert.equal(latest[0].input_tokens, 150);
+    assert.equal(latest[0].output_tokens, 30);
+    assert.equal(latest[0].cached_input_tokens, 25);
+    assert.equal(latest[0].reasoning_output_tokens, 5);
+    assert.equal(latest[0].total_tokens, 210);
+    assert.equal(latest[0].conversation_count, 1, "growth in an existing App session must not add another conversation");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental does not emit negative deltas when counters shrink", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "reset",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T13:00:00Z",
+      updated_at: "2026-07-07T13:05:00Z",
+      total_input_tokens: 500,
+      total_output_tokens: 100,
+      total_cached_tokens: 50,
+      total_reasoning_tokens: 25,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    const beforeRows = readQueue(queuePath).length;
+
+    updateSession(dbPath, "reset", {
+      updated_at: "2026-07-07T13:20:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 0,
+    });
+    const second = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(readQueue(queuePath).length, beforeRows);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental falls back to github-copilot when model is missing", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "missing-model",
+      session_type: "project",
+      model: null,
+      provider_id: "github",
+      created_at: "2026-07-07T14:00:00Z",
+      updated_at: "2026-07-07T14:01:00Z",
+      total_input_tokens: 10,
+      total_output_tokens: 2,
+      total_cached_tokens: 3,
+      total_reasoning_tokens: 4,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].model, "github-copilot");
+    assert.equal(rows[0].input_tokens, 7);
+    assert.equal(rows[0].cached_input_tokens, 3);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental clamps cached input to raw input delta", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "cache-heavy",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T14:30:00Z",
+      updated_at: "2026-07-07T14:31:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 7,
+      total_cached_tokens: 150,
+      total_reasoning_tokens: 3,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].input_tokens, 0);
+    assert.equal(rows[0].cached_input_tokens, 100);
+    assert.equal(rows[0].output_tokens, 7);
+    assert.equal(rows[0].reasoning_output_tokens, 3);
+    assert.equal(rows[0].total_tokens, 110);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental does not advance DB fingerprint after SQLite read failure", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "read-failure-retry",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T14:45:00Z",
+      updated_at: "2026-07-07T14:46:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+      total_cached_tokens: 10,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    await assert.rejects(
+      parseCopilotAppDbIncremental({
+        dbPath,
+        cursors,
+        queuePath,
+        sqliteOptions: {
+          execFileSync() {
+            throw new Error("simulated sqlite cli read failure");
+          },
+          requireFn() {
+            throw new Error("node:sqlite DatabaseSync is unavailable");
+          },
+        },
+      }),
+      /Cannot read GitHub Copilot App SQLite database/,
+    );
+    assert.equal(cursors.copilotApp, undefined, "failed read must not mark DB fingerprint as consumed");
+
+    const retry = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(retry.eventsAggregated, 1);
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].input_tokens, 90);
+    assert.equal(rows[0].cached_input_tokens, 10);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental normalizes dotted Claude App model ids for pricing", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "dotted-claude",
+      session_type: "project",
+      model: "claude-opus-4.8",
+      provider_id: "anthropic",
+      created_at: "2026-07-07T14:50:00Z",
+      updated_at: "2026-07-07T14:51:00Z",
+      total_input_tokens: 1_000_000,
+      total_output_tokens: 0,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].model, "claude-opus-4-8");
+    assert.ok(computeRowCost(rows[0]) > 0, "normalized App model should hit Copilot pricing");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental skips rows recognizable as OTEL-backed Copilot CLI usage", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "cli-mirror",
+      session_type: "cli",
+      model: "gpt-4o",
+      provider_id: "copilot-cli",
+      created_at: "2026-07-07T15:00:00Z",
+      updated_at: "2026-07-07T15:01:00Z",
+      total_input_tokens: 1000,
+      total_output_tokens: 200,
+      total_cached_tokens: 100,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const result = await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    assert.equal(result.recordsProcessed, 1);
+    assert.equal(result.eventsAggregated, 0);
+    assert.deepEqual(readQueue(queuePath), []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Copilot App DB and OTEL parsing coexist without sharing cursors or changing source names", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "app-session",
+      session_type: "project",
+      model: "claude-sonnet-4-6",
+      provider_id: "anthropic",
+      created_at: "2026-07-07T16:00:00Z",
+      updated_at: "2026-07-07T16:03:00Z",
+      total_input_tokens: 50,
+      total_output_tokens: 10,
+      total_cached_tokens: 5,
+      total_reasoning_tokens: 2,
+    },
+  ]);
+  try {
+    const otelPath = path.join(dir, "copilot-otel.jsonl");
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    writeCopilotOtelFile(otelPath, [
+      makeCopilotOtelSpan({
+        traceId: "otel-trace",
+        spanId: "otel-span",
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheRead: 10,
+        model: "gpt-4o",
+      }),
+    ]);
+
+    const otelFirst = await parseCopilotIncremental({ otelPaths: [otelPath], cursors, queuePath });
+    const appFirst = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(otelFirst.eventsAggregated, 1);
+    assert.equal(appFirst.eventsAggregated, 1);
+    assert.ok(cursors.copilot?.fileOffsets?.[otelPath], "OTEL cursor remains in cursors.copilot");
+    assert.ok(cursors.copilotApp?.dbs?.[dbPath], "App DB cursor uses cursors.copilotApp");
+
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 2);
+    const byModel = new Map(rows.map((row) => [row.model, row]));
+    assert.equal(byModel.get("gpt-4o").input_tokens, 90);
+    assert.equal(byModel.get("gpt-4o").cached_input_tokens, 10);
+    assert.equal(byModel.get("gpt-4o").output_tokens, 20);
+    assert.equal(byModel.get("claude-sonnet-4-6").input_tokens, 45);
+    assert.equal(byModel.get("claude-sonnet-4-6").cached_input_tokens, 5);
+    assert.equal(byModel.get("claude-sonnet-4-6").output_tokens, 10);
+
+    const otelSecond = await parseCopilotIncremental({ otelPaths: [otelPath], cursors, queuePath });
+    const appSecond = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(otelSecond.eventsAggregated, 0);
+    assert.equal(appSecond.eventsAggregated, 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental reprocesses when only SQLite sidecars change", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "wal-session",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T17:00:00Z",
+      updated_at: "2026-07-07T17:05:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 10,
+      total_cached_tokens: 20,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  let walWriter = null;
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {};
+    await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+
+    walWriter = await updateSessionPreserveDbMtimeWithWal(dbPath, "wal-session", {
+      updated_at: "2026-07-07T17:20:00Z",
+      total_input_tokens: 150,
+      total_output_tokens: 15,
+      total_cached_tokens: 30,
+      total_reasoning_tokens: 0,
+    });
+    assert.ok(fs.existsSync(`${dbPath}-wal`), "test must leave a WAL sidecar for the parser to fingerprint");
+    // Simulate the problematic state exactly: a legacy mtime-only gate would
+    // believe data.db itself is unchanged and skip this WAL-only commit.
+    cursors.copilotApp.dbs[dbPath].lastDbMtimeMs = fs.statSync(dbPath).mtimeMs;
+
+    const second = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 1);
+    const latest = latestByBucket(readQueue(queuePath).filter((row) => row.source === "copilot"));
+    assert.equal(latest[0].input_tokens, 120);
+    assert.equal(latest[0].cached_input_tokens, 30);
+    assert.equal(latest[0].output_tokens, 15);
+    assert.equal(latest[0].total_tokens, 165);
+  } finally {
+    if (walWriter) walWriter.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotAppDbIncremental does not re-count nonzero sessions after cursor pruning", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "would-be-evicted",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T18:00:00Z",
+      updated_at: "2026-07-07T18:05:00Z",
+      total_input_tokens: 1,
+      total_output_tokens: 0,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 0,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    const dbState = { sessionTotals: {} };
+    dbState.sessionTotals["would-be-evicted"] = {
+      input: 1,
+      output: 0,
+      cached: 0,
+      reasoning: 0,
+      model: "gpt-5.5",
+      updatedAt: "2026-07-07T18:05:00Z",
+    };
+    for (let i = 0; i < 10_000; i++) {
+      dbState.sessionTotals[`larger-${i}`] = {
+        input: 2,
+        output: 0,
+        cached: 0,
+        reasoning: 0,
+        model: "gpt-5.5",
+        updatedAt: "2026-07-07T18:00:00Z",
+      };
+    }
+    const cursors = { copilotApp: { dbs: { [dbPath]: dbState } } };
+
+    const first = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(first.eventsAggregated, 0);
+    assert.ok(
+      cursors.copilotApp.dbs[dbPath].sessionTotals["would-be-evicted"],
+      "nonzero baselines must survive pruning",
+    );
+
+    updateSession(dbPath, "would-be-evicted", {
+      updated_at: "2026-07-07T18:20:00Z",
+      total_input_tokens: 2,
+      total_output_tokens: 0,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 0,
+    });
+    const second = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 1);
+    const rows = readQueue(queuePath).filter((row) => row.source === "copilot");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].input_tokens, 1);
+    assert.equal(rows[0].total_tokens, 1);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveCopilotAppDbPaths includes COPILOT_HOME/data.db and ~/.copilot/data.db", () => {
+  const paths = resolveCopilotAppDbPaths({
+    HOME: "/tmp/home",
+    COPILOT_HOME: "/tmp/copilot-custom",
+  });
+  assert.ok(paths.includes(path.join("/tmp/copilot-custom", "data.db")));
+  assert.ok(paths.includes(path.join("/tmp/home", ".copilot", "data.db")));
+});
+
+test("resolveCopilotAppDbPaths respects Windows wsl-only mode by not adding native fallback", (t) => {
+  mockPlatform(t, "win32");
+  mockMethod(t, cp, "execFileSync", () => {
+    throw new Error("no WSL distros");
+  });
+  const paths = resolveCopilotAppDbPaths({
+    HOME: "C:\\Users\\dev",
+    TOKENTRACKER_WSL_MODE: "wsl-only",
+  });
+  assert.deepEqual(paths, []);
+});

--- a/test/status-json-light.test.js
+++ b/test/status-json-light.test.js
@@ -43,6 +43,8 @@ test("status --json emits a JSON object with required summary fields", () => {
   assert.ok("pending_bytes" in parsed.queue);
   assert.ok("claude" in parsed.hooks);
   assert.ok("openclaw_session_plugin_conversation_access" in parsed.hooks);
+  assert.ok("app_db_has_file" in parsed.copilot);
+  assert.ok("app_db_path" in parsed.copilot);
   assert.equal(typeof parsed.device_token_set, "boolean");
 });
 


### PR DESCRIPTION
## Summary

Adds a passive GitHub Copilot App usage reader that imports local token summaries from `~/.copilot/data.db` (and `COPILOT_HOME/data.db`) into the existing `source: "copilot"` aggregate statistics.

This is intentionally scoped to usage/statistics only. It does not change Copilot OAuth/quota credential discovery.

## What changed

- Read only privacy-safe `sessions.total_*` summary fields from the Copilot App SQLite database.
- Keep a separate `cursors.copilotApp` namespace so existing Copilot CLI / Chat extension OTEL cursors remain unchanged.
- Feed positive deltas into the existing hourly queue/dashboard/cost pipeline as `source: "copilot"`.
- Avoid parsing `session-state/<id>/events.jsonl`; forked sessions can inherit parent events before they produce any new tokens.
- Handle incremental edge cases:
  - forked sessions with zero totals contribute zero
  - cached input is separated from uncached input
  - SQLite WAL sidecars are included in change detection
  - read failures do not advance the DB fingerprint
  - nonzero session baselines are retained so pruning cannot re-count history
  - conversation count is only incremented on first positive observation
  - dotted Copilot App Claude model IDs are normalized for pricing
  - Windows `wsl-only` mode does not fall back to native paths
- Surface Copilot App DB status in `tokentracker status` / JSON / light output.

## Validation

- `node --test test/copilot-app-parser.test.js test/rollout-parser.test.js test/status-json-light.test.js`
- `npm test`
- `npm run validate:guardrails`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot App passive usage tracking alongside existing Copilot CLI/Chat (OTEL) reporting.
  * Enhanced `status` and `sync` to detect, parse, and present Copilot App DB usage separately (including JSON and compact table views).
* **Bug Fixes**
  * Prevented duplicate counting across Copilot App and OTEL sources; suppressed negative deltas when counters shrink.
* **Documentation**
  * Updated README content to distinguish Copilot App vs Copilot CLI/Chat passive readers.
* **Tests**
  * Added a comprehensive Copilot App parser test suite and extended status JSON assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->