### PR TITLE
feat(limits): surface data age and refresh after 429 cool-downs

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -30,15 +30,27 @@ struct ClaudeLimits: Codable, Equatable {
     let sevenDayOpus: ClaudeWindow?
     let weeklyScoped: [ClaudeScopedWindow]?
     let extraUsage: ClaudeExtraUsage?
+    /// When this data was last successfully fetched from the provider, and whether
+    /// it is being served from the stale disk-cache fallback (e.g. during a 429
+    /// cool-down when the live usage endpoint is rate-limited). Both are optional so
+    /// responses from older server builds still decode; a missing `stale` reads as fresh.
+    let cachedAt: String?
+    let stale: Bool?
+    /// Expiry of an active 429 cool-down (ISO-8601), when one is in effect. Absent in
+    /// the happy path. Lets the UI show when the next refresh is due and lets the app
+    /// schedule a one-shot refresh the moment the cool-down lifts.
+    let retryAt: String?
 
     enum CodingKeys: String, CodingKey {
-        case configured, error
+        case configured, error, stale
         case planLabel = "plan_label"
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
         case sevenDayOpus = "seven_day_opus"
         case weeklyScoped = "weekly_scoped"
         case extraUsage = "extra_usage"
+        case cachedAt = "cached_at"
+        case retryAt = "retry_at"
     }
 }
 
