### PR TITLE
feat: include oh-my-pi subagent transcripts in omp usage totals

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -44,6 +44,7 @@ const {
   resolveKimiCodeWireFiles,
   parseKimiCodeIncremental,
   resolveOmpSessionFiles,
+  resolveOmpSubagentFiles,
   parseOmpIncremental,
   resolvePiSessionFiles,
   parsePiIncremental,
@@ -1184,17 +1185,23 @@ async function cmdSync(argv) {
     }
 
     // ── oh-my-pi (passive ~/.omp/agent/sessions/**/*.jsonl reader) ──
+    // Task-subagent transcripts (nested below the cwd level) are scanned too,
+    // so their usage counts toward the omp totals.
     let ompResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const ompFiles = sourceAllowed("omp")
       ? mergeBothFileSources({ resolveFiles: resolveOmpSessionFiles, env: process.env })
       : [];
-    if (ompFiles.length > 0) {
+    const ompSubagentFiles = sourceAllowed("omp")
+      ? mergeBothFileSources({ resolveFiles: resolveOmpSubagentFiles, env: process.env })
+      : [];
+    if (ompFiles.length > 0 || ompSubagentFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing oh-my-pi ${renderBar(0)} | buckets 0`);
       }
       try {
         ompResult = await parseOmpIncremental({
           sessionFiles: ompFiles,
+          subagentFiles: ompSubagentFiles,
           cursors,
           queuePath,
           env: process.env,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6474,6 +6474,9 @@ async function parseWorkbuddyIncremental({
 //
 // oh-my-pi writes one append-only JSONL per session:
 //   ~/.omp/agent/sessions/--<cwd-encoded>--/<timestamp>_<sessionId>.jsonl
+// Task subagents spawned by that session get their own JSONL files nested in
+// a sibling directory named after the session file (see
+// resolveOmpSubagentFiles); their usage counts toward the same "omp" totals.
 //
 // Per-line record types: the first line is type:"session" (header).
 // Only type:"message" lines with message.role=="assistant" carry token usage.
@@ -6571,6 +6574,63 @@ function resolveOmpSessionFiles(env = process.env) {
       for (const entry of entries) {
         if (!entry.endsWith(".jsonl")) continue;
         files.push(path.join(cwdPath, entry));
+      }
+    }
+  } catch {
+    // ignore — return what we have
+  }
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+// Subagent transcripts live in a directory named after the session file:
+//   ~/.omp/agent/sessions/<cwd>/<session>.jsonl            (main agent)
+//   ~/.omp/agent/sessions/<cwd>/<session>/<Agent>.jsonl    (task subagent)
+//   ~/.omp/agent/sessions/<cwd>/<session>/<sub>/<A>.jsonl  (nested advisor)
+// oh-my-pi's own stats indexer classifies by depth (packages/stats/parser.ts:
+// rel path <= 2 segments → main, deeper → subagent/advisor), so we mirror
+// that: everything below the cwd level is subagent traffic. Session dirs also
+// hold non-JSONL artefacts (*.bash-original.log, *.md) — skipped by extension.
+function resolveOmpSubagentFiles(env = process.env) {
+  const agentDir = resolveOmpAgentDir(env);
+  if (!agentDir) return [];
+  const sessionsDir = path.join(agentDir, "sessions");
+  if (!fssync.existsSync(sessionsDir)) return [];
+  const files = [];
+  const walk = (dir) => {
+    let entries;
+    try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      let isDir = entry.isDirectory();
+      let isFile = entry.isFile();
+      // Resolve symlinks defensively (Dirent flags are false for symlinks).
+      if (!isDir && !isFile) {
+        try {
+          const st = fssync.statSync(full);
+          isDir = st.isDirectory();
+          isFile = st.isFile();
+        } catch { continue; }
+      }
+      if (isDir) walk(full);
+      else if (isFile && entry.name.endsWith(".jsonl")) files.push(full);
+    }
+  };
+  try {
+    for (const cwdDir of fssync.readdirSync(sessionsDir)) {
+      const cwdPath = path.join(sessionsDir, cwdDir);
+      let stat;
+      try { stat = fssync.statSync(cwdPath); } catch { continue; }
+      if (!stat.isDirectory()) continue;
+      let entries;
+      try { entries = fssync.readdirSync(cwdPath, { withFileTypes: true }); } catch { continue; }
+      for (const entry of entries) {
+        const full = path.join(cwdPath, entry.name);
+        let isDir = entry.isDirectory();
+        if (!isDir && !entry.isFile()) {
+          try { isDir = fssync.statSync(full).isDirectory(); } catch { continue; }
+        }
+        if (isDir) walk(full);
       }
     }
   } catch {
@@ -8331,6 +8391,7 @@ async function parseKilocodeIncremental({
 
 async function parseOmpIncremental({
   sessionFiles,
+  subagentFiles,
   cursors,
   queuePath,
   onProgress,
@@ -8345,9 +8406,19 @@ async function parseOmpIncremental({
       ? { ...ompState.fileOffsets }
       : {};
 
-  const files = Array.isArray(sessionFiles)
+  const mainFiles = Array.isArray(sessionFiles)
     ? sessionFiles
     : resolveOmpSessionFiles(env || process.env);
+  // Subagent transcripts share the session format and count toward the same
+  // "omp" totals; they're discovered separately because they nest below the
+  // cwd level. When the caller supplies explicit sessionFiles (tests), don't
+  // auto-resolve — keep the parse hermetic.
+  const subFiles = Array.isArray(subagentFiles)
+    ? subagentFiles
+    : Array.isArray(sessionFiles)
+      ? []
+      : resolveOmpSubagentFiles(env || process.env);
+  const files = [...mainFiles, ...subFiles];
   const fallbackModel = defaultModel || resolveOmpDefaultModel();
 
   if (files.length === 0) {
@@ -10782,6 +10853,7 @@ module.exports = {
   resolveOmpHome,
   resolveOmpAgentDir,
   resolveOmpSessionFiles,
+  resolveOmpSubagentFiles,
   resolveOmpDefaultModel,
   parseOmpIncremental,
   resolveKilocodeRoots,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -32,6 +32,7 @@ const {
   resolveWorkbuddyProjectFiles,
   parseOmpIncremental,
   resolveOmpSessionFiles,
+  resolveOmpSubagentFiles,
   parsePiIncremental,
   resolvePiSessionFiles,
   resolvePiAgentDir,
@@ -7784,6 +7785,102 @@ test("parseOmpIncremental counts pure-reasoning rows (only reasoningTokens > 0)"
     assert.equal(queued[0].source, "omp");
     assert.equal(queued[0].reasoning_output_tokens, 42);
     assert.equal(queued[0].total_tokens, 42);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveOmpSubagentFiles discovers nested subagent jsonl and skips main files and non-jsonl artefacts", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-"));
+  try {
+    const cwdDir = path.join(tmp, "agent", "sessions", "--myproject--");
+    const sessionDir = path.join(cwdDir, "2026-04-05T14-00-00-000Z_session-1");
+    const deepDir = path.join(sessionDir, "smol-review");
+    await fs.mkdir(deepDir, { recursive: true });
+
+    // Main session file — must NOT be returned by the subagent resolver.
+    await fs.writeFile(path.join(cwdDir, "2026-04-05T14-00-00-000Z_session-1.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+    // Subagent transcript + non-JSONL session artefacts.
+    await fs.writeFile(path.join(sessionDir, "AgentA.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+    await fs.writeFile(path.join(sessionDir, "12.bash-original.log"), "log\n", "utf8");
+    await fs.writeFile(path.join(sessionDir, "notes.md"), "notes\n", "utf8");
+    // Advisor transcript nested one level deeper inside the session dir.
+    await fs.writeFile(path.join(deepDir, "smol-review.AdvisorReview.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const result = resolveOmpSubagentFiles({ OMP_HOME: tmp });
+    assert.deepEqual(result, [
+      path.join(sessionDir, "AgentA.jsonl"),
+      path.join(deepDir, "smol-review.AdvisorReview.jsonl"),
+    ]);
+
+    // Main resolver stays main-only: exactly the one top-level session file.
+    const mainResult = resolveOmpSessionFiles({ OMP_HOME: tmp });
+    assert.equal(mainResult.length, 1);
+    assert.ok(mainResult[0].endsWith("session-1.jsonl"));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseOmpIncremental counts subagent files toward the same omp bucket", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-"));
+  try {
+    const cwdDir = path.join(tmp, "sessions", "--test--");
+    const sessionDir = path.join(cwdDir, "session-1");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const mainPath = path.join(cwdDir, "session-1.jsonl");
+    const subPath = path.join(sessionDir, "AgentA.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const ts = Date.UTC(2026, 3, 5, 14, 10, 0);
+    await fs.writeFile(mainPath, [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "msg-1", model: "claude-sonnet-4-5", input: 100, output: 20, timestamp: ts, totalTokens: 120 }),
+    ].join("\n") + "\n", "utf8");
+    await fs.writeFile(subPath, [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "msg-2", model: "claude-sonnet-4-5", input: 200, output: 40, timestamp: ts, totalTokens: 240 }),
+    ].join("\n") + "\n", "utf8");
+
+    const res = await parseOmpIncremental({ sessionFiles: [mainPath], subagentFiles: [subPath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 2);
+
+    // Same source + model + half-hour → one merged bucket (main + subagent).
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "omp");
+    assert.equal(queued[0].model, "claude-sonnet-4-5");
+    assert.equal(queued[0].input_tokens, 300);
+    assert.equal(queued[0].output_tokens, 60);
+    assert.equal(queued[0].total_tokens, 360);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseOmpIncremental dedupes subagent entries across two runs", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-"));
+  try {
+    const cwdDir = path.join(tmp, "sessions", "--test--");
+    const sessionDir = path.join(cwdDir, "session-1");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const subPath = path.join(sessionDir, "AgentA.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const ts = Date.UTC(2026, 3, 5, 14, 10, 0);
+    await fs.writeFile(subPath, [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "msg-1", model: "claude-sonnet-4-5", input: 10, output: 5, timestamp: ts, totalTokens: 15 }),
+    ].join("\n") + "\n", "utf8");
+
+    const res1 = await parseOmpIncremental({ sessionFiles: [], subagentFiles: [subPath], cursors, queuePath });
+    assert.equal(res1.eventsAggregated, 1);
+
+    const res2 = await parseOmpIncremental({ sessionFiles: [], subagentFiles: [subPath], cursors, queuePath });
+    assert.equal(res2.eventsAggregated, 0);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

oh-my-pi nests task-subagent transcripts in a directory named after the session file (`sessions/<cwd>/<session>/<Agent>.jsonl`, advisors one level deeper); the omp reader only globbed one level, so all subagent token usage was silently missing from the `omp` totals — this PR scans those nested transcripts and counts them into the same `omp` buckets.

## Why

oh-my-pi's own stats dashboard (`localhost:3847`, `/api/stats/overview`) splits usage `byAgentType` — on a real corpus subagent traffic was ~16% of total tokens (144M of 872M), all of it invisible to TokenTracker. Users comparing TokenTracker against omp's dashboard see a persistent undercount.

## What

- `src/lib/rollout.js`: new `resolveOmpSubagentFiles()` — recursive `*.jsonl` scan below the cwd level, mirroring the existing workbuddy precedent (`resolveWorkbuddyProjectFiles`, which recurses for exactly the same reason). Non-JSONL session artefacts (`*.bash-original.log`, `*.md`) are skipped by extension; symlinks resolved defensively like the workbuddy walker.
- `src/lib/rollout.js`: `parseOmpIncremental()` gains a `subagentFiles` param; nested transcripts share the session JSONL format, so parsing/dedup/offset logic is unchanged. Hermeticity: when a caller passes explicit `sessionFiles` (tests), subagent auto-resolution stays off.
- `src/commands/sync.js`: resolves and passes the subagent file list (same `sourceAllowed("omp")` gate, WSL merge wrapper).
- `test/rollout-parser.test.js`: 3 new tests — nested discovery incl. deep nesting + artefact exclusion + main/sub resolver separation, merged bucketing, dedup across runs.

`pi` shares the on-disk format but upstream pi doesn't emit nested subagent transcripts (verified on a live install), so its parser is intentionally left untouched.

## Verification

- `npm test`: 1346/1346 pass.
- Real-data cross-check against a live `~/.omp` corpus (7.8k session files, 168 nested subagent transcripts): after this change the subagent token sum ingested by TokenTracker matches oh-my-pi's own `stats.db` `byAgentType` subagent total **exactly** (144,208,561 tokens); dashboard renders the merged totals per model as before.
- Privacy rule respected: only token counts/timestamps are read; nested transcript discovery stores the same cursor metadata (offsets/inodes) the main-session scan already stores.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (none added)
- [x] Commits follow conventional style (`feat:`)
- [x] PR description explains *why*, not just *what*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync now includes usage from task subagent transcripts found within nested session folders.
  * Subagent activity is combined with main session usage for more complete totals.

* **Bug Fixes**
  * Prevented subagent transcript entries from being counted more than once during repeated syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->