### PR TITLE
Revert "Migrate workflows to Blacksmith (#292)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   ci:
     name: test + validate + build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -63,7 +63,7 @@ jobs:
 
   macos-tests:
     name: macOS unit tests
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (javascript-typescript)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/leaderboard-freshness.yml
+++ b/.github/workflows/leaderboard-freshness.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   probe:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       API: https://srctyff5.us-east.insforge.app/functions/tokentracker-leaderboard
       # Staleness budgets (hours). Each period's cron cadence + generous slack:

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lock:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
   # 22.18+) and loads undici 8 (needs webidl.markAsUncloneable) — neither works
   # on Node 20. The published package itself is built/published on Node 20 below.
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -21,7 +21,7 @@ jobs:
   # PREVIOUS complete version until the publish job flips this one live, once
   # every asset is attached. Cheap (~10s on ubuntu).
   create-release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -48,7 +48,7 @@ jobs:
     # and hero number disappeared in shipped DMGs even though the same
     # source rendered fine locally. Pinning to macos-26 keeps the SDK in
     # sync with local builds.
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: macos-26
     permissions:
       contents: write
     steps:
@@ -248,7 +248,7 @@ jobs:
   # where the tap saw vX.Y.Z before the DMG asset existed.
   publish:
     needs: [build, windows]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
This reverts commit 0aecd4eb02ab50ce45e9672438f2e1f00940281c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows to use GitHub-hosted runners instead of pinned custom environments.
  * Improved consistency across CI, code scanning, labeling, stale handling, package publishing, and release workflows.
  * Updated macOS, Windows, and Linux job targets to current hosted images for broader compatibility and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->