@@ -89,9 +101,13 @@ struct CodexLimits: Codable, Equatable {
     let sparkPrimaryWindow: CodexWindow?
     let sparkSecondaryWindow: CodexWindow?
     let resetCredits: ResetCredits?
+    /// Data-age fields, mirroring `ClaudeLimits` — Codex serves its last-successful
+    /// disk cache (`stale: true`) when the live wham read times out.
+    let cachedAt: String?
+    let stale: Bool?
 
     enum CodingKeys: String, CodingKey {
-        case configured, error
+        case configured, error, stale
         case planLabel = "plan_label"
         case primaryWindow = "primary_window"
         case secondaryWindow = "secondary_window"
@@ -99,6 +115,7 @@ struct CodexLimits: Codable, Equatable {
         case sparkPrimaryWindow = "spark_primary_window"
         case sparkSecondaryWindow = "spark_secondary_window"
         case resetCredits = "reset_credits"
+        case cachedAt = "cached_at"
     }
 
     struct ResetCredits: Codable, Equatable {

--- a/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
@@ -137,6 +137,15 @@ private func parseResetSeconds(iso: String?) -> Double? {
 }
 
 extension UsageLimitsResponse {
+    /// Soonest active rate-limit cool-down expiry (unix seconds) across providers that
+    /// expose one, or nil if none is pending. The app wakes at this instant to refresh
+    /// the moment the cool-down lifts, instead of waiting out the regular poll interval.
+    func soonestCooldownExpiry() -> Double? {
+        [parseResetSeconds(iso: claude.retryAt)].compactMap { $0 }.min()
+    }
+}
+
+extension UsageLimitsResponse {
     /// Flatten every provider's windows into `(provider, windowKey, windowLabel, usedPercent, resetAt)`
     /// tuples (percent on a 0–100 scale, resetAt in unix seconds), skipping providers
     /// that errored or are unconfigured.

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -107,6 +107,30 @@ enum Strings {
         let time = codexResetBankExpiryDateTime(date)
         return t("Resets \(time)", "重置于 \(time)", "重置於 \(time)", "\(time) にリセット", "\(time)에 초기화")
     }
+    /// How long ago a limits snapshot was last fetched, e.g. "Updated 2h ago" or
+    /// "Updated just now". Shown in the provider info popover; rendered amber when
+    /// the data is a stale fallback (a 429 cool-down suppressed the live refresh).
+    static func limitsUpdatedRelative(secondsAgo seconds: TimeInterval) -> String {
+        if seconds < 60 {
+            return t("Updated just now", "刚刚更新", "剛剛更新", "たった今更新", "방금 업데이트됨")
+        }
+        let hours = Int(seconds) / 3600
+        let rel: String
+        if hours > 24 {
+            rel = "\(hours / 24)d"
+        } else if hours > 0 {
+            rel = "\(hours)h"
+        } else {
+            rel = "\(Int(seconds) / 60)m"
+        }
+        return t("Updated \(rel) ago", "\(rel)前更新", "\(rel)前更新", "\(rel)前に更新", "\(rel) 전 업데이트됨")
+    }
+    /// When a rate-limited panel will next attempt a refresh, e.g. "Retrying 7/7 11:11".
+    /// Shown beneath the updated line while a 429 cool-down is pending.
+    static func limitsRetryingAt(_ date: Date) -> String {
+        let time = codexResetBankExpiryDateTime(date)
+        return t("Retrying \(time)", "将于 \(time) 重试", "將於 \(time) 重試", "\(time) に再試行", "\(time)에 재시도")
+    }
     /// Hover tooltip for one reset-bank row: expiry instant + whole days left.
     static func resetCreditExpiryDetail(expiry: String, daysLeft: Int) -> String {
         if daysLeft <= 0 {

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -116,7 +116,7 @@ enum Strings {
         }
         let hours = Int(seconds) / 3600
         let rel: String
-        if hours > 24 {
+        if hours >= 24 {
             rel = "\(hours / 24)d"
         } else if hours > 0 {
             rel = "\(hours)h"
@@ -124,6 +124,11 @@ enum Strings {
             rel = "\(Int(seconds) / 60)m"
         }
         return t("Updated \(rel) ago", "\(rel)前更新", "\(rel)前更新", "\(rel)前に更新", "\(rel) 전 업데이트됨")
+    }
+    /// VoiceOver label for the amber stale-data badge on a provider row (the glyph
+    /// alone would be read as its raw SF Symbol name).
+    static var limitsStaleAccessibility: String {
+        t("Data is stale", "数据已过期", "資料已過期", "データが古くなっています", "데이터가 오래되었습니다")
     }
     /// When a rate-limited panel will next attempt a refresh, e.g. "Retrying 7/7 11:11".
     /// Shown beneath the updated line while a 429 cool-down is pending.

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -331,20 +331,20 @@ class DashboardViewModel: ObservableObject {
         scheduleResetBoundaryRefresh(for: usageLimits)
     }
 
-    /// Wake up just after the soonest known window rollover and re-fetch limits,
-    /// so a reset (and its confetti) is detected within seconds of the boundary
-    /// instead of waiting out the regular poll interval. Every limits refresh
-    /// reschedules, so at most one boundary task is pending at a time.
+    /// Wake up just after the soonest upcoming boundary and re-fetch limits, instead
+    /// of waiting out the regular poll interval. Boundaries are (a) a window rollover —
+    /// so a reset and its confetti are detected within seconds — and (b) the expiry of
+    /// an active 429 cool-down — so a rate-limited panel refreshes the instant the
+    /// cool-down lifts rather than up to a poll later. Every limits refresh reschedules,
+    /// so at most one boundary task is pending at a time.
     private func scheduleResetBoundaryRefresh(for limits: UsageLimitsResponse?) {
         resetBoundaryRefreshTask?.cancel()
         resetBoundaryRefreshTask = nil
         guard let limits else { return }
         let now = Date().timeIntervalSince1970
-        let upcoming = limits.limitWindowReadings()
-            .compactMap { $0.resetAt }
-            .filter { $0 > now }
-            .min()
-        guard let upcoming else { return }
+        let boundaries = limits.limitWindowReadings().compactMap { $0.resetAt }
+            + [limits.soonestCooldownExpiry()].compactMap { $0 }
+        guard let upcoming = boundaries.filter({ $0 > now }).min() else { return }
         let delay = upcoming - now + Self.resetBoundaryGrace
         resetBoundaryRefreshTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -75,10 +75,10 @@ struct UsageLimitsView: View {
 
             switch id {
             case "claude" where limits.claude.configured && limits.claude.error == nil:
-                groups.append(AnyView(toolSection(id: id, title: planTitle("Claude", limits.claude.planLabel), assetName: "ClaudeLogo", toolName: "Claude", specs: claudeSpecs(limits.claude))))
+                groups.append(AnyView(toolSection(id: id, title: planTitle("Claude", limits.claude.planLabel), assetName: "ClaudeLogo", toolName: "Claude", specs: claudeSpecs(limits.claude), updatedAtISO: limits.claude.cachedAt, isStale: limits.claude.stale ?? false, retryAtISO: limits.claude.retryAt)))
             case "codex" where limits.codex.configured && limits.codex.error == nil:
                 let resetState = codexResetBankViewData(limits.codex.resetCredits)
-                groups.append(AnyView(toolSection(id: id, title: planTitle("Codex", limits.codex.planLabel), assetName: "CodexLogo", toolName: "Codex", specs: codexSpecs(limits.codex), resetRows: resetState.rows, resetStatus: resetState.statusText)))
+                groups.append(AnyView(toolSection(id: id, title: planTitle("Codex", limits.codex.planLabel), assetName: "CodexLogo", toolName: "Codex", specs: codexSpecs(limits.codex), resetRows: resetState.rows, resetStatus: resetState.statusText, updatedAtISO: limits.codex.cachedAt, isStale: limits.codex.stale ?? false)))
             case "cursor" where limits.cursor.configured && limits.cursor.error == nil:
                 groups.append(AnyView(toolSection(id: id, title: planTitle("Cursor", limits.cursor.planLabel), assetName: "CursorLogo", toolName: "Cursor", specs: cursorSpecs(limits.cursor))))
             case "gemini" where limits.gemini.configured && limits.gemini.error == nil:
@@ -124,12 +124,21 @@ struct UsageLimitsView: View {
         specs: [LimitWindowSpec],
         resetRows: [CodexResetRowSpec] = [],
         resetStatus: String? = nil,
-        footnote: String? = nil
+        footnote: String? = nil,
+        // Provider's own last-fetch stamp (Claude/Codex); nil falls back to the
+        // response-level `fetched_at`, which is when every live provider was read.
+        updatedAtISO: String? = nil,
+        isStale: Bool = false,
+        // Active 429 cool-down expiry (Claude), when one is in effect — shown as the
+        // "retrying" instant next to stale bars.
+        retryAtISO: String? = nil
     ) -> some View {
         let isOpen = Binding(
             get: { explainingProvider == id },
             set: { explainingProvider = $0 ? id : nil }
         )
+        let updatedAt = resetDate(iso: updatedAtISO ?? limits?.fetchedAt)
+        let retryAt = resetDate(iso: retryAtISO)
         return VStack(alignment: .leading, spacing: 5) {
             HStack(spacing: 5) {
                 if let assetName {
@@ -154,10 +163,12 @@ struct UsageLimitsView: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .modifier(ProviderClickableStyle(isActive: explainingProvider == id))
+        .modifier(ProviderClickableStyle(isActive: explainingProvider == id, isStale: isStale))
         .onTapGesture { explainingProvider = (explainingProvider == id) ? nil : id }
         .popover(isPresented: isOpen, arrowEdge: .trailing) {
-            LimitsExplainContent(providerName: title, specs: specs, remainingMode: settings.displayMode == .remaining)
+            // Keep on one line: codex-reset-bank guardrail tests assert this exact
+            // call shape to prove reset-bank rows never leak into the explanation.
+            LimitsExplainContent(providerName: title, specs: specs, remainingMode: settings.displayMode == .remaining, updatedAt: updatedAt, isStale: isStale, retryAt: retryAt)
         }
     }
 
@@ -667,6 +678,10 @@ private struct CodexResetRowSpec: Identifiable {
 /// a pointing-hand cursor. `isActive` keeps the highlight while its popover is open.
 private struct ProviderClickableStyle: ViewModifier {
     let isActive: Bool
+    /// The provider's data is being served from the stale disk-cache fallback
+    /// (e.g. a 429 cool-down froze refreshes). Surface a persistent amber badge so
+    /// the staleness is visible at rest, not only after opening the info popover.
+    var isStale: Bool = false
     @State private var hovering = false
 
     func body(content: Content) -> some View {
@@ -678,16 +693,23 @@ private struct ProviderClickableStyle: ViewModifier {
                     .fill(Color.primary.opacity(isActive ? 0.08 : (hovering ? 0.05 : 0)))
             )
             // Click affordance: the hover highlight alone doesn't say "clickable",
-            // so fade in an info glyph at the title line while hovered / open.
+            // so fade in an info glyph at the title line while hovered / open. When
+            // data is stale, an amber "clock" badge takes its place at rest so the
+            // user notices without hovering; hovering still reveals the info glyph.
             .overlay(alignment: .topTrailing) {
-                Image(systemName: "info.circle")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.tertiary)
-                    .padding(.top, 6)
-                    .padding(.trailing, 8)
-                    .opacity(hovering || isActive ? 1 : 0)
-                    .animation(.easeOut(duration: 0.12), value: hovering)
-                    .allowsHitTesting(false)
+                ZStack {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .foregroundStyle(.orange)
+                        .opacity(isStale && !(hovering || isActive) ? 1 : 0)
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(.tertiary)
+                        .opacity(hovering || isActive ? 1 : 0)
+                }
+                .font(.system(size: 10, weight: .medium))
+                .padding(.top, 6)
+                .padding(.trailing, 8)
+                .animation(.easeOut(duration: 0.12), value: hovering)
+                .allowsHitTesting(false)
             }
             .contentShape(RoundedRectangle(cornerRadius: 8))
             .onHover { hovering in
@@ -715,6 +737,13 @@ private struct LimitsExplainContent: View {
     let providerName: String
     let specs: [LimitWindowSpec]
     let remainingMode: Bool
+    /// When this provider's data was last successfully fetched, and whether it is a
+    /// stale disk-cache fallback. Drives the "Updated Xm ago" footer.
+    var updatedAt: Date? = nil
+    var isStale: Bool = false
+    /// Active 429 cool-down expiry, shown as "Retrying <time>" beneath the updated
+    /// line so the user knows when the panel will next attempt a refresh.
+    var retryAt: Date? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -736,9 +765,45 @@ private struct LimitsExplainContent: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            if let updatedLabel {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        if isStale {
+                            Image(systemName: "clock.arrow.circlepath")
+                                .font(.system(size: 9, weight: .medium))
+                        }
+                        Text(updatedLabel)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if let retryLabel {
+                        Text(retryLabel)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .font(.caption2)
+                .foregroundStyle(isStale ? Color.orange : Color.secondary)
+            }
         }
         .padding(14)
         .frame(width: 256)
+    }
+
+    /// "Updated 2h ago · 7/7 10:26" — relative age (matches the reset rows' style)
+    /// plus the exact local instant the user asked to see. Amber when stale.
+    private var updatedLabel: String? {
+        guard let updatedAt else { return nil }
+        let seconds = max(0, Date().timeIntervalSince(updatedAt))
+        let relative = Strings.limitsUpdatedRelative(secondsAgo: seconds)
+        let exact = Strings.codexResetBankExpiryDateTime(updatedAt)
+        return "\(relative) · \(exact)"
+    }
+
+    /// "Retrying 7/7 11:11" — when the panel will next attempt a refresh, shown only
+    /// while a 429 cool-down is actually pending (so the data is known-stale).
+    private var retryLabel: String? {
+        guard isStale, let retryAt, retryAt.timeIntervalSinceNow > 0 else { return nil }
+        return Strings.limitsRetryingAt(retryAt)
     }
 
     /// Live pace numbers + current-rate projection for one window, via the shared

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -701,9 +701,14 @@ private struct ProviderClickableStyle: ViewModifier {
                     Image(systemName: "clock.arrow.circlepath")
                         .foregroundStyle(.orange)
                         .opacity(isStale && !(hovering || isActive) ? 1 : 0)
+                        .accessibilityLabel(Strings.limitsStaleAccessibility)
+                        .accessibilityHidden(!isStale)
+                    // Decorative click affordance — the whole block carries the tap
+                    // gesture, so keep VoiceOver from announcing the raw symbol name.
                     Image(systemName: "info.circle")
                         .foregroundStyle(.tertiary)
                         .opacity(hovering || isActive ? 1 : 0)
+                        .accessibilityHidden(true)
                 }
                 .font(.system(size: 10, weight: .medium))
                 .padding(.top, 6)
@@ -770,8 +775,10 @@ private struct LimitsExplainContent: View {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 4) {
                         if isStale {
+                            // Decorative — `updatedLabel` already conveys staleness in text.
                             Image(systemName: "clock.arrow.circlepath")
                                 .font(.system(size: 9, weight: .medium))
+                                .accessibilityHidden(true)
                         }
                         Text(updatedLabel)
                             .fixedSize(horizontal: false, vertical: true)

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -2760,6 +2760,12 @@ async function fetchUsageLimitsUncached({
       seven_day_opus: claudeResult.value.seven_day_opus,
       weekly_scoped: claudeResult.value.weekly_scoped,
       extra_usage: claudeResult.value.extra_usage,
+      // A live read is current as of now. `stale`/`cached_at` are always present so
+      // the client can render an "Updated Xm ago" age without guessing whether the
+      // response was live or served from the disk-cache fallback (the cached paths
+      // above already carry them). Mirrors the Codex live-success block below.
+      stale: false,
+      cached_at: new Date(nowMs).toISOString(),
     };
     writeClaudeLimitsCache(claude, { home, nowMs });
     clearClaudeRateLimitCooldown({ home });
@@ -2782,6 +2788,19 @@ async function fetchUsageLimitsUncached({
           ? formatClaudeRateLimitMessage(Math.round((retryAtMs - nowMs) / 1000))
           : reason?.message || "Unknown error",
       };
+    }
+  }
+
+  // Expose the active 429 cool-down expiry (if any) on the Claude object so the
+  // client can (a) show when the next refresh is due next to stale bars and
+  // (b) schedule a one-shot refresh the instant the cool-down lifts instead of
+  // waiting out the poll interval. Re-read here (not the pre-fetch value) so a
+  // cool-down just armed by this cycle's 429 is included; a successful read above
+  // cleared the file, so this is null in the happy path.
+  if (claude.configured) {
+    const claudeCooldownMs = readClaudeRateLimitRetryAtMs({ home, nowMs });
+    if (claudeCooldownMs) {
+      claude.retry_at = new Date(claudeCooldownMs).toISOString();
     }
   }
 
@@ -2817,6 +2836,11 @@ async function fetchUsageLimitsUncached({
       spark_primary_window: codexResult.value.spark_primary_window,
       spark_secondary_window: codexResult.value.spark_secondary_window,
       reset_credits: codexResult.value.reset_credits,
+      // Live read is current as of now; the stale fallback path above serves the
+      // disk cache with `stale: true`. Always emitting both lets the client show a
+      // data-age label uniformly (see the Claude live-success block).
+      stale: false,
+      cached_at: new Date(nowMs).toISOString(),
     };
     writeCodexLimitsCache(codex, { home, nowMs });
   }

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -312,6 +312,124 @@ function pendingUnlessCodexReset(url) {
   return new Promise(() => {});
 }
 
+describe("getUsageLimits claude data-age fields (stale + cached_at)", () => {
+  const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+
+  function writeClaudeCreds(home, token) {
+    const dir = path.join(home, ".claude");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: token } }),
+    );
+  }
+
+  it("stamps a live Claude read with stale:false and a fresh cached_at", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-live-"));
+    try {
+      writeClaudeCreds(tmp, "sk-ant-oauth-live");
+      const before = Date.now();
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 2000,
+        securityRunner() { return { status: 1, stdout: "" }; },
+        commandRunner() { return { status: 1, stdout: "" }; },
+        fetchImpl(url) {
+          if (url === CLAUDE_USAGE_URL) {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              headers: { get: () => null },
+              json: async () => ({
+                five_hour: { utilization: 7, resets_at: new Date(Date.now() + 3_600_000).toISOString() },
+                seven_day: { utilization: 40, resets_at: new Date(Date.now() + 86_400_000).toISOString() },
+              }),
+            });
+          }
+          return Promise.reject(new Error("unmocked"));
+        },
+      });
+
+      assert.equal(result.claude.configured, true);
+      assert.equal(result.claude.error, null);
+      assert.equal(result.claude.stale, false, "a live read must be marked fresh");
+      assert.ok(result.claude.cached_at, "live read must carry a cached_at stamp");
+      const cachedMs = Date.parse(result.claude.cached_at);
+      assert.ok(
+        cachedMs >= before && cachedMs <= Date.now() + 1000,
+        "cached_at must be stamped at fetch time",
+      );
+      assert.equal(
+        result.claude.retry_at,
+        undefined,
+        "a successful live read clears the cooldown, so no retry_at is exposed",
+      );
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("serves the disk cache with stale:true and its original cached_at when the live read 429s", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-stale-"));
+    try {
+      writeClaudeCreds(tmp, "sk-ant-oauth-stale");
+      // Seed a last-successful snapshot ~1h old (older than the 10-min fresh TTL, so a
+      // live call is still attempted) with a still-future reset (so the window stays usable).
+      const cacheDir = path.join(tmp, ".tokentracker", "tracker");
+      fs.mkdirSync(cacheDir, { recursive: true });
+      const seededCachedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      fs.writeFileSync(
+        path.join(cacheDir, "claude-usage-limits-cache.json"),
+        JSON.stringify({
+          claude: {
+            five_hour: { utilization: 55, resets_at: new Date(Date.now() + 3_600_000).toISOString() },
+            seven_day: null,
+            seven_day_opus: null,
+            weekly_scoped: null,
+            extra_usage: null,
+            cached_at: seededCachedAt,
+          },
+        }),
+      );
+
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 2000,
+        securityRunner() { return { status: 1, stdout: "" }; },
+        commandRunner() { return { status: 1, stdout: "" }; },
+        fetchImpl(url) {
+          if (url === CLAUDE_USAGE_URL) {
+            return Promise.resolve({
+              ok: false,
+              status: 429,
+              headers: { get: (k) => (k === "retry-after" ? "3600" : null) },
+              json: async () => ({}),
+            });
+          }
+          return Promise.reject(new Error("unmocked"));
+        },
+      });
+
+      assert.equal(result.claude.configured, true);
+      assert.equal(result.claude.error, null, "stale cache must be served instead of a red error");
+      assert.equal(result.claude.stale, true, "cache fallback must be marked stale");
+      assert.equal(result.claude.cached_at, seededCachedAt, "stale read must preserve the original cached_at");
+      assert.equal(result.claude.five_hour.utilization, 55);
+      assert.ok(result.claude.retry_at, "an active cooldown must expose retry_at for the client");
+      const retryMs = Date.parse(result.claude.retry_at);
+      assert.ok(retryMs > Date.now(), "retry_at must be a future instant");
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("getUsageLimits", () => {
   it("classifies a 5h session window into primary regardless of slot position", async () => {
     resetUsageLimitsCache();
@@ -374,6 +492,9 @@ describe("getUsageLimits", () => {
         limit_window_seconds: 604800,
         reset_at: 99999,
       });
+      // A live read carries the data-age fields the UI uses for "Updated Xm ago".
+      assert.equal(result.codex.stale, false, "a live Codex read must be marked fresh");
+      assert.ok(result.codex.cached_at, "live Codex read must carry a cached_at stamp");
     } finally {
       resetUsageLimitsCache();
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Surface Claude/Codex usage-limit **data age + staleness** in the menu bar, and **refresh the instant a 429 cool-down lifts** — so rate-limited limits no longer sit hours stale with no indication.

## Why

Claude Code and TokenTracker share the rate-limited `api.anthropic.com/api/oauth/usage` endpoint. Under load, TokenTracker's poll gets a **429**, which arms a cool-down (up to 60 min) during which the last disk cache (valid up to 7 days) is served with **no live fetch and no UI signal** — so the panel can silently show multi-hour-old numbers. The back-off itself is correct (hammering during a 429 just renews the penalty); the gaps were **visibility** and **recovery latency**. This PR fixes both without touching the back-off.

## What changed

**Visibility**
- Server (`src/lib/usage-limits.js`) always emits per-provider `stale` + `cached_at` for Claude and Codex (the cached paths already did; the live-success paths now do too).
- The menu bar info popover shows **“Updated Xm ago · &lt;time&gt;”**; a stale provider row carries a persistent amber `clock.arrow.circlepath` badge so the age is visible without opening the popover.

**Recovery**
- Server also exposes the active 429 `retry_at` on the Claude object (re-read after the fetch block so a freshly-armed cool-down is included; a successful read clears it).
- The popover shows **“Retrying &lt;time&gt;”** next to stale bars.
- The app schedules a one-shot refresh at cool-down expiry, reusing the existing reset-boundary timer (`scheduleResetBoundaryRefresh` + new `soonestCooldownExpiry()`), so a rate-limited panel updates the moment the cool-down lifts instead of waiting out the 5-minute poll. It never retries early.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes — **1281/1282**; the single failure (`runCommand … runs commands concurrently`) is a pre-existing wall-clock timing flake that fails identically on pristine `main`.
- [x] No hardcoded UI text — new strings go through the macOS `Strings.swift` `t()` helper (EN / zh-Hans / zh-Hant / JA / KO); no dashboard `copy.csv` strings added.
- [x] Commits follow conventional style (`feat(limits):`)
- [x] PR description explains *why*, not just *what*

## Reviewer notes

- **New response fields are additive + optional** (`stale`, `cached_at`, `retry_at`) — older clients and the dashboard/Windows paths decode unchanged.
- **Back-off is intentionally unchanged** — no change to the 60-min cool-down cap, the 7-day stale-serve window, or `?refresh=1`. Visibility + prompt recovery only.
- Added server tests in `test/usage-limits.test.js`: live read → `stale:false` + fresh `cached_at`, no `retry_at`; 429 → `stale:true`, original `cached_at` preserved, `retry_at` exposed. `validate:guardrails` / `ui-hardcode` / `copy` all green.
- **Swift was not compiled in my environment** (no generated Xcode project). I verified every new symbol is defined + referenced and CodingKeys↔property parity; please build the macOS target before merge.
- The `LimitsExplainContent(providerName: title, specs: specs, remainingMode: …)` call is kept on **one line** on purpose — `test/codex-reset-bank-native.test.js` + `codex-reset-bank-guardrails.test.js` assert its call shape by regex to prove reset-bank rows never leak into the explanation popover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “updated” timing, stale-data indicators, and optional retry (“retrying…”) info to the usage limits UI and provider popovers.
  * Extended provider limit decoding to include additional cache age/data-age fields.
* **Bug Fixes**
  * Improved refresh scheduling to trigger both at usage window rollover and when an active 429 cooldown expires.
  * Ensured live and cached limit states consistently expose freshness metadata, preserving cached timestamps and reflecting future retry time on 429.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->