### PR TITLE
feat(providers): WSL dual-install for Kilo CLI, Mimo, ZCode (PR1)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -251,6 +251,7 @@ Die meisten Nutzer brauchen das nie – die Standardwerte sind sinnvoll. Für fo
 | `TOKENTRACKER_DEBUG` | Debug-Ausgabe aktivieren (`1` zum Aktivieren) | — |
 | `TOKENTRACKER_NO_TELEMETRY` | Alle anonyme Telemetrie deaktivieren — täglicher Heartbeat und Dashboard-Analytics (`1` zum Deaktivieren; der `DO_NOT_TRACK`-Standard wird ebenfalls respektiert) | — |
 | `TOKENTRACKER_HTTP_TIMEOUT_MS` | HTTP-Timeout in Millisekunden | `20000` |
+| `TOKENTRACKER_WSL_MODE` | WSL-Installations-Auflösungsverhalten unter Windows (zur Aggregation von nativen und WSL-Installationen). `wsl-first` (bevorzugt WSL), `native-first`, `wsl-only`, `native-only`, `both` (aggregiert beide Installationen) | `wsl-first` |
 | `CODEX_HOME` | Codex CLI-Verzeichnis überschreiben | `~/.codex` |
 | `GEMINI_HOME` | Gemini CLI-Verzeichnis überschreiben | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Grok Build-Verzeichnis für Grok-Integration und Skills-Manager | `~/.grok` |

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `TOKENTRACKER_DEBUG` | Enable debug output (`1` to enable) | — |
 | `TOKENTRACKER_NO_TELEMETRY` | Disable all anonymous telemetry — daily heartbeat and dashboard analytics (`1` to disable; the `DO_NOT_TRACK` standard is also respected) | — |
 | `TOKENTRACKER_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds | `20000` |
-| `TOKENTRACKER_WSL_MODE` | WSL install resolution when running inside WSL. `wsl-first` (prefer WSL), `native-first`, `wsl-only`, `native-only`, `both` (aggregate both installs) | `wsl-first` |
+| `TOKENTRACKER_WSL_MODE` | WSL install resolution behavior on Windows (for aggregating native and WSL installations). `wsl-first` (prefer WSL), `native-first`, `wsl-only`, `native-only`, `both` (aggregate both installs) | `wsl-first` |
 | `CODEX_HOME` | Override Codex CLI directory | `~/.codex` |
 | `GEMINI_HOME` | Override Gemini CLI directory | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Override Grok Build directory for the Grok integration and Skills Manager | `~/.grok` |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `TOKENTRACKER_DEBUG` | Enable debug output (`1` to enable) | — |
 | `TOKENTRACKER_NO_TELEMETRY` | Disable all anonymous telemetry — daily heartbeat and dashboard analytics (`1` to disable; the `DO_NOT_TRACK` standard is also respected) | — |
 | `TOKENTRACKER_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds | `20000` |
+| `TOKENTRACKER_WSL_MODE` | WSL install resolution for Windows users running the CLI inside WSL. `wsl-first` (prefer WSL data), `wsl-only` (ignore native Windows installs), `native-only` (ignore WSL installs), `both` (aggregate both installs — same provider running on both sides) | `wsl-first` |
 | `CODEX_HOME` | Override Codex CLI directory | `~/.codex` |
 | `GEMINI_HOME` | Override Gemini CLI directory | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Override Grok Build directory for the Grok integration and Skills Manager | `~/.grok` |

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `TOKENTRACKER_DEBUG` | Enable debug output (`1` to enable) | — |
 | `TOKENTRACKER_NO_TELEMETRY` | Disable all anonymous telemetry — daily heartbeat and dashboard analytics (`1` to disable; the `DO_NOT_TRACK` standard is also respected) | — |
 | `TOKENTRACKER_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds | `20000` |
-| `TOKENTRACKER_WSL_MODE` | WSL install resolution for Windows users running the CLI inside WSL. `wsl-first` (prefer WSL data), `wsl-only` (ignore native Windows installs), `native-only` (ignore WSL installs), `both` (aggregate both installs — same provider running on both sides) | `wsl-first` |
+| `TOKENTRACKER_WSL_MODE` | WSL install resolution for Windows users running the CLI inside WSL. `wsl-first` (prefer WSL, fallback native), `native-first` (prefer native, fallback WSL), `wsl-only`, `native-only`, `both` (aggregate both) | `wsl-first` |
 | `CODEX_HOME` | Override Codex CLI directory | `~/.codex` |
 | `GEMINI_HOME` | Override Gemini CLI directory | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Override Grok Build directory for the Grok integration and Skills Manager | `~/.grok` |

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `TOKENTRACKER_DEBUG` | Enable debug output (`1` to enable) | — |
 | `TOKENTRACKER_NO_TELEMETRY` | Disable all anonymous telemetry — daily heartbeat and dashboard analytics (`1` to disable; the `DO_NOT_TRACK` standard is also respected) | — |
 | `TOKENTRACKER_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds | `20000` |
