### PR TITLE
fix: improve Codex refresh freshness

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
@@ -4,6 +4,8 @@ enum BackgroundRefreshPolicy {
     static let defaultRefreshInterval: TimeInterval = 300
     static let defaultSyncInterval: TimeInterval = 300
     static let defaultCatchUpStaleInterval: TimeInterval = 300
+    static let defaultPopoverOpenSyncInterval: TimeInterval = 60
+    static let defaultPopoverOpenLoadInterval: TimeInterval = 30
 
     static func shouldRunSync(
         now: Date,
@@ -23,5 +25,31 @@ enum BackgroundRefreshPolicy {
         guard staleInterval > 0 else { return false }
         guard let lastSyncAt else { return true }
         return now.timeIntervalSince(lastSyncAt) >= staleInterval
+    }
+
+    static func shouldRunPopoverOpenSync(
+        now: Date,
+        lastAttemptAt: Date?,
+        lastSyncAt: Date?,
+        syncInterval: TimeInterval = defaultPopoverOpenSyncInterval
+    ) -> Bool {
+        guard syncInterval > 0 else { return false }
+        if let lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < syncInterval {
+            return false
+        }
+        if let lastSyncAt, now.timeIntervalSince(lastSyncAt) < syncInterval {
+            return false
+        }
+        return true
+    }
+
+    static func shouldRunPopoverOpenLoad(
+        now: Date,
+        lastRefreshedAt: Date?,
+        loadInterval: TimeInterval = defaultPopoverOpenLoadInterval
+    ) -> Bool {
+        guard loadInterval > 0 else { return false }
+        guard let lastRefreshedAt else { return true }
+        return now.timeIntervalSince(lastRefreshedAt) >= loadInterval
     }
 }

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -575,8 +575,8 @@ final class StatusBarController: NSObject {
             window.makeKey()
         }
 
-        // Refresh data when popover opens
-        Task { await viewModel.loadAll() }
+        // Opportunistically sync stale local data before refreshing the popover.
+        Task { await viewModel.refreshForPopoverOpen() }
     }
 
     private func makePopoverAnchorWindow() -> NSWindow {

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -60,6 +60,7 @@ class DashboardViewModel: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var resetBoundaryRefreshTask: Task<Void, Never>?
     private var lastBackgroundSyncAt: Date?
+    private var lastPopoverOpenSyncAttemptAt: Date?
     private let resetDetector = WeeklyLimitResetDetector()
 
     // MARK: - Computed Properties
@@ -257,6 +258,30 @@ class DashboardViewModel: ObservableObject {
         if shouldSync {
             await syncThenLoad()
         } else {
+            await loadAll()
+        }
+    }
+
+    func refreshForPopoverOpen(
+        now: Date = Date(),
+        syncInterval: TimeInterval = BackgroundRefreshPolicy.defaultPopoverOpenSyncInterval,
+        loadInterval: TimeInterval = BackgroundRefreshPolicy.defaultPopoverOpenLoadInterval
+    ) async {
+        guard !isLoading, !isSyncing else { return }
+        let shouldSync = BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+            now: now,
+            lastAttemptAt: lastPopoverOpenSyncAttemptAt,
+            lastSyncAt: lastBackgroundSyncAt,
+            syncInterval: syncInterval
+        )
+        if shouldSync {
+            lastPopoverOpenSyncAttemptAt = now
+            await syncThenLoad()
+        } else if BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+            now: now,
+            lastRefreshedAt: lastRefreshed,
+            loadInterval: loadInterval
+        ) {
             await loadAll()
         }
     }

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -61,6 +61,7 @@ class DashboardViewModel: ObservableObject {
     private var resetBoundaryRefreshTask: Task<Void, Never>?
     private var lastBackgroundSyncAt: Date?
     private var lastPopoverOpenSyncAttemptAt: Date?
+    private var shouldReloadAfterCurrentLoad = false
     private let resetDetector = WeeklyLimitResetDetector()
 
     // MARK: - Computed Properties
@@ -92,13 +93,17 @@ class DashboardViewModel: ObservableObject {
     // MARK: - Data Loading
 
     func loadAll() async {
-        guard !isLoading else { return }
+        guard !isLoading else {
+            shouldReloadAfterCurrentLoad = true
+            return
+        }
         isLoading = true
         error = nil
 
         serverOnline = await APIClient.shared.checkServerHealth()
         guard serverOnline else {
             isLoading = false
+            await runQueuedReloadIfNeeded()
             return
         }
 
@@ -228,6 +233,13 @@ class DashboardViewModel: ObservableObject {
         // Push the latest data to the widget snapshot file so the desktop
         // widgets pick it up on their next timeline reload.
         await WidgetSnapshotWriter.update(from: self)
+        await runQueuedReloadIfNeeded()
+    }
+
+    private func runQueuedReloadIfNeeded() async {
+        guard shouldReloadAfterCurrentLoad else { return }
+        shouldReloadAfterCurrentLoad = false
+        await loadAll()
     }
 
     // MARK: - Sync

--- a/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
@@ -85,4 +85,108 @@ final class BackgroundRefreshPolicyTests: XCTestCase {
             false
         )
     }
+
+    func testRunsPopoverOpenSyncWhenNoPreviousAttemptOrSyncExists() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastAttemptAt: nil,
+                lastSyncAt: nil,
+                syncInterval: 60
+            ),
+            true
+        )
+    }
+
+    func testSkipsPopoverOpenSyncAfterRecentAttempt() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastAttemptAt: Date(timeIntervalSince1970: 950),
+                lastSyncAt: nil,
+                syncInterval: 60
+            ),
+            false
+        )
+    }
+
+    func testSkipsPopoverOpenSyncAfterRecentSuccessfulSync() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastAttemptAt: nil,
+                lastSyncAt: Date(timeIntervalSince1970: 950),
+                syncInterval: 60
+            ),
+            false
+        )
+    }
+
+    func testRunsPopoverOpenSyncAfterInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastAttemptAt: Date(timeIntervalSince1970: 939),
+                lastSyncAt: Date(timeIntervalSince1970: 939),
+                syncInterval: 60
+            ),
+            true
+        )
+    }
+
+    func testSkipsPopoverOpenSyncForNonPositiveInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastAttemptAt: nil,
+                lastSyncAt: nil,
+                syncInterval: 0
+            ),
+            false
+        )
+    }
+
+    func testRunsPopoverOpenLoadWhenNoPreviousRefreshExists() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastRefreshedAt: nil,
+                loadInterval: 30
+            ),
+            true
+        )
+    }
+
+    func testSkipsPopoverOpenLoadWhenRecentlyRefreshed() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastRefreshedAt: Date(timeIntervalSince1970: 980),
+                loadInterval: 30
+            ),
+            false
+        )
+    }
+
+    func testRunsPopoverOpenLoadAfterInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastRefreshedAt: Date(timeIntervalSince1970: 970),
+                loadInterval: 30
+            ),
+            true
+        )
+    }
+
+    func testSkipsPopoverOpenLoadForNonPositiveInterval() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+                now: Date(timeIntervalSince1970: 1_000),
+                lastRefreshedAt: nil,
+                loadInterval: 0
+            ),
+            false
+        )
+    }
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -916,7 +916,7 @@ async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOr
   if (arraysEqual(currentNotify, expectedNotify)) {
     return { repair: false, reason: "already-set" };
   }
