### PR TITLE
fix(macOS): pause animations when the menu bar popover is hidden

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/CompanionAnimationPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/CompanionAnimationPolicy.swift
@@ -1,0 +1,32 @@
+enum CompanionAnimationPolicy {
+    enum Surface {
+        case popover
+        case floatingPet
+    }
+
+    static func isVisible(
+        surface: Surface,
+        isPopoverVisible: Bool,
+        isFloatingPetVisible: Bool
+    ) -> Bool {
+        switch surface {
+        case .popover:
+            return isPopoverVisible
+        case .floatingPet:
+            return isFloatingPetVisible
+        }
+    }
+
+    static func shouldPauseTimeline(
+        surface: Surface,
+        isPopoverVisible: Bool,
+        isFloatingPetVisible: Bool,
+        isStaticFrame: Bool
+    ) -> Bool {
+        !isVisible(
+            surface: surface,
+            isPopoverVisible: isPopoverVisible,
+            isFloatingPetVisible: isFloatingPetVisible
+        ) || isStaticFrame
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -101,6 +101,7 @@ final class StatusBarController: NSObject {
     }
 
     private func closePopoverIfShown() {
+        viewModel.setPopoverVisible(false)
         if popover.isShown {
             popover.performClose(nil)
         }
@@ -542,6 +543,7 @@ final class StatusBarController: NSObject {
     }
 
     private func handlePopoverDidClose() {
+        viewModel.setPopoverVisible(false)
         popoverAnchorWindow?.orderOut(nil)
         updateStatsDisplay()
     }
@@ -568,6 +570,7 @@ final class StatusBarController: NSObject {
 
         guard let anchorView = positionPopoverAnchorWindow(under: button) else { return }
         popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .minY)
+        viewModel.setPopoverVisible(true)
 
         // Keep keyboard focus inside the popover while it is visible.
         if let window = popover.contentViewController?.view.window {

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -57,6 +57,7 @@ class DashboardViewModel: ObservableObject {
     @Published var error: String?
     @Published var serverOnline = false
     @Published var lastRefreshed: Date?
+    @Published private(set) var isPopoverVisible = false
 
     // Derived (cached) data
     @Published private(set) var fleetData: [FleetEntry] = []
@@ -90,6 +91,11 @@ class DashboardViewModel: ObservableObject {
     var totalCost: String { TokenFormatter.formatCostFromString(totalSummary?.totals.totalCostUsd) }
 
     // MARK: - Period Switching
+
+    func setPopoverVisible(_ isVisible: Bool) {
+        guard isPopoverVisible != isVisible else { return }
+        isPopoverVisible = isVisible
+    }
 
     func switchPeriod(_ newPeriod: DateHelpers.Period) {
         guard newPeriod != period else { return }

--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -263,7 +263,10 @@ struct ClawdCompanionView: View {
     // MARK: - Sync Button
 
     private var syncButton: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: !syncSpinActive)) { timeline in
+        TimelineView(.animation(
+            minimumInterval: 1.0 / 30.0,
+            paused: !syncSpinActive || !viewModel.isPopoverVisible
+        )) { timeline in
             Image(systemName: "arrow.triangle.2.circlepath")
                 .font(.system(size: 11))
                 .foregroundStyle(viewModel.isSyncing ? .tertiary : (hoveringSync ? .primary : .secondary))
@@ -365,7 +368,7 @@ struct ClawdCompanionView: View {
                 PetAtlasSpriteView(
                     character: activeCharacter,
                     state: clawdState,
-                    isVisible: layout != .floating || petState.isWindowVisible,
+                    isVisible: isCharacterTimelineVisible,
                     lookDirectionIndex: hoverDirectionIndex ?? (layout == .floating ? petState.lookDirectionIndex : nil)
                 )
             }
@@ -440,10 +443,24 @@ struct ClawdCompanionView: View {
     }
 
     private var characterTimelinePaused: Bool {
-        if layout == .floating, !petState.isWindowVisible {
-            return true
-        }
-        return clawdState == .miniIdle
+        CompanionAnimationPolicy.shouldPauseTimeline(
+            surface: animationSurface,
+            isPopoverVisible: viewModel.isPopoverVisible,
+            isFloatingPetVisible: petState.isWindowVisible,
+            isStaticFrame: clawdState == .miniIdle
+        )
+    }
+
+    private var isCharacterTimelineVisible: Bool {
+        CompanionAnimationPolicy.isVisible(
+            surface: animationSurface,
+            isPopoverVisible: viewModel.isPopoverVisible,
+            isFloatingPetVisible: petState.isWindowVisible
+        )
+    }
+
+    private var animationSurface: CompanionAnimationPolicy.Surface {
+        layout == .dashboard ? .popover : .floatingPet
     }
 
     private var characterFrameInterval: TimeInterval {

--- a/TokenTrackerBar/TokenTrackerBarTests/CompanionAnimationPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/CompanionAnimationPolicyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+final class CompanionAnimationPolicyTests: XCTestCase {
+    func testPopoverAnimationTracksPopoverVisibility() {
+        XCTAssertFalse(
+            CompanionAnimationPolicy.isVisible(
+                surface: .popover,
+                isPopoverVisible: false,
+                isFloatingPetVisible: true
+            )
+        )
+        XCTAssertTrue(
+            CompanionAnimationPolicy.isVisible(
+                surface: .popover,
+                isPopoverVisible: true,
+                isFloatingPetVisible: false
+            )
+        )
+    }
+
+    func testFloatingAnimationTracksFloatingWindowVisibility() {
+        XCTAssertFalse(
+            CompanionAnimationPolicy.isVisible(
+                surface: .floatingPet,
+                isPopoverVisible: true,
+                isFloatingPetVisible: false
+            )
+        )
+        XCTAssertTrue(
+            CompanionAnimationPolicy.isVisible(
+                surface: .floatingPet,
+                isPopoverVisible: false,
+                isFloatingPetVisible: true
+            )
+        )
+    }
+
+    func testTimelinePausesWhenSurfaceIsHidden() {
+        XCTAssertTrue(
+            CompanionAnimationPolicy.shouldPauseTimeline(
+                surface: .popover,
+                isPopoverVisible: false,
+                isFloatingPetVisible: true,
+                isStaticFrame: false
+            )
+        )
+    }
+
+    func testTimelineRunsForVisibleAnimatedFrame() {
+        XCTAssertFalse(
+            CompanionAnimationPolicy.shouldPauseTimeline(
+                surface: .popover,
+                isPopoverVisible: true,
+                isFloatingPetVisible: false,
+                isStaticFrame: false
+            )
+        )
+    }
+
+    func testStaticFrameStaysPausedWhileVisible() {
+        XCTAssertTrue(
+            CompanionAnimationPolicy.shouldPauseTimeline(
+                surface: .floatingPet,
+                isPopoverVisible: false,
+                isFloatingPetVisible: true,
+                isStaticFrame: true
+            )
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -121,6 +121,7 @@ targets:
       - path: TokenTrackerBar/Models/LimitPace.swift
       - path: TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
       - path: TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+      - path: TokenTrackerBar/Models/CompanionAnimationPolicy.swift
       # WeeklyLimitResetDetector's window labels come from Strings, which
       # resolves the locale via Shared/NativeLocalization (Shared is
       # Foundation-only by design, so pulling the whole dir stays cheap).


### PR DESCRIPTION
## Summary

- pause the dashboard companion and sync-button `TimelineView`s while the menu bar popover is hidden
- track popover visibility across both explicit close and `NSPopover.didCloseNotification`, including outside-click dismissal
- keep the floating desktop pet governed by its own window visibility

This does not change sync cadence, refresh scheduling, source discovery, or token accounting.

## Problem

On an installed 0.80.2 build, the native app continued using roughly 19-44% CPU after the menu bar popover was dismissed, with the desktop pet and menu bar animation disabled and no sync in progress.

A process sample consistently reached this stack:

```text
NSHostingView.layout
  -> TimelineView.UpdateFilter.updateValue
    -> PetAtlasSpriteView.body
```

The popover controller intentionally retains its SwiftUI dashboard tree between presentations, so the dashboard companion remained logically visible and its animation timeline kept invalidating layout after the popover closed. Current `main` retains the same relevant controller/view lifetime.

## Approach

`DashboardViewModel` now exposes read-only popover visibility state. `StatusBarController` updates it after a successful show and clears it on both close paths. A small, tested `CompanionAnimationPolicy` selects the correct visibility source for each surface:

- dashboard companion: menu bar popover visibility
- floating companion: desktop-pet window visibility

The character timeline and sync-button timeline pause while the popover is hidden. Reopening the popover resumes visible animation without rebuilding the dashboard or resetting its local state.

## Runtime Results

Measured with a signed Universal Release build from this branch:

| State | Native app CPU |
| --- | ---: |
| Popover hidden after launch, 8 samples at 5-second intervals | 0.0% in all 8 samples |
| Popover visible | about 24%, confirming animation remained active |
| First sample immediately after close | 13.5% |
| 5 seconds after close | 0.0% |
| Following 55 seconds | about 0.2% median |

A real Codex source sync occurred during the post-close sample window without restoring sustained native CPU usage.

## Verification

- focused `CompanionAnimationPolicyTests`: 5 passed
- complete macOS test target: 68 passed
- repository test suite: 1,590 passed
- copy registry, UI hardcode, and architecture guardrails: passed
- dashboard production build: passed
- Universal Release build: `arm64 + x86_64` for both the app and embedded Node
- native app and embedded CLI versions: 0.80.3
- strict nested code-signature verification: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Companion animations now pause when their associated popover or floating pet is hidden.
  - Animation timelines remain paused for static frames, reducing unnecessary activity.
  - Popover visibility is synchronized more reliably with the dashboard state.
- **Tests**
  - Added coverage for animation visibility and pause behavior across supported display surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->