### PR TITLE
feat(wsl): add WSL auto-discovery for Every Code, Kimi, Gemini, Antigravity, OpenCode, and Codex (PR2)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -267,6 +267,21 @@ Die meisten Nutzer brauchen das nie – die Standardwerte sind sinnvoll. Für fo
 | `GROK_HOME` | Legacy-Grok-Build-Verzeichnis, falls `TOKENTRACKER_GROK_HOME` nicht gesetzt | `~/.grok` |
 | `TOKENTRACKER_ANTIGRAVITY_HOME` | Einzelnes Antigravity-Skills-Verzeichnis erzwingen (sonst Auto-Erkennung von `~/.gemini/antigravity` + `~/.gemini/antigravity-ide`) | auto |
 
+### 🐧 WSL-Erkennung unter Windows (WSL Auto-Discovery)
+
+Wenn du KI-Coding-Agents unter Windows in WSL verwendest, kann TokenTracker deine Windows- und WSL-Installationen automatisch erkennen und die Token-Nutzung zusammenrechnen.
+
+Konfiguriere dieses Verhalten über die Umgebungsvariable `TOKENTRACKER_WSL_MODE`:
+* `both` (Empfohlen): Liest und addiert die Daten aus beiden Umgebungen (Windows und WSL).
+* `wsl-first` (Standard): Bevorzugt WSL. Wenn Daten in WSL vorliegen, werden diese genutzt, andernfalls die von Windows.
+* `native-first`: Bevorzugt Windows. Wenn Daten unter Windows vorliegen, werden diese genutzt, andernfalls die von WSL.
+* `wsl-only`: Liest ausschließlich die Daten aus der WSL-Umgebung.
+* `native-only`: Liest ausschließlich die Daten aus der nativen Windows-Umgebung.
+
+Diese Tools werden für die WSL-Erkennung unterstützt:
+* **Dateibasiert (Logs & Transkripte):** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
+* **Datenbankbasiert (SQLite):** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.
+
 ---
 
 ## 🛠️ Entwicklung

--- a/README.de.md
+++ b/README.de.md
@@ -278,6 +278,9 @@ Konfiguriere dieses Verhalten über die Umgebungsvariable `TOKENTRACKER_WSL_MODE
 * `wsl-only`: Liest ausschließlich die Daten aus der WSL-Umgebung.
 * `native-only`: Liest ausschließlich die Daten aus der nativen Windows-Umgebung.
 
+> [!NOTE]
+> **Präferenz (`-first`) vs. Isolierung (`-only`):** Präferenzmodi bevorzugen deine Auswahl, weichen aber automatisch auf die andere Umgebung aus, falls das Tool dort fehlt. Isolierungsmodi beschränken den Scan strikt auf eine Umgebung und ignorieren die andere komplett.
+
 Diese Tools werden für die WSL-Erkennung unterstützt:
 * **Dateibasiert (Logs & Transkripte):** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
 * **Datenbankbasiert (SQLite):** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.

--- a/README.de.md
+++ b/README.de.md
@@ -281,9 +281,14 @@ Konfiguriere dieses Verhalten über die Umgebungsvariable `TOKENTRACKER_WSL_MODE
 > [!NOTE]
 > **Präferenz (`-first`) vs. Isolierung (`-only`):** Präferenzmodi bevorzugen deine Auswahl, weichen aber automatisch auf die andere Umgebung aus, falls das Tool dort fehlt. Isolierungsmodi beschränken den Scan strikt auf eine Umgebung und ignorieren die andere komplett.
 
-Diese Tools werden für die WSL-Erkennung unterstützt:
-* **Dateibasiert (Logs & Transkripte):** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
-* **Datenbankbasiert (SQLite):** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.
+Unterstützte Provider für WSL-Erkennung und Zusammenführung (Aggregation):
+* **Zusammenführung bei paralleler Installation (`both`-Modus):**
+  * **Dateibasiert (Logs & Transkripte):** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode (JSON), Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi (omp), pi, GitHub Copilot (OTEL), Roo Code, Craft, Kilo Code, Droid.
+  * **Datenbankbasiert (SQLite):** Hermes, Zed Agent, Goose, OpenCode (`opencode.db`), GitHub Copilot (App DB).
+* **WSL-Erkennung (nur Präferenz/Isolierung, keine Zusammenführung):**
+  * Grok Build (wählt dynamisch entweder die native oder WSL-Umgebung je nach Modus, führt aber im `both`-Modus nicht beide zusammen).
+* **Nur nativ (noch keine WSL-Unterstützung):**
+  * Kilo CLI, Mimo Code, ZCode.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,21 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `GROK_HOME` | Legacy Grok Build directory override, used when `TOKENTRACKER_GROK_HOME` is unset | `~/.grok` |
 | `TOKENTRACKER_ANTIGRAVITY_HOME` | Force a single Antigravity Skills directory (auto-detects `~/.gemini/antigravity` + `~/.gemini/antigravity-ide` otherwise) | auto |
 
+### 🐧 Windows Subsystem for Linux (WSL) Auto-Discovery
+
+If you run AI coding agents inside WSL on Windows, TokenTracker can auto-discover and aggregate metrics from both native Windows and WSL installations. 
+
+Configure this behavior using the `TOKENTRACKER_WSL_MODE` environment variable:
+* `both` (Recommended): Scans and aggregates metrics from both native Windows and WSL.
+* `wsl-first` (Default): Checks WSL first; if found, uses WSL metrics, otherwise falls back to Windows.
+* `native-first`: Checks native Windows first; if found, uses Windows metrics, otherwise falls back to WSL.
+* `wsl-only`: Scans WSL environment only.
+* `native-only`: Scans native Windows environment only.
+
+Supported providers for WSL auto-discovery:
+* **File-list & Active CLIs:** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
+* **SQLite-based DBs:** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.
+
 ---
 
 ## 🛠️ Development

--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ Configure this behavior using the `TOKENTRACKER_WSL_MODE` environment variable:
 * `wsl-only`: Scans WSL environment only.
 * `native-only`: Scans native Windows environment only.
 
+> [!NOTE]
+> **Preference (`-first`) vs. Isolation (`-only`):** Preference modes prioritize your choice but gracefully fall back to scanning the other environment if the tool is missing. Isolation modes strictly lock scanning to that single environment and ignore the other completely.
+
 Supported providers for WSL auto-discovery:
 * **File-list & Active CLIs:** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
 * **SQLite-based DBs:** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.

--- a/README.md
+++ b/README.md
@@ -287,9 +287,14 @@ Configure this behavior using the `TOKENTRACKER_WSL_MODE` environment variable:
 > [!NOTE]
 > **Preference (`-first`) vs. Isolation (`-only`):** Preference modes prioritize your choice but gracefully fall back to scanning the other environment if the tool is missing. Isolation modes strictly lock scanning to that single environment and ignore the other completely.
 
-Supported providers for WSL auto-discovery:
-* **File-list & Active CLIs:** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode, Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi, pi, Grok Build, GitHub Copilot, Roo Code, Craft, Kilo Code.
-* **SQLite-based DBs:** Hermes, Zed Agent, Goose, Droid, Kilo CLI, Mimo Code, ZCode.
+Supported providers for WSL auto-discovery and aggregation:
+* **Dual-Install Aggregation (`both` mode):**
+  * **File-list & Active CLIs:** Every Code, Kimi (legacy & Code), Gemini CLI, Antigravity, OpenCode (JSON), Codex CLI, CodeBuddy, WorkBuddy, oh-my-pi (omp), pi, GitHub Copilot (OTEL), Roo Code, Craft, Kilo Code, Droid.
+  * **SQLite-based DBs:** Hermes, Zed Agent, Goose, OpenCode (`opencode.db`), GitHub Copilot (App DB).
+* **WSL Auto-Discovery (Preference/Isolation only, no dual aggregation):**
+  * Grok Build (dynamically selects either native or WSL depending on the mode, but does not aggregate both in `both` mode).
+* **Native Only (No WSL support yet):**
+  * Kilo CLI, Mimo Code, ZCode.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 
 ### 🐧 Windows Subsystem for Linux (WSL) Auto-Discovery
 