-  if (isTokenTrackerNotify(currentNotify)) {
+  if (isTokenTrackerNotify(currentNotify, expectedNotify)) {
     return { repair: true, captureOriginal: false };
   }
   if (isSkyComputerUseNotify(currentNotify)) {
@@ -932,9 +932,13 @@ async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOr
   return { repair: false, reason: "external-notify" };
 }
 
-function isTokenTrackerNotify(cmd) {
+function isTokenTrackerNotify(cmd, expectedNotify) {
   if (!Array.isArray(cmd)) return false;
-  return cmd.some((part) => typeof part === "string" && part.includes("notify.cjs"));
+  if (arraysEqual(cmd, expectedNotify)) return true;
+  const notifyPath = cmd.find((part) => typeof part === "string" && part.endsWith("notify.cjs"));
+  if (!notifyPath) return false;
+  const normalized = notifyPath.replace(/\\/g, "/");
+  return normalized.includes("/.tokentracker/");
 }
 
 function isSkyComputerUseNotify(cmd) {
@@ -1099,8 +1103,8 @@ try {
     const cmd = Array.isArray(original?.notify) ? original.notify : null;
     if (cmd && cmd.length > 0 && !isSelfNotify(cmd) && shouldChainNotify(cmd)) {
       const args = cmd.slice(1);
-      for (const payloadArg of payloadArgs) {
-        if (!args.includes(payloadArg)) args.push(payloadArg);
+      if (payloadArgs.length > 0 && !containsSequence(args, payloadArgs)) {
+        args.push(...payloadArgs);
       }
       spawnDetached([cmd[0], ...args]);
     }
@@ -1153,6 +1157,22 @@ function isRunnableCommand(command) {
   } catch (_) {
     return false;
   }
+}
+
+function containsSequence(haystack, needle) {
+  if (!Array.isArray(haystack) || !Array.isArray(needle) || needle.length === 0) return false;
+  if (needle.length > haystack.length) return false;
+  for (let i = 0; i <= haystack.length - needle.length; i++) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return true;
+  }
+  return false;
 }
 `;
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -344,11 +344,7 @@ async function runSetup({
   await writeJson(configPath, config);
   await chmod600IfPossible(configPath);
 
-  await writeFileAtomic(
-    notifyPath,
-    buildNotifyHandler({ trackerDir, trackerBinPath, packageName: "tokentracker-cli" }),
-  );
-  await fs.chmod(notifyPath, 0o755).catch(() => {});
+  await writeNotifyHandler({ trackerDir, notifyPath });
 
   const summary = await applyIntegrationSetup({
     home,
@@ -364,6 +360,62 @@ async function runSetup({
     deviceId,
     installedAt,
   };
+}
+
+async function writeNotifyHandler({ trackerDir, binDir, notifyPath, packageName = "tokentracker-cli" }) {
+  const resolvedNotifyPath =
+    notifyPath || path.join(binDir || path.join(path.dirname(trackerDir), "bin"), "notify.cjs");
+  await ensureDir(path.dirname(resolvedNotifyPath));
+  await writeFileAtomic(
+    resolvedNotifyPath,
+    buildNotifyHandler({ trackerDir, packageName }),
+  );
+  await fs.chmod(resolvedNotifyPath, 0o755).catch(() => {});
+  return resolvedNotifyPath;
+}
+
+async function repairCodexNotifyIntegration({ home = os.homedir(), trackerDir, binDir, safeMode = true } = {}) {
+  const paths = trackerDir && binDir ? { trackerDir, binDir } : await resolveTrackerPaths({ home });
+  const resolvedTrackerDir = trackerDir || paths.trackerDir;
+  const resolvedBinDir = binDir || paths.binDir;
+  const notifyPath = await writeNotifyHandler({
+    trackerDir: resolvedTrackerDir,
+    binDir: resolvedBinDir,
+  });
+  const context = buildIntegrationTargets({
+    home,
+    trackerDir: resolvedTrackerDir,
+    notifyPath,
+  });
+  const codexProbe = await probeFile(context.codexConfigPath);
+  if (!codexProbe.exists) {
+    return { changed: false, skippedReason: "config-missing", notifyPath };
+  }
+
+  const currentNotify = await readCodexNotify(context.codexConfigPath);
+  if (arraysEqual(currentNotify, context.notifyCmd)) {
+    return { changed: false, skippedReason: null, notifyPath };
+  }
+
+  const repairDecision = safeMode
+    ? await shouldRepairCodexNotify({
+        currentNotify,
+        expectedNotify: context.notifyCmd,
+        notifyOriginalPath: context.notifyOriginalPath,
+      })
+    : { repair: true, captureOriginal: true, replaceOriginal: false };
+  if (!repairDecision.repair) {
+    return { changed: false, skippedReason: repairDecision.reason || "external-notify", notifyPath };
+  }
+
+  const result = await upsertCodexNotify({
+    codexConfigPath: context.codexConfigPath,
+    notifyCmd: context.notifyCmd,
+    notifyOriginalPath: context.notifyOriginalPath,
+    captureOriginal: repairDecision.captureOriginal,
+    replaceOriginal: repairDecision.replaceOriginal,
+  });
+  return { ...result, skippedReason: null, notifyPath };
 }
 
 function buildIntegrationTargets({ home, trackerDir, notifyPath }) {
@@ -857,6 +909,39 @@ function arraysEqual(a, b) {
   return true;
 }
 
+async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOriginalPath }) {
+  if (!Array.isArray(currentNotify) || currentNotify.length === 0) {
+    return { repair: true, captureOriginal: false };
+  }
+  if (arraysEqual(currentNotify, expectedNotify)) {
+    return { repair: false, reason: "already-set" };
+  }
+  if (isTokenTrackerNotify(currentNotify)) {
+    return { repair: true, captureOriginal: false };
+  }
+  if (isSkyComputerUseNotify(currentNotify)) {
+    return { repair: true, captureOriginal: true, replaceOriginal: true };
+  }
+
+  const original = await readJson(notifyOriginalPath);
+  const originalNotify = Array.isArray(original?.notify) ? original.notify : null;
+  if (arraysEqual(currentNotify, originalNotify)) {
+    return { repair: true, captureOriginal: true, replaceOriginal: false };
+  }
+
+  return { repair: false, reason: "external-notify" };
+}
+
+function isTokenTrackerNotify(cmd) {
+  if (!Array.isArray(cmd)) return false;
+  return cmd.some((part) => typeof part === "string" && part.includes("notify.cjs"));
+}
+
+function isSkyComputerUseNotify(cmd) {
+  if (!Array.isArray(cmd)) return false;
+  return cmd.some((part) => typeof part === "string" && part.includes("SkyComputerUseClient"));
+}
+
 function parseArgs(argv) {
   const out = {
     baseUrl: null,
@@ -1014,7 +1099,9 @@ try {
     const cmd = Array.isArray(original?.notify) ? original.notify : null;
     if (cmd && cmd.length > 0 && !isSelfNotify(cmd) && shouldChainNotify(cmd)) {
       const args = cmd.slice(1);
-      if (payloadArgs.length > 0) args.push(...payloadArgs);
+      for (const payloadArg of payloadArgs) {
+        if (!args.includes(payloadArg)) args.push(payloadArg);
+      }
       spawnDetached([cmd[0], ...args]);
     }
   }
@@ -1051,12 +1138,7 @@ function isSelfNotify(cmd) {
 
 function shouldChainNotify(cmd) {
   if (!Array.isArray(cmd) || cmd.length === 0) return false;
-  if (containsSkyComputerUseClient(cmd)) return false;
   return isRunnableCommand(cmd[0]);
-}
-
-function containsSkyComputerUseClient(cmd) {
-  return cmd.some((part) => typeof part === 'string' && part.includes('SkyComputerUseClient'));
 }
 
 function isRunnableCommand(command) {
@@ -1075,7 +1157,12 @@ function isRunnableCommand(command) {
 `;
 }
 
-module.exports = { cmdInit, buildNotifyHandler, installLocalTrackerApp };
+module.exports = {
+  cmdInit,
+  buildNotifyHandler,
+  installLocalTrackerApp,
+  repairCodexNotifyIntegration,
+};
 
 async function probeFile(p) {
   try {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -915,7 +915,7 @@ function arraysEqual(a, b) {
 
 async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOriginalPath }) {
   if (!Array.isArray(currentNotify) || currentNotify.length === 0) {
-    return { repair: true, captureOriginal: false };
+    return { repair: true, captureOriginal: true, replaceOriginal: true };
   }
   if (arraysEqual(currentNotify, expectedNotify)) {
     return { repair: false, reason: "already-set" };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -477,10 +477,12 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
 
   const codexProbe = await probeFile(context.codexConfigPath);
   if (codexProbe.exists) {
+    const currentNotify = await readCodexNotify(context.codexConfigPath);
     const result = await upsertCodexNotify({
       codexConfigPath: context.codexConfigPath,
       notifyCmd: context.notifyCmd,
       notifyOriginalPath: context.notifyOriginalPath,
+      replaceOriginal: shouldReplaceStoredOriginalNotify(currentNotify, context.notifyCmd),
     });
     summary.push({
       label: "Codex CLI",
@@ -730,10 +732,12 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
 
   const codeProbe = await probeFile(context.codeConfigPath);
   if (codeProbe.exists) {
+    const currentNotify = await readEveryCodeNotify(context.codeConfigPath);
     const result = await upsertEveryCodeNotify({
       codeConfigPath: context.codeConfigPath,
       notifyCmd: context.codeNotifyCmd,
       notifyOriginalPath: context.codeNotifyOriginalPath,
+      replaceOriginal: shouldReplaceStoredOriginalNotify(currentNotify, context.codeNotifyCmd),
     });
     summary.push({
       label: "Every Code",
@@ -930,6 +934,11 @@ async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOr
   }
 
   return { repair: false, reason: "external-notify" };
+}
+
+function shouldReplaceStoredOriginalNotify(currentNotify, expectedNotify) {
+  if (isTokenTrackerNotify(currentNotify, expectedNotify)) return false;
+  return currentNotify === null || Array.isArray(currentNotify);
 }
 
 function isTokenTrackerNotify(cmd, expectedNotify) {

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -58,7 +58,7 @@ async function cmdServe(argv) {
   const opts = parseArgs(argv);
 
   // 0. First-time setup: if tracker dir doesn't exist, run init first
-  const { trackerDir } = await resolveTrackerPaths();
+  const { trackerDir, binDir } = await resolveTrackerPaths();
   if (!fssync.existsSync(path.join(trackerDir, "cursors.json"))) {
     process.stdout.write("First time? Setting up Token Tracker...\n\n");
     try {
@@ -70,8 +70,12 @@ async function cmdServe(argv) {
   }
 
   try {
-    const { installLocalTrackerApp } = require("./init");
+    const { installLocalTrackerApp, repairCodexNotifyIntegration } = require("./init");
     await installLocalTrackerApp({ appDir: path.join(trackerDir, "app") });
+    const repairResult = await repairCodexNotifyIntegration({ trackerDir, binDir, safeMode: true });
+    if (repairResult?.skippedReason && repairResult.skippedReason !== "config-missing") {
+      process.stdout.write(`Codex notify repair skipped: ${repairResult.skippedReason}\n`);
+    }
   } catch (e) {
     process.stdout.write(`Runtime refresh warning: ${e?.message || e}\n`);
   }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -108,6 +108,7 @@ async function cmdStatus(argv = []) {
     env: process.env,
   });
   const notifyPath = path.join(binDir, "notify.cjs");
+  const codexNotifyCmd = ["/usr/bin/env", "node", notifyPath];
   const claudeHookCommand = buildClaudeHookCommand(notifyPath);
   const codebuddyHookCommand = buildHookCommand(notifyPath, "codebuddy");
   const workbuddyHookCommand = buildHookCommand(notifyPath, "workbuddy");
@@ -132,7 +133,7 @@ async function cmdStatus(argv = []) {
   );
 
   const codexNotify = await readCodexNotify(codexConfigPath);
-  const notifyConfigured = Array.isArray(codexNotify) && codexNotify.length > 0;
+  const notifyConfigured = arraysEqual(codexNotify, codexNotifyCmd);
   const everyCodeNotify = await readEveryCodeNotify(codeConfigPath);
   const everyCodeConfigured =
     Array.isArray(everyCodeNotify) && everyCodeNotify.length > 0;
@@ -656,6 +657,13 @@ function parseArgs(argv) {
   }
 
   return out;
+}
+
+function arraysEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
 // Pure renderer: turn the structured summary into a fixed-width ASCII table.

--- a/src/commands/uninstall.js
+++ b/src/commands/uninstall.js
@@ -119,6 +119,8 @@ async function cmdUninstall(argv) {
           ? `- Codex notify restored: ${codexConfigPath}`
           : codexRestore?.skippedReason === "no-backup-not-installed"
             ? "- Codex notify: skipped (no backup; not installed)"
+            : codexRestore?.skippedReason === "current-not-managed"
+              ? "- Codex notify: skipped (current notify is not managed by TokenTracker)"
             : "- Codex notify: no change"
         : "- Codex notify: skipped (config.toml not found)",
       codeConfigExists
@@ -126,6 +128,8 @@ async function cmdUninstall(argv) {
           ? `- Every Code notify restored: ${codeConfigPath}`
           : codeRestore?.skippedReason === "no-backup-not-installed"
             ? "- Every Code notify: skipped (no backup; not installed)"
+            : codeRestore?.skippedReason === "current-not-managed"
+              ? "- Every Code notify: skipped (current notify is not managed by TokenTracker)"
             : "- Every Code notify: no change"
         : "- Every Code notify: skipped (config.toml not found)",
       claudeConfigExists

--- a/src/lib/codex-config.js
+++ b/src/lib/codex-config.js
@@ -52,6 +52,10 @@ async function restoreNotify({ configPath, notifyOriginalPath, expectedNotify })
   const originalNotify = Array.isArray(original?.notify) ? original.notify : null;
   const currentNotify = extractNotify(text);
 
+  if (expectedNotify && !arraysEqual(currentNotify, expectedNotify)) {
+    return { restored: false, skippedReason: "current-not-managed" };
+  }
+
   if (!originalNotify && expectedNotify && !arraysEqual(currentNotify, expectedNotify)) {
     return { restored: false, skippedReason: "no-backup-not-installed" };
   }
@@ -216,8 +220,7 @@ function removeNotify(text) {
 }
 
 function parseTomlStringArray(rhs) {
-  // Minimal parser for ["a", "b"] string arrays.
-  // Assumes there are no escapes in strings (good enough for our usage).
+  // Minimal parser for TOML basic/literal string arrays.
   if (!rhs.startsWith("[") || !rhs.endsWith("]")) return null;
   const inner = rhs.slice(1, -1).trim();
   if (!inner) return [];
@@ -240,6 +243,18 @@ function parseTomlStringArray(rhs) {
       parts.push(current);
       inString = false;
       quote = null;
+      continue;
+    }
+    if (quote === '"' && ch === "\\") {
+      if (i + 1 >= inner.length) return null;
+      const next = inner[++i];
+      if (next === "b") current += "\b";
+      else if (next === "t") current += "\t";
+      else if (next === "n") current += "\n";
+      else if (next === "f") current += "\f";
+      else if (next === "r") current += "\r";
+      else if (next === '"' || next === "\\" || next === "/") current += next;
+      else return null;
       continue;
     }
     current += ch;

--- a/src/lib/codex-config.js
+++ b/src/lib/codex-config.js
@@ -3,7 +3,14 @@ const path = require("node:path");
 
 const { ensureDir, readJson, writeJson } = require("./fs");
 
-async function upsertNotify({ configPath, notifyCmd, notifyOriginalPath, configLabel }) {
+async function upsertNotify({
+  configPath,
+  notifyCmd,
+  notifyOriginalPath,
+  configLabel,
+  captureOriginal = true,
+  replaceOriginal = false,
+}) {
   const originalText = await fs.readFile(configPath, "utf8").catch(() => null);
   if (originalText == null) {
     const label =
@@ -16,10 +23,10 @@ async function upsertNotify({ configPath, notifyCmd, notifyOriginalPath, configL
 
   if (!already) {
     // Persist original notify once (for uninstall + chaining).
-    if (existingNotify && existingNotify.length > 0) {
+    if (captureOriginal && existingNotify && existingNotify.length > 0) {
       await ensureDir(path.dirname(notifyOriginalPath));
       const existing = await readJson(notifyOriginalPath);
-      if (!existing) {
+      if (replaceOriginal || !existing) {
         await writeJson(notifyOriginalPath, {
           notify: existingNotify,
           capturedAt: new Date().toISOString(),
@@ -69,12 +76,20 @@ async function readNotify(configPath) {
   return extractNotify(text);
 }
 
-async function upsertCodexNotify({ codexConfigPath, notifyCmd, notifyOriginalPath }) {
+async function upsertCodexNotify({
+  codexConfigPath,
+  notifyCmd,
+  notifyOriginalPath,
+  captureOriginal = true,
+  replaceOriginal = false,
+}) {
   return upsertNotify({
     configPath: codexConfigPath,
     notifyCmd,
     notifyOriginalPath,
     configLabel: "Codex config",
+    captureOriginal,
+    replaceOriginal,
   });
 }
 
@@ -94,12 +109,20 @@ async function readCodexNotify(codexConfigPath) {
   return readNotify(codexConfigPath);
 }
 
-async function upsertEveryCodeNotify({ codeConfigPath, notifyCmd, notifyOriginalPath }) {
+async function upsertEveryCodeNotify({
+  codeConfigPath,
+  notifyCmd,
+  notifyOriginalPath,
+  captureOriginal = true,
+  replaceOriginal = false,
+}) {
   return upsertNotify({
     configPath: codeConfigPath,
     notifyCmd,
     notifyOriginalPath,
     configLabel: "Every Code config",
+    captureOriginal,
+    replaceOriginal,
   });
 }
 

--- a/src/lib/codex-config.js
+++ b/src/lib/codex-config.js
@@ -22,13 +22,16 @@ async function upsertNotify({
   const already = arraysEqual(existingNotify, notifyCmd);
 
   if (!already) {
-    // Persist original notify once (for uninstall + chaining).
-    if (captureOriginal && existingNotify && existingNotify.length > 0) {
+    // Persist original notify once (for uninstall + chaining). When a caller
+    // asks to replace the stored original and the config has no notify, record
+    // that absence so uninstall does not resurrect a stale backup.
+    const hasExistingNotify = Array.isArray(existingNotify);
+    if (captureOriginal && (hasExistingNotify || replaceOriginal)) {
       await ensureDir(path.dirname(notifyOriginalPath));
       const existing = await readJson(notifyOriginalPath);
       if (replaceOriginal || !existing) {
         await writeJson(notifyOriginalPath, {
-          notify: existingNotify,
+          notify: hasExistingNotify ? existingNotify : null,
           capturedAt: new Date().toISOString(),
         });
       }

--- a/src/lib/codex-config.js
+++ b/src/lib/codex-config.js
@@ -302,6 +302,10 @@ function readTomlArrayLiteral(lines, startIndex, rhs) {
       if (ch === quote) {
         inString = false;
         quote = null;
+        continue;
+      }
+      if (quote === '"' && ch === "\\") {
+        i += 1;
       }
     }
     return -1;
@@ -356,6 +360,10 @@ function findTomlArrayBlockEnd(lines, startIndex, rhs) {
       if (ch === quote) {
         inString = false;
         quote = null;
+        continue;
+      }
+      if (quote === '"' && ch === "\\") {
+        i += 1;
       }
     }
     return false;

--- a/test/codex-config-multiline-notify.test.js
+++ b/test/codex-config-multiline-notify.test.js
@@ -34,6 +34,24 @@ test("readNotify parses multi-line notify arrays", async () => {
   ]);
 });
 
+test("readNotify unescapes JSON/TOML basic string escapes", async () => {
+  const dir = tmpDir("tokentracker-codex-config-");
+  const configPath = path.join(dir, "config.toml");
+
+  fs.writeFileSync(
+    configPath,
+    'notify = ["/usr/bin/env", "node", "C:\\\\Users\\\\alice\\\\.tokentracker\\\\bin\\\\notify.cjs"]\n',
+    "utf8",
+  );
+
+  const notify = await readNotify(configPath);
+  assert.deepEqual(notify, [
+    "/usr/bin/env",
+    "node",
+    "C:\\Users\\alice\\.tokentracker\\bin\\notify.cjs",
+  ]);
+});
+
 test("upsertNotify replaces multi-line notify blocks without leaving trailing lines", async () => {
   const dir = tmpDir("tokentracker-codex-upsert-");
   const configPath = path.join(dir, "config.toml");
@@ -118,4 +136,23 @@ test("restoreNotify restores from notifyOriginalPath even if config was updated"
     ),
     true,
   );
+});
+
+test("restoreNotify skips stale backup when current notify is not managed", async () => {
+  const dir = tmpDir("tokentracker-codex-restore-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+
+  fs.writeFileSync(
+    notifyOriginalPath,
+    JSON.stringify({ notify: ["old-notify"], capturedAt: new Date().toISOString() }),
+    "utf8",
+  );
+  fs.writeFileSync(configPath, 'notify = ["third-party-notify", "new"]\n', "utf8");
+
+  const expectedNotify = ["/usr/bin/env", "node", "/Users/alice/.tokentracker/bin/notify.cjs"];
+  const result = await restoreNotify({ configPath, notifyOriginalPath, expectedNotify });
+  assert.equal(result.restored, false);
+  assert.equal(result.skippedReason, "current-not-managed");
+  assert.equal(fs.readFileSync(configPath, "utf8"), 'notify = ["third-party-notify", "new"]\n');
 });

--- a/test/codex-config-multiline-notify.test.js
+++ b/test/codex-config-multiline-notify.test.js
@@ -52,6 +52,23 @@ test("readNotify unescapes JSON/TOML basic string escapes", async () => {
   ]);
 });
 
+test("upsertNotify round-trips escaped quotes in notify strings", async () => {
+  const dir = tmpDir("tokentracker-codex-config-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+  const notify = ["/usr/bin/env", "node", path.join(dir, 'we"ird', "notify.cjs")];
+  fs.writeFileSync(configPath, 'model = "gpt-5"\n', "utf8");
+
+  await upsertNotify({
+    configPath,
+    notifyCmd: notify,
+    notifyOriginalPath,
+    configLabel: "Codex config",
+  });
+
+  assert.deepEqual(await readNotify(configPath), notify);
+});
+
 test("upsertNotify replaces multi-line notify blocks without leaving trailing lines", async () => {
   const dir = tmpDir("tokentracker-codex-upsert-");
   const configPath = path.join(dir, "config.toml");

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -37,7 +37,7 @@ function flattenHookEntries(entries) {
   return entries.flatMap((entry) => (Array.isArray(entry?.hooks) ? entry.hooks : [entry]));
 }
 
-async function runGeneratedNotifyHandler({ trackerDir, notify }) {
+async function runGeneratedNotifyHandler({ trackerDir, notify, args = ["--source=codex", "turn-ended"] }) {
   await fs.mkdir(trackerDir, { recursive: true });
   const notifyPath = path.join(trackerDir, "notify.cjs");
   await fs.writeFile(
@@ -56,7 +56,7 @@ async function runGeneratedNotifyHandler({ trackerDir, notify }) {
     delete env.TOKENTRACKER_DEVICE_TOKEN;
     const child = require("node:child_process").execFile(
       process.execPath,
-      [notifyPath, "--source=codex", "turn-ended"],
+      [notifyPath, ...args],
       { env },
       (err) => (err ? reject(err) : resolve()),
     );
@@ -125,6 +125,30 @@ test("notify handler avoids duplicating existing payload args when chaining", as
 
     const marker = await waitForFile(markerPath, { timeoutMs: 5000 });
     assert.equal(marker, "turn-ended");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler preserves legitimate repeated payload args when chaining", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const markerPath = path.join(tmp, "repeat-marker");
+    const shimPath = path.join(tmp, "repeat-notify.js");
+    await fs.writeFile(
+      shimPath,
+      `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+      "utf8",
+    );
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-repeat"),
+      notify: [process.execPath, shimPath, "turn-ended"],
+      args: ["--source=codex", "--include", "a", "--include", "b"],
+    });
+
+    const marker = await waitForFile(markerPath, { timeoutMs: 5000 });
+    assert.equal(marker, "turn-ended|--include|a|--include|b");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -242,6 +266,44 @@ test("serve-time Codex notify repair skips unknown third-party notify", async ()
     const config = await fs.readFile(path.join(process.env.CODEX_HOME, "config.toml"), "utf8");
     assert.match(config, /third-party-notify/);
     assert.doesNotMatch(config, /notify\.cjs/);
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time Codex notify repair skips unknown notify.cjs command", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevCodexHome = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    const externalNotify = ["/usr/bin/env", "node", path.join(tmp, "custom", "notify.cjs")];
+    await fs.writeFile(
+      path.join(process.env.CODEX_HOME, "config.toml"),
+      `notify = ${JSON.stringify(externalNotify)}\n`,
+      "utf8",
+    );
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, false);
+    assert.equal(result.skippedReason, "external-notify");
+    const config = await fs.readFile(path.join(process.env.CODEX_HOME, "config.toml"), "utf8");
+    assert.match(config, /custom/);
+    assert.doesNotMatch(config, /\.tokentracker/);
+    await assert.rejects(
+      fs.stat(path.join(trackerDir, "codex_notify_original.json")),
+      /ENOENT/,
+    );
   } finally {
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
@@ -429,6 +491,50 @@ test("init then uninstall removes notify when none existed", async () => {
       !/^notify\s*=.*$/m.test(restored),
       "expected uninstall to remove notify when none existed",
     );
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("uninstall does not restore stale backup over active third-party Codex notify", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, 'notify = ["third-party-notify", "new"]\n', "utf8");
+    await fs.writeFile(
+      path.join(trackerDir, "codex_notify_original.json"),
+      JSON.stringify({ notify: ["old-notify"], capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+
+    process.stdout.write = () => true;
+    await cmdUninstall([]);
+
+    const restored = await fs.readFile(codexConfigPath, "utf8");
+    assert.equal(restored, 'notify = ["third-party-notify", "new"]\n');
   } finally {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -4,7 +4,11 @@ const path = require("node:path");
 const fs = require("node:fs/promises");
 const { test } = require("node:test");
 
-const { cmdInit, buildNotifyHandler } = require("../src/commands/init");
+const {
+  cmdInit,
+  buildNotifyHandler,
+  repairCodexNotifyIntegration,
+} = require("../src/commands/init");
 const { cmdUninstall } = require("../src/commands/uninstall");
 const { buildClaudeHookCommand } = require("../src/lib/claude-config");
 const { buildGeminiHookCommand } = require("../src/lib/gemini-config");
@@ -60,7 +64,7 @@ async function runGeneratedNotifyHandler({ trackerDir, notify }) {
   });
 }
 
-test("notify handler skips SkyComputerUseClient and stale explicit original notify paths", async () => {
+test("notify handler chains executable original notify commands and skips stale explicit paths", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
   try {
     const markerPath = path.join(tmp, "unsafe-marker");
@@ -92,13 +96,155 @@ test("notify handler skips SkyComputerUseClient and stale explicit original noti
       trackerDir: path.join(tmp, "tracker-sky"),
       notify: [skyPath, "turn-ended"],
     });
-    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 5000 }), "ran");
 
     await runGeneratedNotifyHandler({
       trackerDir: path.join(tmp, "tracker-missing"),
       notify: [path.join(tmp, "missing-notify"), "turn-ended"],
     });
   } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler avoids duplicating existing payload args when chaining", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const markerPath = path.join(tmp, "dedupe-marker");
+    const shimPath = path.join(tmp, "dedupe-notify.js");
+    await fs.writeFile(
+      shimPath,
+      `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+      "utf8",
+    );
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-dedupe"),
+      notify: [process.execPath, shimPath, "turn-ended"],
+    });
+
+    const marker = await waitForFile(markerPath, { timeoutMs: 5000 });
+    assert.equal(marker, "turn-ended");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time Codex notify repair installs TokenTracker and preserves Sky original", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevCodexHome = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+    const skyNotify = [
+      path.join(tmp, "SkyComputerUseClient.app", "Contents", "MacOS", "SkyComputerUseClient"),
+      "turn-ended",
+    ];
+    await fs.writeFile(
+      path.join(process.env.CODEX_HOME, "config.toml"),
+      `notify = ${JSON.stringify(skyNotify)}\n`,
+      "utf8",
+    );
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, true);
+    await fs.stat(path.join(binDir, "notify.cjs"));
+    const config = await fs.readFile(path.join(process.env.CODEX_HOME, "config.toml"), "utf8");
+    assert.match(config, /notify\.cjs/);
+    const original = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "codex_notify_original.json"), "utf8"),
+    );
+    assert.deepEqual(original.notify, skyNotify);
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time Codex notify repair refreshes stale backup when active notify is Sky", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevCodexHome = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+
+    const staleNotify = ["old-notify", "arg"];
+    await fs.writeFile(
+      path.join(trackerDir, "codex_notify_original.json"),
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const skyNotify = [
+      path.join(tmp, "SkyComputerUseClient.app", "Contents", "MacOS", "SkyComputerUseClient"),
+      "turn-ended",
+    ];
+    await fs.writeFile(
+      path.join(process.env.CODEX_HOME, "config.toml"),
+      `notify = ${JSON.stringify(skyNotify)}\n`,
+      "utf8",
+    );
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, true);
+    const original = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "codex_notify_original.json"), "utf8"),
+    );
+    assert.deepEqual(original.notify, skyNotify);
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time Codex notify repair skips unknown third-party notify", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevCodexHome = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.writeFile(
+      path.join(process.env.CODEX_HOME, "config.toml"),
+      'notify = ["third-party-notify", "arg"]\n',
+      "utf8",
+    );
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, false);
+    assert.equal(result.skippedReason, "external-notify");
+    const config = await fs.readFile(path.join(process.env.CODEX_HOME, "config.toml"), "utf8");
+    assert.match(config, /third-party-notify/);
+    assert.doesNotMatch(config, /notify\.cjs/);
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -240,6 +240,56 @@ test("serve-time Codex notify repair refreshes stale backup when active notify i
   }
 });
 
+test("serve-time Codex notify repair clears stale backup when active notify is absent", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevWrite = process.stdout.write;
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+
+    const staleNotify = ["old-notify", "arg"];
+    const notifyOriginalPath = path.join(trackerDir, "codex_notify_original.json");
+    await fs.writeFile(
+      notifyOriginalPath,
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, "model = \"gpt-5\"\n", "utf8");
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, true);
+    const original = JSON.parse(await fs.readFile(notifyOriginalPath, "utf8"));
+    assert.equal(original.notify, null);
+
+    process.stdout.write = () => true;
+    await cmdUninstall([]);
+    const restored = await fs.readFile(codexConfigPath, "utf8");
+    assert.match(restored, /model = "gpt-5"/);
+    assert.doesNotMatch(restored, /^notify\s*=/m);
+    assert.doesNotMatch(restored, /old-notify/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("serve-time Codex notify repair skips unknown third-party notify", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
   const prevCodexHome = process.env.CODEX_HOME;
@@ -733,6 +783,66 @@ test("init then uninstall restores original Every Code notify (when config exist
       restored.includes('notify = ["echo", "hello-code"]'),
       "expected uninstall to restore Every Code notify",
     );
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevCodeHome === undefined) delete process.env.CODE_HOME;
+    else process.env.CODE_HOME = prevCodeHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("init clears stale Every Code backup when current notify is absent", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevCodeHome = process.env.CODE_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    process.env.CODE_HOME = path.join(tmp, ".code");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.mkdir(process.env.CODE_HOME, { recursive: true });
+
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, "# empty\n", "utf8");
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const staleNotify = ["old-code-notify", "arg"];
+    const notifyOriginalPath = path.join(trackerDir, "code_notify_original.json");
+    await fs.writeFile(
+      notifyOriginalPath,
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const codeConfigPath = path.join(process.env.CODE_HOME, "config.toml");
+    await fs.writeFile(codeConfigPath, "model = \"gpt-5\"\n", "utf8");
+
+    process.stdout.write = () => true;
+    await cmdInit(["--yes", "--no-auth", "--no-open", "--base-url", "https://example.invalid"]);
+
+    const original = JSON.parse(await fs.readFile(notifyOriginalPath, "utf8"));
+    assert.equal(original.notify, null);
+
+    await cmdUninstall([]);
+    const restored = await fs.readFile(codeConfigPath, "utf8");
+    assert.match(restored, /model = "gpt-5"/);
+    assert.doesNotMatch(restored, /^notify\s*=/m);
+    assert.doesNotMatch(restored, /old-code-notify/);
   } finally {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -448,6 +448,111 @@ test("init then uninstall restores original Codex notify (when pre-existing noti
   }
 });
 
+test("init refreshes stale Codex backup when current notify is external", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-refresh-backup-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const staleNotify = ["old-notify", "arg"];
+    await fs.writeFile(
+      path.join(trackerDir, "codex_notify_original.json"),
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const externalNotify = ["third-party-notify", "new"];
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, `notify = ${JSON.stringify(externalNotify)}\n`, "utf8");
+
+    process.stdout.write = () => true;
+    await cmdInit(["--yes", "--no-auth", "--no-open", "--base-url", "https://example.invalid"]);
+
+    const original = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "codex_notify_original.json"), "utf8"),
+    );
+    assert.deepEqual(original.notify, externalNotify);
+
+    await cmdUninstall([]);
+    const restored = await fs.readFile(codexConfigPath, "utf8");
+    assert.match(restored, /third-party-notify/);
+    assert.doesNotMatch(restored, /old-notify/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("init clears stale Codex backup when current notify is absent", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-clear-backup-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const staleNotify = ["old-notify", "arg"];
+    const notifyOriginalPath = path.join(trackerDir, "codex_notify_original.json");
+    await fs.writeFile(
+      notifyOriginalPath,
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, "model = \"gpt-5\"\n", "utf8");
+
+    process.stdout.write = () => true;
+    await cmdInit(["--yes", "--no-auth", "--no-open", "--base-url", "https://example.invalid"]);
+
+    const original = JSON.parse(await fs.readFile(notifyOriginalPath, "utf8"));
+    assert.equal(original.notify, null);
+
+    await cmdUninstall([]);
+    const restored = await fs.readFile(codexConfigPath, "utf8");
+    assert.match(restored, /model = "gpt-5"/);
+    assert.doesNotMatch(restored, /^notify\s*=/m);
+    assert.doesNotMatch(restored, /old-notify/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("opencode plugin uses session.updated event", () => {
   const plugin = buildOpencodePlugin({ notifyPath: "/tmp/notify.cjs" });
   assert.match(plugin, /session\.updated/);

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -859,6 +859,66 @@ test("init clears stale Every Code backup when current notify is absent", async 
   }
 });
 
+test("init refreshes stale Every Code backup when current notify is external", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevCodeHome = process.env.CODE_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    process.env.CODE_HOME = path.join(tmp, ".code");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.mkdir(process.env.CODE_HOME, { recursive: true });
+
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, "# empty\n", "utf8");
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const staleNotify = ["old-code-notify", "arg"];
+    const notifyOriginalPath = path.join(trackerDir, "code_notify_original.json");
+    await fs.writeFile(
+      notifyOriginalPath,
+      JSON.stringify({ notify: staleNotify, capturedAt: "2026-01-01T00:00:00.000Z" }) + "\n",
+      "utf8",
+    );
+    const externalNotify = ["third-party-code-notify", "new"];
+    const codeConfigPath = path.join(process.env.CODE_HOME, "config.toml");
+    await fs.writeFile(codeConfigPath, `notify = ${JSON.stringify(externalNotify)}\n`, "utf8");
+
+    process.stdout.write = () => true;
+    await cmdInit(["--yes", "--no-auth", "--no-open", "--base-url", "https://example.invalid"]);
+
+    const original = JSON.parse(await fs.readFile(notifyOriginalPath, "utf8"));
+    assert.deepEqual(original.notify, externalNotify);
+
+    await cmdUninstall([]);
+    const restored = await fs.readFile(codeConfigPath, "utf8");
+    assert.match(restored, /third-party-code-notify/);
+    assert.doesNotMatch(restored, /old-code-notify/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevCodeHome === undefined) delete process.env.CODE_HOME;
+    else process.env.CODE_HOME = prevCodeHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("init skips Every Code notify when config is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
   const prevHome = process.env.HOME;

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -67,4 +67,29 @@ test("menu-bar popover is anchored to an app-owned positioning window", () => {
     /Task\s*\{\s*@MainActor/,
     "The did-close cleanup must not be deferred through an unstructured MainActor task.",
   );
+  assert.match(
+    source,
+    /Task\s*\{\s*await\s+viewModel\.refreshForPopoverOpen\(\)\s*\}/,
+    "Opening the popover should run the throttled lightweight sync path before reloading dashboard data.",
+  );
+  assert.doesNotMatch(
+    source,
+    /Task\s*\{\s*await\s+viewModel\.loadAll\(\)\s*\}/,
+    "Opening the popover should not only reload cached dashboard data.",
+  );
+
+  const viewModelPath = path.join(
+    __dirname,
+    "..",
+    "TokenTrackerBar",
+    "TokenTrackerBar",
+    "ViewModels",
+    "DashboardViewModel.swift",
+  );
+  const viewModel = fs.readFileSync(viewModelPath, "utf8");
+  assert.match(
+    viewModel,
+    /shouldRunPopoverOpenLoad\([\s\S]*lastRefreshed/,
+    "When popover sync is throttled, dashboard reload should also be debounced by lastRefreshed.",
+  );
 });

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -92,4 +92,14 @@ test("menu-bar popover is anchored to an app-owned positioning window", () => {
     /shouldRunPopoverOpenLoad\([\s\S]*lastRefreshed/,
     "When popover sync is throttled, dashboard reload should also be debounced by lastRefreshed.",
   );
+  assert.match(
+    viewModel,
+    /guard\s+!isLoading\s+else\s*\{\s*shouldReloadAfterCurrentLoad\s*=\s*true\s*return\s*\}/,
+    "Concurrent dashboard reload requests should queue one follow-up load instead of being dropped.",
+  );
+  assert.match(
+    viewModel,
+    /private\s+func\s+runQueuedReloadIfNeeded\(\)\s+async[\s\S]*shouldReloadAfterCurrentLoad\s*=\s*false[\s\S]*await\s+loadAll\(\)/,
+    "A queued reload should run after the current load finishes so sync-now can refresh stale data.",
+  );
 });

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -24,7 +24,7 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
 
     await fs.writeFile(
       path.join(process.env.CODEX_HOME, "config.toml"),
-      'notify = [\"/usr/bin/env\", \"node\", \"~/.tokentracker/bin/notify.cjs\"]\n',
+      `notify = ["/usr/bin/env", "node", ${JSON.stringify(path.join(tmp, ".tokentracker", "bin", "notify.cjs"))}]\n`,
       "utf8",
     );
 
@@ -79,6 +79,50 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
     assert.match(out, /- Last upload: 2025-12-18T10:19:05\.522Z/);
     assert.match(out, /- Last OpenClaw-triggered sync: 2026-02-12T00:00:00.000Z/);
     assert.match(out, /- Next upload after: 2025-12-18T10:19:06\.522Z/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("status reports Codex notify unset when config points to another command", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-notify-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+    await fs.writeFile(
+      path.join(process.env.CODEX_HOME, "config.toml"),
+      'notify = ["/Applications/SkyComputerUseClient", "turn-ended"]\n',
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(trackerDir, "config.json"),
+      JSON.stringify({ baseUrl: "https://example.invalid", deviceToken: "t" }) + "\n",
+      "utf8",
+    );
+
+    let out = "";
+    process.stdout.write = (chunk, enc, cb) => {
+      out += typeof chunk === "string" ? chunk : chunk.toString(enc || "utf8");
+      if (typeof cb === "function") cb();
+      return true;
+    };
+
+    await cmdStatus();
+
+    assert.match(out, /- Codex notify: unset/);
   } finally {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;


### PR DESCRIPTION
## Summary

Fix Codex refresh staleness in the macOS app without making background polling heavier.

## What changed

- Trigger a throttled lightweight sync when the menu bar popover opens, then debounce repeated dashboard reloads.
- Refresh the installed local notify handler from `serve` and safely repair Codex notify when TokenTracker is missing.
- Preserve and runtime-chain an existing SkyComputerUseClient notify command when TokenTracker takes over Codex notify.
- Make `status` report Codex notify as configured only when it points at TokenTracker, so Sky-only configs no longer look healthy.
- Add regression coverage for Sky coexistence, stale notify backups, popover-open refresh routing, and status detection.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Verification

- [x] `node --test test/macos-popover-anchor-window.test.js test/init-uninstall.test.js test/status.test.js test/codex-config-multiline-notify.test.js test/local-api-background.test.js test/sync-background.test.js`
- [x] `npm test` (1328 tests passed)
- [x] `git diff --check`
- [x] `cd TokenTrackerBar && xcodebuild build -scheme TokenTrackerBar -destination 'platform=macOS'`

## Notes

The full `TokenTrackerBarTests` scheme currently fails before this change's tests due an unrelated test-target wiring issue: `WeeklyLimitResetDetector.swift` references `Strings`, which is not available in that test target. The macOS app build itself succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popover opening now uses timing-aware “lightweight sync” logic and conditionally queues follow-up loads.
  * Startup now proactively repairs Codex notification wiring when needed.
* **Bug Fixes**
  * Notify command chaining avoids duplicating payload arguments; status now validates Codex notify via exact command match.
  * Uninstall messaging clarifies when restore is skipped because the current notify isn’t managed.
  * Improved notify/TOML parsing and safer restore gating for mismatched current configuration.
* **Tests**
  * Expanded coverage for popover refresh timing/queueing, Codex notify repair/backup behavior, status output, and multiline escape/restore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->