### PR TITLE
Harden fork-replay burst detection edge cases from #316 review

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -3542,8 +3542,20 @@ async function repairCodexForkReplayInflation({
   // codex file. A forked rollout that was deleted before this repair runs is
   // unreproducible anyway — the #187 reproducibility guard would defer forever
   // — so gating on what is on disk loses nothing. Files forked AFTER the parser
-  // fix shipped never accrue phantom, so marking done here is final.
-  if (!(await hasForkedCodexRollout(rolloutFiles))) {
+  // fix shipped never accrue phantom, so marking done here is final — but ONLY
+  // when every candidate head was actually inspected: an unreadable candidate
+  // could be the one forked rollout, so an indeterminate scan defers with the
+  // retryable {skipped:true} sentinel instead of finalizing.
+  const forkScan = await scanForForkedCodexRollout(rolloutFiles);
+  if (!forkScan.forked) {
+    if (forkScan.indeterminate) {
+      migrations[CODEX_FORK_REPLAY_REPAIR_KEY] = {
+        skipped: true,
+        reason: "fork_scan_indeterminate",
+        at: new Date().toISOString(),
+      };
+      return false;
+    }
     migrations[CODEX_FORK_REPLAY_REPAIR_KEY] = new Date().toISOString();
     return false;
   }
@@ -3560,14 +3572,18 @@ async function repairCodexForkReplayInflation({
   });
 }
 
-// True when any codex rollout's head contains the fork marker. The child
-// session_meta (with forked_from_id) is the FIRST line of a forked rollout —
-// observed at byte offset ≤169 across every local sample — so a bounded head
-// read is sufficient. 64KB leaves ample margin for long base_instructions
-// preceding it; a substring false positive (the marker quoted in unrelated
-// head content) only costs one redundant guarded rebuild, never data.
-async function hasForkedCodexRollout(rolloutFiles) {
+// Scans codex rollout heads for the fork marker. The child session_meta (with
+// forked_from_id) is the FIRST line of a forked rollout — observed at byte
+// offset ≤169 across every local sample — so a bounded head read is
+// sufficient. 64KB leaves ample margin for long base_instructions preceding
+// it; a substring false positive (the marker quoted in unrelated head content)
+// only costs one redundant guarded rebuild, never data. Tri-state result:
+// {forked:true} on a hit, {forked:false, indeterminate:false} only when every
+// candidate was inspected, {forked:false, indeterminate:true} when any head
+// read failed — the caller must not finalize "no forks" off a failed read.
+async function scanForForkedCodexRollout(rolloutFiles) {
   const HEAD_BYTES = 65536;
+  let indeterminate = false;
   for (const entry of Array.isArray(rolloutFiles) ? rolloutFiles : []) {
     const fp = typeof entry === "string" ? entry : entry?.path;
     const src = typeof entry === "string" ? "codex" : String(entry?.source || "codex");
@@ -3577,14 +3593,16 @@ async function hasForkedCodexRollout(rolloutFiles) {
       fh = await fs.open(fp, "r");
       const buf = Buffer.alloc(HEAD_BYTES);
       const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
-      if (buf.toString("utf8", 0, bytesRead).includes('"forked_from_id"')) return true;
+      if (buf.toString("utf8", 0, bytesRead).includes('"forked_from_id"')) {
+        return { forked: true, indeterminate: false };
+      }
     } catch (_e) {
-      // unreadable file: let the rebuild's own guards decide
+      indeterminate = true;
     } finally {
       if (fh) await fh.close().catch(() => {});
     }
   }
-  return false;
+  return { forked: false, indeterminate };
 }
 
 function isCodexSessionCursorPath(filePath) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -1514,7 +1514,12 @@ async function parseRolloutFile({
   let currentCwd = null;
   let currentDate = null;
   let isForkedRollout = false;
-  let replayPrefixActive = true;
+  // The replay prefix only ever exists at the head of a freshly-forked file. A
+  // resumed scan (startOffset > 0) can never see it — and never re-reads the
+  // session_meta line, so isForkedRollout stays false there anyway — but gate
+  // on the offset explicitly so correctness does not hinge on that distant
+  // invariant.
+  let replayPrefixActive = startOffset === 0;
   let prevForkedTokenMs = null;
   const rolloutDate = rolloutDateFromPath(filePath);
   let currentProjectRef = projectRef || null;
@@ -1611,9 +1616,16 @@ async function parseRolloutFile({
     // keeping the cumulative-delta baseline correct for the live turns we keep.
     // Scoped to forked codex rollouts. (issue #169 follow-up.)
     let forkedReplaySkip = false;
-    if (isForkedRollout && source === DEFAULT_SOURCE) {
+    if (isForkedRollout && source === DEFAULT_SOURCE && replayPrefixActive) {
       const tokenMs = Date.parse(tokenTimestamp);
-      if (Number.isFinite(tokenMs)) {
+      // Fail open on anything the burst heuristic was not measured against:
+      // an unparseable timestamp or a backwards clock step permanently ends
+      // the prefix, so no later row can be skipped off a stale baseline.
+      // Replay flushes are monotonic in every sampled rollout (2,116 gaps,
+      // min 0ms), so this never fires on genuine replays.
+      if (!Number.isFinite(tokenMs) || (prevForkedTokenMs !== null && tokenMs < prevForkedTokenMs)) {
+        replayPrefixActive = false;
+      } else {
         if (prevForkedTokenMs !== null && tokenMs - prevForkedTokenMs >= CODEX_FORK_REPLAY_GAP_MS) {
           replayPrefixActive = false;
         }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5,7 +5,20 @@ const fs = require("node:fs/promises");
 const fssync = require("node:fs");
 const { test } = require("node:test");
 
-const cp = require("node:child_process");
+// This suite only uses child_process to run `sqlite3 <db> <sql>` writes when
+// building fixtures. Route those through in-process node:sqlite instead of
+// spawning the CLI per statement — the spawns dominated the suite's wall time.
+// Call sites stay `cp.execFileSync("sqlite3", [dbPath, sql])`; nothing else uses cp.
+const { runSql: runSqliteWrite } = require("./helpers/sqlite-write");
+const cp = {
+  execFileSync(bin, args) {
+    if (bin === "sqlite3") {
+      runSqliteWrite(args[0], args[1]);
+      return "";
+    }
+    throw new Error(`unexpected cp.execFileSync("${bin}") in rollout-parser test`);
+  },
+};
 const {
   parseRolloutIncremental,
   parseClaudeIncremental,
@@ -1666,6 +1679,93 @@ test("parseRolloutIncremental latches off after the replay burst, keeping fast l
     const queued = await readJsonLines(queuePath);
     const total = queued.reduce((n, q) => n + q.total_tokens, 0);
     assert.equal(total, r0.total_tokens + l0.total_tokens + l1.total_tokens);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental counts fast live turns appended after the first sync of a forked rollout", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-2026-06-09T20-46-23-fork.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const u = (i, o) => ({ input_tokens: i, cached_input_tokens: 0, output_tokens: o, reasoning_output_tokens: 0, total_tokens: i + o });
+    const add = (a, b) => ({
+      input_tokens: a.input_tokens + b.input_tokens,
+      cached_input_tokens: 0,
+      output_tokens: a.output_tokens + b.output_tokens,
+      reasoning_output_tokens: 0,
+      total_tokens: a.total_tokens + b.total_tokens,
+    });
+    const r0 = u(100, 10);
+    const r1 = u(200, 20);
+    const t1 = add(r0, r1);
+
+    // First sync: replay burst only.
+    const firstLines = [
+      buildSessionMetaLine({ model: "gpt-5.5", cwd: tmp, forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c" }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.100Z", last: r0, total: r0 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.101Z", last: r1, total: t1 }),
+    ];
+    await fs.writeFile(rolloutPath, firstLines.join("\n") + "\n", "utf8");
+    const first = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(first.eventsAggregated, 1); // first-of-run counted, burst tail skipped
+
+    // Second sync resumes mid-file: two genuine live turns only 200ms apart.
+    // The burst detector must be inert on a resumed scan — these are live.
+    const l0 = u(5, 5);
+    const l1 = u(6, 6);
+    const t2 = add(t1, l0);
+    const t3 = add(t2, l1);
+    const appended = [
+      buildTokenCountLine({ ts: "2026-06-09T20:47:10.000Z", last: l0, total: t2 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:47:10.200Z", last: l1, total: t3 }),
+    ];
+    await fs.appendFile(rolloutPath, appended.join("\n") + "\n", "utf8");
+    const second = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    assert.equal(second.eventsAggregated, 2, "both fast live turns must be counted on resume");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental fails open when a forked rollout's timestamps step backwards", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-2026-06-09T20-46-23-fork.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const u = (i, o) => ({ input_tokens: i, cached_input_tokens: 0, output_tokens: o, reasoning_output_tokens: 0, total_tokens: i + o });
+    const add = (a, b) => ({
+      input_tokens: a.input_tokens + b.input_tokens,
+      cached_input_tokens: 0,
+      output_tokens: a.output_tokens + b.output_tokens,
+      reasoning_output_tokens: 0,
+      total_tokens: a.total_tokens + b.total_tokens,
+    });
+    const r0 = u(100, 10);
+    const l0 = u(5, 5); // clock stepped BACKWARDS before this row (NTP correction)
+    const l1 = u(6, 6); // 100ms after l0 — dense, but the latch must already be off
+    const t1 = add(r0, l0);
+    const t2 = add(t1, l1);
+
+    const lines = [
+      buildSessionMetaLine({ model: "gpt-5.5", cwd: tmp, forkedFromId: "019e095c-c041-7b40-b7cb-43ddb153086c" }),
+      buildTurnContextLine({ model: "gpt-5.5", cwd: tmp, currentDate: "2026-06-09" }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.100Z", last: r0, total: r0 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:22.900Z", last: l0, total: t1 }),
+      buildTokenCountLine({ ts: "2026-06-09T20:46:23.000Z", last: l1, total: t2 }),
+    ];
+    await fs.writeFile(rolloutPath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+    // A backwards step is outside what the burst heuristic was measured
+    // against: the prefix ends permanently and every row is counted.
+    assert.equal(res.eventsAggregated, 3);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -1083,6 +1083,49 @@ describe("repairCodexForkReplayInflation (#169 follow-up) — fork replay histor
     }
   });
 
+  it("defers with a retryable sentinel when a candidate head cannot be read (pre-gate indeterminate)", async () => {
+    const home = await makeTempHome();
+    try {
+      // A directory posing as a rollout file: fh.read() fails with EISDIR, so
+      // the head scan cannot rule out a fork — the gate must NOT finalize.
+      const unreadable = path.join(
+        home, ".codex", "sessions", "2025", "12", "17",
+        "rollout-2025-12-17T00-00-00-cccccccc-dddd-eeee-ffff-000000000000.jsonl",
+      );
+      await fs.mkdir(unreadable, { recursive: true });
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      await fs.writeFile(queuePath, "", "utf8");
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 12 }), "utf8");
+      const cursors = { hourly: { buckets: {}, groupQueued: {} }, files: {}, codexHashes: [], migrations: {} };
+
+      const ran = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: unreadable, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY].skipped, true);
+      assert.equal(cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY].reason, "fork_scan_indeterminate");
+      assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).offset, 12);
+
+      // Once the readable truth is available, the retryable sentinel lets the
+      // gate finalize (here: only a non-forked file remains).
+      const codexFile = await writeCodexFile(home);
+      const ranAgain = await repairCodexForkReplayInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ranAgain, false);
+      assert.equal(typeof cursors.migrations[CODEX_FORK_REPLAY_REPAIR_KEY], "string");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("defers via the reproducibility guard when a previously-counted session is gone", async () => {
     const home = await makeTempHome();
     try {


### PR DESCRIPTION
Follow-up to #316, addressing the three CodeRabbit findings. Assessment against real data:

1. **Pre-gate indeterminate scan (valid — fixed).** An unreadable candidate head could be the one forked rollout; finalizing "no forks" off a failed read would permanently strand that install's phantom. The gate now returns tri-state and defers with the retryable `{skipped:true}` sentinel (same semantics as the #187 reproducibility guard).

2. **Resume false-skip (scenario not reachable — hardened anyway).** On a resumed scan (`startOffset > 0`) the `session_meta` line is never re-read, so `isForkedRollout` stays `false` and the burst detector is inert — the reported failure path cannot occur today. `replayPrefixActive` is now explicitly initialized from `startOffset === 0` so correctness no longer hinges on that distant invariant, with a two-sync regression test (two appended live turns 200ms apart must both count).

3. **Non-finite / backwards timestamps (pathological clocks — fixed, fail open).** A backwards clock step inside a forked head could previously keep the latch on and skip a genuine turn off a stale baseline. Now either condition permanently ends the replay prefix. Verified against all 25 real forked rollouts: 2,116 inter-row gaps, zero negative, so genuine replay detection is unaffected — identical skip set (964 replay rows, 165.4M tokens) before and after the change.

## Tests

- `node --test test/rollout-parser.test.js test/sync-codex-rescan-repair.test.js` — 236/236 (3 new)
- Real-data parity: 25 forked rollouts → identical 64.6M queued / 165.4M skipped pre- and post-hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of forked Codex sessions during synchronization.
  * Prevented repairs from finalizing when rollout data cannot be reliably inspected; these cases are safely deferred for a later attempt.
  * Corrected incremental parsing so newly added live activity is counted accurately after resuming a sync.
  * Improved handling of unusual or invalid timestamps to avoid skipping valid rollout data.
* **Tests**
  * Added coverage for interrupted scans, deferred repairs, and resumed rollout parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->