-| `TOKENTRACKER_WSL_MODE` | WSL install resolution for Windows users running the CLI inside WSL. `wsl-first` (prefer WSL, fallback native), `native-first` (prefer native, fallback WSL), `wsl-only`, `native-only`, `both` (aggregate both) | `wsl-first` |
+| `TOKENTRACKER_WSL_MODE` | WSL install resolution when running inside WSL. `wsl-first` (prefer WSL), `native-first`, `wsl-only`, `native-only`, `both` (aggregate both installs) | `wsl-first` |
 | `CODEX_HOME` | Override Codex CLI directory | `~/.codex` |
 | `GEMINI_HOME` | Override Gemini CLI directory | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Override Grok Build directory for the Grok integration and Skills Manager | `~/.grok` |

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -64,8 +64,21 @@ const {
   resolveCopilotAppDbPaths,
   probeWslDistros,
 } = require("../lib/rollout");
-const { getWslMode, isInvalidWslMode, shouldProbeWsl } = require("../lib/wsl-probe");
+const wsl = require("../lib/wsl-probe");
+const { getWslMode, isInvalidWslMode, shouldProbeWsl } = wsl;
+const { resolveInstallPaths } = require("../lib/install-resolver");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
+
+function formatResolvedPaths(paths, filename) {
+  const active = [];
+  if (paths.native) {
+    active.push(`native: ${filename ? path.join(paths.native, filename) : paths.native}`);
+  }
+  if (paths.wsl) {
+    active.push(`WSL: ${filename ? path.join(paths.wsl, filename) : paths.wsl}`);
+  }
+  return active;
+}
 
 async function cmdStatus(argv = []) {
   const opts = parseArgs(argv);
@@ -247,18 +260,42 @@ async function cmdStatus(argv = []) {
   // Kilo CLI (kilo.ai @kilocode/plugin) — passive scan of kilo.db.
   const xdgDataHome = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
   const kiloHome = process.env.KILO_HOME || path.join(xdgDataHome, "kilo");
-  const kiloDbPath = path.join(kiloHome, "kilo.db");
-  const kiloInstalled = fssync.existsSync(kiloDbPath);
+  const kiloNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+    ? path.join(process.env.APPDATA.trim(), "kilo", "kilo.db")
+    : path.join(kiloHome, "kilo.db");
+  const wslKiloDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+    ? wsl.discoverWslHome(".local/share/kilo")
+    : null;
+  const kiloPaths = resolveInstallPaths({ nativeValue: kiloNativeValue, wslValue: wslKiloDir ? path.join(wslKiloDir, "kilo.db") : null });
+  const kiloActive = formatResolvedPaths(kiloPaths);
+  const kiloInstalled = kiloActive.length > 0;
+  const kiloDbPath = kiloActive.join(" | ");
 
   // Mimo (mimocode — OpenCode-fork SQLite) — passive scan of mimocode.db.
   const mimoHome = process.env.MIMO_HOME || path.join(xdgDataHome, "mimocode");
-  const mimoDbPath = path.join(mimoHome, "mimocode.db");
-  const mimoInstalled = fssync.existsSync(mimoDbPath);
+  const mimoNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+    ? path.join(process.env.APPDATA.trim(), "mimocode", "mimocode.db")
+    : path.join(mimoHome, "mimocode.db");
+  const wslMimoDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+    ? wsl.discoverWslHome(".local/share/mimocode")
+    : null;
+  const mimoPaths = resolveInstallPaths({ nativeValue: mimoNativeValue, wslValue: wslMimoDir ? path.join(wslMimoDir, "mimocode.db") : null });
+  const mimoActive = formatResolvedPaths(mimoPaths);
+  const mimoInstalled = mimoActive.length > 0;
+  const mimoDbPath = mimoActive.join(" | ");
 
   // ZCode (Z.ai's coding agent — OpenCode-fork SQLite) — passive scan of db.sqlite.
   const zcodeHome = process.env.ZCODE_HOME || path.join(home, ".zcode");
-  const zcodeDbPath = path.join(zcodeHome, "cli", "db", "db.sqlite");
-  const zcodeInstalled = fssync.existsSync(zcodeDbPath);
+  const zcodeNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+    ? path.join(process.env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")
+    : path.join(zcodeHome, "cli", "db", "db.sqlite");
+  const wslZcodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+    ? wsl.discoverWslHome(".zcode")
+    : null;
+  const zcodePaths = resolveInstallPaths({ nativeValue: zcodeNativeValue, wslValue: wslZcodeDir ? path.join(wslZcodeDir, "cli", "db", "db.sqlite") : null });
+  const zcodeActive = formatResolvedPaths(zcodePaths);
+  const zcodeInstalled = zcodeActive.length > 0;
+  const zcodeDbPath = zcodeActive.join(" | ");
 
   // Kilo Code VS Code extension — passive scan of all VS Code-family
   // globalStorage/kilocode.kilo-code/tasks/ ui_messages.json files.

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -641,6 +641,8 @@ async function cmdSync(argv) {
     }
 
     // ── Mimo (mimocode — OpenCode-fork SQLite) ──
+    // readMimoDbMessages filters out mirrored Claude Code rows to avoid
+    // double-counting usage already counted as source=claude.
     let mimoResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (sourceAllowed("mimo")) {
       const mimoNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -605,121 +605,104 @@ async function cmdSync(argv) {
       opencodeResult.bucketsQueued += opencodeDbResult.bucketsQueued;
     }
 
-    // ── Kilo CLI (kilo.ai @kilocode/plugin — OpenCode-fork SQLite) ──
-    // Uses the exact same `message` table schema as OpenCode v1.2+. We reuse
-    // the OpenCode DB reader/parser, just with a separate cursor namespace so
-    // the message indexes don't collide.
-    const kiloDbPath = path.join(kiloHome, "kilo.db");
-    let kiloResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kiloDbMessages = sourceAllowed("kilo-cli") ? readOpencodeDbMessages(kiloDbPath) : [];
-    if (kiloDbMessages.length > 0) {
-      if (progress?.enabled) {
-        progress.start(
-          `Parsing Kilo CLI ${renderBar(0)} 0/${formatNumber(kiloDbMessages.length)} msgs | buckets 0`,
-        );
+    async function parseOpencodeDbInstall({ dbPath, readFn, source, cursorKey, ...rest }) {
+      if (!dbPath || !fssync.existsSync(dbPath)) {
+        return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
       }
-      try {
-        kiloResult = await parseOpencodeDbIncremental({
-          dbMessages: kiloDbMessages,
-          cursors,
-          queuePath,
-          projectQueuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Kilo CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} msgs | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-          source: "kilo-cli",
-          cursorKey: "kiloCli",
-        });
-      } catch (err) {
-        warnProviderParseFailure("Kilo CLI", err, opts);
+      const dbMessages = readFn(dbPath);
+      if (dbMessages.length === 0) return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+      const result = await parseOpencodeDbIncremental({ dbMessages, source, cursorKey, ...rest });
+      return {
+        recordsProcessed: result.messagesProcessed || 0,
+        eventsAggregated: result.eventsAggregated || 0,
+        bucketsQueued: result.bucketsQueued || 0,
+      };
+    }
+
+    // ── Kilo CLI (kilo.ai @kilocode/plugin — OpenCode-fork SQLite) ──
+    let kiloResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (sourceAllowed("kilo-cli")) {
+      const kiloNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), "kilo", "kilo.db")
+        : path.join(kiloHome, "kilo.db");
+      const wslKiloDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/kilo") : null;
+      const wslKiloDb = wslKiloDir ? path.join(wslKiloDir, "kilo.db") : null;
+      const kiloPaths = resolveInstallPaths({ nativeValue: kiloNativeValue, wslValue: wslKiloDb });
+      if (kiloPaths.native || kiloPaths.wsl) {
+        if (progress?.enabled) progress.start(`Parsing Kilo CLI ${renderBar(0)} | buckets 0`);
+        try {
+          kiloResult = await multiInstallParse({
+            paths: kiloPaths, parserFn: parseOpencodeDbInstall, providerName: "kiloCli",
+            cursors, getParams: (p) => ({ dbPath: p, readFn: readOpencodeDbMessages, source: "kilo-cli", cursorKey: "kiloCli" }),
+            queuePath, projectQueuePath, onProgress: kiloOnProgress,
+          });
+        } catch (err) { warnProviderParseFailure("Kilo CLI", err, opts); }
       }
     }
 
     // ── Mimo (mimocode — OpenCode-fork SQLite) ──
-    // Xiaomi's Mimo code CLI is an OpenCode fork that stores assistant
-    // messages in the exact same `message` table schema (mimocode.db). Reuse
-    // the OpenCode parser with a dedicated cursor namespace so the message
-    // indexes don't collide. readMimoDbMessages returns ONLY mimo's own-model
-    // rows — mimocode mirrors the user's Claude Code + claude-mem history into
-    // its DB (already counted as source=claude), so anything else would
-    // double-count and mislabel Claude usage as mimo.
-    const mimoDbPath = path.join(mimoHome, "mimocode.db");
-    let mimoResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const mimoDbMessages = sourceAllowed("mimo") ? readMimoDbMessages(mimoDbPath) : [];
-    if (mimoDbMessages.length > 0) {
-      if (progress?.enabled) {
-        progress.start(
-          `Parsing Mimo ${renderBar(0)} 0/${formatNumber(mimoDbMessages.length)} msgs | buckets 0`,
-        );
-      }
-      try {
-        mimoResult = await parseOpencodeDbIncremental({
-          dbMessages: mimoDbMessages,
-          cursors,
-          queuePath,
-          projectQueuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Mimo ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} msgs | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-          source: "mimo",
-          cursorKey: "mimo",
-        });
-      } catch (err) {
-        warnProviderParseFailure("Mimo", err, opts);
+    let mimoResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (sourceAllowed("mimo")) {
+      const mimoNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), "mimocode", "mimocode.db")
+        : path.join(mimoHome, "mimocode.db");
+      const wslMimoDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/mimocode") : null;
+      const wslMimoDb = wslMimoDir ? path.join(wslMimoDir, "mimocode.db") : null;
+      const mimoPaths = resolveInstallPaths({ nativeValue: mimoNativeValue, wslValue: wslMimoDb });
+      if (mimoPaths.native || mimoPaths.wsl) {
+        if (progress?.enabled) progress.start(`Parsing Mimo ${renderBar(0)} | buckets 0`);
+        try {
+          mimoResult = await multiInstallParse({
+            paths: mimoPaths, parserFn: parseOpencodeDbInstall, providerName: "mimo",
+            cursors, getParams: (p) => ({ dbPath: p, readFn: readMimoDbMessages, source: "mimo", cursorKey: "mimo" }),
+            queuePath, projectQueuePath, onProgress: mimoOnProgress,
+          });
+        } catch (err) { warnProviderParseFailure("Mimo", err, opts); }
       }
     }
 
     // ── ZCode (Z.ai's coding agent — OpenCode-fork SQLite) ──
-    // Z.ai's ZCode CLI is an OpenCode fork that stores assistant messages in the
-    // exact same `message` table schema (~/.zcode/cli/db/db.sqlite). Reuse the
-    // OpenCode parser with a dedicated cursor namespace so the message indexes
-    // don't collide. readZcodeDbMessages returns ONLY ZCode's own GLM rows
-    // (providerID zai/bigmodel/zhipu) — ZCode can orchestrate bundled
-    // claude-code/codex/gemini-cli sub-agents whose turns (anthropic/openai/
-    // google) are already counted by the standalone parsers, so anything else
-    // would double-count.
-    const zcodeDbPath = path.join(zcodeHome, "cli", "db", "db.sqlite");
-    let zcodeResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const zcodeDbMessages = sourceAllowed("zcode") ? readZcodeDbMessages(zcodeDbPath) : [];
-    if (zcodeDbMessages.length > 0) {
-      if (progress?.enabled) {
-        progress.start(
-          `Parsing ZCode ${renderBar(0)} 0/${formatNumber(zcodeDbMessages.length)} msgs | buckets 0`,
-        );
+    let zcodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (sourceAllowed("zcode")) {
+      const zcodeDbPath = path.join(zcodeHome, "cli", "db", "db.sqlite");
+      const zcodeNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")
+        : zcodeDbPath;
+      const wslZcodeDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".zcode") : null;
+      const wslZcodeDb = wslZcodeDir ? path.join(wslZcodeDir, "cli", "db", "db.sqlite") : null;
+      const zcodePaths = resolveInstallPaths({ nativeValue: zcodeNativeValue, wslValue: wslZcodeDb });
+      if (zcodePaths.native || zcodePaths.wsl) {
+        if (progress?.enabled) progress.start(`Parsing ZCode ${renderBar(0)} | buckets 0`);
+        try {
+          zcodeResult = await multiInstallParse({
+            paths: zcodePaths, parserFn: parseOpencodeDbInstall, providerName: "zcode",
+            cursors, getParams: (p) => ({ dbPath: p, readFn: readZcodeDbMessages, source: "zcode", cursorKey: "zcode" }),
+            queuePath, projectQueuePath, onProgress: zcodeOnProgress,
+          });
+        } catch (err) { warnProviderParseFailure("ZCode", err, opts); }
       }
-      try {
-        zcodeResult = await parseOpencodeDbIncremental({
-          dbMessages: zcodeDbMessages,
-          cursors,
-          queuePath,
-          projectQueuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing ZCode ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} msgs | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-          source: "zcode",
-          cursorKey: "zcode",
-        });
-      } catch (err) {
-        warnProviderParseFailure("ZCode", err, opts);
-      }
+    }
+
+    function kiloOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing Kilo CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
+    }
+    function mimoOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing Mimo ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
+    }
+    function zcodeOnProgress(p) {
+      if (!progress?.enabled) return;
+      const pct = p.total > 0 ? p.index / p.total : 1;
+      progress.update(
+        `Parsing ZCode ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
+      );
     }
 
     // ── Kilo Code VS Code extension (Cline-style ui_messages.json) ──
@@ -1533,9 +1516,9 @@ async function cmdSync(argv) {
         craftResult.recordsProcessed +
         grokResult.recordsProcessed +
         copilotResult.recordsProcessed +
-        kiloResult.messagesProcessed +
-        mimoResult.messagesProcessed +
-        zcodeResult.messagesProcessed +
+        kiloResult.recordsProcessed +
+        mimoResult.recordsProcessed +
+        zcodeResult.recordsProcessed +
         kilocodeResult.recordsProcessed +
         roocodeResult.recordsProcessed +
         zedResult.recordsProcessed +

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -625,16 +625,17 @@ async function cmdSync(argv) {
       const kiloNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
         ? path.join(process.env.APPDATA.trim(), "kilo", "kilo.db")
         : path.join(kiloHome, "kilo.db");
-      const wslKiloDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/kilo") : null;
-      const wslKiloDb = wslKiloDir ? path.join(wslKiloDir, "kilo.db") : null;
-      const kiloPaths = resolveInstallPaths({ nativeValue: kiloNativeValue, wslValue: wslKiloDb });
+      const wslKiloDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".local/share/kilo")
+        : null;
+      const kiloPaths = resolveInstallPaths({ nativeValue: kiloNativeValue, wslValue: wslKiloDir ? path.join(wslKiloDir, "kilo.db") : null });
       if (kiloPaths.native || kiloPaths.wsl) {
         if (progress?.enabled) progress.start(`Parsing Kilo CLI ${renderBar(0)} | buckets 0`);
         try {
           kiloResult = await multiInstallParse({
             paths: kiloPaths, parserFn: parseOpencodeDbInstall, providerName: "kiloCli",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readOpencodeDbMessages, source: "kilo-cli", cursorKey: "kiloCli" }),
-            queuePath, projectQueuePath, onProgress: kiloOnProgress,
+            queuePath, projectQueuePath, onProgress: makeProviderProgress("Kilo CLI"),
           });
         } catch (err) { warnProviderParseFailure("Kilo CLI", err, opts); }
       }
@@ -648,16 +649,17 @@ async function cmdSync(argv) {
       const mimoNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
         ? path.join(process.env.APPDATA.trim(), "mimocode", "mimocode.db")
         : path.join(mimoHome, "mimocode.db");
-      const wslMimoDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".local/share/mimocode") : null;
-      const wslMimoDb = wslMimoDir ? path.join(wslMimoDir, "mimocode.db") : null;
-      const mimoPaths = resolveInstallPaths({ nativeValue: mimoNativeValue, wslValue: wslMimoDb });
+      const wslMimoDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".local/share/mimocode")
+        : null;
+      const mimoPaths = resolveInstallPaths({ nativeValue: mimoNativeValue, wslValue: wslMimoDir ? path.join(wslMimoDir, "mimocode.db") : null });
       if (mimoPaths.native || mimoPaths.wsl) {
         if (progress?.enabled) progress.start(`Parsing Mimo ${renderBar(0)} | buckets 0`);
         try {
           mimoResult = await multiInstallParse({
             paths: mimoPaths, parserFn: parseOpencodeDbInstall, providerName: "mimo",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readMimoDbMessages, source: "mimo", cursorKey: "mimo" }),
-            queuePath, projectQueuePath, onProgress: mimoOnProgress,
+            queuePath, projectQueuePath, onProgress: makeProviderProgress("Mimo"),
           });
         } catch (err) { warnProviderParseFailure("Mimo", err, opts); }
       }
@@ -666,45 +668,33 @@ async function cmdSync(argv) {
     // ── ZCode (Z.ai's coding agent — OpenCode-fork SQLite) ──
     let zcodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (sourceAllowed("zcode")) {
-      const zcodeDbPath = path.join(zcodeHome, "cli", "db", "db.sqlite");
       const zcodeNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
         ? path.join(process.env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")
-        : zcodeDbPath;
-      const wslZcodeDir = wsl.shouldProbeWsl(process.env) ? wsl.discoverWslHome(".zcode") : null;
-      const wslZcodeDb = wslZcodeDir ? path.join(wslZcodeDir, "cli", "db", "db.sqlite") : null;
-      const zcodePaths = resolveInstallPaths({ nativeValue: zcodeNativeValue, wslValue: wslZcodeDb });
+        : path.join(zcodeHome, "cli", "db", "db.sqlite");
+      const wslZcodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".zcode")
+        : null;
+      const zcodePaths = resolveInstallPaths({ nativeValue: zcodeNativeValue, wslValue: wslZcodeDir ? path.join(wslZcodeDir, "cli", "db", "db.sqlite") : null });
       if (zcodePaths.native || zcodePaths.wsl) {
         if (progress?.enabled) progress.start(`Parsing ZCode ${renderBar(0)} | buckets 0`);
         try {
           zcodeResult = await multiInstallParse({
             paths: zcodePaths, parserFn: parseOpencodeDbInstall, providerName: "zcode",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readZcodeDbMessages, source: "zcode", cursorKey: "zcode" }),
-            queuePath, projectQueuePath, onProgress: zcodeOnProgress,
+            queuePath, projectQueuePath, onProgress: makeProviderProgress("ZCode"),
           });
         } catch (err) { warnProviderParseFailure("ZCode", err, opts); }
       }
     }
 
-    function kiloOnProgress(p) {
-      if (!progress?.enabled) return;
-      const pct = p.total > 0 ? p.index / p.total : 1;
-      progress.update(
-        `Parsing Kilo CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
-      );
-    }
-    function mimoOnProgress(p) {
-      if (!progress?.enabled) return;
-      const pct = p.total > 0 ? p.index / p.total : 1;
-      progress.update(
-        `Parsing Mimo ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
-      );
-    }
-    function zcodeOnProgress(p) {
-      if (!progress?.enabled) return;
-      const pct = p.total > 0 ? p.index / p.total : 1;
-      progress.update(
-        `Parsing ZCode ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
-      );
+    function makeProviderProgress(label) {
+      return (p) => {
+        if (!progress?.enabled) return;
+        const pct = p.total > 0 ? p.index / p.total : 1;
+        progress.update(
+          `Parsing ${label} ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} records | buckets ${formatNumber(p.bucketsQueued)}`,
+        );
+      };
     }
 
     // ── Kilo Code VS Code extension (Cline-style ui_messages.json) ──

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -605,7 +605,7 @@ async function cmdSync(argv) {
       opencodeResult.bucketsQueued += opencodeDbResult.bucketsQueued;
     }
 
-    async function parseOpencodeDbInstall({ dbPath, readFn, source, cursorKey, ...rest }) {
+    async function parseOpencodeDbForInstall({ dbPath, readFn, source, cursorKey, ...rest }) {
       if (!dbPath || !fssync.existsSync(dbPath)) {
         return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
       }
@@ -633,7 +633,7 @@ async function cmdSync(argv) {
         if (progress?.enabled) progress.start(`Parsing Kilo CLI ${renderBar(0)} | buckets 0`);
         try {
           kiloResult = await multiInstallParse({
-            paths: kiloPaths, parserFn: parseOpencodeDbInstall, providerName: "kiloCli",
+            paths: kiloPaths, parserFn: parseOpencodeDbForInstall, providerName: "kiloCli",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readOpencodeDbMessages, source: "kilo-cli", cursorKey: "kiloCli" }),
             queuePath, projectQueuePath, onProgress: makeProviderProgress("Kilo CLI"),
           });
@@ -657,7 +657,7 @@ async function cmdSync(argv) {
         if (progress?.enabled) progress.start(`Parsing Mimo ${renderBar(0)} | buckets 0`);
         try {
           mimoResult = await multiInstallParse({
-            paths: mimoPaths, parserFn: parseOpencodeDbInstall, providerName: "mimo",
+            paths: mimoPaths, parserFn: parseOpencodeDbForInstall, providerName: "mimo",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readMimoDbMessages, source: "mimo", cursorKey: "mimo" }),
             queuePath, projectQueuePath, onProgress: makeProviderProgress("Mimo"),
           });
@@ -679,7 +679,7 @@ async function cmdSync(argv) {
         if (progress?.enabled) progress.start(`Parsing ZCode ${renderBar(0)} | buckets 0`);
         try {
           zcodeResult = await multiInstallParse({
-            paths: zcodePaths, parserFn: parseOpencodeDbInstall, providerName: "zcode",
+            paths: zcodePaths, parserFn: parseOpencodeDbForInstall, providerName: "zcode",
             cursors, getParams: (p) => ({ dbPath: p, readFn: readZcodeDbMessages, source: "zcode", cursorKey: "zcode" }),
             queuePath, projectQueuePath, onProgress: makeProviderProgress("ZCode"),
           });

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -7,7 +7,7 @@ function resolveInstallPaths({ nativeValue, wslDir, wslValue } = {}, env = proce
   }
 
   const wslCandidate = wslValue !== undefined
-    ? (wsl.shouldProbeWsl(env) ? wslValue : null)
+    ? (wsl.shouldProbeWsl(env) && pathExists(wslValue, deps.existsSync) ? wslValue : null)
     : (wslDir && wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslDir, { ...deps, env }) : null);
   const nativeCandidate = wsl.shouldProbeNative(env) && nativeValue
     ? pathExists(nativeValue, deps.existsSync) : null;

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3116,37 +3116,51 @@ async function walkOpencodeMessages(dir, out) {
 function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const sql = `SELECT id, session_id, time_updated, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created ASC`;
-  const rows = readSqliteJsonRows(dbPath, sql, {
-    label: "OpenCode",
-    maxBuffer: 50 * 1024 * 1024,
-    timeout: 30_000,
-    ...sqliteOptions,
-  });
-  const out = [];
-  for (const row of rows) {
-    if (!row || typeof row.data !== "string") continue;
-    let data;
+
+  let snapshot = null;
+  let effectiveDbPath = dbPath;
+  if (isUncPath(dbPath)) {
     try {
-      data = JSON.parse(row.data);
-    } catch (_e) {
-      continue;
-    }
-    const tokens = data?.tokens;
-    if (!tokens || typeof tokens !== "object") continue;
-    // Skip messages with no meaningful token data
-    const hasTokens =
-      toNonNegativeInt(tokens.input) > 0 ||
-      toNonNegativeInt(tokens.output) > 0 ||
-      toNonNegativeInt(tokens.reasoning) > 0;
-    if (!hasTokens) continue;
-    out.push({
-      id: row.id || data.id,
-      sessionID: row.session_id || data.sessionID,
-      timeUpdated: row.time_updated || 0,
-      data,
-    });
+      snapshot = snapshotSqliteDb(dbPath);
+      effectiveDbPath = snapshot.path;
+    } catch (_e) { }
   }
-  return out;
+
+  try {
+    const rows = readSqliteJsonRows(effectiveDbPath, sql, {
+      label: "OpenCode",
+      maxBuffer: 50 * 1024 * 1024,
+      timeout: 30_000,
+      ...sqliteOptions,
+    });
+    const out = [];
+    for (const row of rows) {
+      if (!row || typeof row.data !== "string") continue;
+      let data;
+      try {
+        data = JSON.parse(row.data);
+      } catch (_e) {
+        continue;
+      }
+      const tokens = data?.tokens;
+      if (!tokens || typeof tokens !== "object") continue;
+      // Skip messages with no meaningful token data
+      const hasTokens =
+        toNonNegativeInt(tokens.input) > 0 ||
+        toNonNegativeInt(tokens.output) > 0 ||
+        toNonNegativeInt(tokens.reasoning) > 0;
+      if (!hasTokens) continue;
+      out.push({
+        id: row.id || data.id,
+        sessionID: row.session_id || data.sessionID,
+        timeUpdated: row.time_updated || 0,
+        data,
+      });
+    }
+    return out;
+  } finally {
+    if (snapshot) snapshot.cleanup();
+  }
 }
 
 // mimocode mirrors the user's Claude Code + claude-mem history into its own

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -88,6 +88,98 @@ test("resolveInstallPaths non-both modes return single path with correct selecti
   }
 });
 
+// ── Provider path resolution (PR #261) ────────────────────────────────────────
+
+test("kilo-cli native path defaults to XDG on Linux, APPDATA on Windows", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const r = resolveInstallPaths(
+    { nativeValue: path.join(home, ".local", "share", "kilo", "kilo.db") },
+    {},
+    {},
+  );
+  assert.equal(r.native, path.join(home, ".local", "share", "kilo", "kilo.db"));
+  assert.equal(r.wsl, null);
+});
+
+test("kilo-cli WSL path resolves on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-kilo-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+
+test("mimo native path defaults to XDG on Linux, APPDATA on Windows", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const r = resolveInstallPaths(
+    { nativeValue: path.join(home, ".local", "share", "mimocode", "mimocode.db") },
+    {},
+    {},
+  );
+  assert.equal(r.native, path.join(home, ".local", "share", "mimocode", "mimocode.db"));
+  assert.equal(r.wsl, null);
+});
+
+test("mimo WSL path resolves on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-mimo-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+
+test("zcode native path defaults to HOME on Linux, APPDATA on Windows", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const r = resolveInstallPaths(
+    { nativeValue: path.join(home, ".zcode", "cli", "db", "db.sqlite") },
+    {},
+    {},
+  );
+  assert.equal(r.native, path.join(home, ".zcode", "cli", "db", "db.sqlite"));
+  assert.equal(r.wsl, null);
+});
+
+test("zcode WSL path resolves on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-zcode-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+
 // ── ensureNamespacedCursors ───────────────────────────────────────────────────
 
 test("ensureNamespacedCursors transparent for already-namespaced cursors", () => {

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -88,6 +88,25 @@ test("resolveInstallPaths non-both modes return single path with correct selecti
   }
 });
 
+test("resolveInstallPaths wsl-first falls back to native when WSL DB is missing but native exists", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-wsl-fallback-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDb = path.join(tmpDir, "native.db");
+  const wslDb = path.join(tmpDir, "wsl.db");
+
+  // Create native DB only, leave WSL DB missing
+  fs.writeFileSync(nativeDb, "fake-db");
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDb, wslValue: wslDb },
+    { TOKENTRACKER_WSL_MODE: "wsl-first" },
+    { runWsl: () => "Ubuntu\n" }
+  );
+  assert.equal(r.wsl, null);
+  assert.equal(r.native, nativeDb);
+});
+
 // ── Provider path resolution (PR #261) ────────────────────────────────────────
 
 test("kilo-cli native path defaults to XDG on Linux, APPDATA on Windows", (t) => {

--- a/test/multi-install-parser.test.js
+++ b/test/multi-install-parser.test.js
@@ -156,3 +156,66 @@ test("multiInstallParse dual-to-single transition with namespaced cursor", async
 
   assert.equal(r.recordsProcessed, 1);
 });
+
+test("adapter normalizing messagesProcessed to recordsProcessed works with multiInstallParse", async () => {
+  const cursors = { hourly: {} };
+  async function adapter({ dbPath, ...rest }) {
+    const result = await rawParser({ dbPath, ...rest });
+    return {
+      recordsProcessed: result.messagesProcessed || 0,
+      eventsAggregated: result.eventsAggregated || 0,
+      bucketsQueued: result.bucketsQueued || 0,
+    };
+  }
+  async function rawParser({ dbPath, cursors: c }) {
+    c.adapterTest = { lastPath: dbPath };
+    return { messagesProcessed: 42, eventsAggregated: 10, bucketsQueued: 5 };
+  }
+  const r = await multiInstallParse({
+    paths: { native: "/db", wsl: null },
+    parserFn: adapter,
+    providerName: "adapterTest",
+    cursors,
+    getParams: (path) => ({ dbPath: path }),
+  });
+  assert.equal(r.recordsProcessed, 42);
+  assert.equal(r.eventsAggregated, 10);
+  assert.equal(r.bucketsQueued, 5);
+  assert.equal(cursors.adapterTest.lastPath, "/db");
+});
+
+test("adapter normalizing messagesProcessed works in dual mode", async () => {
+  const cursors = { hourly: { buckets: {} } };
+  const seen = [];
+  async function adapter({ dbPath, ...rest }) {
+    const result = await rawParser({ dbPath, ...rest });
+    seen.push({ dbPath, result });
+    return {
+      recordsProcessed: result.messagesProcessed || 0,
+      eventsAggregated: result.eventsAggregated || 0,
+      bucketsQueued: result.bucketsQueued || 0,
+    };
+  }
+  const counts = { "/native": 10, "/wsl": 32 };
+  async function rawParser({ dbPath, cursors: c }) {
+    const prev = c.adapterTest?.lastCount || 0;
+    c.adapterTest = { lastCount: prev + counts[dbPath], lastPath: dbPath };
+    return { messagesProcessed: counts[dbPath], eventsAggregated: counts[dbPath], bucketsQueued: 1 };
+  }
+  const r = await multiInstallParse({
+    paths: { native: "/native", wsl: "/wsl" },
+    parserFn: adapter,
+    providerName: "adapterTest",
+    cursors,
+    getParams: (path) => ({ dbPath: path }),
+  });
+  assert.equal(seen.length, 2, `adapter called twice, got ${seen.length}`);
+  assert.equal(seen[0].dbPath, "/native");
+  assert.equal(seen[1].dbPath, "/wsl");
+  assert.equal(r.recordsProcessed, 42, "10+32 from both installs");
+  assert.equal(r.eventsAggregated, 42);
+  assert.equal(r.bucketsQueued, 2);
+  assert.deepStrictEqual(Object.keys(cursors.adapterTest).sort(), ["native", "wsl"]);
+  assert.equal(cursors.adapterTest.native.lastCount, 10);
+  assert.equal(cursors.adapterTest.wsl.lastCount, 32);
+});


### PR DESCRIPTION
Rewrite three OpenCode-fork SQLite providers to use `resolveInstallPaths` + `multiInstallParse` for WSL dual-install support.

**Changes:**
- Kilo CLI, Mimo, ZCode: replace inline `parseOpencodeDbIncremental` calls with `parseOpencodeDbInstall` adapter + `multiInstallParse`
- Add native (XDG/APPDATA) + WSL path resolution per provider
- Add `parseOpencodeDbInstall` adapter normalizing `messagesProcessed` → `recordsProcessed`
- Add `kiloOnProgress`, `mimoOnProgress`, `zcodeOnProgress` callbacks
- Fix downstream aggregation lines to read `recordsProcessed`
- Document `TOKENTRACKER_WSL_MODE` env variable in README

**Tests:**
- Provider path resolution: native Linux defaults + Windows both-mode (6 tests)
- Adapter normalization: single-install + dual-install messagesProcessed flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented `TOKENTRACKER_WSL_MODE` for resolving native vs WSL installs, including supported modes and defaulting to `wsl-first`.
- **Bug Fixes**
  - Improved OpenCode sync parsing for Kilo CLI, Mimo, and ZCode by normalizing progress/metrics to “records” and correcting the “Sync finished” totals for multi-install runs.
- **Tests**
  - Added tests for install path resolution across providers (including dual native/WSL “both” mode).
  - Added `multiInstallParse` tests verifying adapter normalization and per-resolved-path cursor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->