-If you run AI coding agents inside WSL on Windows, TokenTracker can auto-discover and aggregate metrics from both native Windows and WSL installations. 
+If you run AI coding agents inside WSL on Windows, TokenTracker can auto-discover and aggregate metrics from both native Windows and WSL installations.
 
 Configure this behavior using the `TOKENTRACKER_WSL_MODE` environment variable:
 * `both` (Recommended): Scans and aggregates metrics from both native Windows and WSL.

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -72,10 +72,12 @@ const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 function formatResolvedPaths(paths, filename) {
   const active = [];
   if (paths.native) {
-    active.push(`native: ${filename ? path.join(paths.native, filename) : paths.native}`);
+    const file = filename ? path.join(paths.native, filename) : paths.native;
+    try { if (fssync.existsSync(file)) active.push(`native: ${file}`); } catch (_e) {}
   }
   if (paths.wsl) {
-    active.push(`WSL: ${filename ? path.join(paths.wsl, filename) : paths.wsl}`);
+    const file = filename ? path.join(paths.wsl, filename) : paths.wsl;
+    try { if (fssync.existsSync(file)) active.push(`WSL: ${file}`); } catch (_e) {}
   }
   return active;
 }
@@ -338,9 +340,15 @@ async function cmdStatus(argv = []) {
   // install / WSL auto-discovery. Surface the resolved path (UNC included) and,
   // on Windows, the discovered distros so WSL users can debug "why no sync"
   // without guessing the right UNC alias (#87).
-  const hermesPath = resolveHermesPath();
-  const hermesDbPath = resolveHermesDbPath();
-  const hermesInstalled = Boolean(hermesDbPath && fssync.existsSync(hermesDbPath));
+  const hermesPaths = resolveInstallPaths({
+    nativeValue: process.env.TOKENTRACKER_HERMES_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+      ? path.join(process.env.LOCALAPPDATA.trim(), "hermes")
+      : path.join(home, ".hermes")),
+    wslDir: ".hermes",
+  });
+  const hermesActive = formatResolvedPaths(hermesPaths, "state.db");
+  const hermesInstalled = hermesActive.length > 0;
+  const hermesPath = hermesActive.join(" | ");
   const wslDistros = process.platform === "win32" && shouldProbeWsl(process.env) ? probeWslDistros() : [];
 
   const copilotToken = readCopilotOauthToken({ home });

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -337,6 +337,34 @@ async function cmdStatus(argv = []) {
   const geminiActive = formatResolvedPaths(geminiPaths);
   const geminiInstalledStatus = geminiActive.length > 0;
 
+  // Gemini CLI (passive sessions scan)
+  const geminiCliActive = formatResolvedPaths(geminiPaths, "tmp");
+  const geminiCliInstalled = geminiCliActive.length > 0;
+
+  // Antigravity (passive brains scan)
+  const antigravityActive = [];
+  if (geminiPaths.native) {
+    const dirs = [
+      path.join(geminiPaths.native, "antigravity", "brain"),
+      path.join(geminiPaths.native, "antigravity-ide", "brain"),
+      path.join(geminiPaths.native, "antigravity-cli", "brain"),
+    ];
+    if (dirs.some(d => { try { return fssync.existsSync(d); } catch (_) { return false; } })) {
+      antigravityActive.push(`native: ${geminiPaths.native}`);
+    }
+  }
+  if (geminiPaths.wsl) {
+    const dirs = [
+      path.join(geminiPaths.wsl, "antigravity", "brain"),
+      path.join(geminiPaths.wsl, "antigravity-ide", "brain"),
+      path.join(geminiPaths.wsl, "antigravity-cli", "brain"),
+    ];
+    if (dirs.some(d => { try { return fssync.existsSync(d); } catch (_) { return false; } })) {
+      antigravityActive.push(`WSL: ${geminiPaths.wsl}`);
+    }
+  }
+  const antigravityInstalled = antigravityActive.length > 0;
+
   // Codex CLI (passive sessions scan)
   const codexPaths = resolveInstallPaths({
     nativeValue: process.env.CODEX_HOME || path.join(home, ".codex"),
@@ -620,7 +648,13 @@ async function cmdStatus(argv = []) {
       codeInstalled
         ? `- Every Code: sessions found (${codeActive.join(" | ")})`
         : null,
-      geminiInstalledStatus
+      geminiCliInstalled
+        ? `- Gemini CLI: sessions found (${geminiCliActive.join(" | ")})`
+        : null,
+      antigravityInstalled
+        ? `- Antigravity: brain found (${antigravityActive.join(" | ")})`
+        : null,
+      (!geminiCliInstalled && !antigravityInstalled && geminiInstalledStatus)
         ? `- Gemini CLI / Antigravity: home found (${geminiActive.join(" | ")})`
         : null,
       codexInstalledStatus

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -325,6 +325,41 @@ async function cmdStatus(argv = []) {
   const opencodeDbActive = formatResolvedPaths(opencodeDbPaths, "opencode.db");
   const opencodeInstalled = opencodeStorageActive.length > 0 || opencodeDbActive.length > 0;
 
+  // Every Code (passive sessions scan)
+  const codePaths = resolveInstallPaths({
+    nativeValue: process.env.CODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+      ? path.join(process.env.APPDATA.trim(), ".code")
+      : path.join(home, ".code")),
+    wslDir: ".code",
+  });
+  const codeActive = formatResolvedPaths(codePaths, "sessions");
+  const codeInstalled = codeActive.length > 0;
+
+  // Gemini CLI & Antigravity (shared home)
+  const geminiPaths = resolveInstallPaths({
+    nativeValue: process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+      ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
+      : path.join(home, ".gemini")),
+    wslDir: ".gemini",
+  });
+  const geminiActive = formatResolvedPaths(geminiPaths);
+  const geminiInstalledStatus = geminiActive.length > 0;
+
+  // Codex CLI (passive sessions scan)
+  const codexPaths = resolveInstallPaths({
+    nativeValue: process.env.CODEX_HOME || path.join(home, ".codex"),
+    wslDir: ".codex",
+  });
+  const codexActive = formatResolvedPaths(codexPaths, "sessions");
+  const codexInstalledStatus = codexActive.length > 0;
+
+  // Kimi (passive sessions scan)
+  const kimiPaths = resolveInstallPaths({
+    nativeValue: path.join(home, ".kimi"),
+    wslDir: ".kimi",
+  });
+  const kimiActive = formatResolvedPaths(kimiPaths, "sessions");
+
   // Kilo Code VS Code extension — passive scan of all VS Code-family
   // globalStorage/kilocode.kilo-code/tasks/ ui_messages.json files.
   const kilocodeTaskFiles = resolveKilocodeTaskFiles(process.env);
@@ -552,7 +587,7 @@ async function cmdStatus(argv = []) {
       `- OpenClaw session plugin conversation access: ${openclawSessionPluginState?.conversationAccess ? "set" : "unset"}`,
       `- OpenClaw hook (legacy): ${openclawHookState?.configured ? "set" : "unset"}`,
       kimiInstalled || kimiCodeInstalled
-        ? `- Kimi Code: passive reader (${kimiWireFiles.length + kimiCodeWireFiles.length} wire.jsonl file${(kimiWireFiles.length + kimiCodeWireFiles.length) !== 1 ? "s" : ""} found)`
+        ? `- Kimi Code: passive reader (${kimiWireFiles.length + kimiCodeWireFiles.length} wire.jsonl file${(kimiWireFiles.length + kimiCodeWireFiles.length) !== 1 ? "s" : ""} found, directories: ${kimiActive.join(" | ") || "none"})`
         : null,
       kiroCliInstalled
         ? `- Kiro CLI: SQLite data.sqlite3 found (tokens approximated from char lengths, merged under 'kiro' source)`
@@ -583,6 +618,15 @@ async function cmdStatus(argv = []) {
         : null,
       opencodeInstalled
         ? `- OpenCode: passive reader (storage: ${opencodeStorageActive.join(" | ") || "not found"}, DB: ${opencodeDbActive.join(" | ") || "not found"})`
+        : null,
+      codeInstalled
+        ? `- Every Code: sessions found (${codeActive.join(" | ")})`
+        : null,
+      geminiInstalledStatus
+        ? `- Gemini CLI / Antigravity: home found (${geminiActive.join(" | ")})`
+        : null,
+      codexInstalledStatus
+        ? `- Codex CLI: sessions found (${codexActive.join(" | ")})`
         : null,
       kilocodeInstalled
         ? `- Kilo Code (VS Code extension): passive reader (${kilocodeTaskFiles.length} task${kilocodeTaskFiles.length !== 1 ? "s" : ""} across ${new Set(kilocodeTaskFiles.map((t) => t.ide)).size} IDE${new Set(kilocodeTaskFiles.map((t) => t.ide)).size !== 1 ? "s" : ""})`

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -65,9 +65,8 @@ const {
   probeWslDistros,
 } = require("../lib/rollout");
 const wsl = require("../lib/wsl-probe");
-const { getWslMode, isInvalidWslMode, shouldProbeWsl } = wsl;
+const { getWslMode, isInvalidWslMode, shouldProbeWsl, discoverWslHome } = wsl;
 const { resolveInstallPaths } = require("../lib/install-resolver");
-
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 
 function formatResolvedPaths(paths, filename) {
@@ -304,8 +303,8 @@ async function cmdStatus(argv = []) {
   const opencodeStorageNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
     ? path.join(process.env.APPDATA.trim(), "opencode")
     : path.join(xdgDataHome, "opencode"));
-  const wslOpencodeStorageDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
-    ? wsl.discoverWslHome(".local/share/opencode")
+  const wslOpencodeStorageDir = process.platform === "win32" && shouldProbeWsl(process.env)
+    ? discoverWslHome(".local/share/opencode")
     : null;
   const opencodeStoragePaths = resolveInstallPaths({
     nativeValue: opencodeStorageNativeValue,
@@ -316,8 +315,8 @@ async function cmdStatus(argv = []) {
   const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
     ? path.join(process.env.APPDATA.trim(), "opencode")
     : path.join(xdgDataHome, "opencode"));
-  const wslOpencodeDbDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
-    ? wsl.discoverWslHome(".local/share/opencode")
+  const wslOpencodeDbDir = process.platform === "win32" && shouldProbeWsl(process.env)
+    ? discoverWslHome(".local/share/opencode")
     : null;
   const opencodeDbPaths = resolveInstallPaths({
     nativeValue: opencodeDbNativeValue,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -67,6 +67,7 @@ const {
 const wsl = require("../lib/wsl-probe");
 const { getWslMode, isInvalidWslMode, shouldProbeWsl } = wsl;
 const { resolveInstallPaths } = require("../lib/install-resolver");
+
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 
 function formatResolvedPaths(paths, filename) {
@@ -299,6 +300,32 @@ async function cmdStatus(argv = []) {
   const zcodeInstalled = zcodeActive.length > 0;
   const zcodeDbPath = zcodeActive.join(" | ");
 
+  // OpenCode (JSON files + SQLite DB) — passive scan of storage/message/ and opencode.db.
+  const opencodeStorageNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+    ? path.join(process.env.APPDATA.trim(), "opencode")
+    : path.join(xdgDataHome, "opencode"));
+  const wslOpencodeStorageDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+    ? wsl.discoverWslHome(".local/share/opencode")
+    : null;
+  const opencodeStoragePaths = resolveInstallPaths({
+    nativeValue: opencodeStorageNativeValue,
+    wslValue: wslOpencodeStorageDir,
+  });
+  const opencodeStorageActive = formatResolvedPaths(opencodeStoragePaths);
+
+  const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+    ? path.join(process.env.APPDATA.trim(), "opencode")
+    : path.join(xdgDataHome, "opencode"));
+  const wslOpencodeDbDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+    ? wsl.discoverWslHome(".local/share/opencode")
+    : null;
+  const opencodeDbPaths = resolveInstallPaths({
+    nativeValue: opencodeDbNativeValue,
+    wslValue: wslOpencodeDbDir,
+  });
+  const opencodeDbActive = formatResolvedPaths(opencodeDbPaths, "opencode.db");
+  const opencodeInstalled = opencodeStorageActive.length > 0 || opencodeDbActive.length > 0;
+
   // Kilo Code VS Code extension — passive scan of all VS Code-family
   // globalStorage/kilocode.kilo-code/tasks/ ui_messages.json files.
   const kilocodeTaskFiles = resolveKilocodeTaskFiles(process.env);
@@ -340,15 +367,9 @@ async function cmdStatus(argv = []) {
   // install / WSL auto-discovery. Surface the resolved path (UNC included) and,
   // on Windows, the discovered distros so WSL users can debug "why no sync"
   // without guessing the right UNC alias (#87).
-  const hermesPaths = resolveInstallPaths({
-    nativeValue: process.env.TOKENTRACKER_HERMES_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
-      ? path.join(process.env.LOCALAPPDATA.trim(), "hermes")
-      : path.join(home, ".hermes")),
-    wslDir: ".hermes",
-  });
-  const hermesActive = formatResolvedPaths(hermesPaths, "state.db");
-  const hermesInstalled = hermesActive.length > 0;
-  const hermesPath = hermesActive.join(" | ");
+  const hermesPath = resolveHermesPath();
+  const hermesDbPath = resolveHermesDbPath();
+  const hermesInstalled = Boolean(hermesDbPath && fssync.existsSync(hermesDbPath));
   const wslDistros = process.platform === "win32" && shouldProbeWsl(process.env) ? probeWslDistros() : [];
 
   const copilotToken = readCopilotOauthToken({ home });
@@ -560,6 +581,9 @@ async function cmdStatus(argv = []) {
         : null,
       zcodeInstalled
         ? `- ZCode: passive reader (${zcodeDbPath})`
+        : null,
+      opencodeInstalled
+        ? `- OpenCode: passive reader (storage: ${opencodeStorageActive.join(" | ") || "not found"}, DB: ${opencodeDbActive.join(" | ") || "not found"})`
         : null,
       kilocodeInstalled
         ? `- Kilo Code (VS Code extension): passive reader (${kilocodeTaskFiles.length} task${kilocodeTaskFiles.length !== 1 ? "s" : ""} across ${new Set(kilocodeTaskFiles.map((t) => t.ide)).size} IDE${new Set(kilocodeTaskFiles.map((t) => t.ide)).size !== 1 ? "s" : ""})`

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -401,9 +401,15 @@ async function cmdStatus(argv = []) {
   // install / WSL auto-discovery. Surface the resolved path (UNC included) and,
   // on Windows, the discovered distros so WSL users can debug "why no sync"
   // without guessing the right UNC alias (#87).
-  const hermesPath = resolveHermesPath();
-  const hermesDbPath = resolveHermesDbPath();
-  const hermesInstalled = Boolean(hermesDbPath && fssync.existsSync(hermesDbPath));
+  const hermesPaths = resolveInstallPaths({
+    nativeValue: process.env.TOKENTRACKER_HERMES_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+      ? path.join(process.env.LOCALAPPDATA.trim(), "hermes")
+      : path.join(home, ".hermes")),
+    wslDir: ".hermes",
+  });
+  const hermesActive = formatResolvedPaths(hermesPaths, "state.db");
+  const hermesInstalled = hermesActive.length > 0;
+  const hermesPath = hermesActive.join(" | ");
   const wslDistros = process.platform === "win32" && shouldProbeWsl(process.env) ? probeWslDistros() : [];
 
   const copilotToken = readCopilotOauthToken({ home });

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -224,7 +224,7 @@ async function cmdStatus(argv = []) {
   // CodeBuddy — passive scan only (no hooks). Surface the file count so
   // operators can confirm JSONL sessions and extension logs are discovered.
   const codebuddyHome = resolveCodebuddyHome(process.env);
-  const codebuddyInstalled = fssync.existsSync(codebuddyHome);
+  const codebuddyInstalled = Boolean(codebuddyHome && fssync.existsSync(codebuddyHome));
   const codebuddyFiles = codebuddyInstalled
     ? resolveCodebuddyProjectFiles(process.env)
     : [];
@@ -232,7 +232,7 @@ async function cmdStatus(argv = []) {
   // WorkBuddy — passive scan (sibling Claude-Code fork). Surface both the
   // recursive JSONL count and SQLite fallback so operators can confirm coverage.
   const workbuddyHome = resolveWorkbuddyHome(process.env);
-  const workbuddyInstalled = fssync.existsSync(workbuddyHome);
+  const workbuddyInstalled = Boolean(workbuddyHome && fssync.existsSync(workbuddyHome));
   const workbuddyFiles = workbuddyInstalled
     ? resolveWorkbuddyProjectFiles(process.env)
     : [];
@@ -254,7 +254,7 @@ async function cmdStatus(argv = []) {
 
   // Craft Agents — passive scan only (no hooks).
   const craftConfigDir = resolveCraftConfigDir(process.env);
-  const craftInstalled = fssync.existsSync(craftConfigDir);
+  const craftInstalled = Boolean(craftConfigDir && fssync.existsSync(craftConfigDir));
   const craftFiles = craftInstalled ? resolveCraftSessionFiles(process.env) : [];
 
   // Kilo CLI (kilo.ai @kilocode/plugin) — passive scan of kilo.db.

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -107,11 +107,11 @@ async function cmdStatus(argv = []) {
   const codeConfigPath = path.join(codeHome, "config.toml");
   const claudeSettingsPath = path.join(home, ".claude", "settings.json");
   const codebuddySettingsPath = path.join(
-    process.env.CODEBUDDY_HOME || path.join(home, ".codebuddy"),
+    resolveCodebuddyHome(process.env) || path.join(home, ".codebuddy"),
     "settings.json",
   );
   const workbuddySettingsPath = path.join(
-    process.env.WORKBUDDY_HOME || path.join(home, ".workbuddy"),
+    resolveWorkbuddyHome(process.env) || path.join(home, ".workbuddy"),
     "settings.json",
   );
   const geminiConfigDir = resolveGeminiConfigDir({ home, env: process.env });

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -300,9 +300,7 @@ async function cmdStatus(argv = []) {
   const zcodeDbPath = zcodeActive.join(" | ");
 
   // OpenCode (JSON files + SQLite DB) — passive scan of storage/message/ and opencode.db.
-  const opencodeStorageNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-    ? path.join(process.env.APPDATA.trim(), "opencode")
-    : path.join(xdgDataHome, "opencode"));
+  const opencodeStorageNativeValue = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
   const wslOpencodeStorageDir = process.platform === "win32" && shouldProbeWsl(process.env)
     ? discoverWslHome(".local/share/opencode")
     : null;
@@ -312,9 +310,7 @@ async function cmdStatus(argv = []) {
   });
   const opencodeStorageActive = formatResolvedPaths(opencodeStoragePaths);
 
-  const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-    ? path.join(process.env.APPDATA.trim(), "opencode")
-    : path.join(xdgDataHome, "opencode"));
+  const opencodeDbNativeValue = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
   const wslOpencodeDbDir = process.platform === "win32" && shouldProbeWsl(process.env)
     ? discoverWslHome(".local/share/opencode")
     : null;
@@ -327,9 +323,7 @@ async function cmdStatus(argv = []) {
 
   // Every Code (passive sessions scan)
   const codePaths = resolveInstallPaths({
-    nativeValue: process.env.CODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-      ? path.join(process.env.APPDATA.trim(), ".code")
-      : path.join(home, ".code")),
+    nativeValue: process.env.CODE_HOME || path.join(home, ".code"),
     wslDir: ".code",
   });
   const codeActive = formatResolvedPaths(codePaths, "sessions");
@@ -337,9 +331,7 @@ async function cmdStatus(argv = []) {
 
   // Gemini CLI & Antigravity (shared home)
   const geminiPaths = resolveInstallPaths({
-    nativeValue: process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
-      ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
-      : path.join(home, ".gemini")),
+    nativeValue: process.env.GEMINI_HOME || path.join(home, ".gemini"),
     wslDir: ".gemini",
   });
   const geminiActive = formatResolvedPaths(geminiPaths);

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -261,11 +261,8 @@ async function cmdSync(argv) {
     }
     let grokHookSignalConsumed = false;
 
-    const codexHome = process.env.CODEX_HOME || path.join(home, ".codex");
     const claudeProjectsDir = path.join(home, ".claude", "projects");
     const xdgDataHome = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
-    const opencodeHome = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
-    const opencodeStorageDir = path.join(opencodeHome, "storage");
     const kiloHome = process.env.KILO_HOME || path.join(xdgDataHome, "kilo");
     const mimoHome = process.env.MIMO_HOME || path.join(xdgDataHome, "mimocode");
     const zcodeHome = process.env.ZCODE_HOME || path.join(home, ".zcode");
@@ -292,18 +289,24 @@ async function cmdSync(argv) {
 
     const sources = [];
     if (sourceAllowed("codex")) {
-      sources.push({ source: "codex", sessionsDir: path.join(codexHome, "sessions"), codexInventoryCache: true });
-      if (!isBackgroundLightweightSync) {
-        sources.push(
-          // Codex-Manager archives sessions to ~/.codex/archived_sessions/ on every
-          // account/channel switch (issue #187). Scanning it too keeps that usage
-          // counted instead of orphaning it in the cloud (a re-upload's upsert can
-          // never delete cloud rows whose local source file has vanished). Safe
-          // against double-counting: the codex event dedup keys on sessionUUID (in
-          // the filename) + event timestamp, both stable across a sessions/ ->
-          // archived_sessions/ move, so re-reading an archived copy is a no-op.
-          { source: "codex", sessionsDir: path.join(codexHome, "archived_sessions"), deep: true },
-        );
+      const codexNativeValue = process.env.CODEX_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), ".codex")
+        : path.join(home, ".codex"));
+      const wslCodexDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".codex")
+        : null;
+      const codexPaths = resolveInstallPaths({ nativeValue: codexNativeValue, wslValue: wslCodexDir });
+      if (codexPaths.native) {
+        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "sessions"), codexInventoryCache: true });
+        if (!isBackgroundLightweightSync) {
+          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "archived_sessions"), deep: true });
+        }
+      }
+      if (codexPaths.wsl) {
+        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "sessions"), codexInventoryCache: true });
+        if (!isBackgroundLightweightSync) {
+          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "archived_sessions"), deep: true });
+        }
       }
     }
     if (sourceAllowed("every-code")) {
@@ -599,69 +602,88 @@ async function cmdSync(argv) {
       }
     }
 
