### PR TITLE
Skip same-day forked Codex replay bursts and repair inflated history

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -172,6 +172,18 @@ const CLOUD_CONVERSATIONS_BACKFILL_KEY = "cloudConversationsBackfill_2026_06";
 // ~/.codex/archived_sessions/ which sync does not scan) — clearing its bucket
 // would lose that history (ref the v6 ground-truth-repair data-loss incident).
 const CODEX_RESCAN_DEDUP_REPAIR_KEY = "codexRescanDedupRepair_2026_06";
+// One-time repair (#169 follow-up): forked Codex rollouts replay the parent
+// session's token history into the child file, and until the same-day burst
+// detector landed in rollout.js the parser counted those replayed rows as live
+// usage (PR #169's date guard only caught cross-day forks). Cursors sit at EOF
+// on every already-parsed file, so the forward fix alone never corrects the
+// inflated history. This re-runs the exact #187 guarded rebuild under a new key
+// — the rebuild re-parses every codex file with the CURRENT (fork-aware)
+// parser, so replay rows are excluded — and inherits all its safety properties
+// (unreproducible-session skip, atomic throwaway rebuild, queue strip, upload
+// offset reset for the cloud overwrite). Pre-gated: installs with no forked
+// rollout on disk carry no fork phantom and mark done without the rebuild.
+const CODEX_FORK_REPLAY_REPAIR_KEY = "codexForkReplayRepair_2026_07";
 const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
 const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const CODEX_COLD_SCAN_AUDIT_MAX_SYNCS = 288;
@@ -405,13 +417,22 @@ async function cmdSync(argv) {
 
     if (isFullSourceScan) {
       await migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rolloutFiles });
