### PR TITLE
fix(test): stop Windows test runs from corrupting the real ~/.tokentracker

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -563,8 +563,11 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
   // oh-my-pi: passive reader — no hook installation needed.
   // TokenTracker reads ~/.omp/agent/sessions/**/*.jsonl directly.
   {
-    const ompSessions = path.join(resolveOmpAgentDir(process.env), "sessions");
-    if (fssync.existsSync(ompSessions)) {
+    // resolveOmpAgentDir returns null on Windows when ~/.omp doesn't exist (the
+    // win32 path resolver only yields a dir it can see) — null means "not
+    // installed", so skip rather than path.join(null, …) and crash.
+    const ompAgentDir = resolveOmpAgentDir(process.env);
+    if (ompAgentDir && fssync.existsSync(path.join(ompAgentDir, "sessions"))) {
       summary.push({ label: "oh-my-pi", status: "detected", detail: "Passive reader (no hook needed)" });
     }
   }
@@ -573,8 +576,10 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
   // TokenTracker reads ~/.pi/agent/sessions/**/*.jsonl directly. Skip when its
   // agent dir collides with omp's so the summary matches what sync will scan.
   if (!piAgentDirCollidesWithOmp(process.env)) {
-    const piSessions = path.join(resolvePiAgentDir(process.env), "sessions");
-    if (fssync.existsSync(piSessions)) {
+    // Same win32 nullability as oh-my-pi above: resolvePiAgentDir is null when
+    // ~/.pi doesn't exist, so guard before joining.
+    const piAgentDir = resolvePiAgentDir(process.env);
+    if (piAgentDir && fssync.existsSync(path.join(piAgentDir, "sessions"))) {
       summary.push({ label: "pi", status: "detected", detail: "Passive reader (no hook needed)" });
     }
   }

--- a/test/auth-relay-forbidden-headers.test.js
+++ b/test/auth-relay-forbidden-headers.test.js
@@ -14,6 +14,7 @@ const path = require("node:path");
 const { mkdtemp, rm } = require("node:fs/promises");
 
 const { createLocalApiHandler } = require("../src/lib/local-api.js");
+const { withHome } = require("./helpers/with-home");
 
 function listen(server, host = "127.0.0.1") {
   return new Promise((resolve, reject) => {
@@ -69,7 +70,7 @@ function request(url, { method = "GET", headers = {}, body = "" } = {}) {
 }
 
 test("POST /api/auth/* strips Content-Length before forwarding to fetch", async () => {
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevBase = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
   const tempHome = await mkdtemp(path.join(os.tmpdir(), "tt-auth-relay-"));
 
@@ -97,7 +98,7 @@ test("POST /api/auth/* strips Content-Length before forwarding to fetch", async 
   });
 
   try {
-    process.env.HOME = tempHome;
+    restoreHome = withHome(tempHome);
     const upAddr = await listen(upstream);
     process.env.TOKENTRACKER_INSFORGE_BASE_URL = `http://127.0.0.1:${upAddr.port}`;
     const localAddr = await listen(local);
@@ -122,8 +123,7 @@ test("POST /api/auth/* strips Content-Length before forwarding to fetch", async 
     await closeServer(local);
     await closeServer(upstream);
     await rm(tempHome, { recursive: true, force: true });
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevBase === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
     else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBase;
   }

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -82,6 +82,9 @@ async function withTempSyncEnv(fn) {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-source-scope-"));
   const saved = {
     HOME: process.env.HOME,
+    // os.homedir() reads USERPROFILE on Windows, so isolate it too or the test
+    // writes into the developer's real ~/.tokentracker.
+    USERPROFILE: process.env.USERPROFILE,
     CODEX_HOME: process.env.CODEX_HOME,
     CODE_HOME: process.env.CODE_HOME,
     GEMINI_HOME: process.env.GEMINI_HOME,
@@ -96,6 +99,7 @@ async function withTempSyncEnv(fn) {
   };
   try {
     process.env.HOME = home;
+    process.env.USERPROFILE = home;
     process.env.CODEX_HOME = path.join(home, ".codex");
     process.env.CODE_HOME = path.join(home, ".code");
     process.env.GEMINI_HOME = path.join(home, ".gemini");

--- a/test/cookie-relay-persistence.test.js
+++ b/test/cookie-relay-persistence.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 
 const { createLocalApiHandler } = require("../src/lib/local-api");
+const { withHome } = require("./helpers/with-home");
 
 function createRequest({ method = "GET", headers = {}, body } = {}) {
   return {
@@ -33,18 +34,17 @@ function createResponse() {
 
 async function withTempHome(run) {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-relay-cookies-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
   const prevFetch = globalThis.fetch;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://example.invalid";
     await run(tmp);
   } finally {
     globalThis.fetch = prevFetch;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
     else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
     await fs.rm(tmp, { recursive: true, force: true });

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -6,17 +6,18 @@ const { test } = require("node:test");
 
 const { cmdDiagnostics } = require("../src/commands/diagnostics");
 const { collectTrackerDiagnostics } = require("../src/lib/diagnostics");
+const { withHome } = require("./helpers/with-home");
 
 test("diagnostics redacts device token and home paths", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-diagnostics-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevTokenTrackerGrokHome = process.env.TOKENTRACKER_GROK_HOME;
   const prevGrokHome = process.env.GROK_HOME;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_GROK_HOME;
     process.env.GROK_HOME = path.join(tmp, ".grok");
@@ -114,8 +115,7 @@ test("diagnostics redacts device token and home paths", async () => {
     assert.equal(data?.auto_retry?.next_retry_at, new Date(retryAtMs).toISOString());
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevTokenTrackerGrokHome === undefined) delete process.env.TOKENTRACKER_GROK_HOME;

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -6,6 +6,7 @@ const { test } = require("node:test");
 
 const { buildDoctorReport } = require("../src/lib/doctor");
 const { cmdDoctor } = require("../src/commands/doctor");
+const { withHome } = require("./helpers/with-home");
 
 test("doctor treats any HTTP response as reachable", async () => {
   const report = await buildDoctorReport({
@@ -78,7 +79,7 @@ test("doctor marks invalid config.json as critical", async () => {
 
 test("doctor --out writes json to file and stdout", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-doctor-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCwd = process.cwd();
   const prevFetch = globalThis.fetch;
   const prevWrite = process.stdout.write;
@@ -86,7 +87,7 @@ test("doctor --out writes json to file and stdout", async () => {
   const prevExit = process.exitCode;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.chdir(tmp);
     globalThis.fetch = async () => ({ status: 204 });
     const outCapture = createWriteCapture();
@@ -107,8 +108,7 @@ test("doctor --out writes json to file and stdout", async () => {
   } finally {
     process.stdout.write = prevWrite;
     process.stderr.write = prevErr;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     process.chdir(prevCwd);
     globalThis.fetch = prevFetch;
     process.exitCode = prevExit;
@@ -118,14 +118,14 @@ test("doctor --out writes json to file and stdout", async () => {
 
 test("doctor sets exitCode on critical failures", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-doctor-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevFetch = globalThis.fetch;
   const prevWrite = process.stdout.write;
   const prevErr = process.stderr.write;
   const prevExit = process.exitCode;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     await fs.mkdir(trackerDir, { recursive: true });
     await fs.writeFile(path.join(trackerDir, "config.json"), "{bad", "utf8");
@@ -142,8 +142,7 @@ test("doctor sets exitCode on critical failures", async () => {
   } finally {
     process.stdout.write = prevWrite;
     process.stderr.write = prevErr;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     globalThis.fetch = prevFetch;
     process.exitCode = prevExit;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -152,14 +151,14 @@ test("doctor sets exitCode on critical failures", async () => {
 
 test("doctor supports CLI base-url override", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-doctor-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevFetch = globalThis.fetch;
   const prevWrite = process.stdout.write;
   const prevErr = process.stderr.write;
   const prevExit = process.exitCode;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     await fs.mkdir(trackerDir, { recursive: true });
     await fs.writeFile(
@@ -182,8 +181,7 @@ test("doctor supports CLI base-url override", async () => {
   } finally {
     process.stdout.write = prevWrite;
     process.stderr.write = prevErr;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     globalThis.fetch = prevFetch;
     process.exitCode = prevExit;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -192,14 +190,14 @@ test("doctor supports CLI base-url override", async () => {
 
 test("doctor tolerates null config.json payload", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-doctor-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevFetch = globalThis.fetch;
   const prevWrite = process.stdout.write;
   const prevErr = process.stderr.write;
   const prevExit = process.exitCode;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     await fs.mkdir(trackerDir, { recursive: true });
     await fs.writeFile(path.join(trackerDir, "config.json"), "null", "utf8");
@@ -217,8 +215,7 @@ test("doctor tolerates null config.json payload", async () => {
   } finally {
     process.stdout.write = prevWrite;
     process.stderr.write = prevErr;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     globalThis.fetch = prevFetch;
     process.exitCode = prevExit;
     await fs.rm(tmp, { recursive: true, force: true });

--- a/test/fixtures/init-spawn-error.cjs
+++ b/test/fixtures/init-spawn-error.cjs
@@ -10,6 +10,11 @@ const cp = require("node:child_process");
 (async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-spawn-"));
   const prevHome = process.env.HOME;
+  // os.homedir() reads USERPROFILE on Windows and ignores HOME, so isolating via
+  // HOME alone leaks cmdInit's config write into the developer's real
+  // ~/.tokentracker on Windows (corrupting config.baseUrl to example.invalid and
+  // breaking cloud upload). Redirect USERPROFILE too.
+  const prevUserProfile = process.env.USERPROFILE;
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevWrite = process.stdout.write;
@@ -19,6 +24,7 @@ const cp = require("node:child_process");
 
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
@@ -48,6 +54,8 @@ const cp = require("node:child_process");
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;

--- a/test/helpers/with-home.js
+++ b/test/helpers/with-home.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// Redirect os.homedir() to an isolated directory for the duration of a test.
+//
+// os.homedir() honors $HOME on POSIX but reads %USERPROFILE% on Windows and
+// ignores HOME. A test that swaps only HOME therefore still resolves to the
+// developer's real home on Windows, so commands under test write into the real
+// ~/.tokentracker — which is how `npm test` on Windows silently rewrote
+// config.baseUrl to a test value and broke cloud upload. Swap BOTH vars.
+//
+// Returns a restore() to call from the test's finally block.
+function withHome(dir) {
+  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+  return function restoreHome() {
+    for (const key of ["HOME", "USERPROFILE"]) {
+      if (prev[key] === undefined) delete process.env[key];
+      else process.env[key] = prev[key];
+    }
+  };
+}
+
+module.exports = { withHome };

--- a/test/init-dry-run.test.js
+++ b/test/init-dry-run.test.js
@@ -6,6 +6,7 @@ const { test } = require("node:test");
 
 const { cmdInit } = require("../src/commands/init");
 const { resolveOpencodePluginDir, DEFAULT_PLUGIN_NAME } = require("../src/lib/opencode-config");
+const { withHome } = require("./helpers/with-home");
 
 function stripAnsi(text) {
   return String(text || "").replace(/\x1b\[[0-9;]*m/g, "");
@@ -13,7 +14,7 @@ function stripAnsi(text) {
 
 test("dry-run preview reports opencode install when config is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-dry-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevWrite = process.stdout.write;
@@ -21,7 +22,7 @@ test("dry-run preview reports opencode install when config is missing", async ()
   let output = "";
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
 
@@ -50,8 +51,7 @@ test("dry-run preview reports opencode install when config is missing", async ()
     await assert.rejects(fs.stat(pluginPath), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
     else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -10,6 +10,7 @@ const {
   repairCodexNotifyIntegration,
 } = require("../src/commands/init");
 const { cmdUninstall } = require("../src/commands/uninstall");
+const { withHome } = require("./helpers/with-home");
 const { buildClaudeHookCommand } = require("../src/lib/claude-config");
 const { buildGeminiHookCommand } = require("../src/lib/gemini-config");
 const {
@@ -378,11 +379,11 @@ test("serve-time Codex notify repair refreshes stale backup when active notify i
 
 test("serve-time Codex notify repair clears stale backup when active notify is absent", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-repair-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevWrite = process.stdout.write;
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     const binDir = path.join(tmp, ".tokentracker", "bin");
@@ -418,8 +419,7 @@ test("serve-time Codex notify repair clears stale backup when active notify is a
     assert.doesNotMatch(restored, /old-notify/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -523,14 +523,14 @@ test("notify handler still chains normal original notify commands", async () => 
 
 test("init preserves existing config fields and custom URLs", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-config-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -566,8 +566,7 @@ test("init preserves existing config fields and custom URLs", async () => {
     assert.equal(config.customFlag, true);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -580,14 +579,14 @@ test("init preserves existing config fields and custom URLs", async () => {
 
 test("init then uninstall restores original Codex notify (when pre-existing notify exists)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex-alt");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -622,8 +621,7 @@ test("init then uninstall restores original Codex notify (when pre-existing noti
     await assert.rejects(fs.stat(notifyHandlerPath), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -636,14 +634,14 @@ test("init then uninstall restores original Codex notify (when pre-existing noti
 
 test("init refreshes stale Codex backup when current notify is external", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-refresh-backup-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -675,8 +673,7 @@ test("init refreshes stale Codex backup when current notify is external", async 
     assert.doesNotMatch(restored, /old-notify/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -689,14 +686,14 @@ test("init refreshes stale Codex backup when current notify is external", async 
 
 test("init clears stale Codex backup when current notify is absent", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-clear-backup-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -727,8 +724,7 @@ test("init clears stale Codex backup when current notify is absent", async () =>
     assert.doesNotMatch(restored, /old-notify/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -753,14 +749,14 @@ test("opencode config exports plugin constants", () => {
 
 test("init then uninstall removes notify when none existed", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -784,8 +780,7 @@ test("init then uninstall removes notify when none existed", async () => {
     );
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -798,14 +793,14 @@ test("init then uninstall removes notify when none existed", async () => {
 
 test("uninstall does not restore stale backup over active third-party Codex notify", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -828,8 +823,7 @@ test("uninstall does not restore stale backup over active third-party Codex noti
     assert.equal(restored, 'notify = ["third-party-notify", "new"]\n');
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -842,7 +836,7 @@ test("uninstall does not restore stale backup over active third-party Codex noti
 
 test("init skips Codex notify when config is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
@@ -850,7 +844,7 @@ test("init skips Codex notify when config is missing", async () => {
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -863,8 +857,7 @@ test("init skips Codex notify when config is missing", async () => {
     await assert.rejects(fs.stat(codexConfigPath), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -879,7 +872,7 @@ test("init skips Codex notify when config is missing", async () => {
 
 test("init then uninstall restores original Every Code notify (when config exists)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -887,7 +880,7 @@ test("init then uninstall restores original Every Code notify (when config exist
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -921,8 +914,7 @@ test("init then uninstall restores original Every Code notify (when config exist
     );
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -937,7 +929,7 @@ test("init then uninstall restores original Every Code notify (when config exist
 
 test("init clears stale Every Code backup when current notify is absent", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -945,7 +937,7 @@ test("init clears stale Every Code backup when current notify is absent", async 
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -981,8 +973,7 @@ test("init clears stale Every Code backup when current notify is absent", async 
     assert.doesNotMatch(restored, /old-code-notify/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -997,7 +988,7 @@ test("init clears stale Every Code backup when current notify is absent", async 
 
 test("init refreshes stale Every Code backup when current notify is external", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1005,7 +996,7 @@ test("init refreshes stale Every Code backup when current notify is external", a
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1041,8 +1032,7 @@ test("init refreshes stale Every Code backup when current notify is external", a
     assert.doesNotMatch(restored, /old-code-notify/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -1057,7 +1047,7 @@ test("init refreshes stale Every Code backup when current notify is external", a
 
 test("init skips Every Code notify when config is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1065,7 +1055,7 @@ test("init skips Every Code notify when config is missing", async () => {
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1083,8 +1073,7 @@ test("init skips Every Code notify when config is missing", async () => {
     await assert.rejects(fs.stat(codeConfigPath), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -1099,14 +1088,14 @@ test("init skips Every Code notify when config is missing", async () => {
 
 test("uninstall skips notify restore when no backup and notify not installed", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -1127,8 +1116,7 @@ test("uninstall skips notify restore when no backup and notify not installed", a
     assert.ok(codeAfter.includes('notify = ["echo", "custom-code"]'));
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -1141,12 +1129,12 @@ test("uninstall skips notify restore when no backup and notify not installed", a
 
 test("uninstall removes Grok Build hook and handler", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-grok-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevGrokHome = process.env.GROK_HOME;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.GROK_HOME = path.join(tmp, ".grok");
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     const hookPath = path.join(process.env.GROK_HOME, "hooks", GROK_HOOK_FILENAME);
@@ -1178,8 +1166,7 @@ test("uninstall removes Grok Build hook and handler", async () => {
     await assert.rejects(fs.stat(legacyHandlerPath), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevGrokHome === undefined) delete process.env.GROK_HOME;
     else process.env.GROK_HOME = prevGrokHome;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -1188,14 +1175,14 @@ test("uninstall removes Grok Build hook and handler", async () => {
 
 test("init then uninstall manages Claude hooks without removing existing hooks", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -1251,8 +1238,7 @@ test("init then uninstall manages Claude hooks without removing existing hooks",
     );
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1265,7 +1251,7 @@ test("init then uninstall manages Claude hooks without removing existing hooks",
 
 test("init then uninstall manages Gemini hooks without removing existing hooks", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
@@ -1273,7 +1259,7 @@ test("init then uninstall manages Gemini hooks without removing existing hooks",
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1338,8 +1324,7 @@ test("init then uninstall manages Gemini hooks without removing existing hooks",
     );
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1354,7 +1339,7 @@ test("init then uninstall manages Gemini hooks without removing existing hooks",
 
 test("init skips Gemini hooks when config directory is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
@@ -1362,7 +1347,7 @@ test("init skips Gemini hooks when config directory is missing", async () => {
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini-missing");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1378,8 +1363,7 @@ test("init skips Gemini hooks when config directory is missing", async () => {
     await assert.rejects(fs.stat(process.env.GEMINI_HOME), /ENOENT/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1394,7 +1378,7 @@ test("init skips Gemini hooks when config directory is missing", async () => {
 
 test("init creates Gemini settings when directory exists but file is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
@@ -1402,7 +1386,7 @@ test("init creates Gemini settings when directory exists but file is missing", a
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1428,8 +1412,7 @@ test("init creates Gemini settings when directory exists but file is missing", a
     assert.ok(hasTracker, "expected tracker Gemini hook to be created in settings.json");
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1444,14 +1427,14 @@ test("init creates Gemini settings when directory exists but file is missing", a
 
 test("init then uninstall manages Opencode plugin without removing other plugins", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -1480,8 +1463,7 @@ test("init then uninstall manages Opencode plugin without removing other plugins
     assert.ok(existing.includes("existing"));
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
@@ -1494,14 +1476,14 @@ test("init then uninstall manages Opencode plugin without removing other plugins
 
 test("init installs Opencode plugin when config dir is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-init-uninstall-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
   const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
   const prevWrite = process.stdout.write;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
@@ -1518,8 +1500,7 @@ test("init installs Opencode plugin when config dir is missing", async () => {
     assert.match(installed, /TOKENTRACKER_PLUGIN/);
   } finally {
     process.stdout.write = prevWrite;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;

--- a/test/local-api-source-scope.test.js
+++ b/test/local-api-source-scope.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 
 const { createLocalApiHandler } = require("../src/lib/local-api");
+const { withHome } = require("./helpers/with-home");
 
 async function writeQueue(queuePath, rows) {
   await fs.promises.writeFile(queuePath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
@@ -227,7 +228,7 @@ test("usage-model-breakdown defaults to all scope and can explicitly exclude acc
 
 test("usage-category-breakdown supports codex source", async () => {
   const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-localapi-codex-context-"));
-  const oldHome = process.env.HOME;
+  let restoreHome = () => {};
   try {
     const queuePath = path.join(tmp, "queue.jsonl");
     await writeQueue(queuePath, []);
@@ -279,7 +280,7 @@ test("usage-category-breakdown supports codex source", async () => {
       ].join("\n") + "\n",
     );
 
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     const result = await callEndpoint(
       queuePath,
       "/functions/tokentracker-usage-category-breakdown?from=2026-05-08&to=2026-05-08&source=codex",
@@ -292,14 +293,14 @@ test("usage-category-breakdown supports codex source", async () => {
     assert.ok(Array.isArray(result.exec_command_breakdown.by_type));
     assert.ok(Array.isArray(result.exec_command_breakdown.by_exit));
   } finally {
-    process.env.HOME = oldHome;
+    restoreHome();
     await fs.promises.rm(tmp, { recursive: true, force: true });
   }
 });
 
 test("usage-category-breakdown falls back to codex queue totals when rollout sessions are unavailable", async () => {
   const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-localapi-codex-context-fallback-"));
-  const oldHome = process.env.HOME;
+  let restoreHome = () => {};
   try {
     const queuePath = path.join(tmp, "queue.jsonl");
     await writeQueue(queuePath, [
@@ -317,7 +318,7 @@ test("usage-category-breakdown falls back to codex queue totals when rollout ses
       },
     ]);
 
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     const result = await callEndpoint(
       queuePath,
       "/functions/tokentracker-usage-category-breakdown?from=2026-05-09&to=2026-05-09&source=codex&tz=Asia/Shanghai",
@@ -332,7 +333,7 @@ test("usage-category-breakdown falls back to codex queue totals when rollout ses
     assert.equal(result.totals.cached_input_tokens, 200);
     assert.equal(result.message_count, 2);
   } finally {
-    process.env.HOME = oldHome;
+    restoreHome();
     await fs.promises.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -83,6 +83,9 @@ async function withTempSyncEnv(fn) {
   const home = await makeTempHome();
   const saved = {
     HOME: process.env.HOME,
+    // os.homedir() reads USERPROFILE on Windows, so isolate it too or the test
+    // writes into the developer's real ~/.tokentracker.
+    USERPROFILE: process.env.USERPROFILE,
     CODEX_HOME: process.env.CODEX_HOME,
     CODE_HOME: process.env.CODE_HOME,
     GEMINI_HOME: process.env.GEMINI_HOME,
@@ -92,6 +95,7 @@ async function withTempSyncEnv(fn) {
   };
   try {
     process.env.HOME = home;
+    process.env.USERPROFILE = home;
     process.env.CODEX_HOME = path.join(home, ".codex");
     process.env.CODE_HOME = path.join(home, ".code");
     process.env.GEMINI_HOME = path.join(home, ".gemini");

--- a/test/sync-cursor-unknown-migration.test.js
+++ b/test/sync-cursor-unknown-migration.test.js
@@ -4,6 +4,7 @@ const fs = require("node:fs/promises");
 const fssync = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { withHome } = require("./helpers/with-home");
 
 const {
   cmdSync,
@@ -417,14 +418,14 @@ describe("repairGrokQueueFromSessionSnapshots", () => {
 
   it("regular sync does not run Grok history repair unless explicitly requested", async () => {
     const dir = await makeTempDir();
-    const prevHome = process.env.HOME;
+    let restoreHome = () => {};
     const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
     const prevCodexHome = process.env.CODEX_HOME;
     const prevCodeHome = process.env.CODE_HOME;
     const prevGrokHome = process.env.GROK_HOME;
     const prevTrackerGrokHome = process.env.TOKENTRACKER_GROK_HOME;
     try {
-      process.env.HOME = dir;
+      restoreHome = withHome(dir);
       delete process.env.TOKENTRACKER_DEVICE_TOKEN;
       process.env.CODEX_HOME = path.join(dir, ".codex");
       process.env.CODE_HOME = path.join(dir, ".code");
@@ -471,8 +472,7 @@ describe("repairGrokQueueFromSessionSnapshots", () => {
         undefined,
       );
     } finally {
-      if (prevHome === undefined) delete process.env.HOME;
-      else process.env.HOME = prevHome;
+      restoreHome();
       if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
       else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
       if (prevCodexHome === undefined) delete process.env.CODEX_HOME;

--- a/test/sync-openclaw-trigger.test.js
+++ b/test/sync-openclaw-trigger.test.js
@@ -5,6 +5,7 @@ const fs = require("node:fs/promises");
 const { test } = require("node:test");
 
 const { cmdSync } = require("../src/commands/sync");
+const { withHome } = require("./helpers/with-home");
 
 async function readJsonl(filePath) {
   const raw = await fs.readFile(filePath, "utf8").catch(() => "");
@@ -17,14 +18,14 @@ async function readJsonl(filePath) {
 
 test("sync --from-openclaw records last OpenClaw trigger marker", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-sync-openclaw-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevGeminiHome = process.env.GEMINI_HOME;
   const prevOpencodeHome = process.env.OPENCODE_HOME;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -37,8 +38,7 @@ test("sync --from-openclaw records last OpenClaw trigger marker", async () => {
     assert.ok(marker.length > 0, "expected openclaw marker to be written");
     assert.ok(!Number.isNaN(Date.parse(marker)), "expected openclaw marker to be ISO timestamp");
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -53,7 +53,7 @@ test("sync --from-openclaw records last OpenClaw trigger marker", async () => {
 
 test("sync keeps Grok hook signal when another sync owns the lock", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-sync-grok-lock-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevGeminiHome = process.env.GEMINI_HOME;
@@ -63,7 +63,7 @@ test("sync keeps Grok hook signal when another sync owns the lock", async () => 
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -94,8 +94,7 @@ test("sync keeps Grok hook signal when another sync owns the lock", async () => 
     const signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
     assert.equal(signal.sessionId, "grok-locked");
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -116,7 +115,7 @@ test("sync keeps Grok hook signal when another sync owns the lock", async () => 
 
 test("sync queues and consumes Grok hook signal after cursor persistence", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-sync-grok-signal-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevGeminiHome = process.env.GEMINI_HOME;
@@ -126,7 +125,7 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -177,8 +176,7 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
     );
     assert.deepEqual(cursorsAfterSecondSync.grok.sessionSnapshots, firstSnapshots);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -199,7 +197,7 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
 
 test("sync keeps malformed Grok hook signal without a session id", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-sync-grok-bad-signal-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevGeminiHome = process.env.GEMINI_HOME;
@@ -209,7 +207,7 @@ test("sync keeps malformed Grok hook signal without a session id", async () => {
   const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -245,8 +243,7 @@ test("sync keeps malformed Grok hook signal without a session id", async () => {
     assert.equal(signal.totalTokens, 99);
     assert.deepEqual(await readJsonl(path.join(trackerDir, "queue.jsonl")), []);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;
@@ -267,7 +264,7 @@ test("sync keeps malformed Grok hook signal without a session id", async () => {
 
 test("sync --from-openclaw falls back to previous session totals when jsonl has zero usage", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-sync-openclaw-fallback-"));
-  const prevHome = process.env.HOME;
+  let restoreHome = () => {};
   const prevCodexHome = process.env.CODEX_HOME;
   const prevCodeHome = process.env.CODE_HOME;
   const prevGeminiHome = process.env.GEMINI_HOME;
@@ -282,7 +279,7 @@ test("sync --from-openclaw falls back to previous session totals when jsonl has 
   const prevUpdatedAt = process.env.TOKENTRACKER_OPENCLAW_PREV_UPDATED_AT;
 
   try {
-    process.env.HOME = tmp;
+    restoreHome = withHome(tmp);
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -354,8 +351,7 @@ test("sync --from-openclaw falls back to previous session totals when jsonl has 
     assert.equal(thirdLast.input_tokens, 98);
     assert.equal(thirdLast.output_tokens, 42);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreHome();
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     if (prevCodeHome === undefined) delete process.env.CODE_HOME;

--- a/test/sync-workbuddy.test.js
+++ b/test/sync-workbuddy.test.js
@@ -7,6 +7,7 @@ const path = require("node:path");
 const cp = require("node:child_process");
 
 const { cmdSync } = require("../src/commands/sync");
+const { withHome } = require("./helpers/with-home");
 
 async function readJsonLines(filePath) {
   const raw = await fs.readFile(filePath, "utf8").catch(() => "");
@@ -19,10 +20,6 @@ async function readJsonLines(filePath) {
 test("cmdSync ingests WorkBuddy SQLite-only installs without duplicate snapshots", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-sync-workbuddy-"));
   const prevEnv = {
-    HOME: process.env.HOME,
-    // os.homedir() reads USERPROFILE on Windows, so isolate it too or the test
-    // writes into the developer's real ~/.tokentracker.
-    USERPROFILE: process.env.USERPROFILE,
     CODEX_HOME: process.env.CODEX_HOME,
     CODE_HOME: process.env.CODE_HOME,
     GEMINI_HOME: process.env.GEMINI_HOME,
@@ -30,9 +27,8 @@ test("cmdSync ingests WorkBuddy SQLite-only installs without duplicate snapshots
     XDG_DATA_HOME: process.env.XDG_DATA_HOME,
     WORKBUDDY_HOME: process.env.WORKBUDDY_HOME,
   };
+  const restoreHome = withHome(tmp);
   try {
-    process.env.HOME = tmp;
-    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");
@@ -74,6 +70,7 @@ test("cmdSync ingests WorkBuddy SQLite-only installs without duplicate snapshots
     assert.equal(rows[1].input_tokens, 150);
     assert.equal(rows[1].total_tokens, 150);
   } finally {
+    restoreHome();
     for (const [key, value] of Object.entries(prevEnv)) {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;

--- a/test/sync-workbuddy.test.js
+++ b/test/sync-workbuddy.test.js
@@ -20,6 +20,9 @@ test("cmdSync ingests WorkBuddy SQLite-only installs without duplicate snapshots
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-sync-workbuddy-"));
   const prevEnv = {
     HOME: process.env.HOME,
+    // os.homedir() reads USERPROFILE on Windows, so isolate it too or the test
+    // writes into the developer's real ~/.tokentracker.
+    USERPROFILE: process.env.USERPROFILE,
     CODEX_HOME: process.env.CODEX_HOME,
     CODE_HOME: process.env.CODE_HOME,
     GEMINI_HOME: process.env.GEMINI_HOME,
@@ -29,6 +32,7 @@ test("cmdSync ingests WorkBuddy SQLite-only installs without duplicate snapshots
   };
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     process.env.CODE_HOME = path.join(tmp, ".code");
     process.env.GEMINI_HOME = path.join(tmp, ".gemini");


### PR DESCRIPTION
## Problem

Running `npm test` on Windows silently writes into the developer's **real** `~/.tokentracker/tracker/`.

`os.homedir()` honors `$HOME` on POSIX but reads `%USERPROFILE%` on Windows and ignores `HOME`. Many tests isolate the home dir with only `process.env.HOME = tmp`, so on Windows they resolve to the real home and the command under test writes there.

Concretely, `test/fixtures/init-spawn-error.cjs` and `test/init-dry-run.test.js` run `cmdInit --base-url https://example.invalid`. On Windows that rewrote the real `config.json` `baseUrl` to `https://example.invalid`. The upload path (`sync.js` → `resolveRuntimeConfig({config})`, which prefers `config.baseUrl`) then sent every cloud upload to a dead host → `"fetch failed"` indefinitely. With cloud sync on, the tray/dashboard request the cross-device (`account=1`) view, which serves the now-stale cloud aggregate, so **today's usage renders as 0** even though local data is intact.

## Fix

- Add `test/helpers/with-home.js` — `withHome(dir)` swaps **both** `HOME` and `USERPROFILE` and returns a `restore()`. Route the 13 home-isolated test files through it (object-pattern env snapshots get `USERPROFILE` added directly).
- `fix(init)`: guard a latent Windows crash the isolation exposed. `resolveOmpAgentDir` / `resolvePiAgentDir` return `null` on win32 when `~/.omp` / `~/.pi` don't exist (the win32 resolver only returns a dir it can see), but `init.js` did `path.join(resolveOmpAgentDir(env), "sessions")` unconditionally → crash. Non-win32 returns a path unconditionally, which is why CI never caught it. Guarded both, mirroring the existing null check in `resolveOmpSessionFiles`.

## Verification (on Windows)

- Running the 13 fixed test files leaves the real `config.json` / `queue.jsonl` / `cursors.json` byte-unchanged.
- Net test result improves (e.g. `init-uninstall` 12→2 failures, `diagnostics` 2→1, `sync-codex-rescan-repair` 2→1). The remaining failures are pre-existing Windows-environment issues (symlink `EPERM`, executable-notify chain, Grok home override, one codex-rescan assertion) that also fail on `main`.

No production runtime behavior changes beyond the null guard; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented initialization checks from crashing when supported agent directories aren’t available.
  * Improved Windows behavior when home-directory environment configuration is missing.
* **Tests**
  * Added a shared home-directory test helper that isolates and restores `HOME`/`USERPROFILE` safely across platforms.
  * Updated multiple tests to use the helper for more reliable setup/cleanup of environment state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->