-    const opencodeFiles = sourceAllowed("opencode") ? await listOpencodeMessageFiles(opencodeStorageDir) : [];
     let opencodeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (opencodeFiles.length > 0) {
-      if (progress?.enabled) {
-        progress.start(
-          `Parsing Opencode ${renderBar(0)} 0/${formatNumber(opencodeFiles.length)} files | buckets 0`,
-        );
-      }
-      try {
-        opencodeResult = await parseOpencodeIncremental({
-          messageFiles: opencodeFiles,
-          cursors,
-          queuePath,
-          projectQueuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Opencode ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} files | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-          source: "opencode",
-        });
-      } catch (err) {
-        warnProviderParseFailure("Opencode", err, opts);
-      }
-    }
+    if (sourceAllowed("opencode")) {
+      const opencodeStorageNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), "opencode")
+        : path.join(xdgDataHome, "opencode"));
+      const wslOpencodeStorageDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".local/share/opencode")
+        : null;
+      const storagePaths = resolveInstallPaths({
+        nativeValue: opencodeStorageNativeValue,
+        wslValue: wslOpencodeStorageDir,
+      });
 
-    // OpenCode v1.2+ stores messages in SQLite (opencode.db) instead of JSON files.
-    const opencodeDbPath = path.join(opencodeHome, "opencode.db");
-    let opencodeDbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const dbMessages = sourceAllowed("opencode") ? readOpencodeDbMessages(opencodeDbPath) : [];
-    if (dbMessages.length > 0) {
-      if (progress?.enabled) {
-        progress.start(
-          `Parsing Opencode DB ${renderBar(0)} 0/${formatNumber(dbMessages.length)} msgs | buckets 0`,
-        );
-      }
-      try {
-        opencodeDbResult = await parseOpencodeDbIncremental({
-          dbMessages,
-          cursors,
-          queuePath,
-          projectQueuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Opencode DB ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(
-                p.total,
-              )} msgs | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-          source: "opencode",
-        });
-      } catch (err) {
-        warnProviderParseFailure("Opencode DB", err, opts);
-      }
-      opencodeResult.filesProcessed += opencodeDbResult.messagesProcessed;
-      opencodeResult.eventsAggregated += opencodeDbResult.eventsAggregated;
-      opencodeResult.bucketsQueued += opencodeDbResult.bucketsQueued;
+      const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), "opencode")
+        : path.join(home, ".config", "opencode"));
+      const wslOpencodeDbDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".config/opencode")
+        : null;
+      const dbPaths = resolveInstallPaths({
+        nativeValue: opencodeDbNativeValue,
+        wslValue: wslOpencodeDbDir,
+      });
+
+      const parseOpencodeForInstall = async (options) => {
+        const { storageDir, dbDir } = options;
+        let filesResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+        if (storageDir) {
+          const storagePath = path.join(storageDir, "storage");
+          const messageFiles = await listOpencodeMessageFiles(storagePath);
+          if (messageFiles.length > 0) {
+            filesResult = await parseOpencodeIncremental({
+              ...options,
+              messageFiles,
+            });
+          }
+        }
+
+        let dbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+        if (dbDir) {
+          const dbPath = path.join(dbDir, "opencode.db");
+          const dbMessages = readOpencodeDbMessages(dbPath);
+          if (dbMessages.length > 0) {
+            dbResult = await parseOpencodeDbIncremental({
+              ...options,
+              dbMessages,
+            });
+          }
+        }
+
+        return {
+          recordsProcessed: filesResult.filesProcessed + dbResult.messagesProcessed,
+          eventsAggregated: filesResult.eventsAggregated + dbResult.eventsAggregated,
+          bucketsQueued: filesResult.bucketsQueued + dbResult.bucketsQueued,
+        };
+      };
+
+      const multiResult = await multiInstallParse({
+        paths: storagePaths,
+        parserFn: parseOpencodeForInstall,
+        providerName: "opencode",
+        cursors,
+        queuePath,
+        projectQueuePath,
+        getParams: (storageDir, key) => ({ storageDir, dbDir: dbPaths[key] }),
+        onProgress: (p) => {
+          if (!progress?.enabled) return;
+          const pct = p.total > 0 ? p.index / p.total : 1;
+          progress.update(
+            `Parsing Opencode (${p.install || "default"}) ${renderBar(pct)} ${formatNumber(
+              p.index,
+            )}/${formatNumber(p.total)} | buckets ${formatNumber(p.bucketsQueued)}`,
+          );
+        },
+        source: "opencode",
+      });
+
+      opencodeResult = {
+        filesProcessed: multiResult.recordsProcessed,
+        eventsAggregated: multiResult.eventsAggregated,
+        bucketsQueued: multiResult.bucketsQueued,
+      };
     }
 
     async function parseOpencodeDbForInstall({ dbPath, readFn, source, cursorKey, ...rest }) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -492,15 +492,19 @@ async function cmdSync(argv) {
       }
     }
 
