### PR TITLE
Fix Copilot auth.db schema v0 quota detection

### DIFF
--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 const http = require("node:http");
 const https = require("node:https");
 const { performance } = require("node:perf_hooks");
+const { promisify } = require("node:util");
 
 const {
   detectClaudeCodeSubscriptionDetails,
@@ -26,7 +27,9 @@ const {
 const { fetchGrokLimits } = require("./grok-limits");
 const { fetchZcodeLimits } = require("./zcode-limits");
 const { fetchOpencodeGoLimits } = require("./opencode-go-limits");
-const { readSqliteJsonRows } = require("./sqlite-reader");
+const { readSqliteJsonRows, readSqliteJsonRowsAsync } = require("./sqlite-reader");
+
+const execFileAsync = promisify(cp.execFile);
 
 // 2-minute in-memory cache. It also expires early at the earliest upcoming window
 // reset in the cached data (see cacheExpiresAtMs), floored so a provider reporting
@@ -1489,6 +1492,32 @@ function readMacosKeychainGenericPassword({ service, account, securityRunner } =
   return trimmed.length > 0 ? trimmed : null;
 }
 
+async function readMacosKeychainGenericPasswordAsync({ service, account, securityRunner } = {}) {
+  if (typeof securityRunner === "function") {
+    return readMacosKeychainGenericPassword({ service, account, securityRunner });
+  }
+  if (!fs.existsSync(MACOS_SECURITY_BIN)) return null;
+  const args = ["find-generic-password", "-s", service];
+  if (account) args.push("-a", account);
+  args.push("-w");
+  try {
+    const result = await execFileAsync(MACOS_SECURITY_BIN, args, {
+      timeout: 2000,
+      encoding: "utf8",
+    });
+    const stdout =
+      typeof result?.stdout === "string"
+        ? result.stdout
+        : Buffer.isBuffer(result?.stdout)
+          ? result.stdout.toString("utf8")
+          : "";
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
 function decryptCopilotAuthDbToken(keyBase64, ciphertextHex) {
   if (typeof keyBase64 !== "string" || typeof ciphertextHex !== "string") return null;
   let key;
@@ -1570,16 +1599,22 @@ function orderCopilotAuthDbRows(rows) {
   return githubRows.concat(fallbackRows);
 }
 
-function readCopilotAuthDbToken({ home, platform = process.platform, securityRunner, sqliteReader } = {}) {
+function readCopilotAuthDbRows({ home, sqliteReader, asyncReader = false } = {}) {
   const resolvedHome = home || os.homedir();
   const dbPath = path.join(resolvedHome, ".config", "github-copilot", "auth.db");
-  const reader = typeof sqliteReader === "function" ? sqliteReader : readSqliteJsonRows;
-  let rows;
-  try {
-    rows = reader(dbPath, COPILOT_AUTH_DB_SQL, { label: "GitHub Copilot" });
-  } catch (_e) {
-    return null;
-  }
+  const reader = typeof sqliteReader === "function"
+    ? sqliteReader
+    : asyncReader
+      ? readSqliteJsonRowsAsync
+      : readSqliteJsonRows;
+  return reader(dbPath, COPILOT_AUTH_DB_SQL, { label: "GitHub Copilot" });
+}
+
+function resolveCopilotAuthDbTokenFromRows(rows, {
+  platform = process.platform,
+  securityRunner,
+  keychainReader = readMacosKeychainGenericPassword,
+} = {}) {
   if (!Array.isArray(rows) || rows.length === 0) return null;
   // Prefer the public github.com host (mirrors the plaintext reader); rows are
   // already ordered most-recently-used first.
@@ -1600,7 +1635,7 @@ function readCopilotAuthDbToken({ home, platform = process.platform, securityRun
     // copilot-language-server uses libsecret / Credential Manager instead, which
     // we don't read yet.
     if (!attemptedKeychain) {
-      keyBase64 = readMacosKeychainGenericPassword({
+      keyBase64 = keychainReader({
         service: COPILOT_LS_KEYCHAIN_SERVICE,
         account: COPILOT_LS_KEYCHAIN_ACCOUNT,
         securityRunner,
@@ -1614,6 +1649,60 @@ function readCopilotAuthDbToken({ home, platform = process.platform, securityRun
   return null;
 }
 
+async function resolveCopilotAuthDbTokenFromRowsAsync(rows, {
+  platform = process.platform,
+  securityRunner,
+  keychainReader = readMacosKeychainGenericPasswordAsync,
+} = {}) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const orderedRows = orderCopilotAuthDbRows(rows);
+  let keyBase64 = null;
+  let attemptedKeychain = false;
+  for (const row of orderedRows) {
+    const schemaVersion = parseCopilotAuthDbSchemaVersion(row?.token_schema_version);
+    if (schemaVersion === 0) {
+      const plaintextToken = decodeCopilotSchemaV0Token(row);
+      if (plaintextToken) return plaintextToken;
+      continue;
+    }
+
+    const ciphertextHex = typeof row?.token_hex === "string" ? row.token_hex : null;
+    if (!ciphertextHex || platform !== "darwin") continue;
+    if (!attemptedKeychain) {
+      keyBase64 = await keychainReader({
+        service: COPILOT_LS_KEYCHAIN_SERVICE,
+        account: COPILOT_LS_KEYCHAIN_ACCOUNT,
+        securityRunner,
+      });
+      attemptedKeychain = true;
+    }
+    if (!keyBase64) continue;
+    const token = decryptCopilotAuthDbToken(keyBase64, ciphertextHex);
+    if (token) return token;
+  }
+  return null;
+}
+
+function readCopilotAuthDbToken({ home, platform = process.platform, securityRunner, sqliteReader } = {}) {
+  let rows;
+  try {
+    rows = readCopilotAuthDbRows({ home, sqliteReader });
+  } catch (_e) {
+    return null;
+  }
+  return resolveCopilotAuthDbTokenFromRows(rows, { platform, securityRunner });
+}
+
+async function readCopilotAuthDbTokenAsync({ home, platform = process.platform, securityRunner, sqliteReader } = {}) {
+  let rows;
+  try {
+    rows = await readCopilotAuthDbRows({ home, sqliteReader, asyncReader: true });
+  } catch (_e) {
+    return null;
+  }
+  return resolveCopilotAuthDbTokenFromRowsAsync(rows, { platform, securityRunner });
+}
+
 function readCopilotOauthToken({
   home = os.homedir(),
   platform = process.platform,
@@ -1624,6 +1713,17 @@ function readCopilotOauthToken({
   if (plaintext) return plaintext;
   // No plaintext token found — recover the live one from the encrypted auth.db.
   return readCopilotAuthDbToken({ home, platform, securityRunner, sqliteReader });
+}
+
+async function readCopilotOauthTokenAsync({
+  home = os.homedir(),
+  platform = process.platform,
+  securityRunner,
+  sqliteReader,
+} = {}) {
+  const plaintext = readPlaintextCopilotOauthToken({ home });
+  if (plaintext) return plaintext;
+  return readCopilotAuthDbTokenAsync({ home, platform, securityRunner, sqliteReader });
 }
 
 function copilotRequestHeaders(token) {
@@ -1698,7 +1798,7 @@ async function fetchCopilotLimits({
   sqliteReader,
 } = {}) {
   const otel = describeCopilotOtelStatus({ home, env });
-  const token = readCopilotOauthToken({
+  const token = await readCopilotOauthTokenAsync({
     home: home || (env.HOME || os.homedir()),
     platform,
     securityRunner,
@@ -2935,7 +3035,9 @@ module.exports = {
   fetchAntigravityLimits,
   fetchCopilotLimits,
   readCopilotOauthToken,
+  readCopilotOauthTokenAsync,
   readCopilotAuthDbToken,
+  readCopilotAuthDbTokenAsync,
   decryptCopilotAuthDbToken,
   describeCopilotOtelStatus,
   fetchGrokLimits,

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -1418,11 +1418,11 @@ function parseKiroUsageOutput(output, { now = new Date() } = {}) {
 // ─────────────────────────────────────────────────────────────────────────────
 // GitHub Copilot — `GET https://api.github.com/copilot_internal/user`
 // Reuses the OAuth token from the user's existing Copilot install. Older clients
-// keep it in plaintext (`~/.config/github-copilot/{apps,hosts}.json`); recent
-// copilot-language-server builds (Zed, copilot.vim) migrate it into an encrypted
-// SQLite store (`auth.db`) and leave the plaintext files behind as stale legacy
-// copies. Read the plaintext first, then fall back to the encrypted store. No
-// device flow needed either way.
+// keep it in plaintext (`~/.config/github-copilot/{apps,hosts}.json`); newer
+// copilot-language-server builds (Zed, copilot.vim) migrate it into SQLite
+// `auth.db`. Schema v0 stores the OAuth token as a plaintext BLOB, while later
+// schemas use AES-GCM ciphertext with the key in the OS credential store. Read
+// legacy plaintext first, then auth.db. No device flow needed either way.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MACOS_SECURITY_BIN = "/usr/bin/security";
@@ -1433,7 +1433,7 @@ const MACOS_SECURITY_BIN = "/usr/bin/security";
 const COPILOT_LS_KEYCHAIN_SERVICE = "copilot-language-server";
 const COPILOT_LS_KEYCHAIN_ACCOUNT = "oauth-token-key";
 const COPILOT_AUTH_DB_SQL =
-  "SELECT user_login, auth_authority, scopes, hex(token_ciphertext) AS token_hex, "
+  "SELECT user_login, auth_authority, scopes, token_schema_version, hex(token_ciphertext) AS token_hex, "
   + "last_used_at, updated_at FROM oauth_tokens ORDER BY last_used_at DESC, updated_at DESC";
 
 function readPlaintextCopilotOauthToken({ home }) {
@@ -1515,11 +1515,62 @@ function decryptCopilotAuthDbToken(keyBase64, ciphertextHex) {
   }
 }
 
+function isLikelyGithubOauthToken(token) {
+  if (typeof token !== "string") return false;
+  const trimmed = token.trim();
+  return /^gh[opsur]_[A-Za-z0-9]{20,}$/.test(trimmed)
+    || /^github_pat_[A-Za-z0-9_]{20,}$/.test(trimmed);
+}
+
+function parseCopilotAuthDbSchemaVersion(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const version = Number(value);
+  return Number.isInteger(version) ? version : null;
+}
+
+function decodeUtf8HexString(value) {
+  if (typeof value !== "string" || !/^(?:[0-9a-f]{2})+$/i.test(value)) return null;
+  try {
+    return Buffer.from(value, "hex").toString("utf8").trim();
+  } catch (_e) {
+    return null;
+  }
+}
+
+function decodeCopilotSchemaV0Token(row) {
+  const candidates = [];
+  const tokenHex = typeof row?.token_hex === "string" ? row.token_hex : null;
+  if (tokenHex) candidates.push(decodeUtf8HexString(tokenHex));
+
+  const rawCiphertext = row?.token_ciphertext;
+  if (Buffer.isBuffer(rawCiphertext)) {
+    candidates.push(rawCiphertext.toString("utf8").trim());
+  } else if (typeof rawCiphertext === "string") {
+    candidates.push(rawCiphertext.trim());
+    candidates.push(decodeUtf8HexString(rawCiphertext));
+  }
+
+  for (const candidate of candidates) {
+    if (isLikelyGithubOauthToken(candidate)) return candidate.trim();
+  }
+  return null;
+}
+
+function orderCopilotAuthDbRows(rows) {
+  const githubRows = [];
+  const fallbackRows = [];
+  for (const row of rows) {
+    const host = String(row?.auth_authority || "").split(":")[0];
+    if (host === "github.com") {
+      githubRows.push(row);
+    } else {
+      fallbackRows.push(row);
+    }
+  }
+  return githubRows.concat(fallbackRows);
+}
+
 function readCopilotAuthDbToken({ home, platform = process.platform, securityRunner, sqliteReader } = {}) {
-  // The decryption key lives in the macOS Keychain. On Linux/Windows the
-  // copilot-language-server uses libsecret / Credential Manager instead, which we
-  // don't read yet — callers fall back to the plaintext path there.
-  if (platform !== "darwin") return null;
   const resolvedHome = home || os.homedir();
   const dbPath = path.join(resolvedHome, ".config", "github-copilot", "auth.db");
   const reader = typeof sqliteReader === "function" ? sqliteReader : readSqliteJsonRows;
@@ -1532,17 +1583,35 @@ function readCopilotAuthDbToken({ home, platform = process.platform, securityRun
   if (!Array.isArray(rows) || rows.length === 0) return null;
   // Prefer the public github.com host (mirrors the plaintext reader); rows are
   // already ordered most-recently-used first.
-  const row =
-    rows.find((r) => String(r?.auth_authority || "").split(":")[0] === "github.com") || rows[0];
-  const ciphertextHex = typeof row?.token_hex === "string" ? row.token_hex : null;
-  if (!ciphertextHex) return null;
-  const keyBase64 = readMacosKeychainGenericPassword({
-    service: COPILOT_LS_KEYCHAIN_SERVICE,
-    account: COPILOT_LS_KEYCHAIN_ACCOUNT,
-    securityRunner,
-  });
-  if (!keyBase64) return null;
-  return decryptCopilotAuthDbToken(keyBase64, ciphertextHex);
+  const orderedRows = orderCopilotAuthDbRows(rows);
+  let keyBase64 = null;
+  let attemptedKeychain = false;
+  for (const row of orderedRows) {
+    const schemaVersion = parseCopilotAuthDbSchemaVersion(row?.token_schema_version);
+    if (schemaVersion === 0) {
+      const plaintextToken = decodeCopilotSchemaV0Token(row);
+      if (plaintextToken) return plaintextToken;
+      continue;
+    }
+
+    const ciphertextHex = typeof row?.token_hex === "string" ? row.token_hex : null;
+    if (!ciphertextHex || platform !== "darwin") continue;
+    // The decryption key lives in the macOS Keychain. On Linux/Windows the
+    // copilot-language-server uses libsecret / Credential Manager instead, which
+    // we don't read yet.
+    if (!attemptedKeychain) {
+      keyBase64 = readMacosKeychainGenericPassword({
+        service: COPILOT_LS_KEYCHAIN_SERVICE,
+        account: COPILOT_LS_KEYCHAIN_ACCOUNT,
+        securityRunner,
+      });
+      attemptedKeychain = true;
+    }
+    if (!keyBase64) continue;
+    const token = decryptCopilotAuthDbToken(keyBase64, ciphertextHex);
+    if (token) return token;
+  }
+  return null;
 }
 
 function readCopilotOauthToken({

--- a/test/copilot-auth-db.test.js
+++ b/test/copilot-auth-db.test.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const {
   readCopilotOauthToken,
   readCopilotAuthDbToken,
+  readCopilotAuthDbTokenAsync,
   decryptCopilotAuthDbToken,
 } = require("../src/lib/usage-limits");
 
@@ -166,6 +167,54 @@ describe("readCopilotAuthDbToken", () => {
       sqliteReader: () => [],
     });
     assert.equal(token, null);
+  });
+});
+
+describe("readCopilotAuthDbTokenAsync", () => {
+  it("reads schema-v0 plaintext rows cross-platform through the async SQLite reader", async () => {
+    const expected = makeSchemaV0GithubToken();
+    let readerCalled = false;
+    const token = await readCopilotAuthDbTokenAsync({
+      home: "/home/test",
+      platform: "linux",
+      async sqliteReader() {
+        readerCalled = true;
+        await Promise.resolve();
+        return [{
+          auth_authority: "github.com",
+          token_schema_version: 0,
+          token_hex: schemaV0TokenHex(expected),
+        }];
+      },
+      securityRunner() {
+        throw new Error("schema-v0 plaintext rows must not read keychain");
+      },
+    });
+
+    assert.equal(readerCalled, true);
+    assert.equal(token, expected);
+  });
+
+  it("skips encrypted rows on non-darwin without reading the keychain", async () => {
+    const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_linux_encrypted");
+    let readerCalled = false;
+    let keychainCalled = false;
+    const token = await readCopilotAuthDbTokenAsync({
+      home: "/home/test",
+      platform: "linux",
+      async sqliteReader() {
+        readerCalled = true;
+        return [{ auth_authority: "github.com", token_schema_version: 1, token_hex: tokenHex }];
+      },
+      securityRunner() {
+        keychainCalled = true;
+        return { status: 0, stdout: keyBase64 };
+      },
+    });
+
+    assert.equal(token, null);
+    assert.equal(readerCalled, true);
+    assert.equal(keychainCalled, false);
   });
 });
 

--- a/test/copilot-auth-db.test.js
+++ b/test/copilot-auth-db.test.js
@@ -31,6 +31,14 @@ function makeAuthDbFixture(token, { authority = "github.com" } = {}) {
   };
 }
 
+function makeSchemaV0GithubToken() {
+  return ["gho", "1234567890abcdef1234567890abcdef1234"].join("_");
+}
+
+function schemaV0TokenHex(token = makeSchemaV0GithubToken()) {
+  return Buffer.from(token, "utf8").toString("hex");
+}
+
 describe("decryptCopilotAuthDbToken", () => {
   it("round-trips an AES-256-GCM token", () => {
     const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_decrypted_example_token");
@@ -59,13 +67,45 @@ describe("decryptCopilotAuthDbToken", () => {
 describe("readCopilotAuthDbToken", () => {
   const okRunner = (keyBase64) => () => ({ status: 0, stdout: keyBase64 });
 
+  it("reads schema-v0 plaintext BLOB tokens without requiring a keychain item", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-authdb-v0-"));
+    try {
+      const expected = makeSchemaV0GithubToken();
+      let observedSql = "";
+      let keychainCalled = false;
+      const token = readCopilotAuthDbToken({
+        home: tmp,
+        platform: "darwin",
+        sqliteReader(dbPath, sql) {
+          assert.equal(dbPath, path.join(tmp, ".config", "github-copilot", "auth.db"));
+          observedSql = sql;
+          return [{
+            auth_authority: "github.com",
+            token_schema_version: 0,
+            token_hex: schemaV0TokenHex(expected),
+          }];
+        },
+        securityRunner() {
+          keychainCalled = true;
+          return { status: 1, stdout: "" };
+        },
+      });
+
+      assert.match(observedSql, /token_schema_version/);
+      assert.equal(keychainCalled, false);
+      assert.equal(token, expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("decrypts the token from auth.db via the keychain key (macOS)", () => {
     const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_authdb_token");
     const token = readCopilotAuthDbToken({
       home: "/home/test",
       platform: "darwin",
       securityRunner: okRunner(keyBase64),
-      sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+      sqliteReader: () => [{ auth_authority: "github.com", token_schema_version: 1, token_hex: tokenHex }],
     });
     assert.equal(token, "ghu_authdb_token");
   });
@@ -79,27 +119,32 @@ describe("readCopilotAuthDbToken", () => {
       platform: "darwin",
       securityRunner: okRunner(publicHost.keyBase64),
       sqliteReader: () => [
-        { auth_authority: "github.example.com", token_hex: enterprise.tokenHex },
-        { auth_authority: "github.com", token_hex: publicHost.tokenHex },
+        { auth_authority: "github.example.com", token_schema_version: 1, token_hex: enterprise.tokenHex },
+        { auth_authority: "github.com", token_schema_version: 1, token_hex: publicHost.tokenHex },
       ],
     });
     assert.equal(token, "ghu_public");
   });
 
-  it("returns null on non-darwin platforms (no keychain reader yet)", () => {
+  it("returns null for encrypted rows on non-darwin platforms (no keychain reader yet)", () => {
     const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_token");
     let readerCalled = false;
+    let keychainCalled = false;
     const token = readCopilotAuthDbToken({
       home: "/home/test",
       platform: "linux",
-      securityRunner: okRunner(keyBase64),
+      securityRunner: () => {
+        keychainCalled = true;
+        return { status: 0, stdout: keyBase64 };
+      },
       sqliteReader: () => {
         readerCalled = true;
-        return [{ auth_authority: "github.com", token_hex: tokenHex }];
+        return [{ auth_authority: "github.com", token_schema_version: 1, token_hex: tokenHex }];
       },
     });
     assert.equal(token, null);
-    assert.equal(readerCalled, false);
+    assert.equal(readerCalled, true);
+    assert.equal(keychainCalled, false);
   });
 
   it("returns null when the keychain key is unavailable", () => {
@@ -108,7 +153,7 @@ describe("readCopilotAuthDbToken", () => {
       home: "/home/test",
       platform: "darwin",
       securityRunner: () => ({ status: 1, stdout: "" }),
-      sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+      sqliteReader: () => [{ auth_authority: "github.com", token_schema_version: 1, token_hex: tokenHex }],
     });
     assert.equal(token, null);
   });
@@ -161,7 +206,7 @@ describe("readCopilotOauthToken precedence", () => {
         home: tmp, // no apps.json / hosts.json present
         platform: "darwin",
         securityRunner: () => ({ status: 0, stdout: keyBase64 }),
-        sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+        sqliteReader: () => [{ auth_authority: "github.com", token_schema_version: 1, token_hex: tokenHex }],
       });
       assert.equal(token, "ghu_fallback_token");
     } finally {

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -310,7 +310,8 @@ describe("fetchCopilotLimits", () => {
       const result = await fetchCopilotLimits({
         home: tmp,
         platform: "darwin",
-        sqliteReader() {
+        async sqliteReader() {
+          await Promise.resolve();
           return [{
             auth_authority: "github.com",
             token_schema_version: 0,
@@ -356,6 +357,36 @@ describe("fetchCopilotLimits", () => {
       assert.equal(result.primary_window.reset_at, "2026-07-09T00:00:00.000Z");
       assert.equal(result.secondary_window.used_percent, 50);
       assert.equal(result.secondary_window.reset_at, "2026-07-09T00:00:00.000Z");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not call the Copilot API for non-darwin encrypted auth.db rows", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-limits-linux-encrypted-"));
+    try {
+      let readerCalled = false;
+      const result = await fetchCopilotLimits({
+        home: tmp,
+        platform: "linux",
+        async sqliteReader() {
+          readerCalled = true;
+          return [{
+            auth_authority: "github.com",
+            token_schema_version: 1,
+            token_hex: "00",
+          }];
+        },
+        securityRunner() {
+          assert.fail("non-darwin encrypted Copilot rows must not read keychain");
+        },
+        fetchImpl() {
+          assert.fail("no token should mean no Copilot API request");
+        },
+      });
+
+      assert.equal(readerCalled, true);
+      assert.equal(result.configured, false);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -19,6 +19,7 @@ const {
   parseListeningPorts,
   detectAntigravityProcess,
   fetchAntigravityLimits,
+  fetchCopilotLimits,
 } = require("../src/lib/usage-limits");
 
 // Match a fetch URL by host (exact or subdomain) rather than substring, so the
@@ -291,6 +292,75 @@ function writeCodexAuth(tmp, planType = "plus", extraTokens = {}) {
 function inactiveRunner() {
   return { status: 1, stdout: "" };
 }
+
+function makeCopilotTestToken() {
+  return ["gho", "1234567890abcdef1234567890abcdef1234"].join("_");
+}
+
+function copilotTokenHex(token = makeCopilotTestToken()) {
+  return Buffer.from(token, "utf8").toString("hex");
+}
+
+describe("fetchCopilotLimits", () => {
+  it("fetches Copilot limits with a schema-v0 auth.db token", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-limits-v0-"));
+    try {
+      const token = makeCopilotTestToken();
+      let observedAuthorization = "";
+      const result = await fetchCopilotLimits({
+        home: tmp,
+        platform: "darwin",
+        sqliteReader() {
+          return [{
+            auth_authority: "github.com",
+            token_schema_version: 0,
+            token_hex: copilotTokenHex(token),
+          }];
+        },
+        securityRunner() {
+          assert.fail("schema-v0 Copilot tokens must not require keychain access");
+        },
+        fetchImpl(url, options) {
+          assert.equal(url, "https://api.github.com/copilot_internal/user");
+          observedAuthorization = options?.headers?.Authorization || "";
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                copilot_plan: "individual",
+                quota_reset_date: "2026-07-09",
+                quota_snapshots: {
+                  premium_interactions: {
+                    entitlement: 100,
+                    remaining: 75,
+                    percent_remaining: 75,
+                  },
+                  chat: {
+                    entitlement: 200,
+                    remaining: 100,
+                    percent_remaining: 50,
+                  },
+                },
+              };
+            },
+          });
+        },
+      });
+
+      assert.equal(observedAuthorization, `token ${token}`);
+      assert.equal(result.configured, true);
+      assert.equal(result.error, null);
+      assert.equal(result.plan_name, "Individual");
+      assert.equal(result.primary_window.used_percent, 25);
+      assert.equal(result.primary_window.reset_at, "2026-07-09T00:00:00.000Z");
+      assert.equal(result.secondary_window.used_percent, 50);
+      assert.equal(result.secondary_window.reset_at, "2026-07-09T00:00:00.000Z");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
 
 const CODEX_WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";


### PR DESCRIPTION
## Summary

Fixes GitHub Copilot quota detection for installs whose `~/.config/github-copilot/auth.db` stores schema-v0 OAuth tokens.

On those installs, `oauth_tokens.token_ciphertext` is a plaintext GitHub OAuth token BLOB, not AES-GCM ciphertext. TokenTracker previously attempted the macOS keychain decrypt path for every auth.db row, so Copilot appeared disconnected even though Copilot CLI / compatible clients were authenticated.

## What changed

- Select `token_schema_version` from `oauth_tokens`.
- Decode schema-v0 `token_ciphertext` BLOBs as UTF-8 plaintext only when they match GitHub token shape.
- Preserve the existing AES-GCM + macOS keychain path for encrypted schemas.
- Keep token contents out of logs and test output.
- Add focused coverage for:
  - schema-v0 auth.db token decoding
  - encrypted/keychain auth.db decoding
  - mocked `fetchCopilotLimits` quota lookup with schema-v0 credentials

## Validation

- Original local status loop now reports `copilot.token_set=true`.
- `node --test test/copilot-auth-db.test.js test/usage-limits.test.js`
- `npm test`
- `npm run dashboard:build`
- `npm run validate:copy && npm run validate:ui-hardcode && npm run validate:guardrails`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Copilot usage tracking to fetch limits more reliably across different stored sign-in token formats.
* **Bug Fixes**
  * Improved auth.db/OAuth token handling, including legacy plaintext and newer encrypted token variants.
  * Better token recovery behavior on macOS, preferring the correct GitHub.com token and avoiding unnecessary keychain access when not needed. 
* **Tests**
  * Expanded Copilot token and `fetchCopilotLimits` coverage for additional token-schema scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->