### PR TITLE
fix: correct Copilot token accounting

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9443,10 +9443,28 @@ async function parseCopilotIncremental({ otelPaths, cursors, queuePath, onProgre
           attrs["gen_ai.usage.reasoning_tokens"] ??
           attrs["gen_ai.usage.reasoning_output_tokens"],
       );
-      // OTEL input_tokens INCLUDES cache_read — subtract per project convention
+      const reasoningClamped = Math.min(reasoning, output);
+      const outputWithoutReasoning = Math.max(0, output - reasoningClamped);
+      const cliSpan = isCopilotV1ChatSpan(record);
+      // CLI input includes both cache reads and writes. Chat-extension
+      // LogRecords expose cache creation separately, so preserve their existing
+      // input-minus-read semantics.
       const cacheReadClamped = Math.min(cacheRead, inputRaw);
-      const input = Math.max(0, inputRaw - cacheReadClamped);
-      const totalInteresting = input + output + cacheReadClamped + cacheWrite + reasoning;
+      const cacheWriteClamped = Math.min(
+        cacheWrite,
+        Math.max(0, inputRaw - cacheReadClamped),
+      );
+      const cacheWriteForAccounting = cliSpan ? cacheWriteClamped : cacheWrite;
+      const input = Math.max(
+        0,
+        inputRaw - cacheReadClamped - (cliSpan ? cacheWriteClamped : 0),
+      );
+      const totalInteresting =
+        input +
+        outputWithoutReasoning +
+        cacheReadClamped +
+        cacheWriteForAccounting +
+        reasoningClamped;
       if (totalInteresting === 0) continue;
 
       // CLI Span uses endTime/startTime; Chat extension LogRecord uses hrTime/hrTimeObserved.
@@ -9460,15 +9478,22 @@ async function parseCopilotIncremental({ otelPaths, cursors, queuePath, onProgre
       const bucketStart = toUtcHalfHourStart(tsIso);
       if (!bucketStart) continue;
 
-      const model = normalizeModelInput(pickCopilotModel(attrs)) || "github-copilot";
+      const model =
+        normalizeCopilotAppModel(pickCopilotModel(attrs)) ||
+        COPILOT_APP_DEFAULT_MODEL;
 
       const delta = {
         input_tokens: input,
         cached_input_tokens: cacheReadClamped,
-        cache_creation_input_tokens: cacheWrite,
-        output_tokens: output,
-        reasoning_output_tokens: reasoning,
-        total_tokens: input + output + cacheReadClamped + cacheWrite + reasoning,
+        cache_creation_input_tokens: cacheWriteForAccounting,
+        output_tokens: outputWithoutReasoning,
+        reasoning_output_tokens: reasoningClamped,
+        total_tokens:
+          input +
+          outputWithoutReasoning +
+          cacheReadClamped +
+          cacheWriteForAccounting +
+          reasoningClamped,
         conversation_count: 1,
       };
 
@@ -9735,8 +9760,13 @@ function normalizeCopilotAppTokenDelta(curr, prev) {
   const cachedDelta = Math.max(0, Number(curr?.cached || 0) - Number(prev?.cached || 0));
   const cachedInputTokens = Math.min(cachedDelta, inputDelta);
   const inputTokens = Math.max(0, inputDelta - cachedInputTokens);
-  const outputTokens = Math.max(0, Number(curr?.output || 0) - Number(prev?.output || 0));
-  const reasoningTokens = Math.max(0, Number(curr?.reasoning || 0) - Number(prev?.reasoning || 0));
+  const outputDelta = Math.max(0, Number(curr?.output || 0) - Number(prev?.output || 0));
+  const reasoningDelta = Math.max(
+    0,
+    Number(curr?.reasoning || 0) - Number(prev?.reasoning || 0),
+  );
+  const reasoningTokens = Math.min(reasoningDelta, outputDelta);
+  const outputTokens = Math.max(0, outputDelta - reasoningTokens);
   const totalTokens = inputTokens + cachedInputTokens + outputTokens + reasoningTokens;
   return {
     input_tokens: inputTokens,

--- a/test/copilot-app-parser.test.js
+++ b/test/copilot-app-parser.test.js
@@ -389,6 +389,33 @@ test("parseCopilotAppDbIncremental clamps cached input to raw input delta", asyn
   }
 });
 
+test("parseCopilotAppDbIncremental clamps reasoning to inclusive output totals", async () => {
+  const { dir, dbPath } = makeCopilotAppDb([
+    {
+      id: "reasoning-heavy",
+      session_type: "project",
+      model: "gpt-5.5",
+      created_at: "2026-07-07T14:35:00Z",
+      updated_at: "2026-07-07T14:36:00Z",
+      total_input_tokens: 100,
+      total_output_tokens: 50,
+      total_cached_tokens: 0,
+      total_reasoning_tokens: 80,
+    },
+  ]);
+  try {
+    const queuePath = path.join(dir, "queue.jsonl");
+    await parseCopilotAppDbIncremental({ dbPath, cursors: {}, queuePath });
+    const [row] = readQueue(queuePath).filter((entry) => entry.source === "copilot");
+    assert.equal(row.input_tokens, 100);
+    assert.equal(row.output_tokens, 0);
+    assert.equal(row.reasoning_output_tokens, 50);
+    assert.equal(row.total_tokens, 150);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotAppDbIncremental isolates one DB read failure without dropping healthy progress", async () => {
   const { dir, dbPath } = makeCopilotAppDb([
     {

--- a/test/copilot-app-parser.test.js
+++ b/test/copilot-app-parser.test.js
@@ -217,11 +217,11 @@ test("parseCopilotAppDbIncremental reads sessions table summaries into copilot b
     assert.equal(rows.length, 1);
     assert.equal(rows[0].model, "claude-sonnet-4-6");
     assert.equal(rows[0].input_tokens, 700);
-    assert.equal(rows[0].output_tokens, 200);
+    assert.equal(rows[0].output_tokens, 160);
     assert.equal(rows[0].cached_input_tokens, 300);
     assert.equal(rows[0].reasoning_output_tokens, 40);
     assert.equal(rows[0].cache_creation_input_tokens, 0);
-    assert.equal(rows[0].total_tokens, 1240);
+    assert.equal(rows[0].total_tokens, 1200);
     assert.equal(rows[0].conversation_count, 1);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -287,10 +287,10 @@ test("parseCopilotAppDbIncremental emits only positive deltas on subsequent sync
     const latest = latestByBucket(readQueue(queuePath).filter((row) => row.source === "copilot"));
     assert.equal(latest.length, 1);
     assert.equal(latest[0].input_tokens, 150);
-    assert.equal(latest[0].output_tokens, 30);
+    assert.equal(latest[0].output_tokens, 25);
     assert.equal(latest[0].cached_input_tokens, 25);
     assert.equal(latest[0].reasoning_output_tokens, 5);
-    assert.equal(latest[0].total_tokens, 210);
+    assert.equal(latest[0].total_tokens, 205);
     assert.equal(latest[0].conversation_count, 1, "growth in an existing App session must not add another conversation");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -381,9 +381,9 @@ test("parseCopilotAppDbIncremental clamps cached input to raw input delta", asyn
     assert.equal(rows.length, 1);
     assert.equal(rows[0].input_tokens, 0);
     assert.equal(rows[0].cached_input_tokens, 100);
-    assert.equal(rows[0].output_tokens, 7);
+    assert.equal(rows[0].output_tokens, 4);
     assert.equal(rows[0].reasoning_output_tokens, 3);
-    assert.equal(rows[0].total_tokens, 110);
+    assert.equal(rows[0].total_tokens, 107);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -572,7 +572,7 @@ test("Copilot App DB and OTEL parsing coexist without sharing cursors or changin
     assert.equal(byModel.get("gpt-4o").output_tokens, 20);
     assert.equal(byModel.get("claude-sonnet-4-6").input_tokens, 45);
     assert.equal(byModel.get("claude-sonnet-4-6").cached_input_tokens, 5);
-    assert.equal(byModel.get("claude-sonnet-4-6").output_tokens, 10);
+    assert.equal(byModel.get("claude-sonnet-4-6").output_tokens, 8);
 
     const otelSecond = await parseCopilotIncremental({ otelPaths: [otelPath], cursors, queuePath });
     const appSecond = await parseCopilotAppDbIncremental({ dbPath, cursors, queuePath });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5314,6 +5314,38 @@ test("parseCopilotIncremental normalizes CLI cache writes, reasoning, and dotted
   }
 });
 
+test("parseCopilotIncremental clamps reasoning to inclusive output tokens", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
+  try {
+    const otelPath = path.join(tmp, "copilot-otel-reasoning-clamp.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    writeCopilotOtelFile(otelPath, [
+      makeCopilotChatSpan({
+        traceId: "t-reasoning-clamp",
+        spanId: "s-reasoning-clamp",
+        inputTokens: 100,
+        outputTokens: 5,
+        cacheRead: 10,
+        cacheWrite: 20,
+        reasoning: 8,
+      }),
+    ]);
+
+    await parseCopilotIncremental({ otelPaths: [otelPath], cursors: {}, queuePath });
+    const [row] = (await readJsonLines(queuePath)).filter(
+      (entry) => entry.source === "copilot",
+    );
+    assert.equal(row.input_tokens, 70);
+    assert.equal(row.cached_input_tokens, 10);
+    assert.equal(row.cache_creation_input_tokens, 20);
+    assert.equal(row.output_tokens, 0);
+    assert.equal(row.reasoning_output_tokens, 5);
+    assert.equal(row.total_tokens, 105);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotIncremental dedups by traceId:spanId across runs", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5275,6 +5275,45 @@ test("parseCopilotIncremental aggregates chat spans and subtracts cache from inp
   }
 });
 
+test("parseCopilotIncremental normalizes CLI cache writes, reasoning, and dotted models", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
+  try {
+    const otelPath = path.join(tmp, "copilot-otel-cli.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    writeCopilotOtelFile(otelPath, [
+      makeCopilotChatSpan({
+        traceId: "t-cli-semantics",
+        spanId: "s-cli-semantics",
+        inputTokens: 125,
+        outputTokens: 7,
+        cacheRead: 20,
+        cacheWrite: 100,
+        reasoning: 3,
+        model: "claude-opus-4.8",
+      }),
+    ]);
+
+    const result = await parseCopilotIncremental({
+      otelPaths: [otelPath],
+      cursors: {},
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 1);
+    const [row] = (await readJsonLines(queuePath)).filter(
+      (entry) => entry.source === "copilot",
+    );
+    assert.equal(row.model, "claude-opus-4-8");
+    assert.equal(row.input_tokens, 5);
+    assert.equal(row.cached_input_tokens, 20);
+    assert.equal(row.cache_creation_input_tokens, 100);
+    assert.equal(row.output_tokens, 4);
+    assert.equal(row.reasoning_output_tokens, 3);
+    assert.equal(row.total_tokens, 132);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotIncremental dedups by traceId:spanId across runs", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
   try {
@@ -5428,9 +5467,9 @@ test("parseCopilotIncremental reads short cache_creation + reasoning_tokens keys
     assert.equal(b.input_tokens, 3500);
     assert.equal(b.cached_input_tokens, 1500);
     assert.equal(b.cache_creation_input_tokens, 800);
-    assert.equal(b.output_tokens, 300);
+    assert.equal(b.output_tokens, 50);
     assert.equal(b.reasoning_output_tokens, 250);
-    assert.equal(b.total_tokens, 3500 + 1500 + 800 + 300 + 250);
+    assert.equal(b.total_tokens, 3500 + 1500 + 800 + 50 + 250);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -5465,9 +5504,9 @@ test("parseCopilotIncremental reads flat cached/reasoning usage keys from Copilo
     assert.ok(b, "copilot bucket present");
     assert.equal(b.input_tokens, 71_163);
     assert.equal(b.cached_input_tokens, 1_517_440);
-    assert.equal(b.output_tokens, 15_768);
+    assert.equal(b.output_tokens, 6_467);
     assert.equal(b.reasoning_output_tokens, 9_301);
-    assert.equal(b.total_tokens, 1_613_672);
+    assert.equal(b.total_tokens, 1_604_371);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- split Copilot CLI cache reads and cache writes out of inclusive input tokens
- split reasoning tokens out of inclusive output tokens so totals and cost count them once
- normalize dotted Claude model IDs from Copilot OTEL to pricing-compatible IDs

## Background

While investigating token accounting across GitHub Copilot App and Copilot CLI session resumes, I compared the existing parser with the raw local usage records and found three issues in the current Copilot paths:

1. Copilot CLI OTEL `input_tokens` includes both cache reads and cache writes. The parser subtracted cache reads but then counted cache writes again without removing them from input.
2. Copilot `output_tokens` includes reasoning tokens. Emitting the full output count plus a separate reasoning count inflated token totals and estimated cost.
3. Copilot OTEL may report Claude model IDs such as `claude-opus-4.8`, while the pricing registry uses `claude-opus-4-8`.

This PR only corrects the existing Copilot OTEL and App DB token semantics. It does not change Codex, Every Code, global pricing behavior, or add the separate session-store integration.

Chat-extension LogRecords retain their existing cache-creation behavior; the cache-write subtraction applies only to Copilot CLI spans.

## Validation

- added a Copilot CLI regression fixture covering cache read/write, reasoning, and dotted model IDs
- updated App DB and Chat-extension assertions for inclusive reasoning output
- `npm test` - 1,349 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Copilot token usage accounting by clamping reasoning to output to prevent invalid or negative counts.
  * More accurately separates reasoning, output, input, cached input, and cache-creation tokens during incremental parsing.
  * Improved normalization of Copilot chat and CLI-style telemetry data into a consistent token schema.
  * Standardized Copilot model name attribution for more consistent usage aggregation.
  * Updated token totals and related expectations across Copilot App DB and OTEL sources to match corrected calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->