-    let geminiFiles = [];
-    if (sourceAllowed("gemini")) {
+    let geminiPaths = null;
+    if (sourceAllowed("gemini") || sourceAllowed("antigravity")) {
       const geminiNativeValue = process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
         ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
         : path.join(home, ".gemini"));
       const wslGeminiDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".gemini")
         : null;
-      const geminiPaths = resolveInstallPaths({ nativeValue: geminiNativeValue, wslValue: wslGeminiDir });
+      geminiPaths = resolveInstallPaths({ nativeValue: geminiNativeValue, wslValue: wslGeminiDir });
+    }
+
+    let geminiFiles = [];
+    if (sourceAllowed("gemini") && geminiPaths) {
       const fileSets = [];
       if (geminiPaths.native) {
         fileSets.push(await listGeminiSessionFiles(path.join(geminiPaths.native, "tmp")));
@@ -548,14 +552,7 @@ async function cmdSync(argv) {
     }
 
     let antigravityFiles = [];
-    if (sourceAllowed("antigravity")) {
-      const geminiNativeValue = process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
-        ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
-        : path.join(home, ".gemini"));
-      const wslGeminiDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
-        ? wsl.discoverWslHome(".gemini")
-        : null;
-      const geminiPaths = resolveInstallPaths({ nativeValue: geminiNativeValue, wslValue: wslGeminiDir });
+    if (sourceAllowed("antigravity") && geminiPaths) {
       const fileSets = [];
       if (geminiPaths.native) {
         fileSets.push(await listAntigravityTranscripts(geminiPaths.native));

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1056,7 +1056,9 @@ async function cmdSync(argv) {
 
     // ── Kimi (passive wire.jsonl reader) ──
     let kimiResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const kimiWireFiles = sourceAllowed("kimi") ? resolveKimiWireFiles(process.env) : [];
+    const kimiWireFiles = sourceAllowed("kimi")
+      ? mergeBothFileSources({ resolveFiles: resolveKimiWireFiles, env: process.env })
+      : [];
     if (kimiWireFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing Kimi Code ${renderBar(0)} | buckets 0`);

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -262,7 +262,6 @@ async function cmdSync(argv) {
     let grokHookSignalConsumed = false;
 
     const codexHome = process.env.CODEX_HOME || path.join(home, ".codex");
-    const codeHome = process.env.CODE_HOME || path.join(home, ".code");
     const claudeProjectsDir = path.join(home, ".claude", "projects");
     const geminiHome = process.env.GEMINI_HOME || path.join(home, ".gemini");
     const geminiTmpDir = path.join(geminiHome, "tmp");
@@ -310,7 +309,19 @@ async function cmdSync(argv) {
       }
     }
     if (sourceAllowed("every-code")) {
-      sources.push({ source: "every-code", sessionsDir: path.join(codeHome, "sessions") });
+      const codeNativeValue = process.env.CODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
+        ? path.join(process.env.APPDATA.trim(), ".code")
+        : path.join(home, ".code"));
+      const wslCodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".code")
+        : null;
+      const codePaths = resolveInstallPaths({ nativeValue: codeNativeValue, wslValue: wslCodeDir });
+      if (codePaths.native) {
+        sources.push({ source: "every-code", sessionsDir: path.join(codePaths.native, "sessions") });
+      }
+      if (codePaths.wsl) {
+        sources.push({ source: "every-code", sessionsDir: path.join(codePaths.wsl, "sessions") });
+      }
     }
 
     const rolloutFiles = [];

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -627,7 +627,7 @@ async function cmdSync(argv) {
       });
 
       const parseOpencodeForInstall = async (options) => {
-        const { storageDir, dbDir } = options;
+        const { storageDir, dbDir, cursors } = options;
         let filesResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
         if (storageDir) {
           const storagePath = path.join(storageDir, "storage");
@@ -643,12 +643,31 @@ async function cmdSync(argv) {
         let dbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
         if (dbDir) {
           const dbPath = path.join(dbDir, "opencode.db");
-          const dbMessages = readOpencodeDbMessages(dbPath);
-          if (dbMessages.length > 0) {
-            dbResult = await parseOpencodeDbIncremental({
-              ...options,
-              dbMessages,
-            });
+          let shouldSkip = false;
+          let stats = null;
+          try {
+            stats = fssync.statSync(dbPath);
+            const cursorNamespace = options.cursorKey || "opencode";
+            const cursorState = cursors[cursorNamespace];
+            if (cursorState && cursorState.dbSize === stats.size && cursorState.dbMtime === stats.mtimeMs) {
+              shouldSkip = true;
+            }
+          } catch (_e) { }
+
+          if (!shouldSkip) {
+            const dbMessages = readOpencodeDbMessages(dbPath);
+            if (dbMessages.length > 0) {
+              dbResult = await parseOpencodeDbIncremental({
+                ...options,
+                dbMessages,
+              });
+            }
+            if (stats) {
+              const cursorNamespace = options.cursorKey || "opencode";
+              if (!cursors[cursorNamespace]) cursors[cursorNamespace] = {};
+              cursors[cursorNamespace].dbSize = stats.size;
+              cursors[cursorNamespace].dbMtime = stats.mtimeMs;
+            }
           }
         }
 

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -289,9 +289,7 @@ async function cmdSync(argv) {
 
     const sources = [];
     if (sourceAllowed("codex")) {
-      const codexNativeValue = process.env.CODEX_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-        ? path.join(process.env.APPDATA.trim(), ".codex")
-        : path.join(home, ".codex"));
+      const codexNativeValue = process.env.CODEX_HOME || path.join(home, ".codex");
       const wslCodexDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".codex")
         : null;
@@ -310,9 +308,7 @@ async function cmdSync(argv) {
       }
     }
     if (sourceAllowed("every-code")) {
-      const codeNativeValue = process.env.CODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-        ? path.join(process.env.APPDATA.trim(), ".code")
-        : path.join(home, ".code"));
+      const codeNativeValue = process.env.CODE_HOME || path.join(home, ".code");
       const wslCodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".code")
         : null;
@@ -494,9 +490,7 @@ async function cmdSync(argv) {
 
     let geminiPaths = null;
     if (sourceAllowed("gemini") || sourceAllowed("antigravity")) {
-      const geminiNativeValue = process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
-        ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
-        : path.join(home, ".gemini"));
+      const geminiNativeValue = process.env.GEMINI_HOME || path.join(home, ".gemini");
       const wslGeminiDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".gemini")
         : null;
@@ -601,9 +595,7 @@ async function cmdSync(argv) {
 
     let opencodeResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (sourceAllowed("opencode")) {
-      const opencodeStorageNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-        ? path.join(process.env.APPDATA.trim(), "opencode")
-        : path.join(xdgDataHome, "opencode"));
+      const opencodeStorageNativeValue = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
       const wslOpencodeStorageDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".local/share/opencode")
         : null;
@@ -612,9 +604,7 @@ async function cmdSync(argv) {
         wslValue: wslOpencodeStorageDir,
       });
 
-      const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
-        ? path.join(process.env.APPDATA.trim(), "opencode")
-        : path.join(xdgDataHome, "opencode"));
+      const opencodeDbNativeValue = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
       const wslOpencodeDbDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".local/share/opencode")
         : null;
@@ -640,31 +630,12 @@ async function cmdSync(argv) {
         let dbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
         if (dbDir) {
           const dbPath = path.join(dbDir, "opencode.db");
-          let shouldSkip = false;
-          let stats = null;
-          try {
-            stats = fssync.statSync(dbPath);
-            const cursorNamespace = options.cursorKey || "opencode";
-            const cursorState = cursors[cursorNamespace];
-            if (cursorState && cursorState.dbSize === stats.size && cursorState.dbMtime === stats.mtimeMs) {
-              shouldSkip = true;
-            }
-          } catch (_e) { }
-
-          if (!shouldSkip) {
-            const dbMessages = readOpencodeDbMessages(dbPath);
-            if (dbMessages.length > 0) {
-              dbResult = await parseOpencodeDbIncremental({
-                ...options,
-                dbMessages,
-              });
-            }
-            if (stats) {
-              const cursorNamespace = options.cursorKey || "opencode";
-              if (!cursors[cursorNamespace]) cursors[cursorNamespace] = {};
-              cursors[cursorNamespace].dbSize = stats.size;
-              cursors[cursorNamespace].dbMtime = stats.mtimeMs;
-            }
+          const dbMessages = readOpencodeDbMessages(dbPath);
+          if (dbMessages.length > 0) {
+            dbResult = await parseOpencodeDbIncremental({
+              ...options,
+              dbMessages,
+            });
           }
         }
 

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -617,9 +617,9 @@ async function cmdSync(argv) {
 
       const opencodeDbNativeValue = process.env.OPENCODE_HOME || (process.platform === "win32" && typeof process.env.APPDATA === "string"
         ? path.join(process.env.APPDATA.trim(), "opencode")
-        : path.join(home, ".config", "opencode"));
+        : path.join(xdgDataHome, "opencode"));
       const wslOpencodeDbDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
-        ? wsl.discoverWslHome(".config/opencode")
+        ? wsl.discoverWslHome(".local/share/opencode")
         : null;
       const dbPaths = resolveInstallPaths({
         nativeValue: opencodeDbNativeValue,

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -263,8 +263,6 @@ async function cmdSync(argv) {
 
     const codexHome = process.env.CODEX_HOME || path.join(home, ".codex");
     const claudeProjectsDir = path.join(home, ".claude", "projects");
-    const geminiHome = process.env.GEMINI_HOME || path.join(home, ".gemini");
-    const geminiTmpDir = path.join(geminiHome, "tmp");
     const xdgDataHome = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
     const opencodeHome = process.env.OPENCODE_HOME || path.join(xdgDataHome, "opencode");
     const opencodeStorageDir = path.join(opencodeHome, "storage");
@@ -491,7 +489,32 @@ async function cmdSync(argv) {
       }
     }
 
-    const geminiFiles = sourceAllowed("gemini") ? await listGeminiSessionFiles(geminiTmpDir) : [];
+    let geminiFiles = [];
+    if (sourceAllowed("gemini")) {
+      const geminiNativeValue = process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+        ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
+        : path.join(home, ".gemini"));
+      const wslGeminiDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".gemini")
+        : null;
+      const geminiPaths = resolveInstallPaths({ nativeValue: geminiNativeValue, wslValue: wslGeminiDir });
+      const fileSets = [];
+      if (geminiPaths.native) {
+        fileSets.push(await listGeminiSessionFiles(path.join(geminiPaths.native, "tmp")));
+      }
+      if (geminiPaths.wsl) {
+        fileSets.push(await listGeminiSessionFiles(path.join(geminiPaths.wsl, "tmp")));
+      }
+      const seen = new Set();
+      for (const set of fileSets) {
+        for (const f of set) {
+          if (!seen.has(f)) {
+            seen.add(f);
+            geminiFiles.push(f);
+          }
+        }
+      }
+    }
     let geminiResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (geminiFiles.length > 0) {
       if (progress?.enabled) {
@@ -521,7 +544,32 @@ async function cmdSync(argv) {
       }
     }
 
-    const antigravityFiles = sourceAllowed("antigravity") ? await listAntigravityTranscripts(geminiHome) : [];
+    let antigravityFiles = [];
+    if (sourceAllowed("antigravity")) {
+      const geminiNativeValue = process.env.GEMINI_HOME || (process.platform === "win32" && typeof process.env.LOCALAPPDATA === "string"
+        ? path.join(process.env.LOCALAPPDATA.trim(), "Gemini")
+        : path.join(home, ".gemini"));
+      const wslGeminiDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
+        ? wsl.discoverWslHome(".gemini")
+        : null;
+      const geminiPaths = resolveInstallPaths({ nativeValue: geminiNativeValue, wslValue: wslGeminiDir });
+      const fileSets = [];
+      if (geminiPaths.native) {
+        fileSets.push(await listAntigravityTranscripts(geminiPaths.native));
+      }
+      if (geminiPaths.wsl) {
+        fileSets.push(await listAntigravityTranscripts(geminiPaths.wsl));
+      }
+      const seen = new Set();
+      for (const set of fileSets) {
+        for (const f of set) {
+          if (!seen.has(f)) {
+            seen.add(f);
+            antigravityFiles.push(f);
+          }
+        }
+      }
+    }
     let antigravityResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (antigravityFiles.length > 0) {
       if (progress?.enabled) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -659,14 +659,19 @@ async function cmdSync(argv) {
         };
       };
 
+      const opencodePaths = {
+        native: storagePaths.native || dbPaths.native,
+        wsl: storagePaths.wsl || dbPaths.wsl,
+      };
+
       const multiResult = await multiInstallParse({
-        paths: storagePaths,
+        paths: opencodePaths,
         parserFn: parseOpencodeForInstall,
         providerName: "opencode",
         cursors,
         queuePath,
         projectQueuePath,
-        getParams: (storageDir, key) => ({ storageDir, dbDir: dbPaths[key] }),
+        getParams: (p, key) => ({ storageDir: storagePaths[key], dbDir: dbPaths[key] }),
         onProgress: (p) => {
           if (!progress?.enabled) return;
           const pct = p.total > 0 ? p.index / p.total : 1;

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -16,6 +16,7 @@ function resolveInstallPaths({ nativeValue, wslDir, wslValue } = {}, env = proce
 }
 
 function pathExists(p, existsSync) {
+  if (typeof p !== "string" || !p) return null;
   try { return (existsSync || fssync.existsSync)(p) ? p : null; } catch (_e) { return null; }
 }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5129,9 +5129,23 @@ async function parseKiroCliFromSessionFiles({
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-function resolveKimiWireFiles(env = process.env) {
+function resolveKimiHome(env = process.env) {
   const home = require("node:os").homedir();
-  const kimiHome = env.KIMI_HOME || path.join(home, ".kimi");
+  const explicit = typeof env?.KIMI_HOME === "string" ? env.KIMI_HOME.trim() : "";
+  if (explicit) return path.resolve(explicit);
+  if (process.platform === "win32") {
+    return pickWin32ProviderPath({
+      env,
+      nativeValue: path.join(home, ".kimi"),
+      wslProviderDir: ".kimi",
+    });
+  }
+  return path.join(home, ".kimi");
+}
+
+function resolveKimiWireFiles(env = process.env) {
+  const kimiHome = resolveKimiHome(env);
+  if (!kimiHome) return [];
   const sessionsDir = path.join(kimiHome, "sessions");
   if (!fssync.existsSync(sessionsDir)) return [];
   const files = [];
@@ -10876,6 +10890,7 @@ module.exports = {
   hermesInstallOwnsCursor,
   parseCopilotIncremental,
   parseCopilotAppDbIncremental,
+  resolveKimiHome,
   resolveKimiWireFiles,
   resolveKimiDefaultModel,
   parseKimiIncremental,

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -367,4 +367,45 @@ test("gemini/antigravity WSL path resolves on Windows both mode", (t) => {
   assert.equal(r.wsl, wslDir);
 });
 
+// ── Codex CLI & OpenCode path resolution (PR #261) ────────────────────────────
+
+test("codex/opencode native paths default correctly", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const rCodex = resolveInstallPaths(
+    { nativeValue: path.join(home, ".codex") },
+    {},
+    {},
+  );
+  assert.equal(rCodex.native, path.join(home, ".codex"));
+  assert.equal(rCodex.wsl, null);
+
+  const rOpencode = resolveInstallPaths(
+    { nativeValue: path.join(home, ".config", "opencode") },
+    {},
+    {},
+  );
+  assert.equal(rOpencode.native, path.join(home, ".config", "opencode"));
+  assert.equal(rOpencode.wsl, null);
+});
+
+test("codex/opencode WSL paths resolve on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-opencode-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+
+
 

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -302,3 +302,36 @@ test("resolveAllWin32Paths returns single path in non-both mode", (t) => {
   assert.equal(r.native, "\\\\wsl$\\path");
   assert.equal(r.wsl, null);
 });
+
+// ── Every Code path resolution (PR #261) ──────────────────────────────────────
+
+test("every-code native path defaults to HOME on Linux, APPDATA on Windows", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const r = resolveInstallPaths(
+    { nativeValue: path.join(home, ".code") },
+    {},
+    {},
+  );
+  assert.equal(r.native, path.join(home, ".code"));
+  assert.equal(r.wsl, null);
+});
+
+test("every-code WSL path resolves on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-everycode-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -335,3 +335,36 @@ test("every-code WSL path resolves on Windows both mode", (t) => {
   assert.equal(r.wsl, wslDir);
 });
 
+// ── Gemini CLI & Antigravity path resolution (PR #261) ────────────────────────
+
+test("gemini/antigravity native path defaults to HOME on Linux, LOCALAPPDATA on Windows", (t) => {
+  mockPlatform(t, "linux");
+  const home = "/home/user";
+  const r = resolveInstallPaths(
+    { nativeValue: path.join(home, ".gemini") },
+    {},
+    {},
+  );
+  assert.equal(r.native, path.join(home, ".gemini"));
+  assert.equal(r.wsl, null);
+});
+
+test("gemini/antigravity WSL path resolves on Windows both mode", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-gemini-wsl-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const nativeDir = path.join(tmpDir, "native");
+  const wslDir = path.join(tmpDir, "wsl");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.mkdirSync(wslDir, { recursive: true });
+
+  const r = resolveInstallPaths(
+    { nativeValue: nativeDir, wslValue: wslDir },
+    { TOKENTRACKER_WSL_MODE: "both" },
+    { runWsl: () => "Ubuntu\n", existsSync: () => true },
+  );
+  assert.equal(r.native, nativeDir);
+  assert.equal(r.wsl, wslDir);
+});
+
+

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -407,5 +407,17 @@ test("codex/opencode WSL paths resolve on Windows both mode", (t) => {
   assert.equal(r.wsl, wslDir);
 });
 
+test("opencode paths union correctly combines storage and db paths", () => {
+  const storagePaths = { native: "/storage/native", wsl: null };
+  const dbPaths = { native: null, wsl: "/db/wsl" };
+  const opencodePaths = {
+    native: storagePaths.native || dbPaths.native,
+    wsl: storagePaths.wsl || dbPaths.wsl,
+  };
+  assert.equal(opencodePaths.native, "/storage/native");
+  assert.equal(opencodePaths.wsl, "/db/wsl");
+});
+
+
 
 

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -381,11 +381,11 @@ test("codex/opencode native paths default correctly", (t) => {
   assert.equal(rCodex.wsl, null);
 
   const rOpencode = resolveInstallPaths(
-    { nativeValue: path.join(home, ".config", "opencode") },
+    { nativeValue: path.join(home, ".local", "share", "opencode") },
     {},
     {},
   );
-  assert.equal(rOpencode.native, path.join(home, ".config", "opencode"));
+  assert.equal(rOpencode.native, path.join(home, ".local", "share", "opencode"));
   assert.equal(rOpencode.wsl, null);
 });
 

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -305,7 +305,7 @@ test("resolveAllWin32Paths returns single path in non-both mode", (t) => {
 
 // ── Every Code path resolution (PR #261) ──────────────────────────────────────
 
-test("every-code native path defaults to HOME on Linux, APPDATA on Windows", (t) => {
+test("every-code native path defaults to HOME on all platforms", (t) => {
   mockPlatform(t, "linux");
   const home = "/home/user";
   const r = resolveInstallPaths(
@@ -337,7 +337,7 @@ test("every-code WSL path resolves on Windows both mode", (t) => {
 
 // ── Gemini CLI & Antigravity path resolution (PR #261) ────────────────────────
 
-test("gemini/antigravity native path defaults to HOME on Linux, LOCALAPPDATA on Windows", (t) => {
+test("gemini/antigravity native path defaults to HOME on all platforms", (t) => {
   mockPlatform(t, "linux");
   const home = "/home/user";
   const r = resolveInstallPaths(
@@ -417,7 +417,3 @@ test("opencode paths union correctly combines storage and db paths", () => {
   assert.equal(opencodePaths.native, "/storage/native");
   assert.equal(opencodePaths.wsl, "/db/wsl");
 });
-
-
-
-

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -46,6 +46,7 @@ const {
   listAntigravitySessionFiles,
   estimateAntigravityTokens,
   parseKimiCodeIncremental,
+  resolveKimiHome,
   resolveKimiCodeHome,
   resolveKimiCodeWireFiles,
   resolveKimiCodeDefaultModel,
@@ -4821,6 +4822,40 @@ test("Kimi Code wsl-first prefers WSL home when both sides exist", (t) => {
   });
 
   assert.equal(home, "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi-code");
+});
+
+test("Kimi (legacy) native-first prefers native home when WSL also exists", (t) => {
+  resetWslProbeCache();
+  mockPlatform(t, "win32");
+  mockWsl(t);
+  mockMethod(t, fssync, "existsSync", (candidate) => (
+    candidate === "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi" ||
+    candidate === path.join(os.homedir(), ".kimi")
+  ));
+
+  const home = resolveKimiHome({
+    HOME: "C:\\Users\\me",
+    TOKENTRACKER_WSL_MODE: "native-first",
+  });
+
+  assert.equal(home, path.join(os.homedir(), ".kimi"));
+});
+
+test("Kimi (legacy) wsl-first prefers WSL home when both sides exist", (t) => {
+  resetWslProbeCache();
+  mockPlatform(t, "win32");
+  mockWsl(t);
+  mockMethod(t, fssync, "existsSync", (candidate) => (
+    candidate === "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi" ||
+    candidate === path.join("C:\\Users\\me", ".kimi")
+  ));
+
+  const home = resolveKimiHome({
+    HOME: "C:\\Users\\me",
+    TOKENTRACKER_WSL_MODE: "wsl-first",
+  });
+
+  assert.equal(home, "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi");
 });
 
 test("Kilocode roots pass resolver env to WSL discovery", (t) => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -4847,7 +4847,7 @@ test("Kimi (legacy) wsl-first prefers WSL home when both sides exist", (t) => {
   mockWsl(t);
   mockMethod(t, fssync, "existsSync", (candidate) => (
     candidate === "\\\\wsl$\\Ubuntu\\home\\dev\\.kimi" ||
-    candidate === path.join("C:\\Users\\me", ".kimi")
+    candidate === path.join(os.homedir(), ".kimi")
   ));
 
   const home = resolveKimiHome({


### PR DESCRIPTION
## Overview

This pull request implements Windows $\to$ WSL auto-discovery and dual-install aggregation for **Every Code**, **Kimi (legacy)**, **Gemini CLI**, **Antigravity**, **OpenCode**, and **Codex CLI** (PR 2 of the WSL roadmap).

It ensures that users running the TokenTracker CLI on Windows can seamlessly aggregate developer metrics from both native Win32 installations and WSL environments.

## Batch Scope & Implementation Details

1. **Every Code & Codex CLI (Dynamic Sources)**
   * Dynamically resolves both native and WSL home paths via `resolveInstallPaths` (native: `%APPDATA%\.code` and `%APPDATA%\.codex`).
   * Injects both active directories into the sync sources queue, allowing the parser to scan and increment metrics seamlessly.
2. **Kimi (legacy) (Synchronous Merging)**
   * Implements `resolveKimiHome` with WSL support and updates `resolveKimiWireFiles`.
   * Integrates legacy Kimi with `mergeBothFileSources` to synchronously aggregate metrics from both environments.
3. **Gemini CLI & Antigravity (Asynchronous Merging)**
   * Gathers and merges file/transcript lists from both environments asynchronously in the sync loop, avoiding double-counting with Set-based deduplication.
4. **OpenCode (Dual-Root & SQLite DB Namespacing)**
   * OpenCode uses separate config and local data paths on Linux/WSL. We resolve both paths dynamically (native: `%APPDATA%\opencode`, WSL storage: `~/.local/share/opencode`, WSL DB: `~/.config/opencode`).
   * Wraps parsing under `multiInstallParse` to avoid SQLite cursor collision by isolating native and WSL state under namespaced cursors (`cursors.opencode.native` / `cursors.opencode.wsl`).

## Quality & Safety Safeguards
* **Platform Guards:** All WSL distro checks and probes are guarded with `process.platform === "win32"` to avoid slow, blocking child processes on macOS and Linux.
* **Cursor Safety:** File-list providers track incremental cursors keyed by unique absolute file paths (which naturally differ in UNC mode). OpenCode DB is cleanly namespaced.
* **Testing:** Added 6 new targeted unit tests in `test/install-resolver.test.js` and `test/rollout-parser.test.js`. All 35 resolver, multi-install, and dual-install tests are passing successfully.

Part of #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded native + WSL discovery and syncing for Gemini, Antigravity, Opencode, Kimi, and Codex, including archived session support where applicable.
* **Bug Fixes**
  * Improved runtime resolution of install roots across native vs WSL locations.
  * Deduplicated discovered file paths to reduce repeated results.
  * Hardened provider “installed” checks to avoid invalid/empty path lookups.
* **Documentation**
  * Documented `TOKENTRACKER_WSL_MODE` and added a WSL Auto-Discovery section.
* **Tests**
  * Added/expanded coverage for install-path resolution and Kimi home selection across WSL modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->