### PR TITLE
perf(macOS): keep usage totals fresh with bounded background work

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
@@ -6,6 +6,11 @@ enum BackgroundRefreshPolicy {
     static let defaultCatchUpStaleInterval: TimeInterval = 300
     static let defaultPopoverOpenSyncInterval: TimeInterval = 300
     static let defaultPopoverOpenLoadInterval: TimeInterval = 30
+    // Account edge functions cache grouped rows for 30 seconds. A successful
+    // ingest can also precede read-model visibility, so publish after the cache
+    // window plus a small guard instead of preserving a stale total for five
+    // more minutes.
+    static let defaultAccountUploadVisibilityDelay: TimeInterval = 35
 
     static func shouldRunSync(
         now: Date,

--- a/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
@@ -151,6 +151,15 @@ enum MenuBarDisplayMetric: String, CaseIterable {
     }
 }
 
+struct MenuBarSummarySelection: OptionSet, Equatable {
+    let rawValue: Int
+
+    static let today = MenuBarSummarySelection(rawValue: 1 << 0)
+    static let rolling = MenuBarSummarySelection(rawValue: 1 << 1)
+    static let total = MenuBarSummarySelection(rawValue: 1 << 2)
+    static let all: MenuBarSummarySelection = [.today, .rolling, .total]
+}
+
 private extension UsageLimitsResponse {
     /// Whether a provider is currently usable (configured with no error).
     /// Optional providers (kimi, copilot) treated as unavailable when nil.
@@ -272,6 +281,34 @@ enum MenuBarDisplayPreferences {
 
     static func write(_ ids: [String], to defaults: UserDefaults = .standard) {
         defaults.set(normalize(ids), forKey: key)
+    }
+
+    /// Queue writes only affect token and cost summaries. Limit-only menu bar
+    /// configurations need no local usage request when the queue changes.
+    static func summarySelection(for ids: [String]) -> MenuBarSummarySelection {
+        ids.reduce(into: MenuBarSummarySelection()) { selection, id in
+            guard let metric = MenuBarDisplayMetric(rawValue: id) else { return }
+            switch metric {
+            case .todayTokens, .todayCost:
+                selection.insert(.today)
+            case .last7dTokens:
+                selection.insert(.rolling)
+            case .totalTokens, .totalCost:
+                selection.insert(.total)
+            case .claude5h, .claude7d,
+                 .codex5h, .codex7d, .codexCredits, .codexSpark5h, .codexSpark7d,
+                 .cursorPlan, .cursorAuto, .cursorAPI,
+                 .geminiPro, .geminiFlash, .geminiLite,
+                 .kimiWeekly, .kimi5h, .kimiTotal,
+                 .kiroMonth, .kiroBonus,
+                 .grokMonth, .grokOndemand,
+                 .copilotPremium, .copilotChat,
+                 .antigravityClaudeWeekly, .antigravityClaude5h,
+                 .antigravityGeminiWeekly, .antigravityGemini5h,
+                 .zcodeGlm52, .zcodeGlm5Turbo:
+                break
+            }
+        }
     }
 
     static func normalize(_ ids: [String]) -> [String] {

--- a/TokenTrackerBar/TokenTrackerBar/Models/UsagePublicationPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsagePublicationPolicy.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+struct UsagePublicationSource: OptionSet, Equatable {
+    let rawValue: Int
+
+    static let localQueue = UsagePublicationSource(rawValue: 1 << 0)
+    static let accountUpload = UsagePublicationSource(rawValue: 1 << 1)
+}
+
+enum UsageSummaryViewSource: Equatable {
+    case localQueue
+    case accountUpload
+}
+
+enum MenuBarSummarySlot: CaseIterable, Hashable {
+    case today
+    case rolling
+    case total
+
+    var selection: MenuBarSummarySelection {
+        switch self {
+        case .today: return .today
+        case .rolling: return .rolling
+        case .total: return .total
+        }
+    }
+}
+
+struct SummaryPublicationState {
+    private var sourceBySlot: [MenuBarSummarySlot: UsageSummaryViewSource] = [:]
+    private var accountReadCompletedAtBySlot: [MenuBarSummarySlot: Date] = [:]
+
+    mutating func record(
+        source: UsageSummaryViewSource,
+        completedAt: Date,
+        for summaries: MenuBarSummarySelection
+    ) {
+        for slot in MenuBarSummarySlot.allCases where summaries.contains(slot.selection) {
+            sourceBySlot[slot] = source
+            if source == .accountUpload {
+                accountReadCompletedAtBySlot[slot] = completedAt
+            } else {
+                accountReadCompletedAtBySlot.removeValue(forKey: slot)
+            }
+        }
+    }
+
+    func source(for slot: MenuBarSummarySlot) -> UsageSummaryViewSource? {
+        sourceBySlot[slot]
+    }
+
+    func latestAccountReadCompletion(
+        for summaries: MenuBarSummarySelection
+    ) -> Date? {
+        MenuBarSummarySlot.allCases.compactMap { slot in
+            guard summaries.contains(slot.selection),
+                  sourceBySlot[slot] == .accountUpload else { return nil }
+            return accountReadCompletedAtBySlot[slot]
+        }.max()
+    }
+}
+
+struct PendingUsagePublicationQueue {
+    private(set) var sources = UsagePublicationSource()
+    private(set) var summaries = MenuBarSummarySelection()
+
+    var isEmpty: Bool { sources.isEmpty }
+
+    mutating func enqueue(
+        _ source: UsagePublicationSource,
+        summaries nextSummaries: MenuBarSummarySelection
+    ) {
+        sources.formUnion(source)
+        summaries.formUnion(nextSummaries)
+    }
+
+    mutating func removeAll() {
+        sources = []
+        summaries = []
+    }
+
+    mutating func takeIfReady(
+        isLoading: Bool,
+        syncInFlight: Bool,
+        hiddenRefreshInFlight: Bool
+    ) -> (sources: UsagePublicationSource, summaries: MenuBarSummarySelection)? {
+        guard !isEmpty,
+              !UsagePublicationPolicy.shouldQueueRefresh(
+                isLoading: isLoading,
+                syncInFlight: syncInFlight,
+                hiddenRefreshInFlight: hiddenRefreshInFlight
+              ) else { return nil }
+        let result = (sources, summaries)
+        removeAll()
+        return result
+    }
+}
+
+enum UsagePublicationPolicy {
+    static func shouldQueueRefresh(
+        isLoading: Bool,
+        syncInFlight: Bool,
+        hiddenRefreshInFlight: Bool
+    ) -> Bool {
+        isLoading || syncInFlight || hiddenRefreshInFlight
+    }
+
+    static func summariesToRefresh(
+        state: SummaryPublicationState,
+        sources: UsagePublicationSource,
+        requested: MenuBarSummarySelection
+    ) -> MenuBarSummarySelection {
+        var result = MenuBarSummarySelection()
+        for slot in MenuBarSummarySlot.allCases where requested.contains(slot.selection) {
+            let shouldRefresh: Bool
+            switch state.source(for: slot) {
+            case .accountUpload:
+                shouldRefresh = sources.contains(.accountUpload)
+            case .localQueue:
+                shouldRefresh = sources.contains(.localQueue)
+            case nil:
+                // Before the first successful summary read, either publication
+                // is useful because it also establishes this slot's authority.
+                shouldRefresh = !sources.isEmpty
+            }
+            if shouldRefresh {
+                result.formUnion(slot.selection)
+            }
+        }
+        return result
+    }
+
+    static func remainingAccountCacheDelay(
+        state: SummaryPublicationState,
+        summaries: MenuBarSummarySelection,
+        now: Date,
+        visibilityDelay: TimeInterval = BackgroundRefreshPolicy.defaultAccountUploadVisibilityDelay
+    ) -> TimeInterval {
+        remainingAccountCacheDelay(
+            latestReadCompletedAt: state.latestAccountReadCompletion(for: summaries),
+            now: now,
+            visibilityDelay: visibilityDelay
+        )
+    }
+
+    static func remainingAccountCacheDelay(
+        latestReadCompletedAt: Date?,
+        now: Date,
+        visibilityDelay: TimeInterval = BackgroundRefreshPolicy.defaultAccountUploadVisibilityDelay
+    ) -> TimeInterval {
+        guard visibilityDelay > 0, let latestReadCompletedAt else {
+            return 0
+        }
+        return max(
+            0,
+            latestReadCompletedAt.addingTimeInterval(visibilityDelay).timeIntervalSince(now)
+        )
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -1,28 +1,35 @@
 import Foundation
 
+struct UsageSummaryFetchResult {
+    let summary: UsageSummaryResponse
+    let source: UsageSummaryViewSource
+    let completedAt: Date
+}
+
 actor APIClient {
     static let shared = APIClient()
     private static let usageLimitsRequestTimeout: TimeInterval = 25
+    private static let localSyncResourceTimeout: TimeInterval = 130
     private struct LocalAuthResponse: Decodable {
         let token: String
     }
 
     private let baseURL = Constants.serverBaseURL
     private let session: URLSession
+    private let syncSession: URLSession
     private let decoder: JSONDecoder
-
-    /// Whether the most recent account-eligible fetch returned cross-device
-    /// ("account view") data rather than local single-machine data. Mirrors the
-    /// dashboard: the local server serves the cross-device aggregate only when
-    /// the user is signed in and cloud sync is on, and reports which it served
-    /// via the `X-TokenTracker-Account-View` response header.
-    private(set) var accountViewActive: Bool = false
+    private(set) var latestAccountSummaryReadCompletedAt: Date?
 
     private init() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
         config.timeoutIntervalForResource = 30
         self.session = URLSession(configuration: config)
+
+        let syncConfig = URLSessionConfiguration.default
+        syncConfig.timeoutIntervalForRequest = Self.localSyncResourceTimeout
+        syncConfig.timeoutIntervalForResource = Self.localSyncResourceTimeout
+        self.syncSession = URLSession(configuration: syncConfig)
 
         let jsonDecoder = JSONDecoder()
         // No .convertFromSnakeCase — all models use explicit CodingKeys with snake_case rawValues
@@ -32,11 +39,37 @@ actor APIClient {
     // MARK: - Public API
 
 	func fetchSummary(from: String, to: String) async throws -> UsageSummaryResponse {
-		try await fetch("/functions/tokentracker-usage-summary", queryItems: withAccountQueryItems([
-			URLQueryItem(name: "from", value: from),
-			URLQueryItem(name: "to", value: to)
-		]))
+        try await fetchSummaryWithSource(from: from, to: to).summary
 	}
+
+    func fetchSummaryWithSource(from: String, to: String) async throws -> UsageSummaryFetchResult {
+        let (data, response) = try await request(
+            "/functions/tokentracker-usage-summary",
+            queryItems: withAccountQueryItems([
+                URLQueryItem(name: "from", value: from),
+                URLQueryItem(name: "to", value: to)
+            ])
+        )
+        let source: UsageSummaryViewSource
+        switch response.value(forHTTPHeaderField: "X-TokenTracker-Account-View") {
+        case "1":
+            source = .accountUpload
+        case "0":
+            source = .localQueue
+        default:
+            throw APIError.invalidResponse
+        }
+        let completedAt = Date()
+        if source == .accountUpload {
+            latestAccountSummaryReadCompletedAt = completedAt
+        }
+        let summary = try decoder.decode(UsageSummaryResponse.self, from: data)
+        return UsageSummaryFetchResult(
+            summary: summary,
+            source: source,
+            completedAt: completedAt
+        )
+    }
 
 	func fetchDaily(from: String, to: String) async throws -> DailyUsageResponse {
 		try await fetch("/functions/tokentracker-usage-daily", queryItems: withAccountQueryItems([
@@ -91,7 +124,9 @@ actor APIClient {
         if drain {
             body = Data(#"{"drain":true}"#.utf8)
         } else if auto {
-            body = Data(#"{"auto":true,"background":true}"#.utf8)
+            body = Data(
+                #"{"auto":true,"background":true,"allLocalSources":true,"publishAccount":true}"#.utf8
+            )
         } else {
             body = Data("{}".utf8)
         }
@@ -121,6 +156,19 @@ actor APIClient {
         queryItems: [URLQueryItem] = [],
         requestTimeout: TimeInterval? = nil
     ) async throws -> T {
+        let (data, _) = try await request(
+            path,
+            queryItems: queryItems,
+            requestTimeout: requestTimeout
+        )
+        return try decoder.decode(T.self, from: data)
+    }
+
+    private func request(
+        _ path: String,
+        queryItems: [URLQueryItem] = [],
+        requestTimeout: TimeInterval? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
         guard var components = URLComponents(string: baseURL + path) else {
             throw APIError.invalidURL
         }
@@ -140,14 +188,10 @@ actor APIClient {
             (data, response) = try await session.data(from: url)
         }
         try validateResponse(response)
-        // Account-eligible endpoints tag whether the server served cross-device
-        // (account) data or fell back to local single-machine data. Other
-        // endpoints omit the header, so only update when it's present.
-        if let httpResponse = response as? HTTPURLResponse,
-           let raw = httpResponse.value(forHTTPHeaderField: "X-TokenTracker-Account-View") {
-            accountViewActive = (raw == "1")
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
         }
-        return try decoder.decode(T.self, from: data)
+        return (data, httpResponse)
     }
 
 	private func withTimeZoneQueryItems(_ items: [URLQueryItem]) -> [URLQueryItem] {
@@ -176,7 +220,10 @@ actor APIClient {
             request.setValue(try await fetchLocalAuthToken(), forHTTPHeaderField: "x-tokentracker-local-auth")
         }
         request.httpBody = body
-        let (data, response) = try await session.data(for: request)
+        let requestSession = path == "/functions/tokentracker-local-sync"
+            ? syncSession
+            : session
+        let (data, response) = try await requestSession.data(for: request)
         try validateResponse(response)
         return try decoder.decode(T.self, from: data)
     }

--- a/TokenTrackerBar/TokenTrackerBar/Services/QueueActivityMonitor.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/QueueActivityMonitor.swift
@@ -1,43 +1,73 @@
 import Foundation
 
-/// Watches `~/.tokentracker/tracker/queue.jsonl` for appends. Every AI CLI turn
-/// ends with a hook that appends usage rows to the queue, so a write event is a
-/// real-time "the AI just did work" signal — this is what makes the menu bar
-/// runner sprint the moment tokens are burned, instead of waiting for the next
-/// 300s background refresh.
+/// Watches a TokenTracker state file (queue.jsonl by default) for writes and
+/// atomic replacements. Queue writes drive real-time activity; a second
+/// instance watches queue.state.json to publish completed account uploads.
 @MainActor
 final class QueueActivityMonitor {
 
-    /// Fired on the main actor whenever the queue file grows or is rewritten.
+    /// Fired immediately for latency-sensitive visuals.
     var onActivity: (() -> Void)?
+    /// Fired once after a burst of queue writes settles.
+    var onSettledActivity: (() -> Void)?
 
     private var source: DispatchSourceFileSystemObject?
+    private var directorySource: DispatchSourceFileSystemObject?
     private var retryTimer: Timer?
+    private var settleTask: Task<Void, Never>?
+    private var waitingForFile = false
+    private var hasArmed = false
     private let queueURL: URL
+    private let settleDelayNanoseconds: UInt64
+    private let retryDelay: TimeInterval
+    private let publishInitialState: Bool
 
-    init(queueURL: URL? = nil) {
+    init(
+        queueURL: URL? = nil,
+        settleDelay: TimeInterval = 1,
+        retryDelay: TimeInterval = 60,
+        publishInitialState: Bool = false
+    ) {
         self.queueURL = queueURL ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".tokentracker/tracker/queue.jsonl")
+        settleDelayNanoseconds = UInt64(max(0, settleDelay) * 1_000_000_000)
+        self.retryDelay = max(0, retryDelay)
+        self.publishInitialState = publishInitialState
     }
 
     func start() {
-        guard source == nil, retryTimer == nil else { return }
+        guard source == nil, directorySource == nil, retryTimer == nil else { return }
         openAndWatch()
     }
 
     func stop() {
         source?.cancel()
         source = nil
+        directorySource?.cancel()
+        directorySource = nil
         retryTimer?.invalidate()
         retryTimer = nil
+        settleTask?.cancel()
+        settleTask = nil
+        waitingForFile = false
+        hasArmed = false
     }
 
     private func openAndWatch() {
         let fd = open(queueURL.path, O_EVTONLY)
         guard fd >= 0 else {
-            scheduleRetry()
+            waitingForFile = true
+            watchParentDirectoryOrRetry()
             return
         }
+        directorySource?.cancel()
+        directorySource = nil
+        retryTimer?.invalidate()
+        retryTimer = nil
+        let shouldPublishInitialState =
+            waitingForFile || (!hasArmed && publishInitialState)
+        waitingForFile = false
+        hasArmed = true
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
@@ -50,20 +80,71 @@ final class QueueActivityMonitor {
             if event.contains(.delete) || event.contains(.rename) {
                 // sync occasionally rewrites the queue (repairs/migrations);
                 // the old fd now points at a dead inode — re-arm on the new file.
-                self.stop()
+                source.cancel()
+                self.source = nil
                 self.openAndWatch()
-            } else {
-                self.onActivity?()
             }
+            self.noteActivity()
         }
         source.setCancelHandler { close(fd) }
         source.resume()
         self.source = source
+        if shouldPublishInitialState {
+            noteActivity()
+        }
     }
 
-    /// The queue may not exist yet on a fresh install; keep trying until it does.
+    /// A fresh install may not have created queue.state.json yet. Watching its
+    /// parent directory avoids waking the app on a fixed polling cadence while
+    /// still reacting immediately when the file is created or atomically moved
+    /// into place.
+    private func watchParentDirectoryOrRetry() {
+        guard directorySource == nil, retryTimer == nil else { return }
+        let directoryURL = queueURL.deletingLastPathComponent()
+        let fd = open(directoryURL.path, O_EVTONLY)
+        guard fd >= 0 else {
+            scheduleRetry()
+            return
+        }
+
+        let directorySource = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .attrib, .delete, .rename],
+            queue: .main
+        )
+        directorySource.setEventHandler { [weak self] in
+            guard let self, let activeSource = self.directorySource else { return }
+            let event = activeSource.data
+            if event.contains(.delete) || event.contains(.rename) {
+                activeSource.cancel()
+                self.directorySource = nil
+                self.scheduleRetry()
+                return
+            }
+            self.openAndWatch()
+        }
+        directorySource.setCancelHandler { close(fd) }
+        directorySource.resume()
+        self.directorySource = directorySource
+    }
+
+    private func noteActivity() {
+        onActivity?()
+        settleTask?.cancel()
+        settleTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: settleDelayNanoseconds)
+            guard !Task.isCancelled else { return }
+            settleTask = nil
+            onSettledActivity?()
+        }
+    }
+
+    /// Only used when even the parent directory is absent. Once the directory
+    /// exists, filesystem events replace this low-frequency fallback.
     private func scheduleRetry() {
-        retryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: false) { [weak self] _ in
+        guard retryTimer == nil else { return }
+        retryTimer = Timer.scheduledTimer(withTimeInterval: retryDelay, repeats: false) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.retryTimer = nil

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -33,6 +33,12 @@ final class StatusBarController: NSObject {
     private let desktopPetController: DesktopPetWindowController
     private var animator: MenuBarAnimator?
     private let queueActivityMonitor = QueueActivityMonitor()
+    private let accountUploadMonitor = QueueActivityMonitor(
+        queueURL: FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".tokentracker/tracker/queue.state.json"),
+        settleDelay: BackgroundRefreshPolicy.defaultAccountUploadVisibilityDelay,
+        publishInitialState: true
+    )
     private let confettiController = ScreenConfettiOverlayController()
     private var cancellables = Set<AnyCancellable>()
     /// While the status-item menu is open, refreshes the “Check for Updates” row when download/check status changes.
@@ -158,9 +164,34 @@ final class StatusBarController: NSObject {
         queueActivityMonitor.onActivity = { [weak self] in
             self?.animator?.noteActivity()
         }
+        // Publish committed usage without turning every queue write into a full
+        // dashboard + widget refresh. QueueActivityMonitor coalesces bursts.
+        queueActivityMonitor.onSettledActivity = { [weak self] in
+            guard let self else { return }
+            let summaries = self.selectedMenuBarSummaries()
+            Task { @MainActor [weak self] in
+                await self?.viewModel.refreshAfterQueueChange(menuBarSummaries: summaries)
+            }
+        }
         queueActivityMonitor.start()
 
+        // Cross-device account summaries are authoritative only after upload
+        // advances queue.state.json. Local queue writes happen earlier.
+        accountUploadMonitor.onSettledActivity = { [weak self] in
+            guard let self else { return }
+            let summaries = self.selectedMenuBarSummaries()
+            Task { @MainActor [weak self] in
+                await self?.viewModel.refreshAfterAccountUpload(menuBarSummaries: summaries)
+            }
+        }
+        accountUploadMonitor.start()
+
         updateStatsDisplay()
+    }
+
+    private func selectedMenuBarSummaries() -> MenuBarSummarySelection {
+        guard showStats else { return [] }
+        return MenuBarDisplayPreferences.summarySelection(for: MenuBarDisplayPreferences.read())
     }
 
     /// Single derivation of the animator state from the view model.

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -33,6 +33,24 @@ enum WidgetSnapshotWriter {
         let usageLimits: UsageLimitsResponse?
     }
 
+    /// Preserve the pre-existing five-minute widget freshness contract only
+    /// for users who actually placed a TokenTracker widget. Everyone else can
+    /// stay on the lightweight hidden refresh path.
+    static func hasConfiguredWidgets() async -> Bool {
+        await withCheckedContinuation { continuation in
+            WidgetCenter.shared.getCurrentConfigurations { result in
+                switch result {
+                case .success(let configurations):
+                    continuation.resume(returning: !configurations.isEmpty)
+                case .failure:
+                    // Fail toward freshness: a transient WidgetKit query error
+                    // must not leave an existing widget stale indefinitely.
+                    continuation.resume(returning: true)
+                }
+            }
+        }
+    }
+
     static func update(from vm: DashboardViewModel) async {
         // STEP 1 — synchronously freeze every VM field we will need. After
         // this point we never touch `vm` again. This is the fix for the

--- a/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
+++ b/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
@@ -87,6 +87,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         notificationCenter.addObserver(
             self,
             selector: #selector(scheduleWakeCatchUp(_:)),
+            name: NSWorkspace.screensDidWakeNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(scheduleWakeCatchUp(_:)),
             name: NSWorkspace.sessionDidBecomeActiveNotification,
             object: nil
         )

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -124,13 +124,20 @@ class DashboardViewModel: ObservableObject {
         isLoading = true
         pendingFullRefreshAfterHiddenRefresh = false
         needsFullRefreshOnPopoverOpen = false
-        // A full load starting after a queue event covers every summary that
-        // event requested. Events arriving during this load are queued below.
-        pendingUsagePublications.removeAll()
         error = nil
+
+        // Events already queued are covered by this full load. Remove only
+        // that starting snapshot so events arriving while the health check or
+        // fetches are in flight remain queued for the next pass.
+        let pendingAtLoadStart = pendingUsagePublications
+        pendingUsagePublications.removeAll()
 
         serverOnline = await APIClient.shared.checkServerHealth()
         guard serverOnline else {
+            pendingUsagePublications.enqueue(
+                pendingAtLoadStart.sources,
+                summaries: pendingAtLoadStart.summaries
+            )
             isLoading = false
             await finishDataLoad()
             return
@@ -276,6 +283,16 @@ class DashboardViewModel: ObservableObject {
             }
         }
 
+        // A partial API failure means the starting snapshot was not fully
+        // covered. Restore it alongside any events that arrived during the
+        // load so the next pass can retry without dropping the publication.
+        if errorCount > 0 {
+            pendingUsagePublications.enqueue(
+                pendingAtLoadStart.sources,
+                summaries: pendingAtLoadStart.summaries
+            )
+        }
+
         if errorCount >= totalFetches {
             self.error = firstError
         }
@@ -289,10 +306,14 @@ class DashboardViewModel: ObservableObject {
         // Push the latest data to the widget snapshot file so the desktop
         // widgets pick it up on their next timeline reload.
         await WidgetSnapshotWriter.update(from: self)
-        await finishDataLoad()
+        await finishDataLoad(allowPendingRefresh: errorCount == 0)
     }
 
-    private func finishDataLoad() async {
+    private func finishDataLoad(allowPendingRefresh: Bool = true) async {
+        // Preserve pending publications while the local API is offline, or
+        // when a partial load failed, but do not immediately feed them back
+        // into another retry loop. The next scheduled/manual load retries.
+        guard serverOnline, allowPendingRefresh else { return }
         if shouldReloadAfterCurrentLoad {
             shouldReloadAfterCurrentLoad = false
             await loadAll()
@@ -336,13 +357,14 @@ class DashboardViewModel: ObservableObject {
     private func waitForAccountCacheVisibility(
         for summaries: MenuBarSummarySelection
     ) async {
-        guard !summaries.isEmpty else { return }
         while !Task.isCancelled {
-            let slotDelay = UsagePublicationPolicy.remainingAccountCacheDelay(
-                state: summaryPublicationState,
-                summaries: summaries,
-                now: Date()
-            )
+            let slotDelay: TimeInterval = summaries.isEmpty
+                ? 0
+                : UsagePublicationPolicy.remainingAccountCacheDelay(
+                    state: summaryPublicationState,
+                    summaries: summaries,
+                    now: Date()
+                )
             let latestAccountRead = await APIClient.shared.latestAccountSummaryReadCompletedAt
             let globalDelay = UsagePublicationPolicy.remainingAccountCacheDelay(
                 latestReadCompletedAt: latestAccountRead,
@@ -472,7 +494,7 @@ class DashboardViewModel: ObservableObject {
 
         isMenuBarSummaryLoading = false
         isLoading = false
-        await finishDataLoad()
+        await finishDataLoad(allowPendingRefresh: firstError == nil)
     }
 
     // MARK: - Sync

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -72,6 +72,12 @@ class DashboardViewModel: ObservableObject {
     private var lastBackgroundSyncAt: Date?
     private var lastPopoverOpenSyncAttemptAt: Date?
     private var shouldReloadAfterCurrentLoad = false
+    private var isMenuBarSummaryLoading = false
+    private var hiddenRefreshInFlight = false
+    private var pendingFullRefreshAfterHiddenRefresh = false
+    private var pendingUsagePublications = PendingUsagePublicationQueue()
+    private var needsFullRefreshOnPopoverOpen = false
+    private var summaryPublicationState = SummaryPublicationState()
     private let resetDetector = WeeklyLimitResetDetector()
 
     // MARK: - Computed Properties
@@ -95,6 +101,9 @@ class DashboardViewModel: ObservableObject {
     func setPopoverVisible(_ isVisible: Bool) {
         guard isPopoverVisible != isVisible else { return }
         isPopoverVisible = isVisible
+        if isVisible && hiddenRefreshInFlight {
+            pendingFullRefreshAfterHiddenRefresh = true
+        }
     }
 
     func switchPeriod(_ newPeriod: DateHelpers.Period) {
@@ -113,12 +122,17 @@ class DashboardViewModel: ObservableObject {
             return
         }
         isLoading = true
+        pendingFullRefreshAfterHiddenRefresh = false
+        needsFullRefreshOnPopoverOpen = false
+        // A full load starting after a queue event covers every summary that
+        // event requested. Events arriving during this load are queued below.
+        pendingUsagePublications.removeAll()
         error = nil
 
         serverOnline = await APIClient.shared.checkServerHealth()
         guard serverOnline else {
             isLoading = false
-            await runQueuedReloadIfNeeded()
+            await finishDataLoad()
             return
         }
 
@@ -136,7 +150,16 @@ class DashboardViewModel: ObservableObject {
             group.addTask { @MainActor in
                 do {
                     let today = DateHelpers.todayString()
-                    self.todaySummary = try await APIClient.shared.fetchSummary(from: today, to: today)
+                    let result = try await APIClient.shared.fetchSummaryWithSource(
+                        from: today,
+                        to: today
+                    )
+                    self.todaySummary = result.summary
+                    self.summaryPublicationState.record(
+                        source: result.source,
+                        completedAt: result.completedAt,
+                        for: .today
+                    )
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -154,7 +177,16 @@ class DashboardViewModel: ObservableObject {
             // Rolling summary (always 30-day for the rolling cards)
             group.addTask { @MainActor in
                 do {
-                    self.rollingSummary = try await APIClient.shared.fetchSummary(from: rollingFrom, to: rollingTo)
+                    let result = try await APIClient.shared.fetchSummaryWithSource(
+                        from: rollingFrom,
+                        to: rollingTo
+                    )
+                    self.rollingSummary = result.summary
+                    self.summaryPublicationState.record(
+                        source: result.source,
+                        completedAt: result.completedAt,
+                        for: .rolling
+                    )
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -163,7 +195,16 @@ class DashboardViewModel: ObservableObject {
             // All-time total summary (matches dashboard "Total" range)
             group.addTask { @MainActor in
                 do {
-                    self.totalSummary = try await APIClient.shared.fetchSummary(from: totalRange.from, to: totalRange.to)
+                    let result = try await APIClient.shared.fetchSummaryWithSource(
+                        from: totalRange.from,
+                        to: totalRange.to
+                    )
+                    self.totalSummary = result.summary
+                    self.summaryPublicationState.record(
+                        source: result.source,
+                        completedAt: result.completedAt,
+                        for: .total
+                    )
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -248,13 +289,190 @@ class DashboardViewModel: ObservableObject {
         // Push the latest data to the widget snapshot file so the desktop
         // widgets pick it up on their next timeline reload.
         await WidgetSnapshotWriter.update(from: self)
-        await runQueuedReloadIfNeeded()
+        await finishDataLoad()
     }
 
-    private func runQueuedReloadIfNeeded() async {
-        guard shouldReloadAfterCurrentLoad else { return }
-        shouldReloadAfterCurrentLoad = false
-        await loadAll()
+    private func finishDataLoad() async {
+        if shouldReloadAfterCurrentLoad {
+            shouldReloadAfterCurrentLoad = false
+            await loadAll()
+            return
+        }
+        await runPendingQueueRefreshIfNeeded()
+    }
+
+    private func runPendingQueueRefreshIfNeeded() async {
+        // Keep the publication queued until every owning operation has fully
+        // released its state. Otherwise finishDataLoad() can dequeue it while
+        // syncInFlight is still true and leave it stranded indefinitely.
+        guard let pending = pendingUsagePublications.takeIfReady(
+            isLoading: isLoading,
+            syncInFlight: syncInFlight,
+            hiddenRefreshInFlight: hiddenRefreshInFlight
+        ) else { return }
+        await refreshAfterUsagePublication(
+            pending.sources,
+            menuBarSummaries: pending.summaries
+        )
+    }
+
+    /// Queue writes are already-synced data. Refresh only what is visible in
+    /// the menu bar while the popover is closed; a visible popover gets the
+    /// normal complete load. Concurrent loads are serialized so an older
+    /// response cannot overwrite data fetched after the queue event.
+    func refreshAfterQueueChange(menuBarSummaries summaries: MenuBarSummarySelection) async {
+        await refreshAfterUsagePublication(.localQueue, menuBarSummaries: summaries)
+    }
+
+    /// Account summaries become authoritative only after this machine's queue
+    /// offset advances. This avoids re-reading an old cloud aggregate merely
+    /// because the local parser wrote its queue first.
+    func refreshAfterAccountUpload(menuBarSummaries summaries: MenuBarSummarySelection) async {
+        let relevantSummaries = isPopoverVisible ? .all : summaries
+        await waitForAccountCacheVisibility(for: relevantSummaries)
+        await refreshAfterUsagePublication(.accountUpload, menuBarSummaries: summaries)
+    }
+
+    private func waitForAccountCacheVisibility(
+        for summaries: MenuBarSummarySelection
+    ) async {
+        guard !summaries.isEmpty else { return }
+        while !Task.isCancelled {
+            let slotDelay = UsagePublicationPolicy.remainingAccountCacheDelay(
+                state: summaryPublicationState,
+                summaries: summaries,
+                now: Date()
+            )
+            let latestAccountRead = await APIClient.shared.latestAccountSummaryReadCompletedAt
+            let globalDelay = UsagePublicationPolicy.remainingAccountCacheDelay(
+                latestReadCompletedAt: latestAccountRead,
+                now: Date()
+            )
+            let delay = max(slotDelay, globalDelay)
+            guard delay > 0 else { return }
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                return
+            }
+            // Re-evaluate after sleeping because another account read may have
+            // populated the edge cache while this publication was waiting.
+        }
+    }
+
+    private func refreshAfterUsagePublication(
+        _ source: UsagePublicationSource,
+        menuBarSummaries summaries: MenuBarSummarySelection
+    ) async {
+        guard !UsagePublicationPolicy.shouldQueueRefresh(
+            isLoading: isLoading,
+            syncInFlight: syncInFlight,
+            hiddenRefreshInFlight: hiddenRefreshInFlight
+        ) else {
+            pendingUsagePublications.enqueue(source, summaries: summaries)
+            return
+        }
+
+        let affectedSummaries = UsagePublicationPolicy.summariesToRefresh(
+            state: summaryPublicationState,
+            sources: source,
+            requested: .all
+        )
+        guard !affectedSummaries.isEmpty else { return }
+
+        if isPopoverVisible {
+            await loadAll()
+        } else {
+            needsFullRefreshOnPopoverOpen = true
+            let visibleSummaries = affectedSummaries.intersection(summaries)
+            guard !visibleSummaries.isEmpty else { return }
+            await loadMenuBarSummaries(visibleSummaries)
+        }
+    }
+
+    private func loadMenuBarSummaries(
+        _ summaries: MenuBarSummarySelection,
+        checkHealth: Bool = true
+    ) async {
+        guard !summaries.isEmpty else { return }
+        guard !isLoading else { return }
+
+        isLoading = true
+        isMenuBarSummaryLoading = true
+        if checkHealth {
+            serverOnline = await APIClient.shared.checkServerHealth()
+            guard serverOnline else {
+                isMenuBarSummaryLoading = false
+                isLoading = false
+                await finishDataLoad()
+                return
+            }
+        }
+        var successfulFetches = 0
+        var firstError: Error?
+
+        await withTaskGroup(of: Void.self) { group in
+            if summaries.contains(.today) || summaries.contains(.rolling) {
+                group.addTask { @MainActor in
+                    do {
+                        let today = DateHelpers.todayString()
+                        let result = try await APIClient.shared.fetchSummaryWithSource(
+                            from: today,
+                            to: today
+                        )
+                        if summaries.contains(.today) {
+                            self.todaySummary = result.summary
+                        }
+                        // Rolling windows are identical on every summary
+                        // response, so today + 7d needs only one request.
+                        if summaries.contains(.rolling) {
+                            self.rollingSummary = result.summary
+                        }
+                        self.summaryPublicationState.record(
+                            source: result.source,
+                            completedAt: result.completedAt,
+                            for: summaries.intersection([.today, .rolling])
+                        )
+                        successfulFetches += 1
+                    } catch {
+                        if firstError == nil { firstError = error }
+                    }
+                }
+            }
+
+            if summaries.contains(.total) {
+                group.addTask { @MainActor in
+                    do {
+                        let range = DateHelpers.rangeForPeriod(.total)
+                        let result = try await APIClient.shared.fetchSummaryWithSource(
+                            from: range.from,
+                            to: range.to
+                        )
+                        self.totalSummary = result.summary
+                        self.summaryPublicationState.record(
+                            source: result.source,
+                            completedAt: result.completedAt,
+                            for: .total
+                        )
+                        successfulFetches += 1
+                    } catch {
+                        if firstError == nil { firstError = error }
+                    }
+                }
+            }
+        }
+
+        if successfulFetches > 0 {
+            serverOnline = true
+        } else if let firstError {
+            Self.logger.warning(
+                "Queue summary refresh failed: \(firstError.localizedDescription, privacy: .public)"
+            )
+        }
+
+        isMenuBarSummaryLoading = false
+        isLoading = false
+        await finishDataLoad()
     }
 
     // MARK: - Sync
@@ -267,10 +485,6 @@ class DashboardViewModel: ObservableObject {
         guard !syncInFlight else { return }
         syncInFlight = true
         if !silent { isSyncing = true }
-        defer {
-            syncInFlight = false
-            if !silent { isSyncing = false }
-        }
         var didSync = false
         do {
             _ = try await APIClient.shared.triggerSync(auto: true)
@@ -282,6 +496,85 @@ class DashboardViewModel: ObservableObject {
             lastBackgroundSyncAt = Date()
         }
         await loadAll()
+        syncInFlight = false
+        if !silent { isSyncing = false }
+        await runPendingQueueRefreshIfNeeded()
+    }
+
+    /// The hidden app only needs menu-bar summaries and limits after its
+    /// five-minute sync. Full charts are marked dirty and loaded when the user
+    /// opens the popover, avoiding nine endpoint requests while idle.
+    private func syncThenRefreshHidden(
+        menuBarSummaries summaries: MenuBarSummarySelection
+    ) async {
+        guard !syncInFlight, !hiddenRefreshInFlight else { return }
+        syncInFlight = true
+        hiddenRefreshInFlight = true
+        isSyncing = true
+        var didSync = false
+        do {
+            _ = try await APIClient.shared.triggerSync(auto: true)
+            didSync = true
+        } catch {
+            // Sync failure is non-fatal; visible cached data can still refresh.
+        }
+        if didSync {
+            lastBackgroundSyncAt = Date()
+        }
+        if isPopoverVisible {
+            pendingFullRefreshAfterHiddenRefresh = true
+        } else {
+            await refreshHiddenDataContents(menuBarSummaries: summaries)
+        }
+        syncInFlight = false
+        isSyncing = false
+        await finishHiddenRefresh()
+        await runPendingQueueRefreshIfNeeded()
+    }
+
+    private func refreshHiddenData(
+        menuBarSummaries summaries: MenuBarSummarySelection
+    ) async {
+        guard !hiddenRefreshInFlight else { return }
+        hiddenRefreshInFlight = true
+        await refreshHiddenDataContents(menuBarSummaries: summaries)
+        await finishHiddenRefresh()
+        await runPendingQueueRefreshIfNeeded()
+    }
+
+    private func refreshHiddenDataContents(
+        menuBarSummaries summaries: MenuBarSummarySelection
+    ) async {
+        needsFullRefreshOnPopoverOpen = true
+        serverOnline = await APIClient.shared.checkServerHealth()
+        guard serverOnline,
+              !pendingFullRefreshAfterHiddenRefresh,
+              !isPopoverVisible else { return }
+        if await WidgetSnapshotWriter.hasConfiguredWidgets() {
+            // Active desktop widgets are visible even while the popover is
+            // closed. Preserve their complete snapshot refresh; the cheaper
+            // summary-only path is for installations without configured
+            // widgets.
+            await loadAll()
+            return
+        }
+        // Publications observed while sync/health work was in flight are
+        // covered by the summary request that starts after this point. Events
+        // arriving once the request is active are queued by `isLoading` and
+        // replayed after it finishes.
+        pendingUsagePublications.removeAll()
+        await loadMenuBarSummaries(summaries, checkHealth: false)
+        guard !pendingFullRefreshAfterHiddenRefresh,
+              !isPopoverVisible else { return }
+        await refreshUsageLimits()
+    }
+
+    private func finishHiddenRefresh() async {
+        hiddenRefreshInFlight = false
+        guard pendingFullRefreshAfterHiddenRefresh else { return }
+        pendingFullRefreshAfterHiddenRefresh = false
+        guard isPopoverVisible else { return }
+        await loadAll()
     }
 
     func catchUpAfterWakeOrSessionActive(now: Date = Date()) async {
@@ -289,10 +582,19 @@ class DashboardViewModel: ObservableObject {
             now: now,
             lastSyncAt: lastBackgroundSyncAt
         )
+        let summaries = MenuBarDisplayPreferences.summarySelection(
+            for: MenuBarDisplayPreferences.read()
+        )
         if shouldSync {
-            await syncThenLoad()
-        } else {
+            if isPopoverVisible {
+                await syncThenLoad()
+            } else {
+                await syncThenRefreshHidden(menuBarSummaries: summaries)
+            }
+        } else if isPopoverVisible {
             await loadAll()
+        } else {
+            await refreshHiddenData(menuBarSummaries: summaries)
         }
     }
 
@@ -301,7 +603,19 @@ class DashboardViewModel: ObservableObject {
         syncInterval: TimeInterval = BackgroundRefreshPolicy.defaultPopoverOpenSyncInterval,
         loadInterval: TimeInterval = BackgroundRefreshPolicy.defaultPopoverOpenLoadInterval
     ) async {
-        guard !isLoading, !syncInFlight else { return }
+        if hiddenRefreshInFlight {
+            pendingFullRefreshAfterHiddenRefresh = true
+            return
+        }
+        if isLoading {
+            // A menu-only publication load does not cover the dashboard the
+            // user just opened. Queue one complete load behind it.
+            if isMenuBarSummaryLoading {
+                shouldReloadAfterCurrentLoad = true
+            }
+            return
+        }
+        guard !syncInFlight else { return }
         let shouldSync = BackgroundRefreshPolicy.shouldRunPopoverOpenSync(
             now: now,
             lastAttemptAt: lastPopoverOpenSyncAttemptAt,
@@ -311,7 +625,7 @@ class DashboardViewModel: ObservableObject {
         if shouldSync {
             lastPopoverOpenSyncAttemptAt = now
             await syncThenLoad(silent: true)
-        } else if BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
+        } else if needsFullRefreshOnPopoverOpen || BackgroundRefreshPolicy.shouldRunPopoverOpenLoad(
             now: now,
             lastRefreshedAt: lastRefreshed,
             loadInterval: loadInterval
@@ -333,6 +647,7 @@ class DashboardViewModel: ObservableObject {
         }
         isSyncing = false
         syncInFlight = false
+        await runPendingQueueRefreshIfNeeded()
     }
 
     // MARK: - Auto Refresh
@@ -351,10 +666,15 @@ class DashboardViewModel: ObservableObject {
                     lastSyncAt: self.lastBackgroundSyncAt,
                     syncInterval: syncInterval
                 )
+                let summaries = MenuBarDisplayPreferences.summarySelection(
+                    for: MenuBarDisplayPreferences.read()
+                )
                 if shouldSync {
-                    await self.syncThenLoad()
-                } else {
+                    await self.syncThenRefreshHidden(menuBarSummaries: summaries)
+                } else if self.isPopoverVisible {
                     await self.loadAll()
+                } else {
+                    await self.refreshHiddenData(menuBarSummaries: summaries)
                 }
             }
         }

--- a/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/BackgroundRefreshPolicyTests.swift
@@ -1,6 +1,17 @@
 import XCTest
 
 final class BackgroundRefreshPolicyTests: XCTestCase {
+    func testAccountUploadVisibilityDelayCoversCloudReadModelLag() {
+        XCTAssertEqual(
+            BackgroundRefreshPolicy.defaultAccountUploadVisibilityDelay,
+            35
+        )
+        XCTAssertGreaterThan(
+            BackgroundRefreshPolicy.defaultAccountUploadVisibilityDelay,
+            30
+        )
+    }
+
     func testRunsSyncWhenNoPreviousSyncExists() {
         XCTAssertEqual(
             BackgroundRefreshPolicy.shouldRunSync(

--- a/TokenTrackerBar/TokenTrackerBarTests/MenuBarDisplayPreferencesTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/MenuBarDisplayPreferencesTests.swift
@@ -91,6 +91,33 @@ final class MenuBarDisplayPreferencesTests: XCTestCase {
         }
     }
 
+    func testDefaultMetricsNeedOnlyTodaySummary() {
+        XCTAssertEqual(
+            MenuBarDisplayPreferences.summarySelection(for: MenuBarDisplayPreferences.defaultIDs),
+            [.today]
+        )
+    }
+
+    func testSummarySelectionCoalescesMetricsByEndpoint() {
+        let selection = MenuBarDisplayPreferences.summarySelection(for: [
+            MenuBarDisplayMetric.todayTokens.rawValue,
+            MenuBarDisplayMetric.todayCost.rawValue,
+            MenuBarDisplayMetric.last7dTokens.rawValue,
+            MenuBarDisplayMetric.totalCost.rawValue,
+        ])
+
+        XCTAssertEqual(selection, [.today, .rolling, .total])
+    }
+
+    func testLimitOnlyMetricsNeedNoUsageSummary() {
+        XCTAssertTrue(
+            MenuBarDisplayPreferences.summarySelection(for: [
+                MenuBarDisplayMetric.codex5h.rawValue,
+                MenuBarDisplayMetric.codex7d.rawValue,
+            ]).isEmpty
+        )
+    }
+
     private func decodeResponse(overrides: [String: Any] = [:]) throws -> UsageLimitsResponse {
         var payload: [String: Any] = [
             "fetched_at": "2026-07-01T00:00:00Z",

--- a/TokenTrackerBar/TokenTrackerBarTests/QueueActivityMonitorTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/QueueActivityMonitorTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+@MainActor
+final class QueueActivityMonitorTests: XCTestCase {
+
+    func testAppendPublishesOneSettledActivityAfterBurst() throws {
+        let fixture = try makeFixture()
+        let monitor = QueueActivityMonitor(queueURL: fixture.queueURL, settleDelay: 0.05)
+        let settled = expectation(description: "queue append settled")
+        var settledCount = 0
+        monitor.onSettledActivity = {
+            settledCount += 1
+            settled.fulfill()
+        }
+        defer {
+            monitor.stop()
+            try? FileManager.default.removeItem(at: fixture.directoryURL)
+        }
+        monitor.start()
+
+        let handle = try FileHandle(forWritingTo: fixture.queueURL)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("one\n".utf8))
+        try handle.write(contentsOf: Data("two\n".utf8))
+        try handle.close()
+
+        wait(for: [settled], timeout: 3)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.15))
+        XCTAssertEqual(settledCount, 1)
+    }
+
+    func testAtomicReplacementPublishesSettledActivityAndRearmsWatcher() throws {
+        let fixture = try makeFixture()
+        let monitor = QueueActivityMonitor(queueURL: fixture.queueURL, settleDelay: 0.05)
+        let replacements = expectation(description: "queue replacements settled")
+        replacements.expectedFulfillmentCount = 2
+        monitor.onSettledActivity = { replacements.fulfill() }
+        defer {
+            monitor.stop()
+            try? FileManager.default.removeItem(at: fixture.directoryURL)
+        }
+        monitor.start()
+
+        try replaceQueue(in: fixture, contents: "replacement-one\n")
+        RunLoop.main.run(until: Date().addingTimeInterval(0.15))
+        try replaceQueue(in: fixture, contents: "replacement-two\n")
+
+        wait(for: [replacements], timeout: 3)
+    }
+
+    func testFileCreatedAfterStartPublishesWhenWatcherArms() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QueueActivityMonitorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let queueURL = directoryURL.appendingPathComponent("queue.state.json")
+        let monitor = QueueActivityMonitor(
+            queueURL: queueURL,
+            settleDelay: 0.02,
+            retryDelay: 60
+        )
+        let settled = expectation(description: "new state file published")
+        monitor.onSettledActivity = { settled.fulfill() }
+        defer {
+            monitor.stop()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+
+        monitor.start()
+        try Data("{}\n".utf8).write(to: queueURL)
+
+        wait(for: [settled], timeout: 2)
+    }
+
+    func testExistingFilePublishesWhenInitialStateIsRequested() throws {
+        let fixture = try makeFixture()
+        let monitor = QueueActivityMonitor(
+            queueURL: fixture.queueURL,
+            settleDelay: 0.02,
+            publishInitialState: true
+        )
+        let settled = expectation(description: "existing state published")
+        monitor.onSettledActivity = { settled.fulfill() }
+        defer {
+            monitor.stop()
+            try? FileManager.default.removeItem(at: fixture.directoryURL)
+        }
+
+        monitor.start()
+
+        wait(for: [settled], timeout: 2)
+    }
+
+    private func makeFixture() throws -> (directoryURL: URL, queueURL: URL) {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QueueActivityMonitorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let queueURL = directoryURL.appendingPathComponent("queue.jsonl")
+        try Data("initial\n".utf8).write(to: queueURL)
+        return (directoryURL, queueURL)
+    }
+
+    private func replaceQueue(
+        in fixture: (directoryURL: URL, queueURL: URL),
+        contents: String
+    ) throws {
+        let replacementURL = fixture.directoryURL.appendingPathComponent(UUID().uuidString)
+        try Data(contents.utf8).write(to: replacementURL)
+        _ = try FileManager.default.replaceItemAt(fixture.queueURL, withItemAt: replacementURL)
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBarTests/UsagePublicationPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/UsagePublicationPolicyTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+
+final class UsagePublicationPolicyTests: XCTestCase {
+
+    func testRefreshQueuesBehindAnyOwningLoadOrSync() {
+        XCTAssertFalse(
+            UsagePublicationPolicy.shouldQueueRefresh(
+                isLoading: false,
+                syncInFlight: false,
+                hiddenRefreshInFlight: false
+            )
+        )
+        XCTAssertTrue(
+            UsagePublicationPolicy.shouldQueueRefresh(
+                isLoading: true,
+                syncInFlight: false,
+                hiddenRefreshInFlight: false
+            )
+        )
+        XCTAssertTrue(
+            UsagePublicationPolicy.shouldQueueRefresh(
+                isLoading: false,
+                syncInFlight: true,
+                hiddenRefreshInFlight: false
+            )
+        )
+        XCTAssertTrue(
+            UsagePublicationPolicy.shouldQueueRefresh(
+                isLoading: false,
+                syncInFlight: false,
+                hiddenRefreshInFlight: true
+            )
+        )
+    }
+
+    func testPendingPublicationsRemainQueuedUntilEveryOwnerFinishes() {
+        var queue = PendingUsagePublicationQueue()
+        queue.enqueue(.localQueue, summaries: [.today, .rolling])
+        queue.enqueue(.accountUpload, summaries: .total)
+
+        XCTAssertNil(
+            queue.takeIfReady(
+                isLoading: false,
+                syncInFlight: true,
+                hiddenRefreshInFlight: false
+            )
+        )
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.sources, [.localQueue, .accountUpload])
+        XCTAssertEqual(queue.summaries, .all)
+
+        XCTAssertNil(
+            queue.takeIfReady(
+                isLoading: false,
+                syncInFlight: false,
+                hiddenRefreshInFlight: true
+            )
+        )
+        XCTAssertFalse(queue.isEmpty)
+
+        let pending = queue.takeIfReady(
+            isLoading: false,
+            syncInFlight: false,
+            hiddenRefreshInFlight: false
+        )
+        XCTAssertEqual(pending?.sources, [.localQueue, .accountUpload])
+        XCTAssertEqual(pending?.summaries, .all)
+        XCTAssertTrue(queue.isEmpty)
+    }
+
+    func testPendingPublicationResetClearsSourcesAndSummarySelectionTogether() {
+        var queue = PendingUsagePublicationQueue()
+        queue.enqueue(.localQueue, summaries: .today)
+        queue.removeAll()
+
+        XCTAssertTrue(queue.isEmpty)
+        XCTAssertTrue(queue.sources.isEmpty)
+        XCTAssertTrue(queue.summaries.isEmpty)
+    }
+
+    func testUnknownSlotsRefreshFromFirstPublication() {
+        let state = SummaryPublicationState()
+
+        XCTAssertEqual(
+            UsagePublicationPolicy.summariesToRefresh(
+                state: state,
+                sources: .localQueue,
+                requested: [.today, .total]
+            ),
+            [.today, .total]
+        )
+        XCTAssertEqual(
+            UsagePublicationPolicy.summariesToRefresh(
+                state: state,
+                sources: .accountUpload,
+                requested: .rolling
+            ),
+            .rolling
+        )
+    }
+
+    func testMixedSummarySourcesRouteIndependently() {
+        var state = SummaryPublicationState()
+        state.record(
+            source: .accountUpload,
+            completedAt: Date(timeIntervalSince1970: 100),
+            for: [.today, .rolling]
+        )
+        state.record(
+            source: .localQueue,
+            completedAt: Date(timeIntervalSince1970: 101),
+            for: .total
+        )
+
+        XCTAssertEqual(
+            UsagePublicationPolicy.summariesToRefresh(
+                state: state,
+                sources: .accountUpload,
+                requested: .all
+            ),
+            [.today, .rolling]
+        )
+        XCTAssertEqual(
+            UsagePublicationPolicy.summariesToRefresh(
+                state: state,
+                sources: .localQueue,
+                requested: .all
+            ),
+            .total
+        )
+    }
+
+    func testCoalescedPublicationsRefreshEveryKnownSource() {
+        var state = SummaryPublicationState()
+        state.record(
+            source: .accountUpload,
+            completedAt: Date(timeIntervalSince1970: 100),
+            for: .today
+        )
+        state.record(
+            source: .localQueue,
+            completedAt: Date(timeIntervalSince1970: 101),
+            for: [.rolling, .total]
+        )
+
+        XCTAssertEqual(
+            UsagePublicationPolicy.summariesToRefresh(
+                state: state,
+                sources: [.localQueue, .accountUpload],
+                requested: .all
+            ),
+            .all
+        )
+    }
+
+    func testLocalFallbackClearsAccountReadTimestamp() {
+        var state = SummaryPublicationState()
+        state.record(
+            source: .accountUpload,
+            completedAt: Date(timeIntervalSince1970: 100),
+            for: .today
+        )
+        state.record(
+            source: .localQueue,
+            completedAt: Date(timeIntervalSince1970: 110),
+            for: .today
+        )
+
+        XCTAssertEqual(state.source(for: .today), .localQueue)
+        XCTAssertNil(state.latestAccountReadCompletion(for: .today))
+    }
+
+    func testCacheDelayUsesLatestRelevantAccountRead() {
+        var state = SummaryPublicationState()
+        state.record(
+            source: .accountUpload,
+            completedAt: Date(timeIntervalSince1970: 100),
+            for: .today
+        )
+        state.record(
+            source: .accountUpload,
+            completedAt: Date(timeIntervalSince1970: 110),
+            for: .total
+        )
+
+        XCTAssertEqual(
+            UsagePublicationPolicy.remainingAccountCacheDelay(
+                state: state,
+                summaries: .all,
+                now: Date(timeIntervalSince1970: 120),
+                visibilityDelay: 35
+            ),
+            25
+        )
+        XCTAssertEqual(
+            UsagePublicationPolicy.remainingAccountCacheDelay(
+                state: state,
+                summaries: .today,
+                now: Date(timeIntervalSince1970: 120),
+                visibilityDelay: 35
+            ),
+            15
+        )
+    }
+
+    func testExpiredOrMissingAccountReadNeedsNoDelay() {
+        XCTAssertEqual(
+            UsagePublicationPolicy.remainingAccountCacheDelay(
+                latestReadCompletedAt: nil,
+                now: Date(timeIntervalSince1970: 200),
+                visibilityDelay: 35
+            ),
+            0
+        )
+        XCTAssertEqual(
+            UsagePublicationPolicy.remainingAccountCacheDelay(
+                latestReadCompletedAt: Date(timeIntervalSince1970: 100),
+                now: Date(timeIntervalSince1970: 200),
+                visibilityDelay: 35
+            ),
+            0
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -122,7 +122,9 @@ targets:
       - path: TokenTrackerBar/Models/LimitPace.swift
       - path: TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
       - path: TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+      - path: TokenTrackerBar/Models/UsagePublicationPolicy.swift
       - path: TokenTrackerBar/Services/ResumableDownloader.swift
+      - path: TokenTrackerBar/Services/QueueActivityMonitor.swift
       - path: TokenTrackerBar/Models/CompanionAnimationPolicy.swift
       # WeeklyLimitResetDetector's window labels come from Strings, which
       # resolves the locale via Shared/NativeLocalization (Shared is

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -220,13 +220,15 @@ async function cmdServe(argv) {
 
   await maybeShowStarCta({ trackerDir });
 
-  // Native desktop apps keep this server alive even when the dashboard window
-  // is closed. Provider hooks are the fast path, but they can be removed by a
-  // tool update or skipped by a provider. Scan every local source once a
+  // The Windows desktop app keeps this server alive even when the dashboard
+  // window is closed. Provider hooks are the fast path, but they can be removed
+  // by a tool update or skipped by a provider. Scan every local source once a
   // minute as a bounded fallback so the queue cannot remain stale indefinitely.
   // `--no-sync` still skips the blocking startup sync; this periodic pass is
-  // native-shell-only and uses the lightweight local mode (no cloud upload,
-  // Cursor network request, or deep Codex archive scan).
+  // Windows-only and uses the lightweight local mode (no cloud upload, Cursor
+  // network request, or deep Codex archive scan). The macOS app owns its own
+  // wake-aware refresh loop; running both loops made sync.lock nearly
+  // continuous and starved provider notify syncs.
   const nativeBackgroundSync = startNativeBackgroundSync({
     onError: (e) =>
       process.stdout.write(`Background local sync warning: ${e?.message || e}\n`),
@@ -273,7 +275,7 @@ function startNativeBackgroundSync({
   onError = () => {},
 } = {}) {
   const normalizedShell = String(appShell || "").trim().toLowerCase();
-  if (normalizedShell !== "macos" && normalizedShell !== "windows") return null;
+  if (normalizedShell !== "windows") return null;
 
   const sync = runSync || (async (args) => {
     const { cmdSync } = require("./sync");

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -191,6 +191,8 @@ const CODEX_RESCAN_DEDUP_REPAIR_KEY = "codexRescanDedupRepair_2026_06";
 const CODEX_FORK_REPLAY_REPAIR_KEY = "codexForkReplayRepair_2026_07";
 const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
 const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const NOTIFY_LOCK_WAIT_MS = 130_000;
+const NOTIFY_LOCK_POLL_MS = 5_000;
 const CODEX_COLD_SCAN_AUDIT_MAX_SYNCS = 288;
 // 0.57.0 mis-attributed mimocode's mirrored Claude/claude-mem history to
 // source=mimo (read the whole DB instead of only providerID=mimo rows). This
@@ -290,12 +292,51 @@ function mergeCopilotAppDbStates(primary = {}, alias = {}) {
   return { ...primary, ...newer, sessionTotals };
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireSyncLock(
+  lockPath,
+  opts,
+  {
+    notifyWaitMs = NOTIFY_LOCK_WAIT_MS,
+    notifyPollMs = NOTIFY_LOCK_POLL_MS,
+  } = {},
+) {
+  let lock = await openLock(lockPath, { quietIfLocked: opts.auto });
+  if (lock || !opts.fromNotify || notifyWaitMs <= 0) return lock;
+
+  // One low-frequency waiter coalesces every notify that lands behind an
+  // active native/background sync. This avoids both losing the final Codex
+  // turn and spawning a fleet of idle retry processes during a long scan.
+  const waiter = await openLock(`${lockPath}.notify-wait`, {
+    quietIfLocked: true,
+  });
+  if (!waiter) return null;
+
+  try {
+    const deadline = Date.now() + notifyWaitMs;
+    while (!lock && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      await sleep(Math.min(Math.max(1, notifyPollMs), remaining));
+      lock = await openLock(lockPath, { quietIfLocked: true });
+    }
+    return lock;
+  } finally {
+    await waiter.release();
+  }
+}
+
 async function cmdSync(argv, context = {}) {
   const opts = parseArgs(argv);
   const diagnostics = context && typeof context === "object" ? context.diagnostics : null;
   const cursorStoreOptions = context && typeof context === "object"
     ? context.cursorStoreOptions
     : null;
+  const lockWaitOptions = context && typeof context === "object"
+    ? context.lockWaitOptions
+    : undefined;
   const syncDiagnostics = diagnostics && typeof diagnostics === "object" ? diagnostics : null;
   const home = os.homedir();
   const { trackerDir } = await resolveTrackerPaths({ home });
@@ -306,7 +347,7 @@ async function cmdSync(argv, context = {}) {
   }
 
   const lockPath = path.join(trackerDir, "sync.lock");
-  const lock = await openLock(lockPath, { quietIfLocked: opts.auto });
+  const lock = await acquireSyncLock(lockPath, opts, lockWaitOptions);
   if (!lock) return;
 
   let progress = null;
@@ -321,6 +362,13 @@ async function cmdSync(argv, context = {}) {
     const uploadThrottlePath = path.join(trackerDir, "upload.throttle.json");
     const grokSignalPath = path.join(trackerDir, "grok-last-session.json");
     const legacyGrokSignalPath = path.join(trackerDir, "tracker", "grok-last-session.json");
+
+    // Native publication owns backlog and failure-backoff retries on its next
+    // five-minute tick. Remove any legacy detached retry marker immediately so
+    // an already-sleeping retry process observes the missing marker and exits.
+    if (opts.publishAccount) {
+      await clearAutoRetry(trackerDir);
+    }
 
     const config = await readJson(configPath);
     const codexCursorRoots = [process.env.CODEX_HOME || path.join(home, ".codex")];
@@ -1923,8 +1971,37 @@ async function cmdSync(argv, context = {}) {
 
     let uploadResult = { inserted: 0, skipped: 0 };
     let uploadAttempted = false;
+    let backgroundUploadDecision = null;
 
-    if (runtime.deviceToken && runtime.baseUrl && !isBackgroundLightweightSync) {
+    if (opts.publishAccount) {
+      const uploadStateBefore = (await readJson(queueStatePath)) || { offset: 0 };
+      const queueSizeBefore = await safeStatSize(queuePath);
+      const pendingBytesBefore = Math.max(
+        0,
+        queueSizeBefore - Number(uploadStateBefore.offset || 0),
+      );
+      // The native five-minute loop is already the success cadence. Reuse the
+      // shared decision helper for pending/backoff handling, but intentionally
+      // ignore the legacy 30-minute success throttle so account publication
+      // does not become stale again. Failure backoff remains authoritative.
+      backgroundUploadDecision = decideAutoUpload({
+        nowMs: Date.now(),
+        pendingBytes: pendingBytesBefore,
+        state: {
+          ...uploadThrottleState,
+          nextAllowedAtMs: Number(uploadThrottleState.backoffUntilMs || 0),
+        },
+        config: {
+          batchSize: 200,
+          maxBatchesSmall: 5,
+          maxBatchesLarge: 5,
+        },
+      });
+    }
+
+    if (runtime.deviceToken && runtime.baseUrl &&
+        (!isBackgroundLightweightSync || opts.publishAccount) &&
+        (!backgroundUploadDecision || backgroundUploadDecision.allowed)) {
       uploadAttempted = true;
       // Mirror the machine identity into the purge-surviving seed file so a
       // future `uninstall --purge` + reinstall recovers the same cloud device
@@ -1941,8 +2018,8 @@ async function cmdSync(argv, context = {}) {
           deviceToken: runtime.deviceToken,
           queuePath,
           queueStatePath,
-          maxBatches: opts.drain ? 100 : 5,
-          batchSize: 200,
+          maxBatches: opts.drain ? 100 : (backgroundUploadDecision?.maxBatches || 5),
+          batchSize: backgroundUploadDecision?.batchSize || 200,
         });
         // Record success so the exponential backoff step resets — otherwise
         // a single past failure keeps us pessimistically throttled forever.
@@ -1981,7 +2058,7 @@ async function cmdSync(argv, context = {}) {
 
     if (pendingBytes <= 0) {
       await clearAutoRetry(trackerDir);
-    } else if (opts.auto && uploadAttempted) {
+    } else if (opts.auto && uploadAttempted && !opts.publishAccount) {
       const retryAtMs = Number(uploadThrottleState?.nextAllowedAtMs || 0);
       if (retryAtMs > Date.now()) {
         await scheduleAutoRetry({
@@ -2082,7 +2159,6 @@ async function cmdSync(argv, context = {}) {
   } finally {
     progress?.stop();
     await lock.release();
-    await fs.unlink(lockPath).catch(() => {});
   }
 }
 
@@ -2095,6 +2171,7 @@ function parseArgs(argv) {
     source: null,
     drain: false,
     background: false,
+    publishAccount: false,
     allLocalSources: false,
     repairGrok: false,
   };
@@ -2111,6 +2188,7 @@ function parseArgs(argv) {
     else if (a.startsWith("--source=")) out.source = normalizeSyncSource(a.slice("--source=".length));
     else if (a === "--drain") out.drain = true;
     else if (a === "--background" || a === "--lightweight") out.background = true;
+    else if (a === "--publish-account") out.publishAccount = true;
     else if (a === "--all-local-sources") out.allLocalSources = true;
     else if (a === "--repair-grok") out.repairGrok = true;
     else throw new Error(`Unknown option: ${a}`);
@@ -2184,6 +2262,7 @@ function recordCodexColdScanAudit(cursors, { fullAudit = false, skipped = 0 } = 
 
 module.exports = {
   cmdSync,
+  acquireSyncLock,
   migrateCursorUnknownBuckets,
   migrateRolloutCumulativeDeltaBuckets,
   repairCodexRescanInflation,

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -51,6 +51,8 @@ async function chmod600IfPossible(filePath) {
 const LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
 const LOCK_HEARTBEAT_MS = 30 * 1000;
 const MAX_RECLAIM_DEPTH = 4;
+const TRANSITION_GUARD_RETRY_MS = 5;
+const TRANSITION_GUARD_ATTEMPTS = 1000;
 
 function parseLockOwner(raw) {
   try {
@@ -148,17 +150,52 @@ async function releaseOwnedLock(
   heartbeatHandle,
   heartbeatTimer,
   token,
+  {
+    beforeReleaseUnlink = null,
+    reclaimDepth = 0,
+    serializeRelease = true,
+  } = {},
 ) {
-  clearInterval(heartbeatTimer);
-  await handle.close().catch(() => {});
-  await heartbeatHandle?.close().catch(() => {});
+  let transitionGuard = null;
+  if (serializeRelease) {
+    // Reclaimers use the same guard while moving a stale lease aside. Holding
+    // it across token validation and unlink makes that ownership transition
+    // indivisible: an old owner cannot delete a replacement installed by a
+    // concurrent stale-lock reclaimer.
+    for (let attempt = 0; attempt < TRANSITION_GUARD_ATTEMPTS; attempt += 1) {
+      transitionGuard = await openLock(`${lockPath}.reclaim`, {
+        quietIfLocked: true,
+        reclaimDepth: reclaimDepth + 1,
+        // This short-lived internal guard is the serialization primitive; its
+        // own release must not recursively acquire another transition guard.
+        serializeRelease: false,
+      });
+      if (transitionGuard) break;
+      await new Promise((resolve) => setTimeout(resolve, TRANSITION_GUARD_RETRY_MS));
+    }
+    if (!transitionGuard) {
+      throw new Error(`Timed out serializing lock release: ${lockPath}`);
+    }
+  }
+
   try {
+    clearInterval(heartbeatTimer);
+    await handle.close().catch(() => {});
+    await heartbeatHandle?.close().catch(() => {});
     const owner = parseLockOwner(await fs.readFile(lockPath, "utf8"));
     if (owner?.token === token) {
+      if (typeof beforeReleaseUnlink === "function") {
+        await beforeReleaseUnlink({ lockPath });
+      }
       await fs.unlink(lockPath).catch(() => {});
       await fs.unlink(heartbeatPathFor(lockPath, token)).catch(() => {});
     }
-  } catch (_e) {}
+  } catch (_e) {
+    // Missing or replaced owner paths are already released from this token's
+    // perspective. Other failures retain the conservative no-delete outcome.
+  } finally {
+    await transitionGuard?.release();
+  }
 }
 
 async function openLock(
@@ -166,7 +203,9 @@ async function openLock(
   {
     quietIfLocked = false,
     beforeReclaim = null,
+    beforeReleaseUnlink = null,
     reclaimDepth = 0,
+    serializeRelease = true,
   } = {},
 ) {
   try {
@@ -190,6 +229,11 @@ async function openLock(
             heartbeatHandle,
             heartbeatTimer,
             token,
+            {
+              beforeReleaseUnlink,
+              reclaimDepth,
+              serializeRelease,
+            },
           );
         },
       };
@@ -214,6 +258,7 @@ async function openLock(
         const reclaimGuard = await openLock(`${lockPath}.reclaim`, {
           quietIfLocked: true,
           reclaimDepth: reclaimDepth + 1,
+          serializeRelease: false,
         });
         if (!reclaimGuard) return null;
 

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -174,6 +174,10 @@ async function releaseOwnedLock(
       await new Promise((resolve) => setTimeout(resolve, TRANSITION_GUARD_RETRY_MS));
     }
     if (!transitionGuard) {
+      clearInterval(heartbeatTimer);
+      await handle.close().catch(() => {});
+      await heartbeatHandle?.close().catch(() => {});
+      await fs.unlink(heartbeatPathFor(lockPath, token)).catch(() => {});
       throw new Error(`Timed out serializing lock release: ${lockPath}`);
     }
   }
@@ -273,7 +277,12 @@ async function openLock(
             await fs.rename(lockPath, quarantinePath);
           } catch (renameError) {
             if (renameError?.code === "ENOENT") {
-              return openLock(lockPath, { quietIfLocked, reclaimDepth });
+              return openLock(lockPath, {
+                quietIfLocked,
+                beforeReleaseUnlink,
+                reclaimDepth,
+                serializeRelease,
+              });
             }
             if (!quietIfLocked) {
               process.stdout.write("Another sync is already running.\n");
@@ -289,7 +298,12 @@ async function openLock(
             // to a replacement lease created after the atomic rename.
             await fs.unlink(heartbeatPathFor(lockPath, staleOwner.token)).catch(() => {});
           }
-          return await openLock(lockPath, { quietIfLocked, reclaimDepth });
+          return await openLock(lockPath, {
+            quietIfLocked,
+            beforeReleaseUnlink,
+            reclaimDepth,
+            serializeRelease,
+          });
         } finally {
           if (quarantinePath) await fs.unlink(quarantinePath).catch(() => {});
           await reclaimGuard.release();

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -49,6 +49,8 @@ async function chmod600IfPossible(filePath) {
 }
 
 const LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
+const LOCK_HEARTBEAT_MS = 30 * 1000;
+const MAX_RECLAIM_DEPTH = 4;
 
 function parseLockOwner(raw) {
   try {
@@ -60,6 +62,11 @@ function parseLockOwner(raw) {
   } catch (_e) {
     return null;
   }
+}
+
+function heartbeatPathFor(lockPath, token) {
+  const tokenDigest = crypto.createHash("sha256").update(token, "utf8").digest("hex");
+  return `${lockPath}.heartbeat.${tokenDigest}`;
 }
 
 function isProcessAlive(pid) {
@@ -75,64 +82,173 @@ function isProcessAlive(pid) {
 }
 
 async function existingLockCanBeReclaimed(lockPath) {
+  let lockHandle = null;
   try {
+    // Inspect one opened inode instead of stat-ing a path and then reading
+    // that path. The latter is a TOCTOU window and is also unsafe if a
+    // concurrent reclaimer replaces the lock between the two operations.
+    lockHandle = await fs.open(lockPath, "r");
     const [stat, raw] = await Promise.all([
-      fs.stat(lockPath),
-      fs.readFile(lockPath, "utf8").catch(() => ""),
+      lockHandle.stat(),
+      lockHandle.readFile({ encoding: "utf8" }),
     ]);
     const owner = parseLockOwner(raw);
-    if (owner) return !isProcessAlive(owner.pid);
+    if (owner) {
+      if (!isProcessAlive(owner.pid)) return true;
+
+      // New leases keep a token-specific heartbeat separate from the owner
+      // file. This lets a PID that has since been reused be recognized as an
+      // abandoned lease without reclaiming a live, long-running sync whose
+      // heartbeat is still fresh. Locks from before heartbeat support retain
+      // the conservative live-PID behavior.
+      let heartbeatHandle = null;
+      try {
+        heartbeatHandle = await fs.open(heartbeatPathFor(lockPath, owner.token), "r");
+        const heartbeat = await heartbeatHandle.stat();
+        return Date.now() - heartbeat.mtimeMs > LOCK_STALE_MS;
+      } catch (_e) {
+        return false;
+      } finally {
+        await heartbeatHandle?.close().catch(() => {});
+      }
+    }
     return Date.now() - stat.mtimeMs > LOCK_STALE_MS;
   } catch (e) {
     // The lock disappeared between open and inspection, so retry acquisition.
     if (e?.code === "ENOENT") return true;
     return false;
+  } finally {
+    await lockHandle?.close().catch(() => {});
   }
 }
 
-async function releaseOwnedLock(lockPath, handle, token) {
+function startLockHeartbeat(handle, heartbeatHandle) {
+  const beat = async () => {
+    try {
+      const now = new Date();
+      await Promise.all([
+        handle.utimes(now, now),
+        heartbeatHandle.utimes(now, now),
+      ]);
+    } catch (_e) {
+      // A failed heartbeat makes the lease eligible for bounded stale
+      // reclamation. The owning sync will still finish or release normally.
+    }
+  };
+  const timer = setInterval(() => {
+    void beat();
+  }, LOCK_HEARTBEAT_MS);
+  timer.unref?.();
+  return timer;
+}
+
+async function releaseOwnedLock(
+  lockPath,
+  handle,
+  heartbeatHandle,
+  heartbeatTimer,
+  token,
+) {
+  clearInterval(heartbeatTimer);
   await handle.close().catch(() => {});
+  await heartbeatHandle?.close().catch(() => {});
   try {
     const owner = parseLockOwner(await fs.readFile(lockPath, "utf8"));
     if (owner?.token === token) {
       await fs.unlink(lockPath).catch(() => {});
+      await fs.unlink(heartbeatPathFor(lockPath, token)).catch(() => {});
     }
   } catch (_e) {}
 }
 
-async function openLock(lockPath, { quietIfLocked } = {}) {
+async function openLock(
+  lockPath,
+  {
+    quietIfLocked = false,
+    beforeReclaim = null,
+    reclaimDepth = 0,
+  } = {},
+) {
   try {
     const handle = await fs.open(lockPath, "wx");
     const token = crypto.randomUUID();
+    const heartbeatPath = heartbeatPathFor(lockPath, token);
+    let heartbeatHandle = null;
     try {
       await handle.writeFile(
         JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() }) + "\n",
         "utf8",
       );
+      heartbeatHandle = await fs.open(heartbeatPath, "wx");
+      await heartbeatHandle.writeFile(`${token}\n`, "utf8");
+      const heartbeatTimer = startLockHeartbeat(handle, heartbeatHandle);
+      return {
+        async release() {
+          await releaseOwnedLock(
+            lockPath,
+            handle,
+            heartbeatHandle,
+            heartbeatTimer,
+            token,
+          );
+        },
+      };
     } catch (e) {
+      await heartbeatHandle?.close().catch(() => {});
+      await fs.unlink(heartbeatPath).catch(() => {});
       await handle.close().catch(() => {});
       await fs.unlink(lockPath).catch(() => {});
       throw e;
     }
-    return {
-      async release() {
-        await releaseOwnedLock(lockPath, handle, token);
-      },
-    };
   } catch (e) {
     if (e && e.code === "EEXIST") {
       if (await existingLockCanBeReclaimed(lockPath)) {
+        if (typeof beforeReclaim === "function") {
+          await beforeReclaim({ lockPath });
+        }
+        if (reclaimDepth >= MAX_RECLAIM_DEPTH) return null;
+
+        // Serialize all reclaimers before re-checking the target. A stale
+        // check can be shared by many contenders; only the holder of this
+        // atomic guard may move the old lease out of the way.
+        const reclaimGuard = await openLock(`${lockPath}.reclaim`, {
+          quietIfLocked: true,
+          reclaimDepth: reclaimDepth + 1,
+        });
+        if (!reclaimGuard) return null;
+
+        let quarantinePath = null;
         try {
-          await fs.unlink(lockPath);
-        } catch (unlinkError) {
-          if (unlinkError?.code !== "ENOENT") {
+          // Re-check while holding the guard. A competing reclaimer may have
+          // already replaced the target since our initial stale inspection.
+          if (!(await existingLockCanBeReclaimed(lockPath))) return null;
+
+          quarantinePath = `${lockPath}.stale.${process.pid}.${crypto.randomUUID()}`;
+          try {
+            await fs.rename(lockPath, quarantinePath);
+          } catch (renameError) {
+            if (renameError?.code === "ENOENT") {
+              return openLock(lockPath, { quietIfLocked, reclaimDepth });
+            }
             if (!quietIfLocked) {
               process.stdout.write("Another sync is already running.\n");
             }
             return null;
           }
+
+          const staleOwner = parseLockOwner(
+            await fs.readFile(quarantinePath, "utf8").catch(() => ""),
+          );
+          if (staleOwner) {
+            // The heartbeat name contains the old token, so it cannot belong
+            // to a replacement lease created after the atomic rename.
+            await fs.unlink(heartbeatPathFor(lockPath, staleOwner.token)).catch(() => {});
+          }
+          return await openLock(lockPath, { quietIfLocked, reclaimDepth });
+        } finally {
+          if (quarantinePath) await fs.unlink(quarantinePath).catch(() => {});
+          await reclaimGuard.release();
         }
-        return openLock(lockPath, { quietIfLocked });
       }
       if (!quietIfLocked) {
         process.stdout.write("Another sync is already running.\n");

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -1,4 +1,5 @@
 const fs = require("node:fs/promises");
+const crypto = require("node:crypto");
 const path = require("node:path");
 
 async function ensureDir(p) {
@@ -49,26 +50,88 @@ async function chmod600IfPossible(filePath) {
 
 const LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
 
-async function openLock(lockPath, { quietIfLocked }) {
+function parseLockOwner(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    const pid = Number(parsed?.pid);
+    const token = typeof parsed?.token === "string" ? parsed.token : null;
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !token) return null;
+    return { pid, token };
+  } catch (_e) {
+    return null;
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    if (e?.code === "ESRCH") return false;
+    // EPERM means the process exists but belongs to another user. Unknown
+    // errors are treated conservatively so a live lock is never reclaimed.
+    return true;
+  }
+}
+
+async function existingLockCanBeReclaimed(lockPath) {
+  try {
+    const [stat, raw] = await Promise.all([
+      fs.stat(lockPath),
+      fs.readFile(lockPath, "utf8").catch(() => ""),
+    ]);
+    const owner = parseLockOwner(raw);
+    if (owner) return !isProcessAlive(owner.pid);
+    return Date.now() - stat.mtimeMs > LOCK_STALE_MS;
+  } catch (e) {
+    // The lock disappeared between open and inspection, so retry acquisition.
+    if (e?.code === "ENOENT") return true;
+    return false;
+  }
+}
+
+async function releaseOwnedLock(lockPath, handle, token) {
+  await handle.close().catch(() => {});
+  try {
+    const owner = parseLockOwner(await fs.readFile(lockPath, "utf8"));
+    if (owner?.token === token) {
+      await fs.unlink(lockPath).catch(() => {});
+    }
+  } catch (_e) {}
+}
+
+async function openLock(lockPath, { quietIfLocked } = {}) {
   try {
     const handle = await fs.open(lockPath, "wx");
+    const token = crypto.randomUUID();
+    try {
+      await handle.writeFile(
+        JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() }) + "\n",
+        "utf8",
+      );
+    } catch (e) {
+      await handle.close().catch(() => {});
+      await fs.unlink(lockPath).catch(() => {});
+      throw e;
+    }
     return {
       async release() {
-        await handle.close().catch(() => {});
-        await fs.unlink(lockPath).catch(() => {});
+        await releaseOwnedLock(lockPath, handle, token);
       },
     };
   } catch (e) {
     if (e && e.code === "EEXIST") {
-      // Check if lock is stale
-      try {
-        const stat = await fs.stat(lockPath);
-        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-          await fs.unlink(lockPath).catch(() => {});
-          return openLock(lockPath, { quietIfLocked });
+      if (await existingLockCanBeReclaimed(lockPath)) {
+        try {
+          await fs.unlink(lockPath);
+        } catch (unlinkError) {
+          if (unlinkError?.code !== "ENOENT") {
+            if (!quietIfLocked) {
+              process.stdout.write("Another sync is already running.\n");
+            }
+            return null;
+          }
         }
-      } catch (_statErr) {
-        // Lock file disappeared between checks, retry
         return openLock(lockPath, { quietIfLocked });
       }
       if (!quietIfLocked) {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -35,6 +35,7 @@ const {
   getModelPricing,
   computeRowCost,
   ensurePricingLoaded,
+  getPricingRevision,
 } = require("./pricing");
 
 const {
@@ -66,6 +67,33 @@ const CLAUDE_MEM_OBSERVER_PROJECT_KEY = deriveProjectKeyFromRef(
   CLAUDE_MEM_OBSERVER_PROJECT_REF,
 );
 const PROJECT_USAGE_MAX_ENTRIES = 10;
+const MAX_TIME_ZONE_CACHE_ENTRIES = 16;
+
+// The native dashboard fans one refresh out across several local endpoints.
+// Keep one immutable, deduped view of the current queue so those endpoints do
+// not all read and JSON.parse the same append-only file. A file identity +
+// nanosecond timestamp signature invalidates the cache immediately on append,
+// in-place rewrite, or atomic replacement.
+let queueDataCache = null;
+const dailyAggregationCache = new WeakMap();
+const zonedPartsFormatters = new Map();
+
+function boundedCacheSet(cache, key, value, maxEntries) {
+  if (cache.has(key)) cache.delete(key);
+  cache.set(key, value);
+  while (cache.size > maxEntries) {
+    cache.delete(cache.keys().next().value);
+  }
+}
+
+function queueFileSignature(queuePath) {
+  const stat = fs.statSync(queuePath, { bigint: true });
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+}
+
+function timeZoneContextKey({ timeZone, offsetMinutes } = {}) {
+  return `${timeZone || ""}|${Number.isFinite(offsetMinutes) ? offsetMinutes : ""}|p${getPricingRevision()}`;
+}
 
 // Shared by project-usage-summary and project-usage-detail: reads the
 // deduped project bucket log, drops the claude-mem pseudo project, and
@@ -160,6 +188,21 @@ function normalizeQueueRow(row) {
 }
 
 function readQueueData(queuePath) {
+  let signature;
+  try {
+    signature = queueFileSignature(queuePath);
+  } catch (e) {
+    if (queueDataCache?.queuePath === queuePath) queueDataCache = null;
+    if (e?.code !== "ENOENT") {
+      console.error("[LocalAPI] readQueueData: failed to stat queue:", e?.message || e);
+    }
+    return [];
+  }
+
+  if (queueDataCache?.queuePath === queuePath && queueDataCache.signature === signature) {
+    return queueDataCache.rows;
+  }
+
   let raw;
   try {
     raw = fs.readFileSync(queuePath, "utf8");
@@ -196,7 +239,9 @@ function readQueueData(queuePath) {
     const key = `${row.source || ""}|${row.model || ""}|${row.hour_start || ""}`;
     seen.set(key, normalizeQueueRow(row));
   }
-  return Array.from(seen.values());
+  const rows = Array.from(seen.values());
+  queueDataCache = { queuePath, signature, rows };
+  return rows;
 }
 
 function rowDayKey(row, timeZoneContext) {
@@ -214,8 +259,19 @@ function rowDayKey(row, timeZoneContext) {
 }
 
 function aggregateByDay(rows, timeZoneContext = null) {
+  const normalizedRows = Array.isArray(rows) ? rows : [];
+  const cacheKey = timeZoneContextKey(timeZoneContext || {});
+  let cachedByTimeZone = dailyAggregationCache.get(normalizedRows);
+  if (cachedByTimeZone?.has(cacheKey)) {
+    const cached = cachedByTimeZone.get(cacheKey);
+    // Touch the entry so the small per-queue map behaves as an LRU.
+    cachedByTimeZone.delete(cacheKey);
+    cachedByTimeZone.set(cacheKey, cached);
+    return cached;
+  }
+
   const byDay = new Map();
-  for (const row of rows) {
+  for (const row of normalizedRows) {
     if (!row.hour_start) continue;
     const day = rowDayKey(row, timeZoneContext);
     if (!day) continue;
@@ -250,7 +306,13 @@ function aggregateByDay(rows, timeZoneContext = null) {
     const model = row.model || "unknown";
     a.models[model] = (a.models[model] || 0) + (row.total_tokens || 0);
   }
-  return Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
+  const daily = Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
+  if (!cachedByTimeZone) {
+    cachedByTimeZone = new Map();
+    dailyAggregationCache.set(normalizedRows, cachedByTimeZone);
+  }
+  boundedCacheSet(cachedByTimeZone, cacheKey, daily, MAX_TIME_ZONE_CACHE_ENTRIES);
+  return daily;
 }
 
 function buildCodexCategoryFallbackFromQueue(queueRows, { from, to, timeZoneContext }) {
@@ -477,17 +539,34 @@ function getZonedParts(date, { timeZone, offsetMinutes } = {}) {
 
   if (timeZone && typeof Intl !== "undefined" && Intl.DateTimeFormat) {
     try {
-      const formatter = new Intl.DateTimeFormat("en-CA", {
-        timeZone,
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hourCycle: "h23",
-      });
-      const parts = formatter.formatToParts(dt);
+      let formatter;
+      if (zonedPartsFormatters.has(timeZone)) {
+        formatter = zonedPartsFormatters.get(timeZone);
+      } else {
+        try {
+          formatter = new Intl.DateTimeFormat("en-CA", {
+            timeZone,
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hourCycle: "h23",
+          });
+        } catch {
+          // Cache invalid zone ids too; otherwise a bad local query would
+          // throw once per queue row before falling back to its fixed offset.
+          formatter = null;
+        }
+        boundedCacheSet(
+          zonedPartsFormatters,
+          timeZone,
+          formatter,
+          MAX_TIME_ZONE_CACHE_ENTRIES,
+        );
+      }
+      const parts = formatter?.formatToParts(dt) || [];
       const values = parts.reduce((acc, part) => {
         if (part.type && part.value) acc[part.type] = part.value;
         return acc;
@@ -685,6 +764,7 @@ function runSyncCommand(extraEnv = {}, opts = {}) {
     const args = [TRACKER_BIN, "sync"];
     if (opts.auto === true) args.push("--auto");
     if (opts.background === true) args.push("--background");
+    if (opts.publishAccount === true) args.push("--publish-account");
     if (opts.allLocalSources === true) args.push("--all-local-sources");
     if (opts.drain === true) args.push("--drain");
     const child = spawn(process.execPath, args, {
@@ -1696,6 +1776,11 @@ function createLocalApiHandler({ queuePath }) {
         const auto = body.auto === true && !drain;
         const background =
           auto && (body.background === true || body.lightweight === true);
+        // The local server is the trust boundary for cloud-sync preferences.
+        // A persisted device token must not let a native background request
+        // upload after the user has explicitly disabled cloud sync.
+        const publishAccount =
+          background && body.publishAccount === true && getCloudSyncPref();
         const allLocalSources = background && body.allLocalSources === true;
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
@@ -1710,7 +1795,10 @@ function createLocalApiHandler({ queuePath }) {
           extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = allowedBaseUrl;
           localSyncBaseUrl = allowedBaseUrl;
         }
-        if (!background && !extraEnv.TOKENTRACKER_DEVICE_TOKEN && getCloudSyncPref() && getRefreshTokenForCloud()) {
+        if ((!background || publishAccount) &&
+            !extraEnv.TOKENTRACKER_DEVICE_TOKEN &&
+            getCloudSyncPref() &&
+            getRefreshTokenForCloud()) {
           let issuedToken = null;
           try {
             issuedToken = await issueDeviceTokenForLocalSync(qp, { baseUrl: localSyncBaseUrl });
@@ -1732,6 +1820,7 @@ function createLocalApiHandler({ queuePath }) {
           drain,
           auto,
           background,
+          publishAccount,
           allLocalSources,
         });
         try {
@@ -1778,7 +1867,8 @@ function createLocalApiHandler({ queuePath }) {
       const to = url.searchParams.get("to") || "";
       const timeZoneContext = getTimeZoneContext(url);
       const { rows, scope, excludedSources } = scopedQueueRows(qp, url);
-      const daily = aggregateByDay(rows, timeZoneContext).filter((d) => d.day >= from && d.day <= to);
+      const allDaily = aggregateByDay(rows, timeZoneContext);
+      const daily = allDaily.filter((d) => d.day >= from && d.day <= to);
       const totals = daily.reduce(
         (acc, r) => {
           acc.total_tokens += r.total_tokens;
@@ -1798,7 +1888,6 @@ function createLocalApiHandler({ queuePath }) {
 
       const todayParts = getZonedParts(new Date(), timeZoneContext);
       const todayStr = formatPartsDayKey(todayParts) || new Date().toISOString().slice(0, 10);
-      const allDaily = aggregateByDay(rows, timeZoneContext);
 
       const shiftDay = (dayStr, delta) => {
         const d = new Date(`${dayStr}T00:00:00Z`);

--- a/src/lib/pricing/index.js
+++ b/src/lib/pricing/index.js
@@ -37,6 +37,7 @@ const seedRaw = loadSeedSync();
 const state = {
   loaded: false,
   loadingPromise: null,
+  revision: 0,
   litellmRawMap: seedRaw, // raw per-token; field shape from LiteLLM JSON
   litellmPerMillionMap: buildLitellmPerMillionMap(seedRaw), // USD/MTok
   source: Object.keys(seedRaw).length ? "seed-snapshot:sync" : null,
@@ -61,6 +62,7 @@ async function ensurePricingLoaded(opts = {}) {
       state.litellmPerMillionMap = buildLitellmPerMillionMap(state.litellmRawMap);
       state.source = source;
       state.loaded = true;
+      state.revision += 1;
       state.negativeCache.clear();
       return state;
     } finally {
@@ -79,7 +81,12 @@ function resetPricingForTests() {
   state.litellmRawMap = seedRaw;
   state.litellmPerMillionMap = buildLitellmPerMillionMap(seedRaw);
   state.source = Object.keys(seedRaw).length ? "seed-snapshot:sync" : null;
+  state.revision += 1;
   state.negativeCache.clear();
+}
+
+function getPricingRevision() {
+  return state.revision;
 }
 
 function getModelPricing(model, opts = {}) {
@@ -133,6 +140,7 @@ const MODEL_PRICING = curatedOverrides.exact;
 
 module.exports = {
   ensurePricingLoaded,
+  getPricingRevision,
   getModelPricing,
   computeRowCost,
   resetPricingForTests,

--- a/test/fs-lock.test.js
+++ b/test/fs-lock.test.js
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { openLock } = require("../src/lib/fs");
+const { acquireSyncLock } = require("../src/commands/sync");
+
+async function withLockPath(fn) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-lock-"));
+  try {
+    await fn(path.join(directory, "sync.lock"));
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("sync lock records its live owner and releases its own lease", async () => {
+  await withLockPath(async (lockPath) => {
+    const lock = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(lock);
+
+    const owner = JSON.parse(await fs.readFile(lockPath, "utf8"));
+    assert.equal(owner.pid, process.pid);
+    assert.equal(typeof owner.token, "string");
+    assert.ok(owner.token.length > 0);
+
+    assert.equal(await openLock(lockPath, { quietIfLocked: true }), null);
+    await lock.release();
+    await assert.rejects(fs.stat(lockPath), { code: "ENOENT" });
+  });
+});
+
+test("sync lock immediately reclaims a fresh lease owned by a dead process", async () => {
+  await withLockPath(async (lockPath) => {
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 2_147_483_647,
+        token: "abandoned",
+        createdAt: new Date().toISOString(),
+      }) + "\n",
+      "utf8",
+    );
+
+    const lock = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(lock);
+    const owner = JSON.parse(await fs.readFile(lockPath, "utf8"));
+    assert.equal(owner.pid, process.pid);
+    assert.notEqual(owner.token, "abandoned");
+    await lock.release();
+  });
+});
+
+test("sync lock never reclaims an old lease while its owner is still alive", async () => {
+  await withLockPath(async (lockPath) => {
+    const active = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(active);
+
+    const old = new Date(Date.now() - 6 * 60 * 1000);
+    await fs.utimes(lockPath, old, old);
+    assert.equal(await openLock(lockPath, { quietIfLocked: true }), null);
+
+    await active.release();
+  });
+});
+
+test("sync lock keeps fresh legacy locks but reclaims them after the fallback age", async () => {
+  await withLockPath(async (lockPath) => {
+    await fs.writeFile(lockPath, "", "utf8");
+    assert.equal(await openLock(lockPath, { quietIfLocked: true }), null);
+
+    const old = new Date(Date.now() - 6 * 60 * 1000);
+    await fs.utimes(lockPath, old, old);
+    const lock = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(lock);
+    await lock.release();
+  });
+});
+
+test("an obsolete owner cannot remove a replacement lock", async () => {
+  await withLockPath(async (lockPath) => {
+    const first = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(first);
+    await fs.unlink(lockPath);
+
+    const replacement = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(replacement);
+    const replacementOwner = await fs.readFile(lockPath, "utf8");
+
+    await first.release();
+    assert.equal(await fs.readFile(lockPath, "utf8"), replacementOwner);
+    await replacement.release();
+  });
+});
+
+test("notify sync waits for the active owner and acquires the released lock", async () => {
+  await withLockPath(async (lockPath) => {
+    const active = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(active);
+
+    const waiting = acquireSyncLock(
+      lockPath,
+      { auto: true, fromNotify: true },
+      { notifyWaitMs: 200, notifyPollMs: 10 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await active.release();
+
+    const acquired = await waiting;
+    assert.ok(acquired);
+    await acquired.release();
+  });
+});
+
+test("notify sync permits only one coalesced lock waiter", async () => {
+  await withLockPath(async (lockPath) => {
+    const active = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(active);
+
+    const firstWaiter = acquireSyncLock(
+      lockPath,
+      { auto: true, fromNotify: true },
+      { notifyWaitMs: 200, notifyPollMs: 10 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const duplicateWaiter = await acquireSyncLock(
+      lockPath,
+      { auto: true, fromNotify: true },
+      { notifyWaitMs: 200, notifyPollMs: 10 },
+    );
+    assert.equal(duplicateWaiter, null);
+
+    await active.release();
+    const acquired = await firstWaiter;
+    assert.ok(acquired);
+    await acquired.release();
+  });
+});
+
+test("notify sync stops waiting at its bounded deadline", async () => {
+  await withLockPath(async (lockPath) => {
+    const active = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(active);
+
+    const acquired = await acquireSyncLock(
+      lockPath,
+      { auto: true, fromNotify: true },
+      { notifyWaitMs: 30, notifyPollMs: 5 },
+    );
+    assert.equal(acquired, null);
+    await assert.rejects(fs.stat(`${lockPath}.notify-wait`), { code: "ENOENT" });
+    await active.release();
+  });
+});

--- a/test/fs-lock.test.js
+++ b/test/fs-lock.test.js
@@ -152,11 +152,13 @@ test("release and stale reclaim serialize ownership before replacement", async (
 
     // This contender classifies the old lease as stale, but it cannot move or
     // replace the lease while release holds the shared transition guard.
-    const blockedReclaimer = await openLock(lockPath, { quietIfLocked: true });
-    assert.equal(blockedReclaimer, null);
-
-    allowRelease();
-    await releasing;
+    try {
+      const blockedReclaimer = await openLock(lockPath, { quietIfLocked: true });
+      assert.equal(blockedReclaimer, null);
+    } finally {
+      allowRelease();
+      await releasing;
+    }
 
     const replacement = await openLock(lockPath, { quietIfLocked: true });
     assert.ok(replacement);

--- a/test/fs-lock.test.js
+++ b/test/fs-lock.test.js
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
@@ -53,6 +54,30 @@ test("sync lock immediately reclaims a fresh lease owned by a dead process", asy
   });
 });
 
+test("sync lock reclaims a reused PID only after its heartbeat expires", async () => {
+  await withLockPath(async (lockPath) => {
+    const token = "reused-pid";
+    const tokenDigest = crypto.createHash("sha256").update(token, "utf8").digest("hex");
+    const heartbeatPath = `${lockPath}.heartbeat.${tokenDigest}`;
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        token,
+        createdAt: new Date().toISOString(),
+      }) + "\n",
+      "utf8",
+    );
+    await fs.writeFile(heartbeatPath, `${token}\n`, "utf8");
+    const old = new Date(Date.now() - 6 * 60 * 1000);
+    await fs.utimes(heartbeatPath, old, old);
+
+    const lock = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(lock);
+    await lock.release();
+  });
+});
+
 test("sync lock never reclaims an old lease while its owner is still alive", async () => {
   await withLockPath(async (lockPath) => {
     const active = await openLock(lockPath, { quietIfLocked: true });
@@ -92,6 +117,38 @@ test("an obsolete owner cannot remove a replacement lock", async () => {
     await first.release();
     assert.equal(await fs.readFile(lockPath, "utf8"), replacementOwner);
     await replacement.release();
+  });
+});
+
+test("two stale reclaimers cannot both acquire the same lock", async () => {
+  await withLockPath(async (lockPath) => {
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 2_147_483_647,
+        token: "abandoned-concurrent",
+        createdAt: new Date().toISOString(),
+      }) + "\n",
+      "utf8",
+    );
+
+    let classified = 0;
+    let releaseBarrier;
+    const bothClassified = new Promise((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const beforeReclaim = async () => {
+      classified += 1;
+      if (classified === 2) releaseBarrier();
+      await bothClassified;
+    };
+
+    const locks = await Promise.all([
+      openLock(lockPath, { quietIfLocked: true, beforeReclaim }),
+      openLock(lockPath, { quietIfLocked: true, beforeReclaim }),
+    ]);
+    assert.equal(locks.filter(Boolean).length, 1);
+    for (const lock of locks) await lock?.release();
   });
 });
 

--- a/test/fs-lock.test.js
+++ b/test/fs-lock.test.js
@@ -120,6 +120,53 @@ test("an obsolete owner cannot remove a replacement lock", async () => {
   });
 });
 
+test("release and stale reclaim serialize ownership before replacement", async () => {
+  await withLockPath(async (lockPath) => {
+    let releaseValidated;
+    const validationReached = new Promise((resolve) => {
+      releaseValidated = resolve;
+    });
+    let allowRelease;
+    const releaseBarrier = new Promise((resolve) => {
+      allowRelease = resolve;
+    });
+
+    const active = await openLock(lockPath, {
+      quietIfLocked: true,
+      beforeReleaseUnlink: async () => {
+        releaseValidated();
+        await releaseBarrier;
+      },
+    });
+    assert.ok(active);
+
+    const owner = JSON.parse(await fs.readFile(lockPath, "utf8"));
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ ...owner, pid: 2_147_483_647 }) + "\n",
+      "utf8",
+    );
+
+    const releasing = active.release();
+    await validationReached;
+
+    // This contender classifies the old lease as stale, but it cannot move or
+    // replace the lease while release holds the shared transition guard.
+    const blockedReclaimer = await openLock(lockPath, { quietIfLocked: true });
+    assert.equal(blockedReclaimer, null);
+
+    allowRelease();
+    await releasing;
+
+    const replacement = await openLock(lockPath, { quietIfLocked: true });
+    assert.ok(replacement);
+    const replacementOwner = await fs.readFile(lockPath, "utf8");
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(await fs.readFile(lockPath, "utf8"), replacementOwner);
+    await replacement.release();
+  });
+});
+
 test("two stale reclaimers cannot both acquire the same lock", async () => {
   await withLockPath(async (lockPath) => {
     await fs.writeFile(

--- a/test/local-api-background.test.js
+++ b/test/local-api-background.test.js
@@ -242,6 +242,70 @@ test("local-api background sync skips relayed cloud device-token issuance", asyn
   }
 });
 
+test("explicit account publication mints a cached token for bounded background sync", async () => {
+  const fixture = createCloudSyncHome("tokentracker-local-api-background-publish-");
+  const savedBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  const savedFetch = global.fetch;
+  const fetchCalls = [];
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+  installDeviceTokenFetch(fetchCalls);
+
+  try {
+    const call = await runLocalSync(
+      { auto: true, background: true, publishAccount: true },
+      {
+        tmpHome: fixture.tmpHome,
+        queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+        includeDeviceToken: false,
+      },
+    );
+
+    assert.deepEqual(call.args.slice(-5), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--auto",
+      "--background",
+      "--publish-account",
+    ]);
+    assert.equal(call.options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")).length, 1);
+    assert.equal(fetchCalls.filter((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")).length, 1);
+  } finally {
+    if (savedBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    else process.env.TOKENTRACKER_INSFORGE_BASE_URL = savedBaseUrl;
+    global.fetch = savedFetch;
+    fs.rmSync(fixture.tmpHome, { recursive: true, force: true });
+  }
+});
+
+test("disabled cloud sync suppresses background account publication even with a device token", async () => {
+  const fixture = createCloudSyncHome("tokentracker-local-api-background-disabled-");
+  fs.writeFileSync(
+    path.join(fixture.trackerDir, "cloud-sync-pref.json"),
+    JSON.stringify({ enabled: false }),
+  );
+
+  try {
+    const call = await runLocalSync(
+      { auto: true, background: true, publishAccount: true },
+      {
+        tmpHome: fixture.tmpHome,
+        queuePath: path.join(fixture.trackerDir, "queue.jsonl"),
+      },
+    );
+
+    assert.deepEqual(call.args.slice(-4), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--auto",
+      "--background",
+    ]);
+    assert.equal(call.options.env.TOKENTRACKER_DEVICE_TOKEN, "device-token");
+  } finally {
+    fs.rmSync(fixture.tmpHome, { recursive: true, force: true });
+  }
+});
+
 test("local-api lightweight sync skips relayed cloud device-token issuance", async () => {
   const fixture = createCloudSyncHome("tokentracker-local-api-lightweight-cloud-");
   const savedBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;

--- a/test/local-api-queue-cache.test.js
+++ b/test/local-api-queue-cache.test.js
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { createLocalApiHandler } = require("../src/lib/local-api");
+const pricing = require("../src/lib/pricing");
+
+function queueRow(totalTokens, { source = "codex", model = "gpt-5.5" } = {}) {
+  return {
+    source,
+    model,
+    hour_start: "2026-07-17T02:00:00.000Z",
+    input_tokens: totalTokens - 10,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 10,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+    billable_total_tokens: totalTokens,
+    conversation_count: 1,
+  };
+}
+
+async function callEndpoint(handler, endpoint) {
+  const url = new URL(`http://localhost${endpoint}`);
+  const chunks = [];
+  const req = {
+    method: "GET",
+    url: url.pathname + url.search,
+    headers: { host: "localhost" },
+  };
+  const res = {
+    statusCode: 200,
+    setHeader() {},
+    writeHead(statusCode) {
+      this.statusCode = statusCode;
+    },
+    write(chunk) {
+      chunks.push(chunk);
+    },
+    end(body) {
+      if (body) chunks.push(body);
+    },
+  };
+  assert.equal(await handler(req, res, url), true);
+  assert.equal(res.statusCode, 200);
+  return JSON.parse(chunks.join(""));
+}
+
+test("local usage endpoints reuse one parsed queue until the file changes", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-queue-cache-"));
+  const queuePath = path.join(tmp, "queue.jsonl");
+  await fs.promises.writeFile(queuePath, `${JSON.stringify(queueRow(100))}\n`);
+  const handler = createLocalApiHandler({ queuePath });
+
+  const originalReadFileSync = fs.readFileSync;
+  let queueReads = 0;
+  fs.readFileSync = function countedRead(filePath, ...args) {
+    if (path.resolve(String(filePath)) === path.resolve(queuePath)) queueReads += 1;
+    return originalReadFileSync.call(this, filePath, ...args);
+  };
+
+  try {
+    const summary = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-07-17&to=2026-07-17&tz=UTC",
+    );
+    const daily = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-daily?from=2026-07-17&to=2026-07-17&tz=UTC",
+    );
+    assert.equal(summary.totals.total_tokens, 100);
+    assert.equal(daily.data[0].total_tokens, 100);
+    assert.equal(queueReads, 1);
+
+    await fs.promises.appendFile(queuePath, `${JSON.stringify(queueRow(250))}\n`);
+    const refreshed = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-07-17&to=2026-07-17&tz=UTC",
+    );
+    assert.equal(refreshed.totals.total_tokens, 250);
+    assert.equal(queueReads, 2);
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cached day aggregation preserves IANA time-zone day boundaries", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-day-cache-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const rows = [
+      { ...queueRow(100), hour_start: "2026-03-08T07:30:00.000Z" },
+      { ...queueRow(200), hour_start: "2026-03-08T10:30:00.000Z" },
+    ];
+    await fs.promises.writeFile(queuePath, `${rows.map(JSON.stringify).join("\n")}\n`);
+    const handler = createLocalApiHandler({ queuePath });
+
+    const march7 = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-03-07&to=2026-03-07&tz=America%2FLos_Angeles",
+    );
+    const march8 = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-03-08&to=2026-03-08&tz=America%2FLos_Angeles",
+    );
+    assert.equal(march7.totals.total_tokens, 100);
+    assert.equal(march8.totals.total_tokens, 200);
+  } finally {
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("pricing revision invalidates cached daily cost without rereading the queue", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-pricing-revision-cache-"));
+  const queuePath = path.join(tmp, "queue.jsonl");
+  const cachePath = path.join(tmp, "pricing.json");
+  const row = {
+    ...queueRow(1_000_000, { source: "revision-source", model: "revision-only-model" }),
+    input_tokens: 1_000_000,
+    output_tokens: 0,
+  };
+  await fs.promises.writeFile(queuePath, `${JSON.stringify(row)}\n`);
+  const handler = createLocalApiHandler({ queuePath });
+  pricing.resetPricingForTests();
+
+  try {
+    const before = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-07-17&to=2026-07-17&tz=UTC",
+    );
+    assert.equal(Number(before.totals.total_cost_usd), 0);
+
+    await pricing.ensurePricingLoaded({
+      cachePath,
+      fetchImpl: async () => ({
+        "revision-only-model": {
+          input_cost_per_token: 2e-6,
+          output_cost_per_token: 0,
+        },
+      }),
+    });
+
+    const after = await callEndpoint(
+      handler,
+      "/functions/tokentracker-usage-summary?from=2026-07-17&to=2026-07-17&tz=UTC",
+    );
+    assert.equal(Number(after.totals.total_cost_usd), 2);
+  } finally {
+    pricing.resetPricingForTests();
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/macos-background-sync-source.test.js
+++ b/test/macos-background-sync-source.test.js
@@ -13,6 +13,7 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   const apiClient = read("TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift");
   const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
   const refreshPolicy = read("TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift");
+  const appDelegate = read("TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift");
 
   assert.match(
     apiClient,
@@ -20,7 +21,7 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   );
   assert.match(
     apiClient,
-    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*Data\(#"\{"auto":true,"background":true\}"#\.utf8\)/,
+    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true/,
   );
   assert.match(
     viewModel,
@@ -28,7 +29,68 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   );
   assert.match(
     viewModel,
+    /private func syncThenRefreshHidden\([\s\S]*triggerSync\(auto: true\)[\s\S]*refreshHiddenData/,
+    "Hidden background refresh should sync once and then load only visible menu data.",
+  );
+  assert.match(
+    viewModel,
+    /if shouldSync \{[\s\S]*syncThenRefreshHidden\(menuBarSummaries: summaries\)[\s\S]*else if self\.isPopoverVisible[\s\S]*refreshHiddenData/,
+    "The five-minute loop must avoid a full dashboard load while the popover is hidden.",
+  );
+  assert.match(
+    apiClient,
+    /localSyncResourceTimeout: TimeInterval = 130[\s\S]*syncConfig\.timeoutIntervalForResource = Self\.localSyncResourceTimeout[\s\S]*requestSession = path == "\/functions\/tokentracker-local-sync"/,
+    "Local sync requests need a resource timeout longer than the server's 120-second child timeout.",
+  );
+  assert.match(
+    apiClient,
+    /func fetchSummaryWithSource\([\s\S]*X-TokenTracker-Account-View[\s\S]*latestAccountSummaryReadCompletedAt = completedAt/,
+    "Every summary response should return its own authority and track account-cache completion.",
+  );
+  assert.match(
+    viewModel,
+    /summaryPublicationState\.record\([\s\S]*for: \.today[\s\S]*for: \.rolling[\s\S]*for: \.total/,
+    "Today, rolling, and total must keep independent publication authority.",
+  );
+  assert.match(
+    viewModel,
     /func triggerSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
   );
   assert.match(refreshPolicy, /static let defaultSyncInterval: TimeInterval = 300/);
+  assert.match(
+    appDelegate,
+    /NSWorkspace\.didWakeNotification[\s\S]*NSWorkspace\.screensDidWakeNotification[\s\S]*NSWorkspace\.sessionDidBecomeActiveNotification/,
+    "System wake, display wake, and session activation should all share the debounced catch-up path.",
+  );
+  assert.match(
+    appDelegate,
+    /wakeCatchUpDebounceInterval: TimeInterval = 60[\s\S]*scheduleWakeCatchUp/,
+    "Overlapping wake notifications must remain coalesced instead of spawning duplicate syncs.",
+  );
+  assert.match(
+    viewModel,
+    /func catchUpAfterWakeOrSessionActive[\s\S]*if isPopoverVisible \{[\s\S]*syncThenLoad\(\)[\s\S]*syncThenRefreshHidden\(menuBarSummaries: summaries\)[\s\S]*else if isPopoverVisible \{[\s\S]*loadAll\(\)[\s\S]*refreshHiddenData\(menuBarSummaries: summaries\)/,
+    "Hidden wake catch-up must use the same lightweight path as the timer.",
+  );
+  assert.match(
+    viewModel,
+    /private func refreshHiddenDataContents[\s\S]*checkServerHealth\(\)[\s\S]*guard serverOnline[\s\S]*WidgetSnapshotWriter\.hasConfiguredWidgets\(\)[\s\S]*await loadAll\(\)[\s\S]*loadMenuBarSummaries\(summaries, checkHealth: false\)[\s\S]*refreshUsageLimits\(\)/,
+    "Hidden refresh must preserve full freshness for configured widgets, then use summaries and limits for everyone else.",
+  );
+  assert.match(
+    viewModel,
+    /if hiddenRefreshInFlight \{[\s\S]*pendingFullRefreshAfterHiddenRefresh = true/,
+    "Opening the popover during hidden work must queue one full refresh.",
+  );
+  assert.match(
+    viewModel,
+    /private func finishHiddenRefresh\(\)[\s\S]*guard pendingFullRefreshAfterHiddenRefresh[\s\S]*await loadAll\(\)/,
+    "The queued full refresh must run when hidden work completes.",
+  );
+  const widgetWriter = read("TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift");
+  assert.match(
+    widgetWriter,
+    /func hasConfiguredWidgets\(\) async -> Bool[\s\S]*getCurrentConfigurations[\s\S]*!configurations\.isEmpty[\s\S]*resume\(returning: true\)/,
+    "Widget discovery should avoid full hidden loads when unused and fail toward freshness on query errors.",
+  );
 });

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -149,7 +149,17 @@ test("menu-bar popover is anchored to an app-owned positioning window", () => {
   );
   assert.match(
     viewModel,
-    /private\s+func\s+runQueuedReloadIfNeeded\(\)\s+async[\s\S]*shouldReloadAfterCurrentLoad\s*=\s*false[\s\S]*await\s+loadAll\(\)/,
+    /private\s+func\s+finishDataLoad\(\)\s+async[\s\S]*shouldReloadAfterCurrentLoad\s*=\s*false[\s\S]*await\s+loadAll\(\)/,
     "A queued reload should run after the current load finishes so sync-now can refresh stale data.",
+  );
+  assert.match(
+    viewModel,
+    /needsFullRefreshOnPopoverOpen\s*=\s*true[\s\S]*guard\s+!summaries\.isEmpty/,
+    "Hidden publication refreshes must mark charts and detail data dirty even when no token summary is selected.",
+  );
+  assert.match(
+    viewModel,
+    /else if needsFullRefreshOnPopoverOpen \|\| BackgroundRefreshPolicy\.shouldRunPopoverOpenLoad/,
+    "Opening the popover must reload dirty full-dashboard data even inside the normal 30-second debounce.",
   );
 });

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -149,7 +149,7 @@ test("menu-bar popover is anchored to an app-owned positioning window", () => {
   );
   assert.match(
     viewModel,
-    /private\s+func\s+finishDataLoad\(\)\s+async[\s\S]*shouldReloadAfterCurrentLoad\s*=\s*false[\s\S]*await\s+loadAll\(\)/,
+    /private\s+func\s+finishDataLoad\([^)]*\)\s+async[\s\S]*shouldReloadAfterCurrentLoad\s*=\s*false[\s\S]*await\s+loadAll\(\)/,
     "A queued reload should run after the current load finishes so sync-now can refresh stale data.",
   );
   assert.match(

--- a/test/macos-sync-now-drain.test.js
+++ b/test/macos-sync-now-drain.test.js
@@ -21,8 +21,8 @@ test("macOS manual Sync now requests drain while launch sync stays lightweight",
   );
   assert.match(
     apiClient,
-    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*Data\(#"\{"auto":true,"background":true\}"#\.utf8\)/,
-    "APIClient should send drain=true for manual sync and auto+background=true for background sync",
+    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*Data\([\s\S]*#"\{"auto":true,"background":true,"allLocalSources":true,"publishAccount":true\}"#\.utf8/,
+    "APIClient should send drain=true for manual sync and publish all local sources for background sync",
   );
   assert.match(
     viewModel,

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -760,6 +760,7 @@ test("index: getModelPricing returns ZERO for empty/null model", () => {
 
 test("index: ensurePricingLoaded is idempotent (concurrent callers share one fetch)", async () => {
   pricing.resetPricingForTests();
+  const revisionBeforeLoad = pricing.getPricingRevision();
   const cachePath = tmpCachePath();
   let fetchCalls = 0;
   const fetchImpl = async () => {
@@ -775,6 +776,9 @@ test("index: ensurePricingLoaded is idempotent (concurrent callers share one fet
   assert.equal(a.loaded, true);
   assert.equal(b.loaded, true);
   assert.equal(c.loaded, true);
+  assert.equal(pricing.getPricingRevision(), revisionBeforeLoad + 1);
+  await pricing.ensurePricingLoaded({ cachePath, fetchImpl });
+  assert.equal(pricing.getPricingRevision(), revisionBeforeLoad + 1);
 });
 
 test("WorkBuddy: hy3-preview-agent has real Hunyuan token pricing (not $0)", () => {

--- a/test/serve-native-background-sync.test.js
+++ b/test/serve-native-background-sync.test.js
@@ -13,7 +13,7 @@ test("native serve schedules a lightweight all-source fallback sync", async () =
   const timer = { unrefCalled: false, unref() { this.unrefCalled = true; } };
   const runSync = test.mock.fn(async () => {});
   const controller = startNativeBackgroundSync({
-    appShell: "macos",
+    appShell: "windows",
     runSync,
     setIntervalFn(callback, delay) {
       intervalCallback = callback;
@@ -63,9 +63,9 @@ test("native background sync coalesces overlapping ticks", async () => {
   controller.stop();
 });
 
-test("non-native serve does not start the fallback timer", () => {
+test("macOS and non-native serve do not start a duplicate fallback timer", () => {
   const setIntervalFn = test.mock.fn();
-  const controller = startNativeBackgroundSync({ appShell: "", setIntervalFn });
-  assert.equal(controller, null);
+  assert.equal(startNativeBackgroundSync({ appShell: "macos", setIntervalFn }), null);
+  assert.equal(startNativeBackgroundSync({ appShell: "", setIntervalFn }), null);
   assert.equal(setIntervalFn.mock.callCount(), 0);
 });

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const { test } = require("node:test");
 
 const { cmdSync } = require("../src/commands/sync");
+const { openLock } = require("../src/lib/fs");
 
 function tokenCountLine({ ts, totalTokens }) {
   const usage = {
@@ -157,6 +158,43 @@ test("background auto sync skips deep Codex archives", async () => {
   });
 });
 
+test("Codex notify sync catches up after an overlapping background sync releases the lock", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-1009-7000-8000-aaaaaaaaaaaa",
+      73,
+    );
+
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const active = await openLock(path.join(trackerDir, "sync.lock"), {
+      quietIfLocked: true,
+    });
+    assert.ok(active);
+
+    const notificationSync = cmdSync(
+      ["--auto", "--from-notify", "--source=codex"],
+      { lockWaitOptions: { notifyWaitMs: 500, notifyPollMs: 10 } },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await active.release();
+    await notificationSync;
+
+    const queue = await readQueue(home);
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":73/);
+  });
+});
+
+test("Codex notify sync accepts an explicit null context", async () => {
+  await withTempSyncEnv(async () => {
+    await cmdSync(["--auto", "--from-notify", "--source=codex"], null);
+  });
+});
+
 test("background auto sync still includes Every Code sessions", async () => {
   await withTempSyncEnv(async (home) => {
     const codeHome = process.env.CODE_HOME;
@@ -283,6 +321,147 @@ test("background auto sync does not upload with cloud credentials", async () => 
 
     assert.equal(fetchCalls, 0);
     assert.equal(await fs.stat(path.join(home, ".tokentracker", "tracker", "queue.state.json")).catch(() => null), null);
+  });
+});
+
+test("explicit account publication uploads after bounded background parsing", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(codexHome, "2026-06-30", "019f16bd-1007-7000-8000-aaaaaaaaaaaa", 64);
+    process.env.TOKENTRACKER_DEVICE_TOKEN = "test-device-token";
+    process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+    const originalFetch = global.fetch;
+    let ingestCalls = 0;
+    global.fetch = async (url) => {
+      if (String(url).endsWith("/functions/tokentracker-ingest")) {
+        ingestCalls += 1;
+        return {
+          ok: true,
+          status: 200,
+          headers: { get() { return null; } },
+          text: async () => JSON.stringify({ inserted: 1, skipped: 0 }),
+        };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    };
+
+    try {
+      await cmdSync(["--auto", "--background", "--publish-account"]);
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(ingestCalls, 1);
+    const queueState = JSON.parse(
+      await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.state.json"), "utf8"),
+    );
+    assert.ok(queueState.offset > 0);
+  });
+});
+
+test("background account publication respects persisted upload failure backoff", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(codexHome, "2026-06-30", "019f16bd-1008-7000-8000-aaaaaaaaaaaa", 65);
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(trackerDir, "upload.throttle.json"),
+      JSON.stringify({
+        version: 1,
+        nextAllowedAtMs: Date.now() + 60_000,
+        backoffUntilMs: Date.now() + 60_000,
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(trackerDir, "auto.retry.json"),
+      JSON.stringify({ version: 1, retryAtMs: Date.now() + 60_000 }),
+      "utf8",
+    );
+    process.env.TOKENTRACKER_DEVICE_TOKEN = "test-device-token";
+    process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+    const originalFetch = global.fetch;
+    let ingestCalls = 0;
+    global.fetch = async (url) => {
+      if (String(url).endsWith("/functions/tokentracker-ingest")) ingestCalls += 1;
+      throw new Error(`unexpected fetch ${url}`);
+    };
+
+    try {
+      await cmdSync(["--auto", "--background", "--publish-account"]);
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(ingestCalls, 0);
+    assert.equal(
+      await fs.stat(path.join(trackerDir, "queue.state.json")).catch(() => null),
+      null,
+    );
+    assert.equal(
+      await fs.stat(path.join(trackerDir, "auto.retry.json")).catch(() => null),
+      null,
+    );
+  });
+});
+
+test("bounded native publication leaves backlog for the next native tick without spawning full retry", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    const queuePath = path.join(trackerDir, "queue.jsonl");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(trackerDir, "auto.retry.json"),
+      JSON.stringify({ version: 1, retryAtMs: Date.now() + 60_000 }),
+      "utf8",
+    );
+    const rows = Array.from({ length: 1_001 }, (_, index) => ({
+      source: "codex",
+      model: `benchmark-model-${index}`,
+      hour_start: "2026-06-30T00:00:00.000Z",
+      input_tokens: 1,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: 1,
+      billable_total_tokens: 1,
+      conversation_count: 1,
+    }));
+    await fs.writeFile(queuePath, `${rows.map(JSON.stringify).join("\n")}\n`, "utf8");
+    process.env.TOKENTRACKER_DEVICE_TOKEN = "test-device-token";
+    process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+    const originalFetch = global.fetch;
+    let ingestCalls = 0;
+    global.fetch = async (url) => {
+      if (String(url).endsWith("/functions/tokentracker-ingest")) {
+        ingestCalls += 1;
+        return {
+          ok: true,
+          status: 200,
+          headers: { get() { return null; } },
+          text: async () => JSON.stringify({ inserted: 200, skipped: 0 }),
+        };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    };
+
+    try {
+      await cmdSync(["--auto", "--background", "--publish-account"]);
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    const queueState = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "queue.state.json"), "utf8"),
+    );
+    assert.equal(ingestCalls, 5);
+    assert.ok(queueState.offset < (await fs.stat(queuePath)).size);
+    assert.equal(
+      await fs.stat(path.join(trackerDir, "auto.retry.json")).catch(() => null),
+      null,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Keep macOS usage totals fresh without leaving the embedded server in continuous scan and aggregation work. This addresses a real 0.81.0 reproduction where a Codex notify collided with an active sync, the cursor advanced only about five minutes later, and the idle embedded server reached 673,648 KB RSS with no sync child.

## What was happening

- macOS ran both the native five-minute refresh loop and the embedded server's one-minute all-provider fallback. The overlapping owners kept `sync.lock` busy and could drop a latency-sensitive Codex notify.
- Every local usage endpoint reread, parsed, deduplicated, and aggregated the full append-only `queue.jsonl`. One native refresh fans out across multiple endpoints, multiplying the same work and memory.
- A local queue write and a completed cloud upload are different publication boundaries. Refreshing account totals at the local-write boundary could repopulate the 30-second account cache with the old aggregate.
- Legacy empty locks relied only on age. New owners needed an explicit identity so dead locks could be reclaimed immediately without allowing an obsolete owner to remove a replacement lock.

## Approach

- Let the macOS native app own the five-minute fallback and wake/session catch-up path. The embedded one-minute loop remains unchanged on Windows.
- Watch `queue.jsonl` and `queue.state.json` with filesystem events, including atomic replacement and initially missing files.
  - Local queue bursts settle for one second before refreshing.
  - Completed account uploads settle past the account cache window before refreshing.
- While the popover is hidden, refresh only selected menu-bar summaries, health, and limits. If TokenTracker widgets are actually configured, preserve the previous complete five-minute snapshot refresh.
- Publish account data only when the persisted cloud-sync preference allows it. Keep batches bounded, honor upload failure backoff, and leave remaining backlog for the next native tick.
- Cache the deduplicated queue by file identity/size/nanosecond timestamps, cache daily aggregation by timezone and pricing revision, and bound timezone formatter entries.
- Store PID plus a unique token in sync locks.
  - Reclaim dead-process locks immediately.
  - Keep live long-running owners regardless of lock age.
  - Prevent an old owner from deleting a replacement lock.
  - Coalesce overlapping Codex notifies behind one low-frequency, bounded waiter.

## Freshness and work bounds

| Path | Behavior |
|---|---|
| Provider notify | Source-scoped fast path; one waiter can catch up after an active sync |
| Local queue publication | Event-driven, one-second burst coalescing |
| Account publication | Triggered by queue offset advancement, then waits through cache visibility |
| Timer fallback | Five minutes, owned by the native macOS app |
| Wake / unlock | Debounced catch-up when the last sync is stale |
| Hidden app, no widgets | Visible menu summaries + health + limits only |
| Configured widgets or visible popover | Complete refresh preserved |

## Benchmark

Fixed snapshot: 12,219 deduplicated rows / 3,584,192 bytes. Three alternating base/current rounds were run against the same queue.

| Median | Base | This PR | Change |
|---|---:|---:|---:|
| First summary | 1208.23 ms | 656.49 ms | -45.7% |
| Warm summary | 2606.56 ms | 1.013 ms | -99.96% |
| Seven local endpoints | 9135.55 ms | 271.49 ms | -97.0% |
| RSS delta | 526.81 MiB | 37.53 MiB | -92.9% |
| Max RSS delta | 538.69 MiB | 40.63 MiB | -92.5% |

All seven endpoint response hashes and byte lengths matched in every round.

## Verification

- `npm run ci:local`: 1,620/1,620 Node tests; copy, UI-hardcode, and architecture guardrails passed; dashboard production build passed.
- Focused lock/background/cache suite: 34/34.
- `TokenTrackerBarTests`: 98/98.
- Clean Universal Release app build passed.
- Native app and embedded Node both verified as `arm64 + x86_64`.
- Release app's embedded `src`, `bin/tracker.js`, `package.json`, and `dashboard/dist` match the branch build inputs.
- Isolated HTTP smoke passed.
- A 69-second Release embedded-server smoke produced no macOS `tracker.js sync` child; idle CPU was approximately 0% and RSS stayed about 29-48 MiB.

## Known follow-up

A real isolated Codex notify sync still peaked around 608-611 MiB and took 1.77-2.78 seconds because `cursors.json` is about 66 MiB (notably `codexHashes` and per-file cursor state). A correctness-preserving storage migration needs cross-version and recovery design, so it is intentionally kept out of this PR.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (none added)
- [x] Commits follow conventional style
- [x] PR description explains why, not just what

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- A native background request cannot upload when cloud sync is disabled.
- Background publication remains bounded and respects persisted failure backoff.
- A queue write cannot make account data authoritative before upload completion and cache visibility.
- One live sync owner remains exclusive even when it runs longer than five minutes.
- Windows keeps its existing embedded fallback behavior.

### Boundary matrix

| Boundary | Expected behavior |
|---|---|
| Cloud sync disabled | Local parse only; no account publication |
| Signed out / no refresh token | Local summaries remain authoritative |
| Notify during active sync | At most one bounded waiter, then source-scoped catch-up |
| Hidden app without widgets | No complete dashboard fan-out |
| Configured widget | Complete snapshot freshness preserved |
| Windows shell | Existing one-minute embedded fallback remains |

</details>

<details>
<summary><strong>Codex review context</strong></summary>

- **Delta since last Codex review:** initial review request for this branch.
- **Intended behavior / invariants:** freshness is event-driven where possible; periodic work is bounded; publication authority follows the source currently displayed.
- **Edge cases covered:** dead/live/legacy/replaced locks, notify collision and timeout, explicit null sync context, missing and atomically replaced queue files, pricing cache revision, cloud preference off, upload backoff, bounded backlog, popover opening during hidden work, configured widgets.
- **Tests run:** listed in Verification above.
- **Known gaps / out of scope:** cursor-state storage migration and its per-sync memory peak.

### Most likely regression surface

macOS event ordering between native sync, queue publication, account-cache visibility, popover visibility, and WidgetKit configuration discovery.

### Verification method

Behavioral unit tests, source-boundary regression tests, fixed-snapshot output hashes, repeated performance rounds, isolated runtime smoke, and clean Universal Release packaging.

### Uncovered scope

Long-duration production monitoring of the new build and cursor storage migration.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publish-account support for background sync (including local sync behavior) and richer usage-summary source tracking.
  * Improved menu-bar summary updates with selection-aware today/rolling/total refreshes.
  * Enhanced status bar responsiveness with delayed “settled” refresh for queue and account uploads.
  * Added a widget-configuration check to avoid unnecessary snapshot work.

* **Bug Fixes**
  * Strengthened sync locking with token/heartbeat leases and notify-based coalescing.
  * Improved wake/sleep and queue file change handling with more reliable refresh timing.

* **Performance**
  * Improved local API caching for queue aggregation using timezone and pricing revision invalidation.

* **Tests**
  * Expanded coverage for publication policies, queue monitoring, caching, locking, and background sync flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->