### PR TITLE
fix(windows): smooth out Windows pet edge tuck/reveal jitter

### DIFF
--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -259,6 +259,15 @@ internal sealed class PetWindow : Window
                     ReleaseCapture();
                     SendMessage(_hwnd, WM_NCLBUTTONDOWN, (nint)HTCAPTION, nint.Zero);
                     _isDragging = false;
+                    // Settle placement synchronously, right here on the UI thread, before
+                    // any DispatcherTimer tick can run. Deferring to the 500ms _saveTimer
+                    // would let HoverTick fire first while _miniMode is still true; its
+                    // edge-anchored reveal/tuck would snap the window back to the right
+                    // edge, so SavePlacement would then always see it at the edge and the
+                    // pet could never leave mini mode. Running it now also covers the
+                    // "release without a final move fires no LocationChanged" case.
+                    _saveTimer.Stop();
+                    SavePlacement();
                     break;
                 case "pet:context-menu":
                     ContextMenuRequested?.Invoke();
@@ -778,6 +787,10 @@ internal sealed class PetWindow : Window
 
     private void SavePlacement()
     {
+        // The native drag's modal move loop keeps pumping messages, so the 500ms
+        // _saveTimer can tick mid-drag. Bail then: snapping/ApplyEdgePlacement here would
+        // start an edge animation that fights the OS drag and reintroduces the jitter.
+        if (_isDragging) return;
         if (WindowState != WindowState.Normal) return;
         var x = Left;
         var y = Top;

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -55,6 +55,12 @@ internal sealed class PetWindow : Window
     private string _character = CurrentCharacter;
     private UsagePoller.UsageStats _stats;
     private bool _connected = true;
+    private bool _isDragging;
+    private bool _isAnimating;
+    private EventHandler? _renderHandler;
+    private System.Diagnostics.Stopwatch? _animStopwatch;
+    private double _animStartX;
+    private double _animTargetX;
 
     // Snapping / Mini mode states
     private bool _miniMode;
@@ -63,6 +69,7 @@ internal sealed class PetWindow : Window
     private double _preMiniY;
     private const double EdgePeek = 30;
     private const double SnapMargin = 24;
+    private const double EdgeTolerance = 4.0;
 
     // Mouse idle / wake tracking
     private POINT _lastMousePos;
@@ -174,7 +181,10 @@ internal sealed class PetWindow : Window
 
     private void ClickThroughTick()
     {
-        if (!IsVisible || _hwnd == nint.Zero || !GetCursorPos(out var cursor)) return;
+        // Skip while dragging or sliding: recomputing IsPointOnPet against the moving
+        // window would thrash WS_EX_TRANSPARENT and issue a SWP_FRAMECHANGED (non-client
+        // recalc + redraw) every 16ms, fighting the edge slide and making it stutter.
+        if (!IsVisible || _hwnd == nint.Zero || _isDragging || _isAnimating || !GetCursorPos(out var cursor)) return;
         SetClickThrough(!IsPointOnPet(new System.Windows.Point(cursor.X, cursor.Y)));
     }
 
@@ -244,8 +254,11 @@ internal sealed class PetWindow : Window
             {
                 case "pet:drag":
                     // Hand the press off to the OS so the borderless window moves natively.
+                    _isDragging = true;
+                    StopEdgeAnimation();
                     ReleaseCapture();
                     SendMessage(_hwnd, WM_NCLBUTTONDOWN, (nint)HTCAPTION, nint.Zero);
+                    _isDragging = false;
                     break;
                 case "pet:context-menu":
                     ContextMenuRequested?.Invoke();
@@ -287,6 +300,7 @@ internal sealed class PetWindow : Window
     public void HidePet()
     {
         _clickThroughTimer.Stop();
+        StopEdgeAnimation();
         SetClickThrough(false);
         Hide();
         _hoverTimer.Stop();
@@ -299,7 +313,7 @@ internal sealed class PetWindow : Window
 
     private void HoverTick()
     {
-        if (!IsVisible || !_coreReady) return;
+        if (!IsVisible || !_coreReady || _isDragging) return;
         if (!GetCursorPos(out var p)) return;
 
         // Global mouse movement & sleep/wake sequence
@@ -332,7 +346,24 @@ internal sealed class PetWindow : Window
         {
             var tl = PointToScreen(new System.Windows.Point(0, 0));
             var br = PointToScreen(new System.Windows.Point(ActualWidth, ActualHeight));
-            inside = p.X >= tl.X && p.X < br.X && p.Y >= tl.Y && p.Y < br.Y;
+            if (_miniMode)
+            {
+                // Anchor the hover test to the *target* geometry (both peek and revealed
+                // states hug the right work-area edge), NOT the live window X, which is
+                // mid-slide during ApplyEdgePlacement. Reading the moving rect here would
+                // let the inside/outside result flip against the animating edge and re-
+                // toggle _isRevealed, cancelling and restarting the slide — the retract
+                // stutter. Using _isRevealed as the reference gives stable hysteresis:
+                // tucked → only the peek strip is "inside"; revealed → the full window is.
+                var wa = SystemParameters.WorkArea;
+                double leftX = _isRevealed ? wa.Right - Width : wa.Right - EdgePeek;
+                double rightLimit = wa.Right + EdgeTolerance; // cursor clamps at the screen edge
+                inside = p.X >= leftX && p.X < rightLimit && p.Y >= tl.Y && p.Y < br.Y;
+            }
+            else
+            {
+                inside = p.X >= tl.X && p.X < br.X && p.Y >= tl.Y && p.Y < br.Y;
+            }
         }
         catch { return; }   // not laid out yet
 
@@ -610,6 +641,7 @@ internal sealed class PetWindow : Window
             return;
         }
         SavePlacement();
+        StopEdgeAnimation();
         _saveTimer.Stop();
         _hoverTimer.Stop();
         _clickThroughTimer.Stop();
@@ -791,9 +823,17 @@ internal sealed class PetWindow : Window
         catch { }
     }
 
-    private async void ApplyEdgePlacement(bool animated)
+    // Duration of the tuck/reveal slide. Time-based (not step-based) so the motion is
+    // frame-rate independent.
+    private const double EdgeAnimMs = 200.0;
+
+    private void ApplyEdgePlacement(bool animated)
     {
         if (!_coreReady) return;
+
+        // Cancel any in-flight slide before starting a new target.
+        StopEdgeAnimation();
+
         var wa = SystemParameters.WorkArea;
         double targetX = _isRevealed ? wa.Right - Width : wa.Right - EdgePeek;
 
@@ -803,21 +843,47 @@ internal sealed class PetWindow : Window
             return;
         }
 
-        double startX = Left;
-        double dx = targetX - startX;
-        if (Math.Abs(dx) < 1) return;
-
-        int steps = 15;
-        int durationMs = 220;
-        int delay = durationMs / steps;
-        for (int i = 1; i <= steps; i++)
+        _animStartX = Left;
+        _animTargetX = targetX;
+        if (Math.Abs(_animTargetX - _animStartX) < 1)
         {
-            double t = (double)i / steps;
-            double eased = t * (2 - t); // ease-out
-            Left = startX + dx * eased;
-            await Task.Delay(delay);
+            Left = targetX;
+            return;
         }
-        Left = targetX;
+
+        // Drive the slide off the composition (render) clock instead of Task.Delay: it
+        // ticks once per WPF frame, vsync-paced, so the motion is smooth. A Task.Delay
+        // loop rounds to the ~15.6ms OS timer quantum, producing the visible stepping.
+        _animStopwatch = System.Diagnostics.Stopwatch.StartNew();
+        _isAnimating = true;
+        _renderHandler = OnEdgeAnimationFrame;
+        System.Windows.Media.CompositionTarget.Rendering += _renderHandler;
+    }
+
+    private void OnEdgeAnimationFrame(object? sender, EventArgs e)
+    {
+        if (_animStopwatch is null) { StopEdgeAnimation(); return; }
+
+        double t = Math.Min(1.0, _animStopwatch.Elapsed.TotalMilliseconds / EdgeAnimMs);
+        double eased = t * (2 - t); // ease-out
+        Left = _animStartX + (_animTargetX - _animStartX) * eased;
+
+        if (t >= 1.0)
+        {
+            Left = _animTargetX;
+            StopEdgeAnimation();
+        }
+    }
+
+    private void StopEdgeAnimation()
+    {
+        if (_renderHandler is not null)
+        {
+            System.Windows.Media.CompositionTarget.Rendering -= _renderHandler;
+            _renderHandler = null;
+        }
+        _animStopwatch = null;
+        _isAnimating = false;
     }
 
     /// <summary>Keep the saved top-left within the virtual desktop (guards against a


### PR DESCRIPTION
## Summary

修复 Windows 桌面宠物贴右边缘后的一系列抖动/卡顿：**展开**时的边缘弹跳、**收回（tuck）时一卡一卡**、以及拖拽与自动滑动互相打架的问题。核心手段是让 hover 判定锚定目标几何、滑动/拖拽期间暂停会抢帧的定时器、并用合成器帧时钟替代 `Task.Delay` 补间。

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [x] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## 问题背景

宠物贴到工作区右边缘后进入 mini 模式：不悬停时只露出一条 `EdgePeek` 窄带，鼠标靠近则滑出整窗，离开再滑回。`0.76.0` 里这套交互存在多处抖动：

1. **展开侧边缘弹跳** —— 光标在屏幕最右被系统钳住、叠加 DPI 取整，导致 in/out 判定在边界反复翻转，窗口不停「探头又缩回」。
2. **收回一卡一卡** —— 收回滑动过程中，多个定时器读取的是「正在移动中」的窗口矩形，判定与动画互相打架：
   - `HoverTick`（150ms）用 `PointToScreen(...)` 拿动画当前 X 判断鼠标是否在窗口内，滑动经过光标时 in/out 翻转 → 反复切换 `_isRevealed` → 动画被取消又重启 → 震荡。
   - `ClickThroughTick`（16ms）在精灵滑过光标时反复翻转 `WS_EX_TRANSPARENT` 并调用 `SetWindowPos(..., SWP_FRAMECHANGED)`（非客户区重算 + 重绘），在 200ms 滑动内每 16ms 抢一次帧。
   - 补间用 `Task.Delay`，被 Windows ~15.6ms 定时器精度不均匀地向上取整，帧间隔忽长忽短 → 可见的分帧/跳步。
3. **拖拽与自动滑动冲突** —— 用户手动拖拽时，自动 tuck/reveal 动画和 hover 判定仍在跑，和拖拽争夺窗口坐标。

## 改动内容（均在 `TokenTrackerWin/PetWindow.cs`）

### 1. 展开侧边缘容差
- 新增常量 `EdgeTolerance = 4.0`，mini 模式下把右侧判定边界放宽到 `wa.Right + EdgeTolerance`，吸收光标屏幕边缘钳制 + DPI 取整误差，消除展开侧的探头/弹跳。

### 2. 锚定式 hover 判定（消除收回震荡的根本）
- mini 模式下 `HoverTick` 不再用移动中的窗口 X，而是用**目标几何**做迟滞（hysteresis）判定：以 `_isRevealed` 为参照——收起时可交互区为右边缘 `EdgePeek` 窄带，展开时为整窗，两者都锚定工作区右边缘。判定结果与动画当前位置无关，不会再随滑动翻转、重启动画。

### 3. 合成器帧时钟补间
- `ApplyEdgePlacement` 由 `async void` + `Task.Delay` 步进循环，改为基于 `CompositionTarget.Rendering` + `Stopwatch` 的按时间推进补间（`EdgeAnimMs = 200`，帧率无关）。每个 WPF 渲染帧走一步、与 vsync 对齐，滑动顺滑。

### 4. 滑动/拖拽期间暂停抢帧的定时器
- `ClickThroughTick` 增加 `_isDragging || _isAnimating` 提前返回，避免滑动/拖拽期间 `SWP_FRAMECHANGED` 抖动抢帧。
- `HoverTick` 增加 `_isDragging` 提前返回，拖拽时不触发自动 tuck/reveal。
- `pet:drag` 处理中，交给 OS 原生移动前先 `_isDragging = true` 并 `StopEdgeAnimation()` 中止在飞的滑动，移动结束再复位。

### 5. 动画生命周期收口
- 新增 `StopEdgeAnimation()` 统一摘除 `CompositionTarget.Rendering` 回调、复位状态；在 `pet:drag`、`HidePet`、`OnClosing`、以及每次 `ApplyEdgePlacement` 启动前调用，确保 render 回调不会残留在隐藏/关闭的窗口上空转或泄漏。

## Checklist

- [ ] `npm test` passes（本次仅改动 `TokenTrackerWin/` C# 代码，Node 测试不覆盖此文件；已通过 `dotnet build` 验证：0 警告 0 错误）
- [x] New user-facing strings go through `dashboard/src/content/copy.csv`（无新增用户可见文案）
- [x] Commits follow conventional style（`fix:`）
- [x] PR description explains *why*, not just *what*

## 验证

- **自动**：`cd TokenTrackerWin && dotnet build` → 0 警告 0 错误。
- **手动（已实机确认）**：
  - 宠物贴右边缘 → 鼠标靠近展开稳定、无探头/弹跳；离开收回连续顺滑、不再来回抖动。
  - 拖拽过程中不被自动 tuck/reveal 拉回边缘。
  - 隐藏 / 退出 / 拖拽开始时在飞的滑动能干净中止，无残留回调。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mini-mode edge slide behavior for smoother, frame-synchronized movement.
  * Prevented mini-mode hover state flickering while the pet is sliding near the screen edge.
  * Enhanced dragging behavior so slide/hover interactions don’t conflict during native drag operations.
  * Ensured edge animations stop reliably when the pet is hidden or the app is closing, and placement is saved appropriately outside active drags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->