### PR TITLE
fix: harden notify chaining repair edge cases

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1232,10 +1232,12 @@ function spawnDetached(argv) {
   } catch (_) {}
 }
 
-function resolveMaybeHome(p) {
+function resolveMaybeHome(p, baseDir = null) {
   if (typeof p !== 'string') return null;
   if (p.startsWith('~/')) return path.join(home, p.slice(2));
-  return path.resolve(p);
+  if (p.startsWith('~\\\\')) return path.join(home, p.slice(2));
+  if (path.isAbsolute(p)) return p;
+  return path.resolve(baseDir || process.cwd(), p);
 }
 
 function isSelfNotify(cmd) {
@@ -1266,14 +1268,15 @@ function isSelfNotifyPath(resolved) {
 
 function shouldChainNotify(cmd) {
   if (!Array.isArray(cmd) || cmd.length === 0) return false;
-  return isRunnableCommand(cmd[0]);
+  if (!isRunnableCommand(cmd[0])) return false;
+  return hasRunnableInterpreterTarget(cmd);
 }
 
-function isRunnableCommand(command) {
+function isRunnableCommand(command, baseDir = null) {
   if (typeof command !== 'string' || command.length === 0) return false;
-  const explicitPath = command.startsWith('~/') || command.includes('/');
+  const explicitPath = isExplicitPath(command);
   if (!explicitPath) return true;
-  const resolved = resolveMaybeHome(command);
+  const resolved = resolveMaybeHome(command, baseDir);
   if (!resolved) return false;
   try {
     fs.accessSync(resolved, fs.constants.X_OK);
@@ -1281,6 +1284,593 @@ function isRunnableCommand(command) {
   } catch (_) {
     return false;
   }
+}
+
+function hasRunnableInterpreterTarget(cmd) {
+  const normalized = normalizeInterpreterCommand(cmd);
+  const interpreterCmd = normalized?.cmd;
+  if (!interpreterCmd || interpreterCmd.length === 0) return false;
+  const targetIndex = findInterpreterTargetIndex(interpreterCmd);
+  if (targetIndex == null) {
+    const command = interpreterCmd[0];
+    if (!isExplicitPath(command)) return true;
+    return isRunnableCommand(command, normalized.cwd);
+  }
+  if (targetIndex === -2) return true;
+  if (targetIndex === -1) return false;
+  const target = interpreterCmd[targetIndex];
+  if (!isExplicitPath(target)) return false;
+  const targetCwd = isBunCommand(interpreterCmd[0])
+    ? findBunScriptCwd(interpreterCmd, 1, normalized.cwd)
+    : normalized.cwd;
+  return isReadablePath(target, targetCwd);
+}
+
+function normalizeInterpreterCommand(cmd) {
+  if (!isEnvCommand(cmd[0])) return { cmd, cwd: null };
+  return extractEnvCommand(cmd);
+}
+
+function findInterpreterTargetIndex(cmd) {
+  const command = cmd[0];
+  if (isNodeCommand(command)) {
+    return findNodeLikeScriptIndex(cmd, 1);
+  }
+  if (isBunCommand(command)) {
+    return findBunScriptIndex(cmd, 1);
+  }
+  if (isDenoCommand(command)) {
+    return findDenoScriptIndex(cmd, 1);
+  }
+  return null;
+}
+
+function isEnvCommand(command) {
+  const base = commandBase(command);
+  return base === 'env';
+}
+
+function extractEnvCommand(cmd) {
+  return normalizeEnvArgs(cmd.slice(1));
+}
+
+function normalizeEnvArgs(args, cwd = null) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg !== 'string' || arg.length === 0) return null;
+    if (arg === '-' || arg === '--ignore-environment' || isEnvValuelessShortOption(arg)) continue;
+    if (arg === '--') return normalizeEnvCommandOperands(args.slice(i + 1), cwd);
+    if (arg === '-S' || arg === '--split-string') {
+      const split = splitEnvString(args[i + 1]);
+      if (!split) return null;
+      return normalizeEnvArgs(split.concat(args.slice(i + 2)), cwd);
+    }
+    if (arg.startsWith('--split-string=')) {
+      const split = splitEnvString(arg.slice('--split-string='.length));
+      if (!split) return null;
+      return normalizeEnvArgs(split.concat(args.slice(i + 1)), cwd);
+    }
+    if (arg === '-u' || arg === '--unset') {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--unset=')) continue;
+    if (arg === '-C' || arg === '--chdir') {
+      const next = args[i + 1];
+      if (typeof next !== 'string' || next.length === 0) return null;
+      cwd = resolveMaybeHome(next, cwd);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--chdir=')) {
+      const dir = arg.slice('--chdir='.length);
+      if (dir.length === 0) return null;
+      cwd = resolveMaybeHome(dir, cwd);
+      continue;
+    }
+    if (isEnvValueOption(arg)) {
+      i += 1;
+      continue;
+    }
+    if (isEnvInlineValueOption(arg)) continue;
+    if (arg.startsWith('-')) return null;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) continue;
+    return { cmd: args.slice(i), cwd };
+  }
+  return null;
+}
+
+function normalizeEnvCommandOperands(args, cwd) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg !== 'string' || arg.length === 0) return null;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) continue;
+    if (arg.startsWith('-')) return null;
+    return { cmd: args.slice(i), cwd };
+  }
+  return null;
+}
+
+function isEnvValuelessShortOption(arg) {
+  return /^-[0iv]+$/.test(arg);
+}
+
+function isEnvValueOption(arg) {
+  return arg === '-P' || arg === '--path';
+}
+
+function isEnvInlineValueOption(arg) {
+  return (
+    arg.startsWith('--path=')
+  );
+}
+
+function splitEnvString(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const parts = [];
+  let current = '';
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\\s/.test(ch)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (escaped || quote) return null;
+  if (current.length > 0) parts.push(current);
+  return parts.length > 0 ? parts : null;
+}
+
+function isNodeCommand(command) {
+  const base = commandBase(command);
+  return base === 'node';
+}
+
+function isBunCommand(command) {
+  const base = commandBase(command);
+  return base === 'bun';
+}
+
+function isDenoCommand(command) {
+  const base = commandBase(command);
+  return base === 'deno';
+}
+
+function commandBase(command) {
+  if (typeof command !== 'string' || command.length === 0) return '';
+  const posixBase = path.basename(command);
+  const winBase = path.win32.basename(command);
+  const base = winBase.length < posixBase.length ? winBase : posixBase;
+  return base.replace(/\\.exe$/i, '').toLowerCase();
+}
+
+function findNodeLikeScriptIndex(cmd, startIndex) {
+  for (let i = startIndex; i < cmd.length; i++) {
+    const arg = cmd[i];
+    if (typeof arg !== 'string' || arg.length === 0) return -1;
+    if (arg === '-e' || arg === '--eval' || arg === '-p' || arg === '--print') return -2;
+    if (arg.startsWith('--eval=') || arg.startsWith('--print=')) return -2;
+    if (isNodeLikeOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (hasInlineNodeLikeOptionValue(arg)) continue;
+    if (isNodeLikeValuelessOption(arg)) continue;
+    if (arg.startsWith('-')) return -1;
+    return i;
+  }
+  return -1;
+}
+
+function findBunScriptIndex(cmd, startIndex) {
+  for (let i = startIndex; i < cmd.length; i++) {
+    const arg = cmd[i];
+    if (typeof arg !== 'string' || arg.length === 0) return -1;
+    if (arg === '-e' || arg === '--eval' || arg === '-p' || arg === '--print') return -2;
+    if (arg.startsWith('--eval=') || arg.startsWith('--print=')) return -2;
+    if (isBunOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (hasInlineBunOptionValue(arg)) continue;
+    if (isBunValuelessOption(arg)) continue;
+    if (arg === 'run') {
+      return findScriptAfterSubcommand(cmd, i + 1, 'bun');
+    }
+    if (arg.startsWith('-')) return -1;
+    return i;
+  }
+  return -1;
+}
+
+function findBunScriptCwd(cmd, startIndex, baseDir = null) {
+  let cwd = baseDir;
+  for (let i = startIndex; i < cmd.length; i++) {
+    const arg = cmd[i];
+    if (typeof arg !== 'string' || arg.length === 0) return cwd;
+    if (arg === '--cwd') {
+      const next = cmd[i + 1];
+      if (typeof next !== 'string' || next.length === 0) return cwd;
+      cwd = resolveMaybeHome(next, cwd);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--cwd=')) {
+      const next = arg.slice('--cwd='.length);
+      if (next.length === 0) return cwd;
+      cwd = resolveMaybeHome(next, cwd);
+      continue;
+    }
+    if (arg === '-e' || arg === '--eval' || arg === '-p' || arg === '--print') return cwd;
+    if (arg.startsWith('--eval=') || arg.startsWith('--print=')) return cwd;
+    if (isBunOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (hasInlineBunOptionValue(arg)) continue;
+    if (isBunValuelessOption(arg)) continue;
+    if (arg === 'run') return findBunScriptCwd(cmd, i + 1, cwd);
+    return cwd;
+  }
+  return cwd;
+}
+
+function findDenoScriptIndex(cmd, startIndex) {
+  for (let i = startIndex; i < cmd.length; i++) {
+    const arg = cmd[i];
+    if (typeof arg !== 'string' || arg.length === 0) return -1;
+    if (arg === 'eval') return -2;
+    if (arg === 'run' || arg === 'test' || arg === 'bench' || arg === 'check') {
+      return findScriptAfterSubcommand(cmd, i + 1, 'deno');
+    }
+    if (isDenoOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (hasInlineDenoOptionValue(arg)) continue;
+    if (isDenoValuelessOption(arg)) continue;
+    if (arg.startsWith('-')) return -1;
+    return i;
+  }
+  return -1;
+}
+
+function findScriptAfterSubcommand(cmd, startIndex, runtime) {
+  for (let i = startIndex; i < cmd.length; i++) {
+    const arg = cmd[i];
+    if (typeof arg !== 'string' || arg.length === 0) return -1;
+    if (runtime === 'bun' && isBunOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (runtime === 'deno' && isDenoOptionWithValue(arg)) {
+      i += 1;
+      continue;
+    }
+    if (runtime === 'bun' && hasInlineBunOptionValue(arg)) continue;
+    if (runtime === 'deno' && hasInlineDenoOptionValue(arg)) continue;
+    if (runtime === 'bun' && isBunValuelessOption(arg)) continue;
+    if (runtime === 'deno' && isDenoValuelessOption(arg)) continue;
+    if (arg.startsWith('-')) return -1;
+    return i;
+  }
+  return -1;
+}
+
+function isNodeLikeOptionWithValue(arg) {
+  return (
+    arg === '-C' ||
+    arg === '-r' ||
+    arg === '--conditions' ||
+    arg === '--debug-port' ||
+    arg === '--disable-warning' ||
+    arg === '--env-file' ||
+    arg === '--env-file-if-exists' ||
+    arg === '--experimental-config-file' ||
+    arg === '--experimental-loader' ||
+    arg === '--import' ||
+    arg === '--inspect-publish-uid' ||
+    arg === '--loader' ||
+    arg === '--localstorage-file' ||
+    arg === '--require'
+  );
+}
+
+function hasInlineNodeLikeOptionValue(arg) {
+  return (
+    arg.startsWith('--conditions=') ||
+    arg.startsWith('--debug-port=') ||
+    arg.startsWith('--disable-warning=') ||
+    arg.startsWith('--env-file=') ||
+    arg.startsWith('--env-file-if-exists=') ||
+    arg.startsWith('--experimental-config-file=') ||
+    arg.startsWith('--experimental-loader=') ||
+    arg.startsWith('--import=') ||
+    arg.startsWith('--inspect-publish-uid=') ||
+    arg.startsWith('--loader=') ||
+    arg.startsWith('--localstorage-file=') ||
+    arg.startsWith('--require=')
+  );
+}
+
+function isNodeLikeValuelessOption(arg) {
+  return (
+    arg === '-' ||
+    arg === '-c' ||
+    arg === '--' ||
+    arg === '--check' ||
+    arg === '--cpu-prof' ||
+    arg === '--enable-source-maps' ||
+    arg === '--expose-gc' ||
+    arg === '--inspect' ||
+    arg === '--inspect-brk' ||
+    arg === '--inspect-wait' ||
+    arg === '--no-deprecation' ||
+    arg === '--no-warnings' ||
+    arg === '--preserve-symlinks' ||
+    arg === '--preserve-symlinks-main' ||
+    arg === '--throw-deprecation' ||
+    arg === '--trace-deprecation' ||
+    arg === '--trace-warnings'
+  );
+}
+
+function isBunOptionWithValue(arg) {
+  return (
+    arg === '-c' ||
+    arg === '-d' ||
+    arg === '-F' ||
+    arg === '-l' ||
+    arg === '-r' ||
+    arg === '--config' ||
+    arg === '--conditions' ||
+    arg === '--console-depth' ||
+    arg === '--cpu-prof-dir' ||
+    arg === '--cpu-prof-interval' ||
+    arg === '--cpu-prof-name' ||
+    arg === '--cwd' ||
+    arg === '--define' ||
+    arg === '--dns-result-order' ||
+    arg === '--drop' ||
+    arg === '--elide-lines' ||
+    arg === '--env-file' ||
+    arg === '--extension-order' ||
+    arg === '--feature' ||
+    arg === '--fetch-preconnect' ||
+    arg === '--filter' ||
+    arg === '--import' ||
+    arg === '--inspect' ||
+    arg === '--inspect-brk' ||
+    arg === '--inspect-wait' ||
+    arg === '--install' ||
+    arg === '--jsx-factory' ||
+    arg === '--jsx-fragment' ||
+    arg === '--jsx-import-source' ||
+    arg === '--jsx-runtime' ||
+    arg === '--loader' ||
+    arg === '--main-fields' ||
+    arg === '--max-http-header-size' ||
+    arg === '--port' ||
+    arg === '--preload' ||
+    arg === '--require' ||
+    arg === '--shell' ||
+    arg === '--title' ||
+    arg === '--tsconfig-override' ||
+    arg === '--unhandled-rejections' ||
+    arg === '--user-agent'
+  );
+}
+
+function hasInlineBunOptionValue(arg) {
+  return (
+    arg.startsWith('--config=') ||
+    arg.startsWith('--conditions=') ||
+    arg.startsWith('--console-depth=') ||
+    arg.startsWith('--cpu-prof-dir=') ||
+    arg.startsWith('--cpu-prof-interval=') ||
+    arg.startsWith('--cpu-prof-name=') ||
+    arg.startsWith('--cwd=') ||
+    arg.startsWith('--define=') ||
+    arg.startsWith('--dns-result-order=') ||
+    arg.startsWith('--drop=') ||
+    arg.startsWith('--elide-lines=') ||
+    arg.startsWith('--env-file=') ||
+    arg.startsWith('--extension-order=') ||
+    arg.startsWith('--feature=') ||
+    arg.startsWith('--fetch-preconnect=') ||
+    arg.startsWith('--filter=') ||
+    arg.startsWith('--import=') ||
+    arg.startsWith('--inspect=') ||
+    arg.startsWith('--inspect-brk=') ||
+    arg.startsWith('--inspect-wait=') ||
+    arg.startsWith('--install=') ||
+    arg.startsWith('--jsx-factory=') ||
+    arg.startsWith('--jsx-fragment=') ||
+    arg.startsWith('--jsx-import-source=') ||
+    arg.startsWith('--jsx-runtime=') ||
+    arg.startsWith('--loader=') ||
+    arg.startsWith('--main-fields=') ||
+    arg.startsWith('--max-http-header-size=') ||
+    arg.startsWith('--port=') ||
+    arg.startsWith('--preload=') ||
+    arg.startsWith('--require=') ||
+    arg.startsWith('--shell=') ||
+    arg.startsWith('--title=') ||
+    arg.startsWith('--tsconfig-override=') ||
+    arg.startsWith('--unhandled-rejections=') ||
+    arg.startsWith('--user-agent=')
+  );
+}
+
+function isBunValuelessOption(arg) {
+  return (
+    arg === '-b' ||
+    arg === '-i' ||
+    arg === '--bun' ||
+    arg === '--cpu-prof' ||
+    arg === '--cpu-prof-md' ||
+    arg === '--expose-gc' ||
+    arg === '--heap-prof' ||
+    arg === '--heap-prof-md' ||
+    arg === '--hot' ||
+    arg === '--if-present' ||
+    arg === '--ignore-dce-annotations' ||
+    arg === '--jsx-side-effects' ||
+    arg === '--no-addons' ||
+    arg === '--no-clear-screen' ||
+    arg === '--no-deprecation' ||
+    arg === '--no-env-file' ||
+    arg === '--no-exit-on-error' ||
+    arg === '--no-install' ||
+    arg === '--no-macros' ||
+    arg === '--parallel' ||
+    arg === '--prefer-latest' ||
+    arg === '--prefer-offline' ||
+    arg === '--preserve-symlinks' ||
+    arg === '--preserve-symlinks-main' ||
+    arg === '--redis-preconnect' ||
+    arg === '--sequential' ||
+    arg === '--silent' ||
+    arg === '--smol' ||
+    arg === '--sql-preconnect' ||
+    arg === '--throw-deprecation' ||
+    arg === '--use-bundled-ca' ||
+    arg === '--use-openssl-ca' ||
+    arg === '--use-system-ca' ||
+    arg === '--watch' ||
+    arg === '--workspaces' ||
+    arg === '--zero-fill-buffers'
+  );
+}
+
+function isDenoOptionWithValue(arg) {
+  return (
+    arg === '-c' ||
+    arg === '--cert' ||
+    arg === '--conditions' ||
+    arg === '--config' ||
+    arg === '--cpu-prof-dir' ||
+    arg === '--cpu-prof-interval' ||
+    arg === '--cpu-prof-name' ||
+    arg === '--ext' ||
+    arg === '--import-map' ||
+    arg === '--location' ||
+    arg === '--lock' ||
+    arg === '--minimum-dependency-age' ||
+    arg === '--preload' ||
+    arg === '--require' ||
+    arg === '--seed'
+  );
+}
+
+function hasInlineDenoOptionValue(arg) {
+  return (
+    arg.startsWith('--cert=') ||
+    arg.startsWith('--conditions=') ||
+    arg.startsWith('--config=') ||
+    arg.startsWith('--coverage=') ||
+    arg.startsWith('--cpu-prof-dir=') ||
+    arg.startsWith('--cpu-prof-interval=') ||
+    arg.startsWith('--cpu-prof-name=') ||
+    arg.startsWith('--env-file=') ||
+    arg.startsWith('--ext=') ||
+    arg.startsWith('--import-map=') ||
+    arg.startsWith('--location=') ||
+    arg.startsWith('--lock=') ||
+    arg.startsWith('--minimum-dependency-age=') ||
+    arg.startsWith('--node-modules-dir=') ||
+    arg.startsWith('--preload=') ||
+    arg.startsWith('--require=') ||
+    arg.startsWith('--seed=') ||
+    arg.startsWith('--vendor=') ||
+    arg.startsWith('--v8-flags=') ||
+    /^--(allow|deny|ignore)-[A-Za-z-]+=/.test(arg) ||
+    arg.startsWith('--permission-set=') ||
+    arg.startsWith('--reload=') ||
+    arg.startsWith('--tunnel=') ||
+    arg.startsWith('--watch=') ||
+    arg.startsWith('--watch-exclude=') ||
+    arg.startsWith('--watch-hmr=')
+  );
+}
+
+function isDenoValuelessOption(arg) {
+  return (
+    arg === '-A' ||
+    arg === '-P' ||
+    arg === '-q' ||
+    arg === '-r' ||
+    arg === '-t' ||
+    arg === '--allow-all' ||
+    arg === '--cached-only' ||
+    arg === '--coverage' ||
+    arg === '--cpu-prof' ||
+    arg === '--cpu-prof-flamegraph' ||
+    arg === '--cpu-prof-md' ||
+    arg === '--env-file' ||
+    arg === '--frozen' ||
+    arg === '--no-check' ||
+    arg === '--no-clear-screen' ||
+    arg === '--no-code-cache' ||
+    arg === '--no-config' ||
+    arg === '--no-lock' ||
+    arg === '--no-npm' ||
+    arg === '--no-prompt' ||
+    arg === '--no-remote' ||
+    arg === '--node-modules-dir' ||
+    arg === '--quiet' ||
+    arg === '--reload' ||
+    arg === '--tunnel' ||
+    arg === '--unstable' ||
+    arg === '--v8-flags' ||
+    arg === '--vendor' ||
+    arg === '--watch' ||
+    arg === '--watch-exclude' ||
+    arg === '--watch-hmr' ||
+    /^-[RWINESA]$/.test(arg) ||
+    /^--(allow|deny|ignore)-[A-Za-z-]+$/.test(arg) ||
+    arg === '--permission-set'
+  );
+}
+
+function isReadablePath(target, baseDir = null) {
+  const resolved = resolveMaybeHome(target, baseDir);
+  if (!resolved) return false;
+  try {
+    fs.accessSync(resolved, fs.constants.R_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function isExplicitPath(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return value.startsWith('~/') || value.startsWith('~\\\\') || value.includes('/') || value.includes('\\\\') || /^[A-Za-z]:/.test(value);
 }
 
 function containsSequence(haystack, needle) {

--- a/src/lib/codex-config.js
+++ b/src/lib/codex-config.js
@@ -55,12 +55,12 @@ async function restoreNotify({ configPath, notifyOriginalPath, expectedNotify })
   const originalNotify = Array.isArray(original?.notify) ? original.notify : null;
   const currentNotify = extractNotify(text);
 
-  if (expectedNotify && !arraysEqual(currentNotify, expectedNotify)) {
-    return { restored: false, skippedReason: "current-not-managed" };
+  if (!originalNotify && expectedNotify && currentNotify == null) {
+    return { restored: false, skippedReason: "no-backup-not-installed" };
   }
 
-  if (!originalNotify && expectedNotify && !arraysEqual(currentNotify, expectedNotify)) {
-    return { restored: false, skippedReason: "no-backup-not-installed" };
+  if (expectedNotify && !arraysEqual(currentNotify, expectedNotify)) {
+    return { restored: false, skippedReason: "current-not-managed" };
   }
 
   const updated = originalNotify ? setNotify(text, originalNotify) : removeNotify(text);
@@ -161,15 +161,16 @@ function extractNotify(text) {
   const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (isTomlTableHeader(line)) break;
     const m = line.match(/^\s*notify\s*=\s*(.*)\s*$/);
     if (!m) continue;
 
     const rhs = (m[1] || "").trim();
     const literal = readTomlArrayLiteral(lines, i, rhs);
-    if (!literal) continue;
+    if (!literal) return null;
 
     const parsed = parseTomlStringArray(literal);
-    if (parsed) return parsed;
+    return parsed;
   }
   return null;
 }
@@ -182,6 +183,14 @@ function setNotify(text, notifyCmd) {
   let replaced = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (isTomlTableHeader(line)) {
+      if (!replaced) {
+        out.push(notifyLine);
+        replaced = true;
+      }
+      out.push(...lines.slice(i));
+      break;
+    }
     const m = line.match(/^\s*notify\s*=\s*(.*)\s*$/);
     if (m) {
       if (!replaced) {
@@ -190,7 +199,7 @@ function setNotify(text, notifyCmd) {
       }
 
       const rhs = (m[1] || "").trim();
-      i = findTomlArrayBlockEnd(lines, i, rhs);
+      i = findNotifyBlockEnd(lines, i, rhs);
       continue;
     }
     out.push(line);
@@ -211,10 +220,14 @@ function removeNotify(text) {
   const out = [];
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (isTomlTableHeader(line)) {
+      out.push(...lines.slice(i));
+      break;
+    }
     const m = line.match(/^\s*notify\s*=\s*(.*)\s*$/);
     if (m) {
       const rhs = (m[1] || "").trim();
-      i = findTomlArrayBlockEnd(lines, i, rhs);
+      i = findNotifyBlockEnd(lines, i, rhs);
       continue;
     }
     out.push(line);
@@ -225,45 +238,78 @@ function removeNotify(text) {
 function parseTomlStringArray(rhs) {
   // Minimal parser for TOML basic/literal string arrays.
   if (!rhs.startsWith("[") || !rhs.endsWith("]")) return null;
-  const inner = rhs.slice(1, -1).trim();
-  if (!inner) return [];
 
   const parts = [];
-  let current = "";
-  let inString = false;
-  let quote = null;
-  for (let i = 0; i < inner.length; i++) {
-    const ch = inner[i];
-    if (!inString) {
-      if (ch === '"' || ch === "'") {
-        inString = true;
-        quote = ch;
-        current = "";
+  let i = 1;
+  let expectValue = true;
+
+  function skipSpaceAndComments() {
+    while (i < rhs.length) {
+      const ch = rhs[i];
+      if (/\s/.test(ch)) {
+        i += 1;
+        continue;
       }
-      continue;
+      if (ch === "#") {
+        while (i < rhs.length && rhs[i] !== "\n") i += 1;
+        continue;
+      }
+      break;
     }
-    if (ch === quote) {
-      parts.push(current);
-      inString = false;
-      quote = null;
-      continue;
-    }
-    if (quote === '"' && ch === "\\") {
-      if (i + 1 >= inner.length) return null;
-      const next = inner[++i];
-      if (next === "b") current += "\b";
-      else if (next === "t") current += "\t";
-      else if (next === "n") current += "\n";
-      else if (next === "f") current += "\f";
-      else if (next === "r") current += "\r";
-      else if (next === '"' || next === "\\" || next === "/") current += next;
-      else return null;
-      continue;
-    }
-    current += ch;
   }
 
-  return parts.length > 0 ? parts : null;
+  function parseString() {
+    const quote = rhs[i];
+    if (quote !== '"' && quote !== "'") return null;
+    i += 1;
+    let value = "";
+    while (i < rhs.length) {
+      const ch = rhs[i];
+      if (ch === quote) {
+        i += 1;
+        return value;
+      }
+      if (ch === "\n" || ch === "\r") return null;
+      if (quote === '"' && ch === "\\") {
+        if (i + 1 >= rhs.length) return null;
+        const next = rhs[i + 1];
+        if (next === "b") value += "\b";
+        else if (next === "t") value += "\t";
+        else if (next === "n") value += "\n";
+        else if (next === "f") value += "\f";
+        else if (next === "r") value += "\r";
+        else if (next === '"' || next === "\\" || next === "/") value += next;
+        else return null;
+        i += 2;
+        continue;
+      }
+      value += ch;
+      i += 1;
+    }
+    return null;
+  }
+
+  while (i < rhs.length) {
+    skipSpaceAndComments();
+    if (rhs[i] === "]") {
+      i += 1;
+      skipSpaceAndComments();
+      return i === rhs.length ? parts : null;
+    }
+    if (!expectValue) {
+      if (rhs[i] !== ",") return null;
+      i += 1;
+      expectValue = true;
+      continue;
+    }
+
+    const value = parseString();
+    if (value == null) return null;
+    parts.push(value);
+    expectValue = false;
+  }
+
+  return null;
 }
 
 function formatTomlStringArray(arr) {
@@ -278,6 +324,7 @@ function readTomlArrayLiteral(lines, startIndex, rhs) {
   let quote = null;
   let depth = 0;
   let sawOpen = false;
+  let invalid = false;
 
   function scanChunk(chunk) {
     for (let i = 0; i < chunk.length; i++) {
@@ -295,7 +342,10 @@ function readTomlArrayLiteral(lines, startIndex, rhs) {
         }
         if (ch === "]") {
           depth -= 1;
-          if (sawOpen && depth === 0) return i;
+          if (sawOpen && depth === 0) {
+            if (!isTomlArrayTrailer(chunk.slice(i + 1))) invalid = true;
+            return i;
+          }
         }
         continue;
       }
@@ -305,6 +355,10 @@ function readTomlArrayLiteral(lines, startIndex, rhs) {
         continue;
       }
       if (quote === '"' && ch === "\\") {
+        if (i + 1 >= chunk.length) {
+          invalid = true;
+          return -1;
+        }
         i += 1;
       }
     }
@@ -313,11 +367,13 @@ function readTomlArrayLiteral(lines, startIndex, rhs) {
 
   const parts = [first];
   let endPos = scanChunk(first);
+  if (invalid) return null;
   if (endPos !== -1) return first.slice(0, endPos + 1).trim();
 
   for (let j = startIndex + 1; j < lines.length; j++) {
     const line = lines[j];
     endPos = scanChunk(line);
+    if (invalid) return null;
     if (endPos !== -1) {
       parts.push(line.slice(0, endPos + 1));
       return parts.join("\n").trim();
@@ -336,6 +392,7 @@ function findTomlArrayBlockEnd(lines, startIndex, rhs) {
   let quote = null;
   let depth = 0;
   let sawOpen = false;
+  let invalid = false;
 
   function scanChunk(chunk) {
     for (let i = 0; i < chunk.length; i++) {
@@ -353,7 +410,10 @@ function findTomlArrayBlockEnd(lines, startIndex, rhs) {
         }
         if (ch === "]") {
           depth -= 1;
-          if (sawOpen && depth === 0) return true;
+          if (sawOpen && depth === 0) {
+            if (!isTomlArrayTrailer(chunk.slice(i + 1))) invalid = true;
+            return true;
+          }
         }
         continue;
       }
@@ -363,6 +423,10 @@ function findTomlArrayBlockEnd(lines, startIndex, rhs) {
         continue;
       }
       if (quote === '"' && ch === "\\") {
+        if (i + 1 >= chunk.length) {
+          invalid = true;
+          return false;
+        }
         i += 1;
       }
     }
@@ -370,10 +434,41 @@ function findTomlArrayBlockEnd(lines, startIndex, rhs) {
   }
 
   if (scanChunk(first)) return startIndex;
+  if (invalid) return startIndex;
   for (let j = startIndex + 1; j < lines.length; j++) {
     if (scanChunk(lines[j])) return j;
+    if (invalid) return startIndex;
   }
   return startIndex;
+}
+
+function findNotifyBlockEnd(lines, startIndex, rhs) {
+  const endIndex = findTomlArrayBlockEnd(lines, startIndex, rhs);
+  const literal = readTomlArrayLiteral(lines, startIndex, rhs);
+  if (
+    endIndex !== startIndex ||
+    !rhs.trim().startsWith("[") ||
+    (literal && parseTomlStringArray(literal))
+  ) {
+    return endIndex;
+  }
+
+  for (let j = startIndex + 1; j < lines.length; j++) {
+    if (isTopLevelTomlBoundary(lines[j])) return j - 1;
+  }
+  return lines.length - 1;
+}
+
+function isTomlTableHeader(line) {
+  return /^\s*\[\[?[^\]]+\]\]?\s*(?:#.*)?$/.test(line);
+}
+
+function isTopLevelTomlBoundary(line) {
+  return /^\s*(?:\[\[?[^\]]+\]\]?|(?:[A-Za-z0-9_-]+|"[^"]+"|'[^']+')(?:\s*\.\s*(?:[A-Za-z0-9_-]+|"[^"]+"|'[^']+'))*\s*=)/.test(line);
+}
+
+function isTomlArrayTrailer(text) {
+  return /^\s*(?:#.*)?$/.test(text);
 }
 
 function arraysEqual(a, b) {

--- a/test/codex-config-multiline-notify.test.js
+++ b/test/codex-config-multiline-notify.test.js
@@ -69,6 +69,25 @@ test("upsertNotify round-trips escaped quotes in notify strings", async () => {
   assert.deepEqual(await readNotify(configPath), notify);
 });
 
+test("readNotify rejects malformed notify arrays", async () => {
+  const cases = [
+    'notify = ["a" "b"]\n',
+    'notify = ["/usr/bin/env", 1]\n',
+    'notify = ["a"] trailing\n',
+    'notify = ["a" "b"]\nnotify = ["valid"]\n',
+    "notify = [\"unterminated\\" + "\n\"]\n",
+    'notify = ["unterminated\\\\\n"]\n',
+  ];
+
+  for (const source of cases) {
+    const dir = tmpDir("tokentracker-codex-config-");
+    const configPath = path.join(dir, "config.toml");
+    fs.writeFileSync(configPath, source, "utf8");
+
+    assert.equal(await readNotify(configPath), null, source);
+  }
+});
+
 test("upsertNotify replaces multi-line notify blocks without leaving trailing lines", async () => {
   const dir = tmpDir("tokentracker-codex-upsert-");
   const configPath = path.join(dir, "config.toml");
@@ -115,6 +134,188 @@ test("upsertNotify replaces multi-line notify blocks without leaving trailing li
     "/Users/tokentracker/.bun/bin/bun",
     "/Users/tokentracker/.confirmo/hooks/confirmo-codex-hook.js",
   ]);
+});
+
+test("upsertNotify removes unterminated multi-line notify blocks before replacing", async () => {
+  const dir = tmpDir("tokentracker-codex-upsert-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+
+  fs.writeFileSync(
+    configPath,
+    [
+      'model = "gpt-5.3-codex"',
+      "notify = [",
+      '  "/Users/tokentracker/.bun/bin/bun",',
+      '  "/Users/tokentracker/.confirmo/hooks/confirmo-codex-hook.js"',
+      'personality = "pragmatic"',
+    ].join("\n"),
+    "utf8",
+  );
+
+  const newNotify = ["/usr/bin/env", "node", "/Users/tokentracker/.tokentracker/bin/notify.cjs"];
+  const result = await upsertNotify({
+    configPath,
+    notifyCmd: newNotify,
+    notifyOriginalPath,
+    configLabel: "Codex config",
+  });
+  assert.equal(result.changed, true);
+
+  const updated = fs.readFileSync(configPath, "utf8");
+  assert.equal(updated.includes("confirmo-codex-hook.js"), false);
+  assert.equal(updated.includes('personality = "pragmatic"'), true);
+  assert.equal(updated.match(/^\s*notify\s*=/gm)?.length, 1);
+  assert.equal(fs.existsSync(notifyOriginalPath), false);
+});
+
+test("upsertNotify preserves valid single-line notify boundaries", async () => {
+  const cases = [
+    ["dotted", 'notify = ["old"]\nprofile.name = "alice"\nmodel = "gpt-5"\n'],
+    ["quoted", 'notify = ["old"]\n"profile.name" = "alice"\nmodel = "gpt-5"\n'],
+    ["comment-eof", 'notify = ["old"]\n# keep this comment\n'],
+  ];
+
+  for (const [name, source] of cases) {
+    const dir = tmpDir(`tokentracker-codex-${name}-`);
+    const configPath = path.join(dir, "config.toml");
+    const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+    const managedNotify = ["/usr/bin/env", "node", "/Users/tokentracker/.tokentracker/bin/notify.cjs"];
+    fs.writeFileSync(configPath, source, "utf8");
+
+    await upsertNotify({
+      configPath,
+      notifyCmd: managedNotify,
+      notifyOriginalPath,
+      configLabel: "Codex config",
+      captureOriginal: false,
+    });
+
+    const updated = fs.readFileSync(configPath, "utf8");
+    assert.equal(updated.includes("profile.name"), source.includes("profile.name"), name);
+    assert.equal(updated.includes("# keep this comment"), source.includes("# keep this comment"), name);
+    assert.equal(updated.match(/^\s*notify\s*=/gm)?.length, 1, name);
+  }
+});
+
+test("top-level notify operations do not rewrite table-scoped notify", async () => {
+  const dir = tmpDir("tokentracker-codex-table-scope-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+  const managedNotify = ["/usr/bin/env", "node", "/Users/tokentracker/.tokentracker/bin/notify.cjs"];
+
+  fs.writeFileSync(
+    configPath,
+    [
+      'model = "gpt-5"',
+      "[profile.work]",
+      'notify = ["table-notify", "turn-ended"]',
+      'model = "profile-model"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await upsertNotify({
+    configPath,
+    notifyCmd: managedNotify,
+    notifyOriginalPath,
+    configLabel: "Codex config",
+    captureOriginal: false,
+  });
+
+  const updated = fs.readFileSync(configPath, "utf8");
+  assert.match(updated, /^model = "gpt-5"\nnotify = \["\/usr\/bin\/env", "node", "\/Users\/tokentracker\/\.tokentracker\/bin\/notify\.cjs"\]\n\[profile\.work\]/);
+  assert.match(updated, /\[profile\.work\]\nnotify = \["table-notify", "turn-ended"\]/);
+  assert.deepEqual(await readNotify(configPath), managedNotify);
+});
+
+test("readNotify ignores table-scoped notify when no top-level notify exists", async () => {
+  const dir = tmpDir("tokentracker-codex-table-only-");
+  const configPath = path.join(dir, "config.toml");
+  fs.writeFileSync(
+    configPath,
+    [
+      "[profile.work]",
+      'notify = ["table-notify", "turn-ended"]',
+      'model = "profile-model"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  assert.equal(await readNotify(configPath), null);
+});
+
+test("restoreNotify removal preserves top-level boundaries and table-scoped notify", async () => {
+  const cases = [
+    ["dotted", 'notify = ["managed"]\nprofile.name = "alice"\nmodel = "gpt-5"\n'],
+    ["quoted", 'notify = ["managed"]\n"profile.name" = "alice"\nmodel = "gpt-5"\n'],
+    ["comment-eof", 'notify = ["managed"]\n# keep this comment\n'],
+    [
+      "table-scoped",
+      [
+        'notify = ["managed"]',
+        "[profile.work]",
+        'notify = ["table-notify", "turn-ended"]',
+        'model = "profile-model"',
+        "",
+      ].join("\n"),
+    ],
+  ];
+
+  for (const [name, source] of cases) {
+    const dir = tmpDir(`tokentracker-codex-restore-remove-${name}-`);
+    const configPath = path.join(dir, "config.toml");
+    const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+    fs.writeFileSync(configPath, source, "utf8");
+    fs.writeFileSync(notifyOriginalPath, JSON.stringify({ notify: null, capturedAt: new Date().toISOString() }), "utf8");
+
+    const result = await restoreNotify({
+      configPath,
+      notifyOriginalPath,
+      expectedNotify: ["managed"],
+    });
+
+    assert.equal(result.restored, true, name);
+    const updated = fs.readFileSync(configPath, "utf8");
+    assert.equal(updated.includes('notify = ["managed"]'), false, name);
+    assert.equal(updated.includes("profile.name"), source.includes("profile.name"), name);
+    assert.equal(updated.includes("# keep this comment"), source.includes("# keep this comment"), name);
+    assert.equal(updated.includes('notify = ["table-notify", "turn-ended"]'), source.includes("table-notify"), name);
+  }
+});
+
+test("upsertNotify does not capture a later duplicate notify after malformed notify", async () => {
+  const dir = tmpDir("tokentracker-codex-upsert-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+
+  fs.writeFileSync(
+    configPath,
+    [
+      'model = "gpt-5"',
+      'notify = ["broken" "missing-comma"]',
+      'notify = ["third-party-valid", "turn-ended"]',
+      'personality = "pragmatic"',
+    ].join("\n"),
+    "utf8",
+  );
+
+  const managedNotify = ["/usr/bin/env", "node", "/Users/tokentracker/.tokentracker/bin/notify.cjs"];
+  const result = await upsertNotify({
+    configPath,
+    notifyCmd: managedNotify,
+    notifyOriginalPath,
+    configLabel: "Codex config",
+  });
+  assert.equal(result.changed, true);
+  assert.equal(fs.existsSync(notifyOriginalPath), false);
+  assert.deepEqual(await readNotify(configPath), managedNotify);
+
+  const updated = fs.readFileSync(configPath, "utf8");
+  assert.equal(updated.includes("third-party-valid"), false);
+  assert.equal(updated.match(/^\s*notify\s*=/gm)?.length, 1);
 });
 
 test("restoreNotify restores from notifyOriginalPath even if config was updated", async () => {
@@ -172,4 +373,18 @@ test("restoreNotify skips stale backup when current notify is not managed", asyn
   assert.equal(result.restored, false);
   assert.equal(result.skippedReason, "current-not-managed");
   assert.equal(fs.readFileSync(configPath, "utf8"), 'notify = ["third-party-notify", "new"]\n');
+});
+
+test("restoreNotify reports no backup when notify is not installed", async () => {
+  const dir = tmpDir("tokentracker-codex-restore-");
+  const configPath = path.join(dir, "config.toml");
+  const notifyOriginalPath = path.join(dir, "codex_notify_original.json");
+
+  fs.writeFileSync(configPath, 'model = "gpt-5"\n', "utf8");
+
+  const expectedNotify = ["/usr/bin/env", "node", "/Users/alice/.tokentracker/bin/notify.cjs"];
+  const result = await restoreNotify({ configPath, notifyOriginalPath, expectedNotify });
+  assert.equal(result.restored, false);
+  assert.equal(result.skippedReason, "no-backup-not-installed");
+  assert.equal(fs.readFileSync(configPath, "utf8"), 'model = "gpt-5"\n');
 });

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -271,6 +271,447 @@ test("notify handler avoids duplicating existing payload args when chaining", as
   }
 });
 
+test("notify handler skips interpreter original notify when script target is missing", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const markerPath = path.join(tmp, "missing-script-marker");
+    const fakeNodePath = path.join(tmp, "node");
+    const missingScriptPath = path.join(tmp, "missing-notify.js");
+    await fs.writeFile(
+      fakeNodePath,
+      `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+      "utf8",
+    );
+    await fs.chmod(fakeNodePath, 0o755);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-missing-script"),
+      notify: [fakeNodePath, missingScriptPath, "turn-ended"],
+    });
+
+    assert.equal(await waitForFile(markerPath), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-missing-env-script"),
+      notify: ["/usr/bin/env", fakeNodePath, missingScriptPath, "turn-ended"],
+    });
+
+    assert.equal(await waitForFile(markerPath), null);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler skips node-like original notify without a script target", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const markerPath = path.join(tmp, "missing-target-marker");
+    const fakeNodePath = path.join(tmp, "node");
+    await fs.writeFile(
+      fakeNodePath,
+      `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+      "utf8",
+    );
+    await fs.chmod(fakeNodePath, 0o755);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-node-no-target"),
+      notify: [fakeNodePath],
+    });
+    assert.equal(await waitForFile(markerPath), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-node-no-target"),
+      notify: ["/usr/bin/env", fakeNodePath],
+    });
+    assert.equal(await waitForFile(markerPath), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-node-payload-token"),
+      notify: [fakeNodePath, "turn-ended"],
+    });
+    assert.equal(await waitForFile(markerPath), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-node-payload-token"),
+      notify: ["/usr/bin/env", fakeNodePath, "turn-ended"],
+    });
+    assert.equal(await waitForFile(markerPath), null);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler validates env split-string interpreter targets", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const markerPath = path.join(tmp, "env-split-marker");
+    const fakeEnvPath = path.join(tmp, "env");
+    const fakeNodePath = path.join(tmp, "node");
+    const explicitScriptPath = path.join(tmp, "notify-script.js");
+    await fs.writeFile(
+      fakeEnvPath,
+      `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+      "utf8",
+    );
+    await fs.chmod(fakeEnvPath, 0o755);
+    await fs.writeFile(fakeNodePath, "// readable node executable placeholder\n", "utf8");
+    await fs.writeFile(explicitScriptPath, "// readable notify script\n", "utf8");
+
+    for (const optionNotify of [
+      [fakeEnvPath, "-C", tmp, fakeNodePath, "turn-ended"],
+      [fakeEnvPath, "-P", tmp, fakeNodePath, "turn-ended"],
+      [fakeEnvPath, "--chdir", tmp, fakeNodePath, "turn-ended"],
+      [fakeEnvPath, `--chdir=${tmp}`, fakeNodePath, "turn-ended"],
+      [fakeEnvPath, "--path", tmp, fakeNodePath, "turn-ended"],
+      [fakeEnvPath, `--path=${tmp}`, fakeNodePath, "turn-ended"],
+    ]) {
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-env-option-payload-token-${optionNotify[1].replace(/[^A-Za-z0-9]/g, "-")}`),
+        notify: optionNotify,
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+    }
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-value-option-explicit-script"),
+      notify: [fakeEnvPath, "-C", tmp, fakeNodePath, explicitScriptPath],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `-C|${tmp}|${fakeNodePath}|${explicitScriptPath}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    const chdirDir = path.join(tmp, "env-chdir");
+    const relativeScriptName = "relative-notify.js";
+    const relativeScriptPath = path.join(chdirDir, relativeScriptName);
+    await fs.mkdir(chdirDir);
+    await fs.writeFile(relativeScriptPath, "// readable relative notify script\n", "utf8");
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-chdir-relative-explicit-script"),
+      notify: [fakeEnvPath, "--chdir", chdirDir, fakeNodePath, `./${relativeScriptName}`],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `--chdir|${chdirDir}|${fakeNodePath}|./${relativeScriptName}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-chdir-relative-missing-script"),
+      notify: [fakeEnvPath, "--chdir", tmp, fakeNodePath, `./${relativeScriptName}`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-chdir-generic-relative-missing-command"),
+      notify: [fakeEnvPath, "--chdir", tmp, "./missing-generic-notify.sh"],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-short-chdir-generic-relative-missing-command"),
+      notify: [fakeEnvPath, "-C", tmp, "./missing-generic-notify.sh"],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-unknown-option-explicit-script"),
+      notify: [fakeEnvPath, "--unknown-option", fakeNodePath, explicitScriptPath],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-payload-token"),
+      notify: [fakeEnvPath, "-S", `${fakeNodePath} turn-ended`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-long-split-payload-token"),
+      notify: [fakeEnvPath, "--split-string", `${fakeNodePath} turn-ended`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-assignment-payload-token"),
+      notify: [fakeEnvPath, "-S", `TOKENTRACKER_TEST=1 ${fakeNodePath} turn-ended`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-double-dash-payload-token"),
+      notify: [fakeEnvPath, "-S", `-- ${fakeNodePath} turn-ended`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-double-dash-assignment-payload-token"),
+      notify: [fakeEnvPath, "--", "TOKENTRACKER_TEST=1", fakeNodePath, "turn-ended"],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-double-dash-assignment-payload-token"),
+      notify: [fakeEnvPath, "-S", `-- TOKENTRACKER_TEST=1 ${fakeNodePath} turn-ended`],
+    });
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-explicit-script"),
+      notify: [fakeEnvPath, "-S", `${fakeNodePath} ${explicitScriptPath}`],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `-S|${fakeNodePath} ${explicitScriptPath}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-long-split-explicit-script"),
+      notify: [fakeEnvPath, `--split-string=${fakeNodePath} ${explicitScriptPath}`],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `--split-string=${fakeNodePath} ${explicitScriptPath}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-assignment-explicit-script"),
+      notify: [fakeEnvPath, "-S", `TOKENTRACKER_TEST=1 ${fakeNodePath} ${explicitScriptPath}`],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `-S|TOKENTRACKER_TEST=1 ${fakeNodePath} ${explicitScriptPath}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-double-dash-assignment-explicit-script"),
+      notify: [fakeEnvPath, "--", "TOKENTRACKER_TEST=1", fakeNodePath, explicitScriptPath],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `--|TOKENTRACKER_TEST=1|${fakeNodePath}|${explicitScriptPath}|turn-ended`,
+    );
+    await fs.rm(markerPath, { force: true });
+
+    await runGeneratedNotifyHandler({
+      trackerDir: path.join(tmp, "tracker-env-split-double-dash-assignment-explicit-script"),
+      notify: [fakeEnvPath, "-S", `-- TOKENTRACKER_TEST=1 ${fakeNodePath} ${explicitScriptPath}`],
+    });
+    assert.equal(
+      await waitForFile(markerPath, { timeoutMs: 5000 }),
+      `-S|-- TOKENTRACKER_TEST=1 ${fakeNodePath} ${explicitScriptPath}|turn-ended`,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler treats exe-suffixed runtimes as node-like interpreters", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    for (const runtimeName of ["node", "bun", "deno"]) {
+      const markerPath = path.join(tmp, `${runtimeName}-exe-marker`);
+      const fakeRuntimePath = path.join(tmp, `${runtimeName}.exe`);
+      const explicitScriptPath = path.join(tmp, `${runtimeName}-notify.js`);
+      await fs.writeFile(
+        fakeRuntimePath,
+        `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+        "utf8",
+      );
+      await fs.chmod(fakeRuntimePath, 0o755);
+      await fs.writeFile(explicitScriptPath, "// readable notify script\n", "utf8");
+
+      const explicitNotify =
+        runtimeName === "node"
+          ? [fakeRuntimePath, explicitScriptPath, "turn-ended"]
+          : [fakeRuntimePath, "run", explicitScriptPath, "turn-ended"];
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-exe-explicit-script`),
+        notify: explicitNotify,
+      });
+      assert.match(
+        await waitForFile(markerPath, { timeoutMs: 5000 }),
+        new RegExp(`${explicitScriptPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|turn-ended`),
+      );
+      await fs.rm(markerPath, { force: true });
+
+      const payloadNotify =
+        runtimeName === "node"
+          ? [fakeRuntimePath, "turn-ended"]
+          : [fakeRuntimePath, "run", "turn-ended"];
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-exe-payload-token`),
+        notify: payloadNotify,
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+    }
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("notify handler skips bun and deno original notify when payload token is not a script", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    for (const runtimeName of ["bun", "deno"]) {
+      const markerPath = path.join(tmp, `${runtimeName}-payload-marker`);
+      const fakeRuntimePath = path.join(tmp, runtimeName);
+      const explicitScriptPath = path.join(tmp, `${runtimeName}-notify.js`);
+      const lockFilePath = path.join(tmp, `${runtimeName}-lock.json`);
+      await fs.writeFile(
+        fakeRuntimePath,
+        `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join('|'));\n`,
+        "utf8",
+      );
+      await fs.chmod(fakeRuntimePath, 0o755);
+      await fs.writeFile(explicitScriptPath, "// readable notify script\n", "utf8");
+      await fs.writeFile(lockFilePath, "{}\n", "utf8");
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-run-explicit-script`),
+        notify: [fakeRuntimePath, "run", explicitScriptPath, "turn-ended"],
+      });
+      assert.match(
+        await waitForFile(markerPath, { timeoutMs: 5000 }),
+        new RegExp(`^run\\|${explicitScriptPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|turn-ended`),
+      );
+      await fs.rm(markerPath, { force: true });
+
+      const valueOptionNotify =
+        runtimeName === "bun"
+          ? [fakeRuntimePath, "run", "--cwd", tmp, explicitScriptPath, "turn-ended"]
+          : [fakeRuntimePath, "run", "--preload", explicitScriptPath, explicitScriptPath, "turn-ended"];
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-run-value-option-explicit-script`),
+        notify: valueOptionNotify,
+      });
+      assert.match(
+        await waitForFile(markerPath, { timeoutMs: 5000 }),
+        new RegExp(`${explicitScriptPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|turn-ended$`),
+      );
+      await fs.rm(markerPath, { force: true });
+
+      if (runtimeName === "bun") {
+        const bunCwdDir = path.join(tmp, "bun-cwd");
+        const relativeBunScript = "relative-bun-notify.js";
+        await fs.mkdir(bunCwdDir, { recursive: true });
+        await fs.writeFile(path.join(bunCwdDir, relativeBunScript), "// readable notify script\n", "utf8");
+
+        await runGeneratedNotifyHandler({
+          trackerDir: path.join(tmp, "tracker-bun-run-cwd-relative-script"),
+          notify: [fakeRuntimePath, "run", "--cwd", bunCwdDir, `./${relativeBunScript}`, "turn-ended"],
+        });
+        assert.match(
+          await waitForFile(markerPath, { timeoutMs: 5000 }),
+          new RegExp(`^run\\|--cwd\\|${bunCwdDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|\\./${relativeBunScript}\\|turn-ended`),
+        );
+        await fs.rm(markerPath, { force: true });
+
+        await runGeneratedNotifyHandler({
+          trackerDir: path.join(tmp, "tracker-bun-run-inline-cwd-relative-script"),
+          notify: [fakeRuntimePath, "run", `--cwd=${bunCwdDir}`, `./${relativeBunScript}`, "turn-ended"],
+        });
+        assert.match(
+          await waitForFile(markerPath, { timeoutMs: 5000 }),
+          new RegExp(`^run\\|--cwd=${bunCwdDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|\\./${relativeBunScript}\\|turn-ended`),
+        );
+        await fs.rm(markerPath, { force: true });
+
+        const processCwdOnlyScriptName = `process-cwd-only-bun-notify-${path.basename(tmp)}.js`;
+        const processCwdOnlyScript = path.join(process.cwd(), processCwdOnlyScriptName);
+        await fs.writeFile(processCwdOnlyScript, "// not under bun --cwd\n", "utf8");
+        try {
+          await runGeneratedNotifyHandler({
+            trackerDir: path.join(tmp, "tracker-bun-run-cwd-rejects-process-cwd-script"),
+            notify: [fakeRuntimePath, "run", "--cwd", bunCwdDir, `./${processCwdOnlyScriptName}`, "turn-ended"],
+          });
+          assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+          await runGeneratedNotifyHandler({
+            trackerDir: path.join(tmp, "tracker-bun-run-inline-cwd-rejects-process-cwd-script"),
+            notify: [fakeRuntimePath, "run", `--cwd=${bunCwdDir}`, `./${processCwdOnlyScriptName}`, "turn-ended"],
+          });
+          assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+        } finally {
+          await fs.rm(processCwdOnlyScript, { force: true });
+        }
+      }
+
+      if (runtimeName === "deno") {
+        await runGeneratedNotifyHandler({
+          trackerDir: path.join(tmp, "tracker-deno-run-lock-explicit-script"),
+          notify: [fakeRuntimePath, "run", "--lock", lockFilePath, explicitScriptPath, "turn-ended"],
+        });
+        assert.equal(
+          await waitForFile(markerPath, { timeoutMs: 5000 }),
+          `run|--lock|${lockFilePath}|${explicitScriptPath}|turn-ended`,
+        );
+        await fs.rm(markerPath, { force: true });
+      }
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-env-${runtimeName}-run-explicit-script`),
+        notify: ["/usr/bin/env", fakeRuntimePath, "run", explicitScriptPath, "turn-ended"],
+      });
+      assert.match(
+        await waitForFile(markerPath, { timeoutMs: 5000 }),
+        new RegExp(`^run\\|${explicitScriptPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\|turn-ended`),
+      );
+      await fs.rm(markerPath, { force: true });
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-payload-token`),
+        notify: [fakeRuntimePath, "turn-ended"],
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-env-${runtimeName}-payload-token`),
+        notify: ["/usr/bin/env", fakeRuntimePath, "turn-ended"],
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-run-payload-token`),
+        notify: [fakeRuntimePath, "run", "turn-ended"],
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+      const valueOptionPayloadNotify =
+        runtimeName === "bun"
+          ? [fakeRuntimePath, "run", "--cwd", tmp, "turn-ended"]
+          : [fakeRuntimePath, "run", "--preload", explicitScriptPath, "turn-ended"];
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-${runtimeName}-run-value-option-payload-token`),
+        notify: valueOptionPayloadNotify,
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+
+      if (runtimeName === "deno") {
+        await runGeneratedNotifyHandler({
+          trackerDir: path.join(tmp, "tracker-deno-run-lock-payload-token"),
+          notify: [fakeRuntimePath, "run", "--lock", lockFilePath, "turn-ended"],
+        });
+        assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+      }
+
+      await runGeneratedNotifyHandler({
+        trackerDir: path.join(tmp, `tracker-env-${runtimeName}-run-payload-token`),
+        notify: ["/usr/bin/env", fakeRuntimePath, "run", "turn-ended"],
+      });
+      assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+    }
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("notify handler preserves legitimate repeated payload args when chaining", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
   try {


### PR DESCRIPTION
## Summary
- fail closed when original notify commands are wrapped through node/bun/deno without an explicit readable script target
- normalize /usr/bin/env wrappers more conservatively, including -S split strings, -- assignments, value-taking env options, and unknown env options
- preserve valid explicit-script chaining, restore no-backup-not-installed reporting, and queue a follow-up popover refresh when a load is already in flight

## Verification
- node --test test/init-uninstall.test.js test/codex-config-multiline-notify.test.js test/macos-popover-anchor-window.test.js
- npm test
- git diff --check && npm run validate:guardrails && node --test test/architecture-guardrails.test.js
- xcodebuild build -scheme TokenTrackerBar -destination 'platform=macOS'

Context: #291 was merged before the final notify-wrapper edge-case fixes landed on the fork branch, so this follow-up is based on the latest main and contains only the remaining hardening patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification command handling on Windows, including support for `~\` paths.
  - Prevented chaining to missing, unreadable, or incomplete interpreter-based notification scripts.
  - Hardened parsing and updating of multiline TOML notification settings.
  - Preserved unrelated and table-scoped configuration during notification updates and restores.
  - Improved recovery when notification settings are malformed or backups are unavailable.
- **Tests**
  - Expanded coverage for malformed TOML, interpreter options, Windows paths, and runtime-specific notification commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->