### PR TITLE
fix: prevent recursive Codex notify chaining

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -923,6 +923,12 @@ async function shouldRepairCodexNotify({ currentNotify, expectedNotify, notifyOr
   if (isTokenTrackerNotify(currentNotify, expectedNotify)) {
     return { repair: true, captureOriginal: false };
   }
+  if (
+    isSkyComputerUseNotify(currentNotify)
+    && containsNestedTokenTrackerNotify(currentNotify, expectedNotify)
+  ) {
+    return { repair: false, reason: "already-wrapped" };
+  }
   if (isSkyComputerUseNotify(currentNotify)) {
     return { repair: true, captureOriginal: true, replaceOriginal: true };
   }
@@ -953,6 +959,17 @@ function isTokenTrackerNotify(cmd, expectedNotify) {
 function isSkyComputerUseNotify(cmd) {
   if (!Array.isArray(cmd)) return false;
   return cmd.some((part) => typeof part === "string" && part.includes("SkyComputerUseClient"));
+}
+
+function containsNestedTokenTrackerNotify(cmd, expectedNotify) {
+  if (!Array.isArray(cmd)) return false;
+  for (const part of cmd) {
+    if (typeof part !== "string") continue;
+    try {
+      if (isTokenTrackerNotify(JSON.parse(part), expectedNotify)) return true;
+    } catch (_) {}
+  }
+  return false;
 }
 
 function parseArgs(argv) {
@@ -1145,6 +1162,10 @@ function isSelfNotify(cmd) {
     if (!part.includes('notify.cjs')) continue;
     const resolved = resolveMaybeHome(part);
     if (resolved && resolved === selfPath) return true;
+    try {
+      const nested = JSON.parse(part);
+      if (Array.isArray(nested) && isSelfNotify(nested)) return true;
+    } catch (_) {}
   }
   return false;
 }

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -107,6 +107,37 @@ test("notify handler chains executable original notify commands and skips stale 
   }
 });
 
+test("notify handler skips an original notify that nests itself", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
+  try {
+    const trackerDir = path.join(tmp, "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const notifyPath = path.join(await fs.realpath(trackerDir), "notify.cjs");
+    const markerPath = path.join(tmp, "sky-marker");
+    const skyPath = path.join(tmp, "SkyComputerUseClient");
+    await fs.writeFile(
+      skyPath,
+      `#!/usr/bin/env node\nrequire('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran');\n`,
+      "utf8",
+    );
+    await fs.chmod(skyPath, 0o755);
+
+    await runGeneratedNotifyHandler({
+      trackerDir,
+      notify: [
+        skyPath,
+        "turn-ended",
+        "--previous-notify",
+        JSON.stringify(["/usr/bin/env", "node", notifyPath]),
+      ],
+    });
+
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("notify handler avoids duplicating existing payload args when chaining", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
   try {
@@ -188,6 +219,47 @@ test("serve-time Codex notify repair installs TokenTracker and preserves Sky ori
       await fs.readFile(path.join(trackerDir, "codex_notify_original.json"), "utf8"),
     );
     assert.deepEqual(original.notify, skyNotify);
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time Codex notify repair leaves Sky wrapping TokenTracker unchanged", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
+  const prevCodexHome = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    const notifyPath = path.join(binDir, "notify.cjs");
+    await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+    const tokenTrackerNotify = ["/usr/bin/env", "node", notifyPath];
+    const skyNotify = [
+      path.join(tmp, "SkyComputerUseClient.app", "Contents", "MacOS", "SkyComputerUseClient"),
+      "turn-ended",
+      "--previous-notify",
+      JSON.stringify(tokenTrackerNotify),
+    ];
+    const codexConfigPath = path.join(process.env.CODEX_HOME, "config.toml");
+    await fs.writeFile(codexConfigPath, `notify = ${JSON.stringify(skyNotify)}\n`, "utf8");
+
+    const result = await repairCodexNotifyIntegration({
+      home: tmp,
+      trackerDir,
+      binDir,
+      safeMode: true,
+    });
+
+    assert.equal(result.changed, false);
+    assert.equal(result.skippedReason, "already-wrapped");
+    assert.deepEqual(await fs.readFile(codexConfigPath, "utf8"), `notify = ${JSON.stringify(skyNotify)}\n`);
+    await assert.rejects(
+      fs.stat(path.join(trackerDir, "codex_notify_original.json")),
+      /ENOENT/,
+    );
   } finally {
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;


### PR DESCRIPTION
## Summary

Prevents an infinite Codex notification loop when Sky Computer Use already delegates to TokenTracker through `--previous-notify`.

TokenTracker's serve-time repair captured the Sky wrapper and replaced it with its own notifier. The generated handler then called Sky, whose previous notifier pointed back to TokenTracker. Each callback spawned another `SkyComputerUseClient` and `node` process.

On macOS, that process storm also drove up `syspolicyd`, `XProtect` and `diagnosticd` CPU usage until the machine was fully saturated.

This change leaves an existing Sky-to-TokenTracker wrapper alone. The generated notifier also checks nested JSON callbacks for self-references, which protects machines that already have a bad saved notification chain.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no user-facing strings added)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- A notification chain must never invoke TokenTracker again.
- Self-detection must work when the callback is stored as a JSON string.
- A Sky wrapper that already delegates to TokenTracker must remain unchanged.
- Existing non-recursive notification commands must still run.

### Boundary matrix (list at least 3)

| Configuration | Expected behavior |
|---|---|
| Plain Sky notifier | TokenTracker may preserve and chain it |
| Sky with TokenTracker in `--previous-notify` | Leave the active notifier unchanged |
| Stored notifier with a nested TokenTracker callback | Skip the stored notifier |
| Unrelated executable notifier | Continue chaining it |

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** Initial review request. Commit `6eb2338` adds nested self-reference detection and preserves an existing Sky-to-TokenTracker wrapper.
- **Intended behavior / invariants:** Notification chains must never call TokenTracker recursively. Existing non-recursive notifiers must keep working, including plain Sky wrappers and unrelated executables.
- **Edge cases covered:** TokenTracker nested inside a JSON-encoded `--previous-notify`; serve-time repair encountering a Sky wrapper that already points back to TokenTracker.
- **Tests run (command + result):** `npm test`, 1,350 passed and 0 failed. The 2 regression tests failed before the fix and passed afterward.
- **Known gaps / out of scope:** No UI, public-access, authentication, or platform-specific app behavior changed.

### Most likely regression surface

- Codex notification chaining for existing Sky Computer Use wrappers and custom executable notifiers.

### Verification method (choose at least one)

- Added a regression test using the exact nested `--previous-notify` shape that caused the loop.
- Added a serve-time repair test for an existing Sky-to-TokenTracker wrapper.
- Both tests failed before the fix and passed afterward.
- Ran the full test suite: 1,350 passed and 0 failed.

### Uncovered scope

- Manual verification on Windows and Linux. The changed code is shared CLI notification handling, and the automated suite covers it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested notification handlers, including SkyComputerUse integrations.
  * Prevented duplicate wrapping when a TokenTracker notification is already nested.
  * Improved detection of self-referencing notification commands.
  * Preserved existing configuration and removed unnecessary backup requirements during repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->