-      await repairCodexRescanInflation({
+      const codexRescanRepairRan = await repairCodexRescanInflation({
         cursors,
         queuePath,
         queueStatePath,
         projectQueuePath,
         projectQueueStatePath,
         rolloutFiles,
+      });
+      await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles,
+        legacyRepairRan: codexRescanRepairRan,
       });
       await repairDroidDuplicateSessionInflation({ cursors, queuePath, queueStatePath });
       await repairMimoClaudeMislabel({
@@ -2097,6 +2118,7 @@ module.exports = {
   migrateCursorUnknownBuckets,
   migrateRolloutCumulativeDeltaBuckets,
   repairCodexRescanInflation,
+  repairCodexForkReplayInflation,
   repairDroidDuplicateSessionInflation,
   repairMimoClaudeMislabel,
   reincludeClaudeMemObserverFiles,
@@ -2109,6 +2131,7 @@ module.exports = {
   CURSOR_UNKNOWN_MIGRATION_KEY,
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
   CODEX_RESCAN_DEDUP_REPAIR_KEY,
+  CODEX_FORK_REPLAY_REPAIR_KEY,
   DROID_DUP_SESSION_REPAIR_KEY,
   CLAUDE_MEM_OBSERVER_REINCLUDE_KEY,
   GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY,
@@ -3157,6 +3180,11 @@ async function repairCodexRescanInflation({
   projectQueuePath,
   projectQueueStatePath,
   rolloutFiles,
+  // The fork-replay repair (#169 follow-up) re-runs this exact rebuild under
+  // its own key: the rebuild always uses the CURRENT parser, so any parser fix
+  // shipped since the last run is applied to the rebuilt history.
+  migrationKey = CODEX_RESCAN_DEDUP_REPAIR_KEY,
+  uploadNote = "reset_after_codex_rescan_dedup_2026_06",
 }) {
   if (!cursors || typeof cursors !== "object") return false;
   const migrations = (cursors.migrations ||= {});
@@ -3167,7 +3195,7 @@ async function repairCodexRescanInflation({
   // found). Treating the skip sentinel as "done" is what left users like #187
   // permanently stuck on the inflated value after upgrading (the key was truthy
   // so the guard never got a second chance).
-  const priorRepair = migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY];
+  const priorRepair = migrations[migrationKey];
   if (priorRepair && !(typeof priorRepair === "object" && priorRepair.skipped)) return false;
 
   // Codex session files THIS sync discovered (source === "codex").
@@ -3203,7 +3231,7 @@ async function repairCodexRescanInflation({
       if (codexFileSet.has(fp)) continue; // exact file re-scanned this run
       const id = codexSessionIdFromPath(fp);
       if (id && scannedSessionIds.has(id)) continue; // same session scanned elsewhere (moved)
-      migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY] = {
+      migrations[migrationKey] = {
         skipped: true,
         reason: "codex_session_unreproducible",
         at: new Date().toISOString(),
@@ -3462,7 +3490,7 @@ async function repairCodexRescanInflation({
     }
     uploadState.offset = 0;
     uploadState.updatedAt = new Date().toISOString();
-    uploadState.note = "reset_after_codex_rescan_dedup_2026_06";
+    uploadState.note = uploadNote;
     await fs.writeFile(queueStatePath, JSON.stringify(uploadState));
   }
   if (projectRepairEnabled && typeof projectQueueStatePath === "string" && projectQueueStatePath) {
@@ -3474,12 +3502,89 @@ async function repairCodexRescanInflation({
     }
     uploadState.offset = 0;
     uploadState.updatedAt = new Date().toISOString();
-    uploadState.note = "reset_after_codex_rescan_dedup_2026_06";
+    uploadState.note = uploadNote;
     await fs.writeFile(projectQueueStatePath, JSON.stringify(uploadState));
   }
 
-  migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY] = new Date().toISOString();
+  migrations[migrationKey] = new Date().toISOString();
   return true;
+}
+
+// #169 follow-up: repair the historical inflation left by same-day forked
+// Codex rollout replays (see CODEX_FORK_REPLAY_REPAIR_KEY). Delegates to the
+// #187 guarded rebuild with the fork-repair key.
+async function repairCodexForkReplayInflation({
+  cursors,
+  queuePath,
+  queueStatePath,
+  projectQueuePath,
+  projectQueueStatePath,
+  rolloutFiles,
+  // True when the #187 repair ran its rebuild earlier in THIS sync: that
+  // rebuild already used the fork-aware parser, so the history is clean and a
+  // second rebuild would be pure waste.
+  legacyRepairRan = false,
+}) {
+  if (!cursors || typeof cursors !== "object") return false;
+  const migrations = (cursors.migrations ||= {});
+  // Same completed-vs-skipped semantics as the #187 repair: an ISO string is
+  // final, a {skipped:true} sentinel retries (the skip condition can clear).
+  const prior = migrations[CODEX_FORK_REPLAY_REPAIR_KEY];
+  if (prior && !(typeof prior === "object" && prior.skipped)) return false;
+
+  if (legacyRepairRan) {
+    migrations[CODEX_FORK_REPLAY_REPAIR_KEY] = new Date().toISOString();
+    return false;
+  }
+
+  // Pre-gate: fork phantom can only exist on installs that have (or had) a
+  // forked rollout. Scanning file heads is cheap; the rebuild re-parses every
+  // codex file. A forked rollout that was deleted before this repair runs is
+  // unreproducible anyway — the #187 reproducibility guard would defer forever
+  // — so gating on what is on disk loses nothing. Files forked AFTER the parser
+  // fix shipped never accrue phantom, so marking done here is final.
+  if (!(await hasForkedCodexRollout(rolloutFiles))) {
+    migrations[CODEX_FORK_REPLAY_REPAIR_KEY] = new Date().toISOString();
+    return false;
+  }
+
+  return repairCodexRescanInflation({
+    cursors,
+    queuePath,
+    queueStatePath,
+    projectQueuePath,
+    projectQueueStatePath,
+    rolloutFiles,
+    migrationKey: CODEX_FORK_REPLAY_REPAIR_KEY,
+    uploadNote: "reset_after_codex_fork_replay_2026_07",
+  });
+}
+
+// True when any codex rollout's head contains the fork marker. The child
+// session_meta (with forked_from_id) is the FIRST line of a forked rollout —
+// observed at byte offset ≤169 across every local sample — so a bounded head
+// read is sufficient. 64KB leaves ample margin for long base_instructions
+// preceding it; a substring false positive (the marker quoted in unrelated
+// head content) only costs one redundant guarded rebuild, never data.
+async function hasForkedCodexRollout(rolloutFiles) {
+  const HEAD_BYTES = 65536;
+  for (const entry of Array.isArray(rolloutFiles) ? rolloutFiles : []) {
+    const fp = typeof entry === "string" ? entry : entry?.path;
+    const src = typeof entry === "string" ? "codex" : String(entry?.source || "codex");
+    if (!fp || src !== "codex") continue;
+    let fh = null;
+    try {
+      fh = await fs.open(fp, "r");
+      const buf = Buffer.alloc(HEAD_BYTES);
+      const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
+      if (buf.toString("utf8", 0, bytesRead).includes('"forked_from_id"')) return true;
+    } catch (_e) {
+      // unreadable file: let the rebuild's own guards decide
+    } finally {
+      if (fh) await fh.close().catch(() => {});
+    }
+  }
+  return false;
 }
 
 function isCodexSessionCursorPath(filePath) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -1514,6 +1514,8 @@ async function parseRolloutFile({
   let currentCwd = null;
   let currentDate = null;
   let isForkedRollout = false;
+  let replayPrefixActive = true;
+  let prevForkedTokenMs = null;
   const rolloutDate = rolloutDateFromPath(filePath);
   let currentProjectRef = projectRef || null;
   let currentProjectKey = projectKey || null;
@@ -1591,8 +1593,43 @@ async function parseRolloutFile({
       totals = totalUsage;
     }
 
-    // date matching is conservative; same-day fork replays are still counted.
-    if (isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate })) continue;
+    // Forked Codex rollouts replay the parent session's entire token history
+    // into the child file the moment the fork is created. The date guard below
+    // (current_date < rolloutDate) catches cross-day forks, but same-day forks
+    // share the parent's current_date and slip through it. The replay is written
+    // in a single flush, so its rows carry near-identical timestamps (sub-ms to a
+    // few ms apart across observed 0.129–0.137 samples), while the first genuine
+    // live turn lands seconds later (≥11s in every sampled fork). We therefore
+    // skip the *leading* run of densely-spaced token_count rows and latch off
+    // permanently at the first multi-second gap: a lone fast turn (always
+    // preceded by a large gap) is never dropped, and an arbitrarily large replay
+    // is fully skipped regardless of length. The threshold sits far above the
+    // flush spacing and well below genuine turn cadence (≥~4.6s observed). The
+    // first replayed row cannot be identified without lookahead, so it is still
+    // counted (a bounded, <1% residual over-count); dropping real usage is the
+    // worse failure, so we bias against it. `totals` is already advanced above,
+    // keeping the cumulative-delta baseline correct for the live turns we keep.
+    // Scoped to forked codex rollouts. (issue #169 follow-up.)
+    let forkedReplaySkip = false;
+    if (isForkedRollout && source === DEFAULT_SOURCE) {
+      const tokenMs = Date.parse(tokenTimestamp);
+      if (Number.isFinite(tokenMs)) {
+        if (prevForkedTokenMs !== null && tokenMs - prevForkedTokenMs >= CODEX_FORK_REPLAY_GAP_MS) {
+          replayPrefixActive = false;
+        }
+        forkedReplaySkip =
+          replayPrefixActive &&
+          prevForkedTokenMs !== null &&
+          tokenMs - prevForkedTokenMs < CODEX_FORK_REPLAY_GAP_MS;
+        prevForkedTokenMs = tokenMs;
+      }
+    }
+
+    // date matching is conservative; same-day fork replays are caught by the
+    // burst detector above rather than this cross-day date guard.
+    if (forkedReplaySkip || isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate })) {
+      continue;
+    }
 
     const bucketStart = toUtcHalfHourStart(tokenTimestamp);
     if (!bucketStart) continue;
@@ -2693,6 +2730,15 @@ function normalizeIsoDate(value) {
   const match = raw.match(/^(\d{4}-\d{2}-\d{2})/);
   return match ? match[1] : null;
 }
+
+// Max inter-row gap (ms) still treated as part of a forked rollout's replay
+// burst. Empirically the replay flush spaces rows sub-ms to a few ms apart while
+// genuine live turns arrive ≥~4.6s apart and the replay→live break is ≥11s, so
+// any value in the ~0.25–2s band separates them with a wide margin; 500ms biases
+// toward the low end because merging a real fast turn (under-count) is worse than
+// leaving a slow replay counted (bounded over-count). See the skip site in
+// parseRolloutFile. (issue #169 follow-up.)
+const CODEX_FORK_REPLAY_GAP_MS = 500;
 
 function isForkedReplayToken({ isForkedRollout, rolloutDate, currentDate }) {
   return Boolean(isForkedRollout && rolloutDate && currentDate && currentDate < rolloutDate);

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -1580,6 +1580,130 @@ test("parseRolloutIncremental skips historical replay tokens in forked Codex rol
   }
 });
 
+test("parseRolloutIncremental skips same-day forked replay burst (issue #169 follow-up)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-2026-06-09T20-46-23-fork.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    // Three replay rows written in a single flush (~1ms apart), then one genuine
+    // live turn 30s later. current_date matches the rollout date, so the
+    // cross-day date guard is inert — only the burst detector can catch this.
+    const r0 = { input_tokens: 100, cached_input_tokens: 0, output_tokens: 10, reasoning_output_tokens: 0, total_tokens: 110 };
+    const r1 = { input_tokens: 200, cached_input_tokens: 0, output_tokens: 20, reasoning_output_tokens: 0, total_tokens: 220 };
+    const r2 = { input_tokens: 300, cached_input_tokens: 0, output_tokens: 30, reasoning_output_tokens: 0, total_tokens: 330 };
+    const live = { input_tokens: 7, cached_input_tokens: 0, output_tokens: 3, reasoning_output_tokens: 0, total_tokens: 10 };
+    const cum = (...xs) => xs.reduce((a, x) => ({
+      input_tokens: a.input_tokens + x.input_tokens,
+      cached_input_tokens: 0,
+      output_tokens: a.output_tokens + x.output_tokens,
+      reasoning_output_tokens: 0,
+      total_tokens: a.total_tokens + x.total_tokens,
+    }), { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_output_tokens: 0, total_tokens: 0 });
+
+    const lines = [
+      buildSessionMetaLine({ model: "gpt-5.5", cwd: tmp, forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c" }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.100Z", last: r0, total: cum(r0) }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.101Z", last: r1, total: cum(r0, r1) }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.102Z", last: r2, total: cum(r0, r1, r2) }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:53.102Z", last: live, total: cum(r0, r1, r2, live) }),
+    ];
+    await fs.writeFile(rolloutPath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(res.filesProcessed, 1);
+    // r1 + r2 (the replay burst tail) are skipped; the first-of-run row cannot be
+    // identified without lookahead so it is still counted, plus the live turn.
+    assert.equal(res.eventsAggregated, 2);
+
+    const queued = await readJsonLines(queuePath);
+    const total = queued.reduce((n, q) => n + q.total_tokens, 0);
+    // Without the fix this would be r0+r1+r2+live = 670; the burst tail (550) is dropped.
+    assert.equal(total, r0.total_tokens + live.total_tokens);
+    // Cumulative baseline advanced across the skipped rows so the live delta is intact.
+    assert.deepEqual(cursors.files[rolloutPath].lastTotal, cum(r0, r1, r2, live));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental latches off after the replay burst, keeping fast live turns", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-2026-06-09T20-46-23-fork.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const u = (i, o) => ({ input_tokens: i, cached_input_tokens: 0, output_tokens: o, reasoning_output_tokens: 0, total_tokens: i + o });
+    const r0 = u(100, 10);
+    const r1 = u(200, 20);
+    const l0 = u(5, 5);
+    const l1 = u(6, 6); // second live turn only 120ms after l0 — must NOT be dropped
+    const add = (a, b) => ({
+      input_tokens: a.input_tokens + b.input_tokens,
+      cached_input_tokens: 0,
+      output_tokens: a.output_tokens + b.output_tokens,
+      reasoning_output_tokens: 0,
+      total_tokens: a.total_tokens + b.total_tokens,
+    });
+    const t0 = r0, t1 = add(t0, r1), t2 = add(t1, l0), t3 = add(t2, l1);
+
+    const lines = [
+      buildSessionMetaLine({ model: "gpt-5.5", cwd: tmp, forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c" }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.100Z", last: r0, total: t0 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.101Z", last: r1, total: t1 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:53.000Z", last: l0, total: t2 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:53.120Z", last: l1, total: t3 }),
+    ];
+    await fs.writeFile(rolloutPath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    // r1 skipped (burst tail); r0 (first-of-run), l0, and l1 all counted.
+    assert.equal(res.eventsAggregated, 3);
+    const queued = await readJsonLines(queuePath);
+    const total = queued.reduce((n, q) => n + q.total_tokens, 0);
+    assert.equal(total, r0.total_tokens + l0.total_tokens + l1.total_tokens);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental never drops genuine turns in a replay-free fork", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-2026-06-09T20-46-23-fork.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    // A forked session that carries no replayed history: every token_count row is
+    // a genuine turn spaced multi-second apart. Nothing may be skipped.
+    const u = (i, o) => ({ input_tokens: i, cached_input_tokens: 0, output_tokens: o, reasoning_output_tokens: 0, total_tokens: i + o });
+    const a = u(50, 5);
+    const b = u(60, 6);
+    const totalA = a;
+    const totalB = { input_tokens: 110, cached_input_tokens: 0, output_tokens: 11, reasoning_output_tokens: 0, total_tokens: 121 };
+
+    const lines = [
+      buildSessionMetaLine({ model: "gpt-5.5", cwd: tmp, forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c" }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:28.000Z", last: a, total: totalA }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:33.000Z", last: b, total: totalB }),
+    ];
+    await fs.writeFile(rolloutPath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 2);
+    const queued = await readJsonLines(queuePath);
+    const total = queued.reduce((n, q) => n + q.total_tokens, 0);
+    assert.equal(total, a.total_tokens + b.total_tokens);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental migrates v1 hourly buckets without resetting totals", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -913,3 +913,207 @@ describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// #169 follow-up: fork-replay historical repair. Re-runs the guarded rebuild
+// under CODEX_FORK_REPLAY_REPAIR_KEY so history parsed before the same-day
+// fork burst detector landed gets rebuilt with the fork-aware parser.
+// ---------------------------------------------------------------------------
+
+const {
+  repairCodexForkReplayInflation,
+  CODEX_FORK_REPLAY_REPAIR_KEY,
+} = require("../src/commands/sync");
+
+// A same-day forked rollout: 2 replay rows in one flush (1ms apart), then one
+// live turn 30s later. Old parser counted all 3 (total 250+150=400 inflated
+// ... replay 100+150, live 50 → phantom 150); fork-aware parser counts the
+// first-of-run replay row (no lookahead) + the live turn.
+const FORK_R1 = { input_tokens: 60, cached_input_tokens: 0, output_tokens: 40, reasoning_output_tokens: 0, total_tokens: 100 };
+const FORK_R2 = { input_tokens: 90, cached_input_tokens: 0, output_tokens: 60, reasoning_output_tokens: 0, total_tokens: 150 };
+const FORK_LIVE = { input_tokens: 30, cached_input_tokens: 0, output_tokens: 20, reasoning_output_tokens: 0, total_tokens: 50 };
+const FORK_T2 = { input_tokens: 150, cached_input_tokens: 0, output_tokens: 100, reasoning_output_tokens: 0, total_tokens: 250 };
+const FORK_T3 = { input_tokens: 180, cached_input_tokens: 0, output_tokens: 120, reasoning_output_tokens: 0, total_tokens: 300 };
+// first-of-run replay row (100) + live (50): the bounded residual documented at the skip site
+const FORK_TRUE_TOTAL = FORK_R1.total_tokens + FORK_LIVE.total_tokens;
+const FORK_INFLATED_TOTAL = FORK_R1.total_tokens + FORK_R2.total_tokens + FORK_LIVE.total_tokens;
+
+async function writeForkedCodexFile(home, uuid = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff") {
+  const dir = path.join(home, ".codex", "sessions", "2025", "12", "17");
+  await fs.mkdir(dir, { recursive: true });
+  const fp = path.join(dir, `rollout-2025-12-17T00-00-00-${uuid}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      type: "session_meta",
+      payload: { id: uuid, forked_from_id: "019e095c-c041-7b40-b7cb-43ddb153086c", model: "gpt-4" },
+    }),
+    JSON.stringify({ type: "turn_context", payload: { model: "gpt-4", current_date: "2025-12-17" } }),
+    tokenCountLine({ ts: "2025-12-17T00:00:00.100Z", last: FORK_R1, total: FORK_R1 }),
+    tokenCountLine({ ts: "2025-12-17T00:00:00.101Z", last: FORK_R2, total: FORK_T2 }),
+    tokenCountLine({ ts: "2025-12-17T00:00:30.101Z", last: FORK_LIVE, total: FORK_T3 }),
+  ];
+  await fs.writeFile(fp, lines.join("\n") + "\n", "utf8");
+  return fp;
+}
+
+describe("repairCodexForkReplayInflation (#169 follow-up) — fork replay historical repair", () => {
+  it("rebuilds fork-replay-inflated codex history with the fork-aware parser", async () => {
+    const home = await makeTempHome();
+    try {
+      const forkedFile = await writeForkedCodexFile(home);
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+
+      // INFLATED state: old parser counted the replay rows.
+      await fs.writeFile(
+        queuePath,
+        [
+          JSON.stringify({ source: "codex", model: "gpt-4", hour_start: "2025-12-17T00:00:00.000Z", total_tokens: FORK_INFLATED_TOTAL }),
+          JSON.stringify({ source: "claude", model: "opus", hour_start: "2025-12-17T00:00:00.000Z", total_tokens: 5000 }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 4321 }), "utf8");
+
+      const cursors = {
+        hourly: {
+          buckets: {
+            "codex|gpt-4|2025-12-17T00:00:00.000Z": { totals: { total_tokens: FORK_INFLATED_TOTAL } },
+            "claude|opus|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 5000 } },
+          },
+          groupQueued: {},
+        },
+        files: { [forkedFile]: { inode: 1, offset: 5, lastTotal: { total_tokens: FORK_T3.total_tokens } } },
+        codexHashes: [],
+        // #187 repair long completed — only the fork key triggers this rebuild.
+        migrations: { [CODEX_RESCAN_DEDUP_REPAIR_KEY]: "2026-06-15T00:00:00.000Z" },
+      };
+
+      const ran = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: forkedFile, source: "codex" }],
+      });
+      assert.equal(ran, true);
+
+      assert.equal(codexBucketTotal(cursors), FORK_TRUE_TOTAL);
+      assert.equal(cursors.hourly.buckets["claude|opus|2025-12-17T00:00:00.000Z"].totals.total_tokens, 5000);
+
+      const q = await queueRowsBySource(queuePath);
+      assert.equal(q.codex.total, FORK_TRUE_TOTAL, "queue codex rebuilt without replay phantom");
+      assert.equal(q.claude.total, 5000);
+
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 0);
+      assert.ok(cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY]);
+      // #187 key untouched
+      assert.equal(cursors.migrations[CODEX_RESCAN_DEDUP_REPAIR_KEY], "2026-06-15T00:00:00.000Z");
+
+      // idempotent
+      assert.equal(
+        await repairCodexForkReplayInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: forkedFile, source: "codex" }],
+        }),
+        false,
+      );
+      assert.equal(codexBucketTotal(cursors), FORK_TRUE_TOTAL);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("marks done without a rebuild when no forked rollout exists (pre-gate)", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeCodexFile(home); // NOT forked
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      await fs.writeFile(
+        queuePath,
+        JSON.stringify({ source: "codex", model: "unknown", hour_start: "2025-12-17T00:00:00.000Z", total_tokens: 250 }) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 777 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: { "codex|unknown|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 250 } } },
+          groupQueued: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 500 } },
+        codexHashes: ["keep:me"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      // nothing touched, key finalized
+      assert.equal(codexBucketTotal(cursors), 250);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 777);
+      assert.deepEqual(cursors.codexHashes, ["keep:me"]);
+      assert.equal(typeof cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY], "string");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("marks done without a rebuild when the #187 repair rebuilt in the same sync", async () => {
+    const home = await makeTempHome();
+    try {
+      const forkedFile = await writeForkedCodexFile(home);
+      const cursors = { hourly: { buckets: {}, groupQueued: {} }, files: {}, codexHashes: [], migrations: {} };
+      const ran = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath: path.join(home, "queue.jsonl"),
+        queueStatePath: path.join(home, "queue.state.json"),
+        rolloutFiles: [{ path: forkedFile, source: "codex" }],
+        legacyRepairRan: true,
+      });
+      assert.equal(ran, false);
+      assert.equal(typeof cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY], "string");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("defers via the reproducibility guard when a previously-counted session is gone", async () => {
+    const home = await makeTempHome();
+    try {
+      const forkedFile = await writeForkedCodexFile(home);
+      const deletedPath = path.join(
+        home, ".codex", "sessions", "2025", "12", "10",
+        "rollout-2025-12-10T00-00-00-99999999-9999-9999-9999-999999999999.jsonl",
+      );
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      await fs.writeFile(queuePath, "", "utf8");
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 55 }), "utf8");
+      const cursors = {
+        hourly: { buckets: { "codex|gpt-4|2025-12-17T00:00:00.000Z": { totals: { total_tokens: 300 } } }, groupQueued: {} },
+        files: { [forkedFile]: { inode: 1, offset: 5 }, [deletedPath]: { inode: 2, offset: 5 } },
+        codexHashes: [],
+        migrations: {},
+      };
+
+      const ran = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: forkedFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 300);
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 55);
+      assert.equal(cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY].skipped, true);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to the same-day fork gap discussed in #169 (h/t @YUDONGLING for proposing the inter-record-gap direction and @lhandal for the original fix).

## Problem

#169's date guard (`current_date < rolloutDate`) only catches cross-day forks. Same-day forks share the parent's `current_date`, so their replayed token history still counted as live usage. All 25 forked rollouts on my machine slip through the date guard this way.

## Approach: leading-burst detection (data-derived boundary)

Measured across 25 real forked rollouts (Codex 0.129–0.140, 8–274 token events each):

- The replay is written in a **single flush**: replayed `token_count` rows sit **≤2ms apart** (most share the same millisecond timestamp).
- The first genuine live turn lands **≥11.2s** after the replay in every sample; genuine turn cadence is **≥~4.6s**.
- 5 of the 25 forks carry **no replay at all** (verified live-only usage) — any fix must not touch them.

So instead of a fixed window from session start (which, as discussed in #169, can both miss slow replays and drop fast first turns), the parser skips the **leading run of densely-spaced rows** (inter-row gap < 500ms) and **latches off permanently at the first larger gap**:

- an arbitrarily long replay is fully skipped (no cutoff to outrun) — the largest sampled replay is 180 rows;
- a lone fast live turn is never dropped (it is always preceded by a multi-second gap, so it can't extend the leading run);
- thresholds from 250ms to 2000ms produce **identical** results on the sample set (separation margin is ~5–20× on both sides);
- fail-open on unparseable timestamps; skipped rows still advance the cumulative-delta baseline so later live deltas stay correct;
- the first replayed row can't be identified without lookahead and is still counted — a bounded residual (0.5% of the phantom in the sample) biased against under-counting.

## Historical repair

Cursors sit at EOF on already-parsed forked files, so the parser fix alone never corrects existing stats. This PR re-runs the #187 guarded rebuild under a new migration key (`codexForkReplayRepair_2026_07`): the rebuild re-parses every codex file with the current (fork-aware) parser and inherits all #187 safety properties — atomic throwaway rebuild, unreproducible-session skip, queue strip, and upload-offset reset so the corrected values overwrite the cloud. Pre-gated on a cheap 64KB head scan (`forked_from_id` sits at byte ≤169 on line 1 in every sample), so the majority of installs — no forked rollouts — mark done without paying for a rebuild.

## Validation on real data

- End-to-end: seeded a sandbox with the 25 real forked files using published v0.79.9, then ran this branch — the migration removed **17.1M phantom tokens (81.6M → 64.6M)**; a second sync is a no-op (idempotent).
- The date guard had already caught ~148M of cross-day replay on the same files; the 17.1M is the same-day gap this PR closes.
- Zero live rows dropped: the latch produced 0 false skips across ~2,000 sampled events, including the 5 replay-free forks and dense post-break live pairs.

## Tests

- `node --test test/rollout-parser.test.js` — 220/220 (3 new: burst skip with inert date guard, latch keeps fast live turns, replay-free fork untouched)
- `node --test test/sync-codex-rescan-repair.test.js` — 16/16 (4 new: rebuild removes fork phantom, pre-gate, same-sync #187 dedup, reproducibility-guard deferral)
- `npm test` — 1538/1538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex rollout parsing to prevent same-day replay events from inflating usage counts.
  * Preserved genuine live turns that occur after replay activity.
  * Added safeguards to avoid unnecessary or unsafe history rebuilds when source data is missing or repairs have already run.

* **Tests**
  * Added coverage for replay detection, live-turn preservation, and repair safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->