### PR TITLE
fix: refresh Claude and other local sources in desktop app

### DIFF
--- a/dashboard/src/lib/api.local-sync.test.ts
+++ b/dashboard/src/lib/api.local-sync.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { triggerLocalSync } from "./api";
+
+vi.mock("./local-api-auth", () => ({
+  getLocalApiAuthHeaders: vi.fn(async () => ({ "x-tokentracker-local-auth": "local-token" })),
+}));
+
+describe("triggerLocalSync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests an all-local background sync for local dashboard reloads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      triggerLocalSync({ auto: true, background: true, allLocalSources: true }),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/functions/tokentracker-local-sync",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-tokentracker-local-auth": "local-token",
+        }),
+        body: JSON.stringify({ auto: true, background: true, allLocalSources: true }),
+      }),
+    );
+  });
+
+  it("keeps manual refresh as a full local sync", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await triggerLocalSync();
+    expect(fetchMock.mock.calls[0][1]?.body).toBe("{}");
+  });
+});

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -485,11 +485,28 @@ export async function getUserStatus(_opts: AnyRecord = {}) {
   return fetchLocalJson(PATHS.userStatus);
 }
 
-export async function triggerLocalSync({ signal }: AnyRecord = {}) {
+export async function triggerLocalSync({
+  signal,
+  auto = false,
+  background = false,
+  allLocalSources = false,
+  drain = false,
+}: AnyRecord = {}) {
   const authHeaders = await getLocalApiAuthHeaders();
+  const body: AnyRecord = {};
+  if (drain) {
+    body.drain = true;
+  } else if (auto) {
+    body.auto = true;
+    if (background) {
+      body.background = true;
+      if (allLocalSources) body.allLocalSources = true;
+    }
+  }
   const response = await fetch(`/functions/${PATHS.localSync}`, {
     method: "POST",
-    headers: { Accept: "application/json", ...authHeaders },
+    headers: { Accept: "application/json", "Content-Type": "application/json", ...authHeaders },
+    body: JSON.stringify(body),
     cache: "no-store",
     signal,
   });

--- a/dashboard/src/lib/local-usage-auto-refresh.test.ts
+++ b/dashboard/src/lib/local-usage-auto-refresh.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LOCAL_USAGE_REFRESH_INTERVAL_MS,
+  startLocalUsageAutoRefresh,
+} from "./local-usage-auto-refresh";
+
+function createEventTarget() {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener: vi.fn((name: string, fn: () => void) => {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)?.add(fn);
+    }),
+    removeEventListener: vi.fn((name: string, fn: () => void) => {
+      listeners.get(name)?.delete(fn);
+    }),
+    dispatch(name: string) {
+      for (const fn of listeners.get(name) || []) fn();
+    },
+  };
+}
+
+describe("startLocalUsageAutoRefresh", () => {
+  it("refreshes on the interval and when a hidden dashboard becomes visible", async () => {
+    let intervalCallback: () => void = () => {
+      throw new Error("interval was not registered");
+    };
+    const windowEvents = createEventTarget();
+    const documentEvents = createEventTarget();
+    const documentRef = { ...documentEvents, visibilityState: "visible" as DocumentVisibilityState };
+    const windowRef = {
+      ...windowEvents,
+      setInterval: vi.fn((callback: () => void, intervalMs: number) => {
+        intervalCallback = callback;
+        expect(intervalMs).toBe(LOCAL_USAGE_REFRESH_INTERVAL_MS);
+        return 17 as unknown as number;
+      }),
+      clearInterval: vi.fn(),
+    };
+    const refresh = vi.fn(async () => {});
+
+    const controller = startLocalUsageAutoRefresh({
+      refresh,
+      windowRef: windowRef as never,
+      documentRef: documentRef as never,
+    });
+
+    intervalCallback();
+    await controller.run();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    documentRef.visibilityState = "hidden";
+    intervalCallback();
+    await Promise.resolve();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    documentRef.visibilityState = "visible";
+    documentEvents.dispatch("visibilitychange");
+    await controller.run();
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    controller.stop();
+    expect(windowRef.clearInterval).toHaveBeenCalledWith(17);
+    expect(windowEvents.removeEventListener).toHaveBeenCalledWith("focus", expect.any(Function));
+    expect(documentEvents.removeEventListener).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
+  it("coalesces overlapping refresh attempts", async () => {
+    let resolveRefresh: () => void = () => {
+      throw new Error("refresh was not started");
+    };
+    const windowEvents = createEventTarget();
+    const documentEvents = createEventTarget();
+    const refresh = vi.fn(
+      () => new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    const controller = startLocalUsageAutoRefresh({
+      refresh,
+      windowRef: {
+        ...windowEvents,
+        setInterval: vi.fn(() => 1),
+        clearInterval: vi.fn(),
+      } as never,
+      documentRef: {
+        ...documentEvents,
+        visibilityState: "visible",
+      } as never,
+    });
+
+    const first = controller.run();
+    const second = controller.run();
+    expect(first).toBe(second);
+    await Promise.resolve();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    resolveRefresh();
+    await first;
+    controller.stop();
+  });
+});

--- a/dashboard/src/lib/local-usage-auto-refresh.ts
+++ b/dashboard/src/lib/local-usage-auto-refresh.ts
@@ -1,0 +1,58 @@
+export const LOCAL_USAGE_REFRESH_INTERVAL_MS = 30_000;
+
+type AutoRefreshOptions = {
+  refresh: () => Promise<unknown> | unknown;
+  intervalMs?: number;
+  windowRef?: Pick<Window, "setInterval" | "clearInterval" | "addEventListener" | "removeEventListener">;
+  documentRef?: Pick<Document, "visibilityState" | "addEventListener" | "removeEventListener">;
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Keep a visible local dashboard current without allowing overlapping reads.
+ * Provider parsing is handled by the native server's background sync; this
+ * loop only re-reads the resulting local aggregates.
+ */
+export function startLocalUsageAutoRefresh({
+  refresh,
+  intervalMs = LOCAL_USAGE_REFRESH_INTERVAL_MS,
+  windowRef = window,
+  documentRef = document,
+  onError = () => {},
+}: AutoRefreshOptions) {
+  let stopped = false;
+  let inFlight: Promise<void> | null = null;
+
+  const run = () => {
+    if (stopped || documentRef.visibilityState !== "visible") return inFlight;
+    if (inFlight) return inFlight;
+    const pending = Promise.resolve()
+      .then(() => refresh())
+      .catch((error) => onError(error))
+      .then(() => undefined)
+      .finally(() => {
+        if (inFlight === pending) inFlight = null;
+      });
+    inFlight = pending;
+    return pending;
+  };
+
+  const timer = windowRef.setInterval(() => {
+    void run();
+  }, intervalMs);
+  const handleVisible = () => {
+    if (documentRef.visibilityState === "visible") void run();
+  };
+  windowRef.addEventListener("focus", handleVisible);
+  documentRef.addEventListener("visibilitychange", handleVisible);
+
+  return {
+    run,
+    stop() {
+      stopped = true;
+      windowRef.clearInterval(timer);
+      windowRef.removeEventListener("focus", handleVisible);
+      documentRef.removeEventListener("visibilitychange", handleVisible);
+    },
+  };
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -28,6 +28,7 @@ import {
 import { shouldShowInstallCard } from "../lib/install-status";
 import { getMockNow, isMockEnabled } from "../lib/mock-data";
 import { publishUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
+import { startLocalUsageAutoRefresh } from "../lib/local-usage-auto-refresh";
 import { buildFleetData, buildTopModels, resolveDisplayTokens } from "../lib/model-breakdown";
 import { safeWriteClipboard } from "../lib/safe-browser";
 import { isScreenshotModeEnabled } from "../lib/screenshot-mode";
@@ -922,6 +923,20 @@ export function DashboardPage({
     return () => {
       active = false;
     };
+  }, [isLocalMode, mockEnabled, refreshUsageStats]);
+
+  // Provider hooks update the queue quickly, while the native server also
+  // performs a once-per-minute all-source fallback scan. Re-read the local
+  // aggregates while this dashboard remains visible so those queue updates
+  // appear without requiring a click or a page reload.
+  useEffect(() => {
+    if (!isLocalMode || mockEnabled) return undefined;
+    const autoRefresh = startLocalUsageAutoRefresh({
+      refresh: refreshUsageStats,
+      onError: (error) =>
+        console.warn("[DashboardPage] Automatic usage refresh failed:", error),
+    });
+    return () => autoRefresh.stop();
   }, [isLocalMode, mockEnabled, refreshUsageStats]);
 
   const handleUsageRefresh = useCallback(async () => {

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -866,7 +866,7 @@ export function DashboardPage({
     }
   }, [selectedPeriod, customFrom, prevPeriod]);
 
-  const refreshAll = useCallback(async () => {
+  const refreshUsageStats = useCallback(async () => {
     await Promise.all([
       refreshUsage(),
       refreshHeatmap(),
@@ -874,7 +874,6 @@ export function DashboardPage({
       refreshModelBreakdown(),
       refreshProjectUsage(),
       refreshDailyBreakdown(),
-      refreshUsageLimits(),
     ]);
   }, [
     refreshDailyBreakdown,
@@ -883,8 +882,47 @@ export function DashboardPage({
     refreshProjectUsage,
     refreshTrend,
     refreshUsage,
+  ]);
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([
+      refreshUsageStats(),
+      refreshUsageLimits(),
+    ]);
+  }, [
+    refreshUsageStats,
     refreshUsageLimits,
   ]);
+
+  // The DMG starts its embedded server with --no-sync, so a page reload used
+  // to fetch the same stale queue again. Refresh all local log/database sources
+  // (Claude, Gemini, OpenCode, Codex, etc.) without doing cloud upload, Cursor
+  // network access, or deep Codex archive work, then re-read local aggregates.
+  // Keep the promise in a ref so React Strict Mode can reattach to the first
+  // request instead of starting a duplicate sync.
+  const localReloadSyncPromiseRef = useRef(null);
+  useEffect(() => {
+    if (!isLocalMode || mockEnabled) return undefined;
+    if (!localReloadSyncPromiseRef.current) {
+      localReloadSyncPromiseRef.current = triggerLocalSync({
+        auto: true,
+        background: true,
+        allLocalSources: true,
+      });
+    }
+    let active = true;
+    localReloadSyncPromiseRef.current
+      .then(() => {
+        if (active) return refreshUsageStats();
+        return undefined;
+      })
+      .catch((error) => {
+        if (active) console.warn("[DashboardPage] Reload sync failed:", error);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isLocalMode, mockEnabled, refreshUsageStats]);
 
   const handleUsageRefresh = useCallback(async () => {
     setManualSyncLoading(true);

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -228,6 +228,9 @@ function readJsonBodyVite(req) {
 async function runLocalSyncCommand(extraEnv = {}, opts = {}) {
   return await new Promise((resolve, reject) => {
     const args = ["tokentracker-cli", "sync"];
+    if (opts.auto === true) args.push("--auto");
+    if (opts.background === true) args.push("--background");
+    if (opts.allLocalSources === true) args.push("--all-local-sources");
     if (opts.drain === true) args.push("--drain");
     const child = spawn(process.platform === "win32" ? "npx.cmd" : "npx", args, {
       cwd: REPO_ROOT,
@@ -451,13 +454,21 @@ async function handleLocalApi(req, res, url) {
       }
       const extraEnv = {};
       const drain = body.drain === true;
+      const auto = body.auto === true && !drain;
+      const background = auto && body.background === true;
+      const allLocalSources = background && body.allLocalSources === true;
       if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
         extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
       }
       if (typeof body.insforgeBaseUrl === "string" && /^https?:\/\//i.test(body.insforgeBaseUrl.trim())) {
         extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = body.insforgeBaseUrl.trim();
       }
-      const result = await runLocalSyncCommand(extraEnv, { drain });
+      const result = await runLocalSyncCommand(extraEnv, {
+        drain,
+        auto,
+        background,
+        allLocalSources,
+      });
       try {
         const esmRequire = createRequire(import.meta.url);
         const { resetUsageLimitsCache } = esmRequire("../src/lib/usage-limits");

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -21,9 +21,11 @@ const {
 } = require("../lib/codex-config");
 const {
   upsertClaudeHook,
+  upsertClaudeUsageHooks,
   buildClaudeHookCommand,
   buildHookCommand,
   isClaudeHookConfigured,
+  areClaudeUsageHooksConfigured,
 } = require("../lib/claude-config");
 const {
   resolveGeminiConfigDir,
@@ -418,6 +420,78 @@ async function repairCodexNotifyIntegration({ home = os.homedir(), trackerDir, b
   return { ...result, skippedReason: null, notifyPath };
 }
 
+async function repairRuntimeIntegrations({
+  home = os.homedir(),
+  trackerDir,
+  binDir,
+  safeMode = true,
+} = {}) {
+  const paths = trackerDir && binDir ? { trackerDir, binDir } : await resolveTrackerPaths({ home });
+  const resolvedTrackerDir = trackerDir || paths.trackerDir;
+  const resolvedBinDir = binDir || paths.binDir;
+  const notifyPath = await writeNotifyHandler({
+    trackerDir: resolvedTrackerDir,
+    binDir: resolvedBinDir,
+  });
+  const context = buildIntegrationTargets({
+    home,
+    trackerDir: resolvedTrackerDir,
+    notifyPath,
+  });
+  const integrations = {};
+  const warnings = [];
+
+  const attempt = async (key, work) => {
+    try {
+      integrations[key] = await work();
+    } catch (error) {
+      integrations[key] = { changed: false, skippedReason: "repair-failed" };
+      warnings.push({ integration: key, error: error?.message || String(error) });
+    }
+  };
+
+  await attempt("codex", () => repairCodexNotifyIntegration({
+    home,
+    trackerDir: resolvedTrackerDir,
+    binDir: resolvedBinDir,
+    safeMode,
+  }));
+
+  const hookRepairs = [
+    ["claude", context.claudeDir, () => upsertClaudeUsageHooks({
+      settingsPath: context.claudeSettingsPath,
+      hookCommand: context.claudeHookCommand,
+    })],
+    ["gemini", context.geminiConfigDir, () => upsertGeminiHook({
+      settingsPath: context.geminiSettingsPath,
+      hookCommand: context.geminiHookCommand,
+    })],
+    ["codebuddy", context.codebuddyDir, () => upsertClaudeHook({
+      settingsPath: context.codebuddySettingsPath,
+      hookCommand: context.codebuddyHookCommand,
+    })],
+    ["workbuddy", context.workbuddyDir, () => upsertClaudeHook({
+      settingsPath: context.workbuddySettingsPath,
+      hookCommand: context.workbuddyHookCommand,
+    })],
+  ];
+  for (const [key, configDir, repair] of hookRepairs) {
+    if (await isDir(configDir)) await attempt(key, repair);
+    else integrations[key] = { changed: false, skippedReason: "config-missing" };
+  }
+
+  if (await isDir(context.opencodeConfigDir)) {
+    await attempt("opencode", () => upsertOpencodePlugin({
+      configDir: context.opencodeConfigDir,
+      notifyPath,
+    }));
+  } else {
+    integrations.opencode = { changed: false, skippedReason: "config-missing" };
+  }
+
+  return { notifyPath, integrations, warnings };
+}
+
 function buildIntegrationTargets({ home, trackerDir, notifyPath }) {
   const codexHome = process.env.CODEX_HOME || path.join(home, ".codex");
   const codexConfigPath = path.join(codexHome, "config.toml");
@@ -495,7 +569,7 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
 
   const claudeDirExists = await isDir(context.claudeDir);
   if (claudeDirExists) {
-    await upsertClaudeHook({
+    await upsertClaudeUsageHooks({
       settingsPath: context.claudeSettingsPath,
       hookCommand: context.claudeHookCommand,
     });
@@ -787,7 +861,7 @@ async function previewIntegrations({ context }) {
 
   const claudeDirExists = await isDir(context.claudeDir);
   if (claudeDirExists) {
-    const configured = await isClaudeHookConfigured({
+    const configured = await areClaudeUsageHooksConfigured({
       settingsPath: context.claudeSettingsPath,
       hookCommand: context.claudeHookCommand,
     });
@@ -1071,7 +1145,6 @@ const codexOriginalPath = ${JSON.stringify(originalPath)};
 const codeOriginalPath = ${JSON.stringify(path.join(trackerDir, "code_notify_original.json"))};
 const trackerBinPath = ${JSON.stringify(trackerBinPath)};
   const depsMarkerPath = path.join(trackerDir, 'app', 'bin', 'tracker.js');
-  const configPath = path.join(trackerDir, 'config.json');
 const fallbackPkg = ${JSON.stringify(fallbackPkg)};
 const selfPath = path.resolve(__filename);
 const home = os.homedir();
@@ -1109,18 +1182,10 @@ if (debugEnabled) {
 // Throttle spawn: at most once per 20 seconds.
 try {
     const throttlePath = path.join(trackerDir, 'sync.throttle');
-    let deviceToken = process.env.TOKENTRACKER_DEVICE_TOKEN || null;
-    if (!deviceToken) {
-      try {
-        const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        if (cfg && typeof cfg.deviceToken === 'string') deviceToken = cfg.deviceToken;
-      } catch (_) {}
-    }
-    const canSync = Boolean(deviceToken && deviceToken.length > 0);
     const now = Date.now();
     let last = 0;
     try { last = Number(fs.readFileSync(throttlePath, 'utf8')) || 0; } catch (_) {}
-    if (canSync && now - last > 20_000) {
+    if (now - last > 20_000) {
     try { fs.writeFileSync(throttlePath, String(now), 'utf8'); } catch (_) {}
     const hasLocalRuntime = fs.existsSync(trackerBinPath);
     const hasLocalDeps = fs.existsSync(depsMarkerPath);
@@ -1241,6 +1306,7 @@ module.exports = {
   buildNotifyHandler,
   installLocalTrackerApp,
   repairCodexNotifyIntegration,
+  repairRuntimeIntegrations,
 };
 
 async function probeFile(p) {

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -22,6 +22,7 @@ const WSL_DEFAULT_PORT = 7681;
 const DEFAULT_MAX_PORT_ATTEMPTS = 20;
 const NPM_PACKAGE_NAME = "tokentracker-cli";
 const LOCAL_BIND_HOST = "127.0.0.1";
+const NATIVE_BACKGROUND_SYNC_INTERVAL_MS = 60_000;
 const STATIC_ASSET_EXTENSIONS = new Set([
   ".css",
   ".gif",
@@ -219,6 +220,18 @@ async function cmdServe(argv) {
 
   await maybeShowStarCta({ trackerDir });
 
+  // Native desktop apps keep this server alive even when the dashboard window
+  // is closed. Provider hooks are the fast path, but they can be removed by a
+  // tool update or skipped by a provider. Scan every local source once a
+  // minute as a bounded fallback so the queue cannot remain stale indefinitely.
+  // `--no-sync` still skips the blocking startup sync; this periodic pass is
+  // native-shell-only and uses the lightweight local mode (no cloud upload,
+  // Cursor network request, or deep Codex archive scan).
+  const nativeBackgroundSync = startNativeBackgroundSync({
+    onError: (e) =>
+      process.stdout.write(`Background local sync warning: ${e?.message || e}\n`),
+  });
+
   // Anonymous daily heartbeat (see src/lib/telemetry.js for the privacy
   // contract). Fire-and-forget at startup, then re-checked every 6 hours so
   // long-lived embedded-app servers still count on later days; the shared
@@ -240,6 +253,7 @@ async function cmdServe(argv) {
   // 5. Graceful shutdown
   const shutdown = () => {
     process.stdout.write("\nShutting down...\n");
+    nativeBackgroundSync?.stop();
     server.close(() => process.exit(0));
     setTimeout(() => process.exit(0), 3000);
   };
@@ -248,6 +262,49 @@ async function cmdServe(argv) {
 
   // Keep process alive
   await new Promise(() => {});
+}
+
+function startNativeBackgroundSync({
+  appShell = process.env.TOKENTRACKER_APP_SHELL,
+  intervalMs = NATIVE_BACKGROUND_SYNC_INTERVAL_MS,
+  runSync,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  onError = () => {},
+} = {}) {
+  const normalizedShell = String(appShell || "").trim().toLowerCase();
+  if (normalizedShell !== "macos" && normalizedShell !== "windows") return null;
+
+  const sync = runSync || (async (args) => {
+    const { cmdSync } = require("./sync");
+    await cmdSync(args);
+  });
+  let inFlight = null;
+  const run = () => {
+    if (inFlight) return inFlight;
+    const pending = Promise.resolve()
+      .then(() => sync(["--auto", "--background", "--all-local-sources"]))
+      .catch((error) => {
+        try { onError(error); } catch (_e) {}
+      })
+      .finally(() => {
+        if (inFlight === pending) inFlight = null;
+      });
+    inFlight = pending;
+    return pending;
+  };
+
+  const timer = setIntervalFn(() => {
+    void run();
+  }, intervalMs);
+  timer?.unref?.();
+
+  return {
+    run,
+    stop() {
+      clearIntervalFn(timer);
+    },
+  };
 }
 
 function findPidOnPort(port) {
@@ -457,4 +514,6 @@ module.exports = {
   isRunningUnderWsl,
   resolveDefaultPort,
   shouldServeSpaFallback,
+  startNativeBackgroundSync,
+  NATIVE_BACKGROUND_SYNC_INTERVAL_MS,
 };

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -71,11 +71,13 @@ async function cmdServe(argv) {
   }
 
   try {
-    const { installLocalTrackerApp, repairCodexNotifyIntegration } = require("./init");
+    const { installLocalTrackerApp, repairRuntimeIntegrations } = require("./init");
     await installLocalTrackerApp({ appDir: path.join(trackerDir, "app") });
-    const repairResult = await repairCodexNotifyIntegration({ trackerDir, binDir, safeMode: true });
-    if (repairResult?.skippedReason && repairResult.skippedReason !== "config-missing") {
-      process.stdout.write(`Codex notify repair skipped: ${repairResult.skippedReason}\n`);
+    const repairResult = await repairRuntimeIntegrations({ trackerDir, binDir, safeMode: true });
+    for (const warning of repairResult?.warnings || []) {
+      process.stdout.write(
+        `Runtime integration repair warning (${warning.integration}): ${warning.error}\n`,
+      );
     }
   } catch (e) {
     process.stdout.write(`Runtime refresh warning: ${e?.message || e}\n`);

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -8,6 +8,7 @@ const { readJson } = require("../lib/fs");
 const { readCodexNotify, readEveryCodeNotify } = require("../lib/codex-config");
 const {
   isClaudeHookConfigured,
+  areClaudeUsageHooksConfigured,
   buildClaudeHookCommand,
   buildHookCommand,
 } = require("../lib/claude-config");
@@ -155,7 +156,7 @@ async function cmdStatus(argv = []) {
   const everyCodeNotify = await readEveryCodeNotify(codeConfigPath);
   const everyCodeConfigured =
     Array.isArray(everyCodeNotify) && everyCodeNotify.length > 0;
-  const claudeHookConfigured = await isClaudeHookConfigured({
+  const claudeHookConfigured = await areClaudeUsageHooksConfigured({
     settingsPath: claudeSettingsPath,
     hookCommand: claudeHookCommand,
   });

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -330,11 +330,18 @@ async function cmdSync(argv) {
 
     const autoSourceScope = resolveAutoSourceScope(opts);
     const isBackgroundLightweightSync = opts.auto && opts.background && !opts.drain;
+    const isBackgroundAllLocalSync = isBackgroundLightweightSync && opts.allLocalSources;
     const isFullSourceScan = !autoSourceScope && !isBackgroundLightweightSync;
     const sourceAllowed = (...sources) => {
       if (isBackgroundLightweightSync) {
         if (autoSourceScope) {
-          return BACKGROUND_AUTO_SYNC_SOURCES.has(autoSourceScope) && sources.includes(autoSourceScope);
+          return (
+            (isBackgroundAllLocalSync || BACKGROUND_AUTO_SYNC_SOURCES.has(autoSourceScope)) &&
+            sources.includes(autoSourceScope)
+          );
+        }
+        if (isBackgroundAllLocalSync) {
+          return sources.some((source) => AUTO_SYNC_SOURCES.has(source));
         }
         return sources.some((source) => BACKGROUND_AUTO_SYNC_SOURCES.has(source));
       }
@@ -1998,6 +2005,7 @@ function parseArgs(argv) {
     source: null,
     drain: false,
     background: false,
+    allLocalSources: false,
     repairGrok: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -2013,6 +2021,7 @@ function parseArgs(argv) {
     else if (a.startsWith("--source=")) out.source = normalizeSyncSource(a.slice("--source=".length));
     else if (a === "--drain") out.drain = true;
     else if (a === "--background" || a === "--lightweight") out.background = true;
+    else if (a === "--all-local-sources") out.allLocalSources = true;
     else if (a === "--repair-grok") out.repairGrok = true;
     else throw new Error(`Unknown option: ${a}`);
   }

--- a/src/commands/uninstall.js
+++ b/src/commands/uninstall.js
@@ -3,7 +3,12 @@ const path = require("node:path");
 const fs = require("node:fs/promises");
 
 const { restoreCodexNotify, restoreEveryCodeNotify } = require("../lib/codex-config");
-const { removeClaudeHook, buildClaudeHookCommand, buildHookCommand } = require("../lib/claude-config");
+const {
+  removeClaudeHook,
+  removeClaudeUsageHooks,
+  buildClaudeHookCommand,
+  buildHookCommand,
+} = require("../lib/claude-config");
 const {
   resolveGeminiConfigDir,
   resolveGeminiSettingsPath,
@@ -64,7 +69,10 @@ async function cmdUninstall(argv) {
       })
     : { restored: false, skippedReason: "config-missing" };
   const claudeRemove = claudeConfigExists
-    ? await removeClaudeHook({ settingsPath: claudeSettingsPath, hookCommand: claudeHookCommand })
+    ? await removeClaudeUsageHooks({
+        settingsPath: claudeSettingsPath,
+        hookCommand: claudeHookCommand,
+      })
     : { removed: false, skippedReason: "config-missing" };
   const codebuddyRemove = codebuddyConfigExists
     ? await removeClaudeHook({

--- a/src/lib/claude-config.js
+++ b/src/lib/claude-config.js
@@ -4,55 +4,73 @@ const path = require("node:path");
 const { ensureDir, readJson, writeJson } = require("./fs");
 
 const DEFAULT_EVENT = "SessionEnd";
+const CLAUDE_USAGE_EVENTS = ["Stop", DEFAULT_EVENT];
 
 async function upsertClaudeHook({ settingsPath, hookCommand, event = DEFAULT_EVENT }) {
+  return upsertClaudeHooks({ settingsPath, hookCommand, events: [event] });
+}
+
+async function upsertClaudeUsageHooks({ settingsPath, hookCommand }) {
+  return upsertClaudeHooks({ settingsPath, hookCommand, events: CLAUDE_USAGE_EVENTS });
+}
+
+async function upsertClaudeHooks({ settingsPath, hookCommand, events }) {
   const existing = await readJson(settingsPath);
   const settings = normalizeSettings(existing);
   const hooks = normalizeHooks(settings.hooks);
-  const entries = normalizeEntries(hooks[event]);
+  const nextHooks = { ...hooks };
+  let changed = false;
 
-  const normalized = normalizeEntriesForCommand(entries, hookCommand);
-  if (normalized.changed) {
-    const nextHooks = { ...hooks, [event]: normalized.entries };
-    const nextSettings = { ...settings, hooks: nextHooks };
-    const backupPath = await writeClaudeSettings({ settingsPath, settings: nextSettings });
-    return { changed: true, backupPath };
+  for (const event of normalizeEventList(events)) {
+    const entries = normalizeEntries(hooks[event]);
+    const normalized = normalizeEntriesForCommand(entries, hookCommand);
+    let nextEntries = normalized.entries;
+    if (!hasHook(nextEntries, hookCommand)) {
+      nextEntries = nextEntries.concat([{ hooks: [{ type: "command", command: hookCommand }] }]);
+      changed = true;
+    }
+    if (normalized.changed) changed = true;
+    if (normalized.changed || nextEntries.length !== entries.length) {
+      nextHooks[event] = nextEntries;
+    }
   }
 
-  if (hasHook(entries, hookCommand)) {
-    return { changed: false, backupPath: null };
-  }
+  if (!changed) return { changed: false, backupPath: null };
 
-  const nextEntries = entries.concat([{ hooks: [{ type: "command", command: hookCommand }] }]);
-  const nextHooks = { ...hooks, [event]: nextEntries };
   const nextSettings = { ...settings, hooks: nextHooks };
-
   const backupPath = await writeClaudeSettings({ settingsPath, settings: nextSettings });
   return { changed: true, backupPath };
 }
 
 async function removeClaudeHook({ settingsPath, hookCommand, event = DEFAULT_EVENT }) {
+  return removeClaudeHooks({ settingsPath, hookCommand, events: [event] });
+}
+
+async function removeClaudeUsageHooks({ settingsPath, hookCommand }) {
+  return removeClaudeHooks({ settingsPath, hookCommand, events: CLAUDE_USAGE_EVENTS });
+}
+
+async function removeClaudeHooks({ settingsPath, hookCommand, events }) {
   const existing = await readJson(settingsPath);
   if (!existing) return { removed: false, skippedReason: "settings-missing" };
 
   const settings = normalizeSettings(existing);
   const hooks = normalizeHooks(settings.hooks);
-  const entries = normalizeEntries(hooks[event]);
-  if (entries.length === 0) return { removed: false, skippedReason: "hook-missing" };
-
+  const nextHooks = { ...hooks };
   let removed = false;
-  const nextEntries = [];
-  for (const entry of entries) {
-    const res = stripHookFromEntry(entry, hookCommand);
-    if (res.removed) removed = true;
-    if (res.entry) nextEntries.push(res.entry);
+  for (const event of normalizeEventList(events)) {
+    const entries = normalizeEntries(hooks[event]);
+    const nextEntries = [];
+    for (const entry of entries) {
+      const res = stripHookFromEntry(entry, hookCommand);
+      if (res.removed) removed = true;
+      if (res.entry) nextEntries.push(res.entry);
+    }
+    if (nextEntries.length > 0) nextHooks[event] = nextEntries;
+    else delete nextHooks[event];
   }
 
   if (!removed) return { removed: false, skippedReason: "hook-missing" };
-
-  const nextHooks = { ...hooks };
-  if (nextEntries.length > 0) nextHooks[event] = nextEntries;
-  else delete nextHooks[event];
 
   const nextSettings = { ...settings };
   if (Object.keys(nextHooks).length > 0) nextSettings.hooks = nextHooks;
@@ -63,12 +81,26 @@ async function removeClaudeHook({ settingsPath, hookCommand, event = DEFAULT_EVE
 }
 
 async function isClaudeHookConfigured({ settingsPath, hookCommand, event = DEFAULT_EVENT }) {
+  return areClaudeHooksConfigured({ settingsPath, hookCommand, events: [event] });
+}
+
+async function areClaudeUsageHooksConfigured({ settingsPath, hookCommand }) {
+  return areClaudeHooksConfigured({
+    settingsPath,
+    hookCommand,
+    events: CLAUDE_USAGE_EVENTS,
+  });
+}
+
+async function areClaudeHooksConfigured({ settingsPath, hookCommand, events }) {
   const settings = await readJson(settingsPath);
   if (!settings || typeof settings !== "object") return false;
   const hooks = settings.hooks;
   if (!hooks || typeof hooks !== "object") return false;
-  const entries = normalizeEntries(hooks[event]);
-  return hasHook(entries, hookCommand);
+  return normalizeEventList(events).every((event) => {
+    const entries = normalizeEntries(hooks[event]);
+    return hasHook(entries, hookCommand);
+  });
 }
 
 // Generic Session-hook command builder. CodeBuddy CLI is a Claude-Code fork
@@ -94,6 +126,11 @@ function normalizeHooks(raw) {
 
 function normalizeEntries(raw) {
   return Array.isArray(raw) ? raw.slice() : [];
+}
+
+function normalizeEventList(events) {
+  const values = Array.isArray(events) ? events : [];
+  return Array.from(new Set(values.filter((event) => typeof event === "string" && event)));
 }
 
 function normalizeCommand(cmd) {
@@ -193,9 +230,13 @@ async function writeClaudeSettings({ settingsPath, settings }) {
 }
 
 module.exports = {
+  CLAUDE_USAGE_EVENTS,
   upsertClaudeHook,
+  upsertClaudeUsageHooks,
   removeClaudeHook,
+  removeClaudeUsageHooks,
   isClaudeHookConfigured,
+  areClaudeUsageHooksConfigured,
   buildClaudeHookCommand,
   buildHookCommand,
   // Aliases for callers that want a name unbiased toward Claude (the schema

--- a/src/lib/diagnostics.js
+++ b/src/lib/diagnostics.js
@@ -4,7 +4,7 @@ const fs = require("node:fs/promises");
 
 const { readJson } = require("./fs");
 const { readCodexNotify, readEveryCodeNotify } = require("./codex-config");
-const { isClaudeHookConfigured, buildClaudeHookCommand } = require("./claude-config");
+const { areClaudeUsageHooksConfigured, buildClaudeHookCommand } = require("./claude-config");
 const {
   resolveGeminiConfigDir,
   resolveGeminiSettingsPath,
@@ -81,7 +81,7 @@ async function collectTrackerDiagnostics({
     ? everyCodeNotifyRaw.map((v) => redactValue(v, home))
     : null;
   const claudeHookCommand = buildClaudeHookCommand(path.join(binDir, "notify.cjs"));
-  const claudeHookConfigured = await isClaudeHookConfigured({
+  const claudeHookConfigured = await areClaudeUsageHooksConfigured({
     settingsPath: claudeConfigPath,
     hookCommand: claudeHookCommand,
   });

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -685,6 +685,7 @@ function runSyncCommand(extraEnv = {}, opts = {}) {
     const args = [TRACKER_BIN, "sync"];
     if (opts.auto === true) args.push("--auto");
     if (opts.background === true) args.push("--background");
+    if (opts.allLocalSources === true) args.push("--all-local-sources");
     if (opts.drain === true) args.push("--drain");
     const child = spawn(process.execPath, args, {
       env: { ...process.env, ...extraEnv },
@@ -1693,6 +1694,7 @@ function createLocalApiHandler({ queuePath }) {
         const auto = body.auto === true && !drain;
         const background =
           auto && (body.background === true || body.lightweight === true);
+        const allLocalSources = background && body.allLocalSources === true;
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
         }
@@ -1724,7 +1726,12 @@ function createLocalApiHandler({ queuePath }) {
             extraEnv.TOKENTRACKER_DEVICE_TOKEN = issuedToken;
           }
         }
-        const result = await runSyncCommand(extraEnv, { drain, auto, background });
+        const result = await runSyncCommand(extraEnv, {
+          drain,
+          auto,
+          background,
+          allLocalSources,
+        });
         try {
           const { resetUsageLimitsCache } = require("./usage-limits");
           resetUsageLimitsCache();

--- a/test/dashboard-local-reload-sync.test.js
+++ b/test/dashboard-local-reload-sync.test.js
@@ -1,0 +1,20 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const pagePath = path.join(__dirname, "..", "dashboard", "src", "pages", "DashboardPage.jsx");
+
+test("local dashboard reload scans all local sources before refreshing usage snapshots", () => {
+  const source = fs.readFileSync(pagePath, "utf8");
+  assert.match(
+    source,
+    /triggerLocalSync\(\{\s*auto:\s*true,\s*background:\s*true,\s*allLocalSources:\s*true,?\s*\}\)/,
+    "DMG page reloads should request the all-local background sync path",
+  );
+  assert.match(
+    source,
+    /localReloadSyncPromiseRef\.current[\s\S]*\.then\(\(\) => \{[\s\S]*refreshUsageStats\(\)/,
+    "usage endpoints should be re-read after the reload-triggered sync finishes",
+  );
+});

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -8,6 +8,7 @@ const {
   cmdInit,
   buildNotifyHandler,
   repairCodexNotifyIntegration,
+  repairRuntimeIntegrations,
 } = require("../src/commands/init");
 const { cmdUninstall } = require("../src/commands/uninstall");
 const { withHome } = require("./helpers/with-home");
@@ -64,6 +65,43 @@ async function runGeneratedNotifyHandler({ trackerDir, notify, args = ["--source
     child.stdin?.end();
   });
 }
+
+test("notify handler runs local source sync without a cloud device token", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-local-sync-"));
+  try {
+    const trackerDir = path.join(tmp, "tracker");
+    const trackerBinPath = path.join(trackerDir, "app", "bin", "tracker.js");
+    const markerPath = path.join(tmp, "sync-args.json");
+    const notifyPath = path.join(tmp, "notify.cjs");
+    await fs.mkdir(path.dirname(trackerBinPath), { recursive: true });
+    await fs.writeFile(
+      trackerBinPath,
+      `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify(process.argv.slice(2)));\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      notifyPath,
+      buildNotifyHandler({ trackerDir, packageName: "tokentracker-cli" }),
+      "utf8",
+    );
+
+    const env = { ...process.env };
+    delete env.TOKENTRACKER_DEVICE_TOKEN;
+    await new Promise((resolve, reject) => {
+      require("node:child_process").execFile(
+        process.execPath,
+        [notifyPath, "--source=codex", "turn-ended"],
+        { env },
+        (err) => (err ? reject(err) : resolve()),
+      );
+    });
+
+    const marker = await waitForFile(markerPath, { timeoutMs: 5000 });
+    assert.deepEqual(JSON.parse(marker), ["sync", "--auto", "--from-notify", "--source", "codex"]);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
 
 test("notify handler chains executable original notify commands and skips stale explicit paths", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-notify-chain-"));
@@ -287,6 +325,90 @@ test("serve-time Codex notify repair installs TokenTracker and preserves Sky ori
   } finally {
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("serve-time runtime repair restores hooks for installed local providers", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-runtime-repair-"));
+  const savedEnv = {
+    CODEX_HOME: process.env.CODEX_HOME,
+    GEMINI_HOME: process.env.GEMINI_HOME,
+    OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+    CODEBUDDY_HOME: process.env.CODEBUDDY_HOME,
+    WORKBUDDY_HOME: process.env.WORKBUDDY_HOME,
+  };
+  try {
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    process.env.GEMINI_HOME = path.join(tmp, ".gemini");
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+    process.env.CODEBUDDY_HOME = path.join(tmp, ".codebuddy");
+    process.env.WORKBUDDY_HOME = path.join(tmp, ".workbuddy");
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const binDir = path.join(tmp, ".tokentracker", "bin");
+    await Promise.all([
+      fs.mkdir(path.join(tmp, ".claude"), { recursive: true }),
+      fs.mkdir(process.env.GEMINI_HOME, { recursive: true }),
+      fs.mkdir(process.env.OPENCODE_CONFIG_DIR, { recursive: true }),
+      fs.mkdir(process.env.CODEBUDDY_HOME, { recursive: true }),
+      fs.mkdir(process.env.WORKBUDDY_HOME, { recursive: true }),
+    ]);
+    await fs.writeFile(
+      path.join(tmp, ".claude", "settings.json"),
+      JSON.stringify({ permissions: { allow: ["Read"] } }),
+      "utf8",
+    );
+
+    const result = await repairRuntimeIntegrations({ home: tmp, trackerDir, binDir });
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(result.integrations.claude.changed, true);
+    assert.equal(result.integrations.gemini.changed, true);
+    assert.equal(result.integrations.opencode.changed, true);
+    assert.equal(result.integrations.codebuddy.changed, true);
+    assert.equal(result.integrations.workbuddy.changed, true);
+    const notifyPath = path.join(binDir, "notify.cjs");
+    await fs.stat(notifyPath);
+
+    const claudeSettings = JSON.parse(
+      await fs.readFile(path.join(tmp, ".claude", "settings.json"), "utf8"),
+    );
+    assert.deepEqual(claudeSettings.permissions, { allow: ["Read"] });
+    assert.equal(
+      flattenHookEntries(claudeSettings.hooks.SessionEnd).some(
+        (hook) => hook.command === buildClaudeHookCommand(notifyPath),
+      ),
+      true,
+    );
+    assert.equal(
+      flattenHookEntries(claudeSettings.hooks.Stop).some(
+        (hook) => hook.command === buildClaudeHookCommand(notifyPath),
+      ),
+      true,
+    );
+
+    const geminiSettings = JSON.parse(
+      await fs.readFile(path.join(process.env.GEMINI_HOME, "settings.json"), "utf8"),
+    );
+    assert.equal(geminiSettings.tools.enableHooks, true);
+    assert.equal(
+      flattenHookEntries(geminiSettings.hooks.SessionEnd).some(
+        (hook) => hook.command === buildGeminiHookCommand(notifyPath),
+      ),
+      true,
+    );
+    assert.equal(
+      await fs.readFile(
+        path.join(process.env.OPENCODE_CONFIG_DIR, "plugin", DEFAULT_PLUGIN_NAME),
+        "utf8",
+      ),
+      buildOpencodePlugin({ notifyPath }),
+    );
+  } finally {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
@@ -1219,6 +1341,10 @@ test("init then uninstall manages Claude hooks without removing existing hooks",
       .map((h) => h?.command);
     assert.ok(allCommands.includes(existingCommand), "expected existing Claude hook to remain");
     assert.ok(allCommands.includes(hookCommand), "expected tracker Claude hook to be added");
+    const stopCommands = (installed?.hooks?.Stop || [])
+      .flatMap((entry) => (Array.isArray(entry?.hooks) ? entry.hooks : [entry]))
+      .map((h) => h?.command);
+    assert.ok(stopCommands.includes(hookCommand), "expected tracker Claude Stop hook to be added");
 
     await cmdUninstall([]);
 
@@ -1235,6 +1361,13 @@ test("init then uninstall manages Claude hooks without removing existing hooks",
     assert.ok(
       !restoredCommands.includes(hookCommand),
       "expected tracker Claude hook to be removed",
+    );
+    const restoredStopCommands = (restored?.hooks?.Stop || [])
+      .flatMap((entry) => (Array.isArray(entry?.hooks) ? entry.hooks : [entry]))
+      .map((h) => h?.command);
+    assert.ok(
+      !restoredStopCommands.includes(hookCommand),
+      "expected tracker Claude Stop hook to be removed",
     );
   } finally {
     process.stdout.write = prevWrite;

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -275,6 +275,46 @@ test("local sync auto background request runs sync with --auto --background", as
   }
 });
 
+test("local sync all-local background request forwards the source expansion flag", async () => {
+  const calls = [];
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({
+        deviceToken: "device-token",
+        auto: true,
+        background: true,
+        allLocalSources: true,
+      }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-5), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--auto",
+      "--background",
+      "--all-local-sources",
+    ]);
+  } finally {
+    restore();
+  }
+});
+
 test("local sync lightweight alias forwards background mode", async () => {
   const calls = [];
   const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));

--- a/test/serve-native-background-sync.test.js
+++ b/test/serve-native-background-sync.test.js
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  NATIVE_BACKGROUND_SYNC_INTERVAL_MS,
+  startNativeBackgroundSync,
+} = require("../src/commands/serve");
+
+test("native serve schedules a lightweight all-source fallback sync", async () => {
+  let intervalCallback = null;
+  let intervalDelay = null;
+  let clearedTimer = null;
+  const timer = { unrefCalled: false, unref() { this.unrefCalled = true; } };
+  const runSync = test.mock.fn(async () => {});
+  const controller = startNativeBackgroundSync({
+    appShell: "macos",
+    runSync,
+    setIntervalFn(callback, delay) {
+      intervalCallback = callback;
+      intervalDelay = delay;
+      return timer;
+    },
+    clearIntervalFn(value) {
+      clearedTimer = value;
+    },
+  });
+
+  assert.ok(controller);
+  assert.equal(intervalDelay, NATIVE_BACKGROUND_SYNC_INTERVAL_MS);
+  assert.equal(timer.unrefCalled, true);
+  intervalCallback();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(runSync.mock.callCount(), 1);
+  assert.deepEqual(runSync.mock.calls[0].arguments[0], [
+    "--auto",
+    "--background",
+    "--all-local-sources",
+  ]);
+  controller.stop();
+  assert.equal(clearedTimer, timer);
+});
+
+test("native background sync coalesces overlapping ticks", async () => {
+  let resolveSync;
+  const errors = [];
+  const runSync = test.mock.fn(() => new Promise((resolve) => { resolveSync = resolve; }));
+  const controller = startNativeBackgroundSync({
+    appShell: "windows",
+    runSync,
+    setIntervalFn() { return 1; },
+    clearIntervalFn() {},
+    onError(error) { errors.push(error); },
+  });
+
+  const first = controller.run();
+  const second = controller.run();
+  assert.equal(first, second);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(runSync.mock.callCount(), 1);
+  resolveSync();
+  await first;
+  assert.deepEqual(errors, []);
+  controller.stop();
+});
+
+test("non-native serve does not start the fallback timer", () => {
+  const setIntervalFn = test.mock.fn();
+  const controller = startNativeBackgroundSync({ appShell: "", setIntervalFn });
+  assert.equal(controller, null);
+  assert.equal(setIntervalFn.mock.callCount(), 0);
+});

--- a/test/serve-runtime-repair.test.js
+++ b/test/serve-runtime-repair.test.js
@@ -1,0 +1,12 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const servePath = path.join(__dirname, "..", "src", "commands", "serve.js");
+
+test("DMG server startup repairs all supported runtime integrations", () => {
+  const source = fs.readFileSync(servePath, "utf8");
+  assert.match(source, /repairRuntimeIntegrations/);
+  assert.doesNotMatch(source, /repairCodexNotifyIntegration/);
+});

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -47,6 +47,32 @@ async function writeArchivedCodexRollout(codexHome, date, uuid, totalTokens) {
   return filePath;
 }
 
+async function writeClaudeSession(home, date, sessionId, totalTokens) {
+  const dir = path.join(home, ".claude", "projects", "sample");
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${sessionId}.jsonl`);
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({
+      type: "assistant",
+      timestamp: `${date}T00:00:00.000Z`,
+      requestId: `request-${sessionId}`,
+      message: {
+        id: `message-${sessionId}`,
+        model: "claude-sonnet-4-5",
+        usage: {
+          input_tokens: totalTokens,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    }) + "\n",
+    "utf8",
+  );
+  return filePath;
+}
+
 async function withTempSyncEnv(fn) {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-background-"));
   const saved = {
@@ -180,6 +206,22 @@ test("background auto sync avoids broad provider traversal", async () => {
     assert.equal(broadReads, 0);
     const queue = await readQueue(home);
     assert.match(queue, /"total_tokens":22/);
+  });
+});
+
+test("all-local background sync includes Claude while preserving lightweight behavior", async () => {
+  await withTempSyncEnv(async (home) => {
+    await writeClaudeSession(home, "2026-06-30", "session-all-local", 53);
+
+    await cmdSync(["--auto", "--background", "--all-local-sources"]);
+
+    const queue = await readQueue(home);
+    assert.match(queue, /"source":"claude"/);
+    assert.match(queue, /"total_tokens":53/);
+    await assert.rejects(
+      fs.stat(path.join(home, ".tokentracker", "tracker", "queue.state.json")),
+      { code: "ENOENT" },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- make local dashboard reload run an all-local background sync so Claude, Gemini, OpenCode, and other local log/database sources refresh without cloud upload, Cursor network access, or deep Codex archive work
- repair existing runtime integrations when the desktop server starts, instead of repairing only Codex notify
- install Claude `Stop` plus `SessionEnd` hooks for per-response updates and session-end fallback
- allow hook-triggered local source sync without requiring a cloud device token
- add a native-shell fallback scan every 60 seconds, covering all local providers even when hooks are absent or overwritten
- re-read visible local dashboard aggregates every 30 seconds and on focus, with single-flight guards to prevent overlapping work

## Root cause

The DMG starts the embedded server with `--no-sync`. Dashboard reload previously used a bounded background path whose source allowlist only included Codex and Every Code. Desktop startup only repaired the Codex notify integration, and the generated notify handler required a cloud device token before starting any local parse.

After those paths were repaired, a second stale-data gap remained: a dashboard left open had no periodic aggregate refresh, and the native server had no fallback scan. A missed or overwritten provider hook could therefore leave local data stale indefinitely until the user clicked Refresh.

## Validation

- targeted Node tests for sync, local API, hook repair, reload, and native periodic sync passed
- dashboard Vitest coverage for local sync payloads and periodic refresh passed
- dashboard TypeScript check, ESLint, production build, copy checks, UI hardcode checks, and architecture guardrails passed
- macOS Release app and DMG built successfully with Xcode 26.6 and were installed as version 0.79.8
- installed notify handler runs without a cloud token; direct trigger advanced `last_notify_spawn` and `last_parse`
- installed native server advanced `last_parse` and the queue file on its 60-second fallback interval without a manual refresh
- local model-breakdown endpoint returned both Codex and Claude sources
- full Node suite: 1530/1531 passed under load; the single timing-sensitive concurrency assertion passed 6/6 when rerun in isolation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dashboard local auto-refresh for usage stats, including a safer reload-trigger flow.
  - Expanded local/background sync controls, including an “all local sources” option for lightweight runs.
  - Added native desktop background syncing with clean startup/shutdown behavior.
  - Added runtime integration repair during server startup and improved Claude usage hooks support (session + usage events).

- **Bug Fixes**
  - Improved local usage refresh sequencing after sync completes.
  - Updated Claude hook configuration detection to the new usage-hooks model.

- **Tests**
  - Added coverage for local sync option forwarding, dashboard auto-refresh behavior, runtime repair, and native background sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->