### PR TITLE
perf(codex): shard large cursor state for incremental sync

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -5,6 +5,7 @@ const fssync = require("node:fs");
 const pkg = require("../../package.json");
 
 const { readJson } = require("../lib/fs");
+const { readCursorStateSummary } = require("../lib/cursor-store");
 const { readCodexNotify, readEveryCodeNotify } = require("../lib/codex-config");
 const {
   isClaudeHookConfigured,
@@ -134,7 +135,7 @@ async function cmdStatus(argv = []) {
   const geminiHookCommand = buildGeminiHookCommand(notifyPath);
 
   const config = await readJson(configPath);
-  const cursors = await readJson(cursorsPath);
+  const { cursors } = await readCursorStateSummary({ trackerDir, cursorsPath });
   const queueState = (await readJson(queueStatePath)) || { offset: 0 };
   const uploadThrottle = normalizeUploadState(
     await readJson(uploadThrottlePath),

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -106,6 +106,10 @@ const {
   parseCursorCsv,
 } = require("../lib/cursor-config");
 const { purgeProjectUsage } = require("../lib/project-usage-purge");
+const {
+  isCodexSessionCursorPath,
+  openCursorStore,
+} = require("../lib/cursor-store");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const { resolveRuntimeConfig } = require("../lib/runtime-config");
 
@@ -288,6 +292,9 @@ function mergeCopilotAppDbStates(primary = {}, alias = {}) {
 async function cmdSync(argv, context = {}) {
   const opts = parseArgs(argv);
   const diagnostics = context && typeof context === "object" ? context.diagnostics : null;
+  const cursorStoreOptions = context && typeof context === "object"
+    ? context.cursorStoreOptions
+    : null;
   const syncDiagnostics = diagnostics && typeof diagnostics === "object" ? diagnostics : null;
   const home = os.homedir();
   const { trackerDir } = await resolveTrackerPaths({ home });
@@ -315,7 +322,16 @@ async function cmdSync(argv, context = {}) {
     const legacyGrokSignalPath = path.join(trackerDir, "tracker", "grok-last-session.json");
 
     const config = await readJson(configPath);
-    const cursors = (await readJson(cursorsPath)) || { version: 1, files: {}, updatedAt: null };
+    const codexCursorRoots = [process.env.CODEX_HOME || path.join(home, ".codex")];
+    const cursorStore = await openCursorStore({
+      trackerDir,
+      cursorsPath,
+      codexRoots: codexCursorRoots,
+      ...(cursorStoreOptions && typeof cursorStoreOptions === "object"
+        ? cursorStoreOptions
+        : {}),
+    });
+    const cursors = cursorStore.cursors;
     const uploadThrottle = normalizeUploadState(await readJson(uploadThrottlePath));
     let uploadThrottleState = uploadThrottle;
     let grokHookSignal = null;
@@ -418,6 +434,7 @@ async function cmdSync(argv, context = {}) {
     }
 
     if (isFullSourceScan) {
+      await cursorStore.materializeAllCodexState(cursors);
       await migrateRolloutCumulativeDeltaBuckets({ cursors, queuePath, rolloutFiles });
       const codexRescanRepairRan = await repairCodexRescanInflation({
         cursors,
@@ -446,7 +463,7 @@ async function cmdSync(argv, context = {}) {
       });
     }
 
-    const codexColdSkipEnabled = opts.auto && (isFullSourceScan || isBackgroundLightweightSync) && sourceAllowed("codex");
+    const codexColdSkipEnabled = opts.auto && sourceAllowed("codex");
     const codexColdAuditDue = codexColdSkipEnabled
       ? isCodexColdScanAuditDue(cursors)
       : false;
@@ -454,12 +471,16 @@ async function cmdSync(argv, context = {}) {
       ? await filterColdCodexRolloutFiles({
           rolloutFiles,
           cursors,
+          codexCursorStore: cursorStore,
           projectEnabled: true,
           auditDue: codexColdAuditDue,
           diagnostics: syncDiagnostics,
         })
       : { rolloutFiles, skipped: 0 };
     const rolloutFilesForParse = codexColdFilter.rolloutFiles;
+    if (!codexColdSkipEnabled && sourceAllowed("codex")) {
+      await cursorStore.loadCodexFilesForPaths(rolloutFilesForParse, cursors);
+    }
 
     const openclawFiles = openclawSignal?.sessionFile
       ? [{ path: openclawSignal.sessionFile, source: "openclaw" }]
@@ -477,6 +498,9 @@ async function cmdSync(argv, context = {}) {
       parseResult = await parseRolloutIncremental({
         rolloutFiles: rolloutFilesForParse,
         cursors,
+        codexEventStore: Array.isArray(cursors.codexHashes)
+          ? null
+          : cursorStore.codexEventStore,
         queuePath,
         projectQueuePath,
         diagnostics: syncDiagnostics,
@@ -1851,12 +1875,12 @@ async function cmdSync(argv, context = {}) {
     }
 
     cursors.updatedAt = new Date().toISOString();
-    await writeJson(cursorsPath, cursors);
+    await cursorStore.commit(cursors);
     if (syncDiagnostics) {
-      const cursorStat = await fs.stat(cursorsPath);
+      const cursorStat = await fs.stat(cursorStore.currentCorePath);
       syncDiagnostics.cursor_commits = Number(syncDiagnostics.cursor_commits || 0) + 1;
       syncDiagnostics.cursor_bytes = Number(syncDiagnostics.cursor_bytes || 0) + cursorStat.size;
-      syncDiagnostics.cursor_path = cursorsPath;
+      syncDiagnostics.cursor_path = cursorStore.currentCorePath;
     }
     if (grokHookSignalConsumed && grokHookSignalPath) {
       await fs.unlink(grokHookSignalPath).catch(() => {});
@@ -3653,12 +3677,6 @@ async function scanForForkedCodexRollout(rolloutFiles) {
     }
   }
   return { forked: false, indeterminate };
-}
-
-function isCodexSessionCursorPath(filePath) {
-  if (typeof filePath !== "string") return false;
-  const normalized = filePath.replace(/\\/g, "/");
-  return /\/\.codex\/(?:archived_)?sessions\//.test(normalized);
 }
 
 async function projectUsageKeysFromQueuePath(queuePath, source) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -108,6 +108,7 @@ const {
 const { purgeProjectUsage } = require("../lib/project-usage-purge");
 const {
   isCodexSessionCursorPath,
+  isCursorStoreRetry,
   openCursorStore,
 } = require("../lib/cursor-store");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
@@ -467,7 +468,7 @@ async function cmdSync(argv, context = {}) {
     const codexColdAuditDue = codexColdSkipEnabled
       ? isCodexColdScanAuditDue(cursors)
       : false;
-    const codexColdFilter = codexColdSkipEnabled
+    let codexColdFilter = codexColdSkipEnabled
       ? await filterColdCodexRolloutFiles({
           rolloutFiles,
           cursors,
@@ -478,8 +479,13 @@ async function cmdSync(argv, context = {}) {
         })
       : { rolloutFiles, skipped: 0 };
     const rolloutFilesForParse = codexColdFilter.rolloutFiles;
+    let codexCursorLoadRestarted = false;
     if (!codexColdSkipEnabled && sourceAllowed("codex")) {
-      await cursorStore.loadCodexFilesForPaths(rolloutFilesForParse, cursors);
+      const loadResult = await cursorStore.loadCodexFilesForPaths(
+        rolloutFilesForParse,
+        cursors,
+      );
+      codexCursorLoadRestarted = Boolean(loadResult?.restarted);
     }
 
     const openclawFiles = openclawSignal?.sessionFile
@@ -494,33 +500,58 @@ async function cmdSync(argv, context = {}) {
 
     let parseResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     let codexParseSucceeded = false;
+    let codexFallbackRetryRan = Boolean(
+      codexColdFilter.restarted || codexCursorLoadRestarted,
+    );
+    const runCodexParse = (files) => parseRolloutIncremental({
+      rolloutFiles: files,
+      cursors,
+      codexEventStore: Array.isArray(cursors.codexHashes)
+        ? null
+        : cursorStore.codexEventStore,
+      queuePath,
+      projectQueuePath,
+      diagnostics: syncDiagnostics,
+      onProgress: (p) => {
+        if (!progress?.enabled) return;
+        const pct = p.total > 0 ? p.index / p.total : 1;
+        progress.update(
+          `Parsing ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} files | buckets ${formatNumber(
+            p.bucketsQueued,
+          )}`,
+        );
+      },
+    });
     try {
-      parseResult = await parseRolloutIncremental({
-        rolloutFiles: rolloutFilesForParse,
-        cursors,
-        codexEventStore: Array.isArray(cursors.codexHashes)
-          ? null
-          : cursorStore.codexEventStore,
-        queuePath,
-        projectQueuePath,
-        diagnostics: syncDiagnostics,
-        onProgress: (p) => {
-          if (!progress?.enabled) return;
-          const pct = p.total > 0 ? p.index / p.total : 1;
-          progress.update(
-            `Parsing ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} files | buckets ${formatNumber(
-              p.bucketsQueued,
-            )}`,
-          );
-        },
-      });
+      parseResult = await runCodexParse(rolloutFilesForParse);
       codexParseSucceeded = true;
     } catch (err) {
-      warnProviderParseFailure("Codex", err, opts);
+      if (isCursorStoreRetry(err)) {
+        await cursorStore.loadCodexFilesForPaths(rolloutFiles, cursors);
+        codexColdFilter = { rolloutFiles, skipped: 0, restarted: true };
+        codexFallbackRetryRan = true;
+        if (syncDiagnostics) {
+          syncDiagnostics.cold_skipped = 0;
+          syncDiagnostics.parse_candidates = rolloutFiles.reduce(
+            (count, entry) => count + (
+              typeof entry === "string" || !entry?.source || entry.source === "codex"
+                ? 1
+                : 0
+            ),
+            0,
+          );
+        }
+        parseResult = await runCodexParse(rolloutFiles);
+        codexParseSucceeded = true;
+      } else if (err?.code === "TOKENTRACKER_CURSOR_STORE_CORRUPT") {
+        throw err;
+      } else {
+        warnProviderParseFailure("Codex", err, opts);
+      }
     }
     if (codexColdSkipEnabled && codexParseSucceeded) {
       recordCodexColdScanAudit(cursors, {
-        fullAudit: codexColdAuditDue,
+        fullAudit: codexColdAuditDue || codexFallbackRetryRan,
         skipped: codexColdFilter.skipped,
       });
     }

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -485,7 +485,7 @@ class V2CursorStore {
         counts: { nonCodexFiles: 0, codexFiles: 0, totalFiles: 0, codexEvents: 0 },
       };
 
-      await linkGenerationFiles({
+      await cloneGenerationFiles({
         fromDirectory: this.generationDir,
         toDirectory: generationDir,
         metadata: nextMetadata,
@@ -575,12 +575,11 @@ class V2CursorStore {
 
       await maybeInjectFailure(this.failureInjector, "beforeManifestSwap");
 
-      const legacyFingerprint = await fingerprintFile(this.cursorsPath);
       const nextManifest = {
         version: STORE_VERSION,
         current: generationId,
         previous: this.generation?.id || null,
-        legacyFingerprint: legacyFingerprint || this.manifest?.legacyFingerprint || null,
+        legacyFingerprint: this.manifest?.legacyFingerprint || null,
         updatedAt: new Date().toISOString(),
       };
       await writeJson(path.join(this.storeRoot, MANIFEST_FILENAME), nextManifest);
@@ -915,24 +914,20 @@ function sameGenerationCounts(left, right) {
     .every((key) => Number(left?.[key]) === Number(right?.[key]));
 }
 
-async function linkGenerationFiles({ fromDirectory, toDirectory, metadata }) {
+async function cloneGenerationFiles({ fromDirectory, toDirectory, metadata }) {
   for (const entry of Object.values(metadata.codexFiles || {})) {
-    if (entry?.file) await linkOrCopy(fromDirectory, toDirectory, entry.file);
+    if (entry?.file) await cloneOrCopy(fromDirectory, toDirectory, entry.file);
   }
   for (const entry of Object.values(metadata.codexEvents || {})) {
-    if (entry?.file) await linkOrCopy(fromDirectory, toDirectory, entry.file);
+    if (entry?.file) await cloneOrCopy(fromDirectory, toDirectory, entry.file);
   }
 }
 
-async function linkOrCopy(fromDirectory, toDirectory, relativeFile) {
+async function cloneOrCopy(fromDirectory, toDirectory, relativeFile) {
   const source = path.join(fromDirectory, relativeFile);
   const target = path.join(toDirectory, relativeFile);
   await ensureDir(path.dirname(target));
-  try {
-    await fs.link(source, target);
-  } catch (_e) {
-    await fs.copyFile(source, target);
-  }
+  await fs.copyFile(source, target, fssync.constants.COPYFILE_FICLONE);
 }
 
 async function rebuildEventShards({ generationDir, metadata, hashes }) {

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -190,6 +190,7 @@ class V2CursorStore {
     storeRoot,
     manifest,
     generation,
+    fallbackGenerationId,
     codexRoots,
     failureInjector,
   }) {
@@ -199,6 +200,7 @@ class V2CursorStore {
     this.manifest = manifest;
     this.generation = generation.metadata;
     this.generationDir = generation.directory;
+    this.fallbackGenerationId = fallbackGenerationId;
     this.codexRoots = codexRoots;
     this.cursors = generation.core;
     this.failureInjector = failureInjector;
@@ -250,6 +252,20 @@ class V2CursorStore {
   }
 
   async loadFileShard(shardKey, cursors = this.cursors) {
+    try {
+      return await this.loadFileShardUnchecked(shardKey, cursors);
+    } catch (error) {
+      if (
+        error?.code !== "TOKENTRACKER_CURSOR_STORE_CORRUPT" ||
+        !this.activateFallbackGeneration(cursors)
+      ) {
+        throw error;
+      }
+      return this.loadFileShardUnchecked(shardKey, cursors);
+    }
+  }
+
+  async loadFileShardUnchecked(shardKey, cursors = this.cursors) {
     if (this.loadedFileShards.has(shardKey)) {
       mergeFileShardIntoCursors(this.loadedFileShards.get(shardKey).data, cursors);
       return this.loadedFileShards.get(shardKey).data;
@@ -260,19 +276,32 @@ class V2CursorStore {
       : null;
     let data = {};
     if (filePath) {
-      const result = await readJsonStrict(filePath);
-      if (result.status !== "ok") {
+      let raw;
+      try {
+        raw = await fs.readFile(filePath, "utf8");
+      } catch (error) {
         throw cursorStoreCorruption(
           `Unable to read Codex cursor shard ${metadata.file}`,
-          result.error,
+          error,
         );
       }
-      data = result.value;
+      assertShardIntegrity(raw, metadata, `Codex cursor shard ${metadata.file}`);
+      try {
+        data = JSON.parse(raw);
+      } catch (error) {
+        throw cursorStoreCorruption(
+          `Invalid Codex cursor shard ${metadata.file}`,
+          error,
+        );
+      }
     }
     const normalized = data && typeof data === "object" && !Array.isArray(data)
       ? data
       : {};
-    if (filePath && normalized !== data) {
+    if (
+      filePath &&
+      (normalized !== data || Object.keys(normalized).length !== metadata.count)
+    ) {
       throw cursorStoreCorruption(`Invalid Codex cursor shard ${metadata.file}`);
     }
     this.loadedFileShards.set(shardKey, {
@@ -350,6 +379,20 @@ class V2CursorStore {
   }
 
   loadEventSet(shardKey) {
+    try {
+      return this.loadEventSetUnchecked(shardKey);
+    } catch (error) {
+      if (
+        error?.code !== "TOKENTRACKER_CURSOR_STORE_CORRUPT" ||
+        !this.activateFallbackGeneration()
+      ) {
+        throw error;
+      }
+      return this.loadEventSetUnchecked(shardKey);
+    }
+  }
+
+  loadEventSetUnchecked(shardKey) {
     if (this.loadedEventSets.has(shardKey)) {
       return this.loadedEventSets.get(shardKey);
     }
@@ -367,10 +410,44 @@ class V2CursorStore {
           e,
         );
       }
+      assertShardIntegrity(raw, metadata, `Codex event shard ${metadata.file}`);
     }
-    const values = new Set(raw.split("\n").filter(Boolean));
+    const rows = raw.split("\n").filter(Boolean);
+    const values = new Set(rows);
+    if (
+      filePath &&
+      (rows.length !== metadata.count || values.size !== metadata.count)
+    ) {
+      throw cursorStoreCorruption(`Invalid Codex event shard ${metadata.file}`);
+    }
     this.loadedEventSets.set(shardKey, values);
     return values;
+  }
+
+  activateFallbackGeneration(cursors = this.cursors) {
+    const generationId = this.fallbackGenerationId;
+    this.fallbackGenerationId = null;
+    if (!generationId) return false;
+
+    const fallback = readGenerationSync({
+      storeRoot: this.storeRoot,
+      generationId,
+    });
+    if (!fallback) return false;
+
+    const fallbackCore = cloneJson(fallback.core);
+    replaceObjectContents(this.cursors, fallbackCore);
+    if (cursors !== this.cursors) {
+      replaceObjectContents(cursors, cloneJson(fallback.core));
+    }
+    this.generation = fallback.metadata;
+    this.generationDir = fallback.directory;
+    this.loadedFileShards.clear();
+    this.loadedEventSets.clear();
+    this.pendingEventKeys.clear();
+    this.skipValidationCache.clear();
+    this.materializedCodexHashes = false;
+    return true;
   }
 
   async commit(cursors = this.cursors) {
@@ -424,11 +501,13 @@ class V2CursorStore {
         delete nextMetadata.codexFiles[shardKey];
         continue;
       }
-      await fs.writeFile(targetPath, `${JSON.stringify(data)}\n`, "utf8");
+      const serialized = `${JSON.stringify(data)}\n`;
+      await fs.writeFile(targetPath, serialized, "utf8");
       nextMetadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
         shardKey,
         data,
         relativeFile,
+        serialized,
         dayInventoryCache: cursors.codexDayInventoryCache,
       });
     }
@@ -447,11 +526,13 @@ class V2CursorStore {
         const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
         const targetPath = path.join(generationDir, relativeFile);
         await fs.unlink(targetPath).catch(() => {});
-        await fs.writeFile(targetPath, serializeEventSet(existing), "utf8");
-        nextMetadata.codexEvents[shardKey] = {
-          file: relativeFile,
-          count: existing.size,
-        };
+        const serialized = serializeEventSet(existing);
+        await fs.writeFile(targetPath, serialized, "utf8");
+        nextMetadata.codexEvents[shardKey] = buildEventShardMetadata({
+          relativeFile,
+          values: existing,
+          serialized,
+        });
       }
     }
 
@@ -509,7 +590,7 @@ async function migrateLegacyCursorState({
   codexRoots,
   failureInjector,
 }) {
-  const cursors = (await readJson(cursorsPath)) || defaultCursorState();
+  const cursors = await readLegacyCursorStateForMigration(cursorsPath);
   const generationId = newGenerationId();
   const generationDir = generationDirectory(storeRoot, generationId);
   await ensureDir(path.join(generationDir, "codex-files"));
@@ -535,30 +616,34 @@ async function migrateLegacyCursorState({
 
   for (const [shardKey, data] of codexFilesByShard.entries()) {
     const relativeFile = path.join("codex-files", `${safeShardFilename(shardKey)}.json`);
+    const serialized = `${JSON.stringify(data)}\n`;
     await fs.writeFile(
       path.join(generationDir, relativeFile),
-      `${JSON.stringify(data)}\n`,
+      serialized,
       "utf8",
     );
     metadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
       shardKey,
       data,
       relativeFile,
+      serialized,
       dayInventoryCache: cursors.codexDayInventoryCache,
     });
   }
 
   for (const [shardKey, values] of eventShards.entries()) {
     const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+    const serialized = serializeEventSet(values);
     await fs.writeFile(
       path.join(generationDir, relativeFile),
-      serializeEventSet(values),
+      serialized,
       "utf8",
     );
-    metadata.codexEvents[shardKey] = {
-      file: relativeFile,
-      count: values.size,
-    };
+    metadata.codexEvents[shardKey] = buildEventShardMetadata({
+      relativeFile,
+      values,
+      serialized,
+    });
   }
 
   await fs.writeFile(
@@ -589,6 +674,27 @@ async function migrateLegacyCursorState({
   return manifest;
 }
 
+async function readLegacyCursorStateForMigration(cursorsPath) {
+  const result = await readJsonStrict(cursorsPath);
+  if (result.status === "missing") return defaultCursorState();
+  if (result.status !== "ok") {
+    throw cursorStoreCorruption(
+      `Unable to read legacy cursor state ${cursorsPath}`,
+      result.error,
+    );
+  }
+  if (!isCursorStateRoot(result.value)) {
+    throw cursorStoreCorruption(`Invalid legacy cursor state ${cursorsPath}`);
+  }
+  if (
+    result.value.codexHashes !== undefined &&
+    !Array.isArray(result.value.codexHashes)
+  ) {
+    throw cursorStoreCorruption(`Invalid legacy Codex event state ${cursorsPath}`);
+  }
+  return result.value;
+}
+
 async function openManifestGeneration({
   cursorsPath,
   storeRoot,
@@ -596,7 +702,11 @@ async function openManifestGeneration({
   codexRoots,
   failureInjector,
 }) {
-  for (const generationId of [manifest.current, manifest.previous]) {
+  const generationIds = Array.from(new Set([
+    manifest.current,
+    manifest.previous,
+  ].filter(Boolean)));
+  for (const generationId of generationIds) {
     const generation = await readGeneration({ storeRoot, generationId });
     if (!generation) continue;
     return new V2CursorStore({
@@ -604,6 +714,10 @@ async function openManifestGeneration({
       storeRoot,
       manifest,
       generation,
+      fallbackGenerationId:
+        generationId === manifest.current && manifest.previous !== generationId
+          ? manifest.previous
+          : null,
       codexRoots,
       failureInjector,
     });
@@ -619,20 +733,43 @@ async function readGeneration({ storeRoot, generationId }) {
     return null;
   }
   const core = await readJson(path.join(directory, metadata.coreFile));
-  if (
-    !core ||
-    typeof core !== "object" ||
-    Array.isArray(core) ||
-    !core.files ||
-    typeof core.files !== "object" ||
-    Array.isArray(core.files)
-  ) {
-    return null;
-  }
+  if (!isCursorStateRoot(core)) return null;
   if (!(await generationReferencesExist(directory, metadata))) return null;
   const counts = calculateGenerationCounts(metadata, core.files);
   if (!sameGenerationCounts(counts, metadata.counts)) return null;
   return { directory, metadata, core };
+}
+
+function readGenerationSync({ storeRoot, generationId }) {
+  if (typeof generationId !== "string" || generationId.length === 0) return null;
+  const directory = generationDirectory(storeRoot, generationId);
+  try {
+    const metadata = JSON.parse(
+      fssync.readFileSync(path.join(directory, "generation.json"), "utf8"),
+    );
+    if (!isGenerationMetadata(metadata, generationId)) return null;
+    const core = JSON.parse(
+      fssync.readFileSync(path.join(directory, metadata.coreFile), "utf8"),
+    );
+    if (!isCursorStateRoot(core)) return null;
+    if (!generationReferencesExistSync(directory, metadata)) return null;
+    const counts = calculateGenerationCounts(metadata, core.files);
+    if (!sameGenerationCounts(counts, metadata.counts)) return null;
+    return { directory, metadata, core };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function isCursorStateRoot(value) {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value.files &&
+    typeof value.files === "object" &&
+    !Array.isArray(value.files)
+  );
 }
 
 function isGenerationMetadata(metadata, generationId) {
@@ -667,11 +804,16 @@ function validShardMetadataMap(shards, expectedDirectory) {
   for (const entry of Object.values(shards)) {
     const reference = normalizeShardReference(entry?.file, expectedDirectory);
     const count = Number(entry?.count);
+    const bytes = Number(entry?.bytes);
     if (
       !reference ||
       files.has(reference.name) ||
       !Number.isSafeInteger(count) ||
-      count < 0
+      count < 0 ||
+      !Number.isSafeInteger(bytes) ||
+      bytes < 0 ||
+      typeof entry?.sha256 !== "string" ||
+      !/^[a-f0-9]{64}$/.test(entry.sha256)
     ) {
       return false;
     }
@@ -695,6 +837,29 @@ async function generationReferencesExist(directory, metadata) {
         withFileTypes: true,
       });
     } catch (_e) {
+      return false;
+    }
+    const files = new Map(entries.map((entry) => [entry.name, entry]));
+    if (expectedNames.some((name) => !files.get(name)?.isFile())) return false;
+  }
+  return true;
+}
+
+function generationReferencesExistSync(directory, metadata) {
+  for (const [expectedDirectory, shards] of [
+    ["codex-files", metadata.codexFiles],
+    ["codex-events", metadata.codexEvents],
+  ]) {
+    const expectedNames = Object.values(shards)
+      .map((entry) => normalizeShardReference(entry.file, expectedDirectory).name);
+    if (expectedNames.length === 0) continue;
+
+    let entries;
+    try {
+      entries = fssync.readdirSync(path.join(directory, expectedDirectory), {
+        withFileTypes: true,
+      });
+    } catch (_error) {
       return false;
     }
     const files = new Map(entries.map((entry) => [entry.name, entry]));
@@ -751,12 +916,17 @@ async function rebuildEventShards({ generationDir, metadata, hashes }) {
   metadata.codexEvents = {};
   for (const [shardKey, values] of partitionEventHashes(hashes).entries()) {
     const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+    const serialized = serializeEventSet(values);
     await fs.writeFile(
       path.join(generationDir, relativeFile),
-      serializeEventSet(values),
+      serialized,
       "utf8",
     );
-    metadata.codexEvents[shardKey] = { file: relativeFile, count: values.size };
+    metadata.codexEvents[shardKey] = buildEventShardMetadata({
+      relativeFile,
+      values,
+      serialized,
+    });
   }
 }
 
@@ -764,6 +934,7 @@ function buildCodexFileShardMetadata({
   shardKey,
   data,
   relativeFile,
+  serialized,
   dayInventoryCache,
 }) {
   const directories = {};
@@ -823,12 +994,38 @@ function buildCodexFileShardMetadata({
     file: relativeFile,
     shardKey,
     count: Object.keys(data || {}).length,
+    ...buildShardIntegrity(serialized),
     directories,
     projectSummary: {
       configs: Array.from(configs.values()),
       absentFreshUntil,
     },
   };
+}
+
+function buildEventShardMetadata({ relativeFile, values, serialized }) {
+  return {
+    file: relativeFile,
+    count: values.size,
+    ...buildShardIntegrity(serialized),
+  };
+}
+
+function buildShardIntegrity(serialized) {
+  return {
+    bytes: Buffer.byteLength(serialized),
+    sha256: crypto.createHash("sha256").update(serialized).digest("hex"),
+  };
+}
+
+function assertShardIntegrity(raw, metadata, label) {
+  const integrity = buildShardIntegrity(raw);
+  if (
+    integrity.bytes !== metadata?.bytes ||
+    integrity.sha256 !== metadata?.sha256
+  ) {
+    throw cursorStoreCorruption(`Integrity check failed for ${label}`);
+  }
 }
 
 async function validateProjectSummary(summary, nowMs) {
@@ -1028,6 +1225,11 @@ async function cleanupGenerations(storeRoot, keep) {
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function replaceObjectContents(target, source) {
+  for (const key of Object.keys(target)) delete target[key];
+  Object.assign(target, source);
 }
 
 function cursorStoreCorruption(message, cause = null) {

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -1,0 +1,1052 @@
+const crypto = require("node:crypto");
+const fssync = require("node:fs");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const {
+  ensureDir,
+  readJson,
+  readJsonStrict,
+  writeJson,
+} = require("./fs");
+
+const STORE_VERSION = 2;
+const STORE_DIRNAME = "cursor-store-v2";
+const MANIFEST_FILENAME = "manifest.json";
+const GENERATIONS_DIRNAME = "generations";
+const DEFAULT_ACTIVATION_BYTES = 16 * 1024 * 1024;
+const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
+
+async function openCursorStore({
+  trackerDir,
+  cursorsPath = path.join(trackerDir, "cursors.json"),
+  activationBytes = DEFAULT_ACTIVATION_BYTES,
+  forceV2 = false,
+  codexRoots = [],
+  failureInjector = null,
+} = {}) {
+  if (typeof trackerDir !== "string" || trackerDir.length === 0) {
+    throw new Error("trackerDir is required");
+  }
+
+  const storeRoot = path.join(trackerDir, STORE_DIRNAME);
+  const manifestPath = path.join(storeRoot, MANIFEST_FILENAME);
+  const normalizedCodexRoots = normalizeCodexRoots(codexRoots);
+  const legacyFingerprint = await fingerprintFile(cursorsPath);
+  let manifest = await readJson(manifestPath);
+
+  if (isManifest(manifest)) {
+    const legacyChanged = legacyFingerprint
+      ? !sameFingerprint(legacyFingerprint, manifest.legacyFingerprint)
+      : false;
+    if (legacyChanged) {
+      manifest = await migrateLegacyCursorState({
+        cursorsPath,
+        storeRoot,
+        legacyFingerprint,
+        previousManifest: manifest,
+        codexRoots: normalizedCodexRoots,
+        failureInjector,
+      });
+    }
+
+    const opened = await openManifestGeneration({
+      cursorsPath,
+      storeRoot,
+      manifest,
+      codexRoots: normalizedCodexRoots,
+      failureInjector,
+    });
+    if (opened) return opened;
+
+    manifest = await migrateLegacyCursorState({
+      cursorsPath,
+      storeRoot,
+      legacyFingerprint,
+      previousManifest: manifest,
+      codexRoots: normalizedCodexRoots,
+      failureInjector,
+    });
+    const recovered = await openManifestGeneration({
+      cursorsPath,
+      storeRoot,
+      manifest,
+      codexRoots: normalizedCodexRoots,
+      failureInjector,
+    });
+    if (recovered) return recovered;
+  }
+
+  const legacySize = Number(legacyFingerprint?.size || 0);
+  const shouldActivate = forceV2 || (
+    Number.isFinite(activationBytes) &&
+    activationBytes >= 0 &&
+    legacySize >= activationBytes
+  );
+  if (!shouldActivate) {
+    const cursors = (await readJson(cursorsPath)) || defaultCursorState();
+    return new LegacyCursorStore({ cursorsPath, cursors });
+  }
+
+  manifest = await migrateLegacyCursorState({
+    cursorsPath,
+    storeRoot,
+    legacyFingerprint,
+    previousManifest: null,
+    codexRoots: normalizedCodexRoots,
+    failureInjector,
+  });
+  const opened = await openManifestGeneration({
+    cursorsPath,
+    storeRoot,
+    manifest,
+    codexRoots: normalizedCodexRoots,
+    failureInjector,
+  });
+  if (!opened) throw new Error("Unable to open migrated cursor store");
+  return opened;
+}
+
+async function readCursorStateSummary({ trackerDir, cursorsPath } = {}) {
+  const resolvedCursorsPath = cursorsPath || path.join(trackerDir, "cursors.json");
+  const storeRoot = path.join(path.dirname(resolvedCursorsPath), STORE_DIRNAME);
+  const manifest = await readJson(path.join(storeRoot, MANIFEST_FILENAME));
+  if (isManifest(manifest)) {
+    const legacyFingerprint = await fingerprintFile(resolvedCursorsPath);
+    if (
+      legacyFingerprint &&
+      !sameFingerprint(legacyFingerprint, manifest.legacyFingerprint)
+    ) {
+      return summarizeLegacyCursorState(
+        await readJson(resolvedCursorsPath),
+        { legacyDrift: true },
+      );
+    }
+    const opened = await readGeneration({ storeRoot, generationId: manifest.current }) ||
+      await readGeneration({ storeRoot, generationId: manifest.previous });
+    if (opened) {
+      return {
+        cursors: opened.core,
+        mode: "v2",
+        legacyDrift: false,
+        fileCount: Number(opened.metadata?.counts?.totalFiles || 0),
+        codexFileCount: Number(opened.metadata?.counts?.codexFiles || 0),
+        codexEventCount: Number(opened.metadata?.counts?.codexEvents || 0),
+      };
+    }
+  }
+  return summarizeLegacyCursorState(await readJson(resolvedCursorsPath));
+}
+
+function summarizeLegacyCursorState(cursors, { legacyDrift = false } = {}) {
+  return {
+    cursors,
+    mode: "legacy",
+    legacyDrift,
+    fileCount:
+      cursors?.files && typeof cursors.files === "object"
+        ? Object.keys(cursors.files).length
+        : null,
+    codexFileCount: null,
+    codexEventCount: Array.isArray(cursors?.codexHashes)
+      ? cursors.codexHashes.length
+      : null,
+  };
+}
+
+class LegacyCursorStore {
+  constructor({ cursorsPath, cursors }) {
+    this.mode = "legacy";
+    this.cursorsPath = cursorsPath;
+    this.cursors = cursors;
+    this.codexEventStore = null;
+    this.fileShardLoadCount = 0;
+  }
+
+  get fileCount() {
+    return Object.keys(this.cursors?.files || {}).length;
+  }
+
+  get currentCorePath() {
+    return this.cursorsPath;
+  }
+
+  async loadCodexFilesForPaths() {}
+
+  async materializeAllCodexState() {}
+
+  async canSkipCodexDay() {
+    return false;
+  }
+
+  async commit(cursors = this.cursors) {
+    await writeJson(this.cursorsPath, cursors);
+  }
+}
+
+class V2CursorStore {
+  constructor({
+    cursorsPath,
+    storeRoot,
+    manifest,
+    generation,
+    codexRoots,
+    failureInjector,
+  }) {
+    this.mode = "v2";
+    this.cursorsPath = cursorsPath;
+    this.storeRoot = storeRoot;
+    this.manifest = manifest;
+    this.generation = generation.metadata;
+    this.generationDir = generation.directory;
+    this.codexRoots = codexRoots;
+    this.cursors = generation.core;
+    this.failureInjector = failureInjector;
+    this.loadedFileShards = new Map();
+    this.loadedEventSets = new Map();
+    this.pendingEventKeys = new Map();
+    this.skipValidationCache = new Map();
+    this.fileShardLoadCount = 0;
+    this.materializedCodexHashes = false;
+
+    if (!this.cursors.files || typeof this.cursors.files !== "object") {
+      this.cursors.files = {};
+    }
+
+    const self = this;
+    this.codexEventStore = {
+      get size() {
+        let pending = 0;
+        for (const values of self.pendingEventKeys.values()) pending += values.size;
+        return Number(self.generation?.counts?.codexEvents || 0) + pending;
+      },
+      has(key) {
+        return self.hasCodexEvent(key);
+      },
+      add(key) {
+        self.addCodexEvent(key);
+      },
+    };
+  }
+
+  get fileCount() {
+    return Number(this.generation?.counts?.totalFiles || 0);
+  }
+
+  get currentCorePath() {
+    return path.join(this.generationDir, this.generation?.coreFile || "core.json");
+  }
+
+  async loadCodexFilesForPaths(paths, cursors = this.cursors) {
+    const shardKeys = new Set();
+    for (const entry of Array.isArray(paths) ? paths : []) {
+      const filePath = typeof entry === "string" ? entry : entry?.path;
+      if (!isCodexSessionCursorPathForRoots(filePath, this.codexRoots)) continue;
+      shardKeys.add(codexFileShardKey(filePath));
+    }
+    for (const shardKey of shardKeys) {
+      await this.loadFileShard(shardKey, cursors);
+    }
+  }
+
+  async loadFileShard(shardKey, cursors = this.cursors) {
+    if (this.loadedFileShards.has(shardKey)) {
+      mergeFileShardIntoCursors(this.loadedFileShards.get(shardKey).data, cursors);
+      return this.loadedFileShards.get(shardKey).data;
+    }
+    const metadata = this.generation?.codexFiles?.[shardKey] || null;
+    const filePath = metadata?.file
+      ? path.join(this.generationDir, metadata.file)
+      : null;
+    let data = {};
+    if (filePath) {
+      const result = await readJsonStrict(filePath);
+      if (result.status !== "ok") {
+        throw cursorStoreCorruption(
+          `Unable to read Codex cursor shard ${metadata.file}`,
+          result.error,
+        );
+      }
+      data = result.value;
+    }
+    const normalized = data && typeof data === "object" && !Array.isArray(data)
+      ? data
+      : {};
+    if (filePath && normalized !== data) {
+      throw cursorStoreCorruption(`Invalid Codex cursor shard ${metadata.file}`);
+    }
+    this.loadedFileShards.set(shardKey, {
+      data: normalized,
+      originalSerialized: JSON.stringify(normalized),
+    });
+    this.fileShardLoadCount += 1;
+    mergeFileShardIntoCursors(normalized, cursors);
+    return normalized;
+  }
+
+  async materializeAllCodexState(cursors = this.cursors) {
+    for (const shardKey of Object.keys(this.generation?.codexFiles || {})) {
+      await this.loadFileShard(shardKey, cursors);
+    }
+    const hashes = [];
+    for (const shardKey of Object.keys(this.generation?.codexEvents || {})) {
+      const values = this.loadEventSet(shardKey);
+      for (const key of values) hashes.push(key);
+    }
+    for (const values of this.pendingEventKeys.values()) {
+      for (const key of values) hashes.push(key);
+    }
+    cursors.codexHashes = hashes;
+    this.materializedCodexHashes = true;
+  }
+
+  async canSkipCodexDay({
+    filePath,
+    dayInventoryCache,
+    nowMs = Date.now(),
+  } = {}) {
+    const shardKey = codexFileShardKey(filePath);
+    if (shardKey === "misc") return false;
+    const dayDir = codexDayDirectory(filePath);
+    if (!dayDir) return false;
+    const shardMetadata = this.generation?.codexFiles?.[shardKey];
+    const directoryMetadata = shardMetadata?.directories?.[dayDir];
+    const inventory = dayInventoryCache?.days?.[dayDir];
+    if (
+      !directoryMetadata?.complete ||
+      !inventory ||
+      typeof inventory.statKey !== "string" ||
+      inventory.statKey !== directoryMetadata.statKey ||
+      !Array.isArray(inventory.files) ||
+      inventory.files.length !== directoryMetadata.fileCount
+    ) {
+      return false;
+    }
+
+    if (this.skipValidationCache.has(shardKey)) {
+      return this.skipValidationCache.get(shardKey);
+    }
+    const valid = await validateProjectSummary(shardMetadata.projectSummary, nowMs);
+    this.skipValidationCache.set(shardKey, valid);
+    return valid;
+  }
+
+  hasCodexEvent(key) {
+    const shardKey = codexEventShardKey(key);
+    if (this.pendingEventKeys.get(shardKey)?.has(key)) return true;
+    return this.loadEventSet(shardKey).has(key);
+  }
+
+  addCodexEvent(key) {
+    if (typeof key !== "string" || key.length === 0) return;
+    const shardKey = codexEventShardKey(key);
+    const loaded = this.loadedEventSets.get(shardKey);
+    if (loaded?.has(key)) return;
+    if (!this.pendingEventKeys.has(shardKey)) {
+      this.pendingEventKeys.set(shardKey, new Set());
+    }
+    this.pendingEventKeys.get(shardKey).add(key);
+    if (loaded) loaded.add(key);
+  }
+
+  loadEventSet(shardKey) {
+    if (this.loadedEventSets.has(shardKey)) {
+      return this.loadedEventSets.get(shardKey);
+    }
+    const metadata = this.generation?.codexEvents?.[shardKey] || null;
+    const filePath = metadata?.file
+      ? path.join(this.generationDir, metadata.file)
+      : null;
+    let raw = "";
+    if (filePath) {
+      try {
+        raw = fssync.readFileSync(filePath, "utf8");
+      } catch (e) {
+        throw cursorStoreCorruption(
+          `Unable to read Codex event shard ${metadata.file}`,
+          e,
+        );
+      }
+    }
+    const values = new Set(raw.split("\n").filter(Boolean));
+    this.loadedEventSets.set(shardKey, values);
+    return values;
+  }
+
+  async commit(cursors = this.cursors) {
+    const generationId = newGenerationId();
+    const generationDir = generationDirectory(this.storeRoot, generationId);
+    await ensureDir(path.join(generationDir, "codex-files"));
+    await ensureDir(path.join(generationDir, "codex-events"));
+
+    const nextMetadata = {
+      version: STORE_VERSION,
+      id: generationId,
+      createdAt: new Date().toISOString(),
+      coreFile: "core.json",
+      codexFiles: cloneJson(this.generation?.codexFiles || {}),
+      codexEvents: cloneJson(this.generation?.codexEvents || {}),
+      counts: { nonCodexFiles: 0, codexFiles: 0, totalFiles: 0, codexEvents: 0 },
+    };
+
+    await linkGenerationFiles({
+      fromDirectory: this.generationDir,
+      toDirectory: generationDir,
+      metadata: nextMetadata,
+    });
+
+    const codexShardKeysPresent = new Set();
+    for (const filePath of Object.keys(cursors.files || {})) {
+      if (isCodexSessionCursorPathForRoots(filePath, this.codexRoots)) {
+        codexShardKeysPresent.add(codexFileShardKey(filePath));
+      }
+    }
+    for (const shardKey of codexShardKeysPresent) {
+      if (!this.loadedFileShards.has(shardKey) && nextMetadata.codexFiles[shardKey]) {
+        await this.loadFileShard(shardKey, cursors);
+      }
+    }
+
+    const { coreFiles, codexFilesByShard } = partitionCursorFiles(
+      cursors.files,
+      this.codexRoots,
+    );
+    const dirtyFileShards = new Set([
+      ...this.loadedFileShards.keys(),
+      ...codexFilesByShard.keys(),
+    ]);
+    for (const shardKey of dirtyFileShards) {
+      const data = codexFilesByShard.get(shardKey) || {};
+      const relativeFile = path.join("codex-files", `${safeShardFilename(shardKey)}.json`);
+      const targetPath = path.join(generationDir, relativeFile);
+      await fs.unlink(targetPath).catch(() => {});
+      if (Object.keys(data).length === 0) {
+        delete nextMetadata.codexFiles[shardKey];
+        continue;
+      }
+      await fs.writeFile(targetPath, `${JSON.stringify(data)}\n`, "utf8");
+      nextMetadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
+        shardKey,
+        data,
+        relativeFile,
+        dayInventoryCache: cursors.codexDayInventoryCache,
+      });
+    }
+
+    if (this.materializedCodexHashes || Array.isArray(cursors.codexHashes)) {
+      await rebuildEventShards({
+        generationDir,
+        metadata: nextMetadata,
+        hashes: Array.isArray(cursors.codexHashes) ? cursors.codexHashes : [],
+      });
+    } else {
+      for (const [shardKey, pending] of this.pendingEventKeys.entries()) {
+        if (pending.size === 0) continue;
+        const existing = this.loadEventSet(shardKey);
+        for (const key of pending) existing.add(key);
+        const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+        const targetPath = path.join(generationDir, relativeFile);
+        await fs.unlink(targetPath).catch(() => {});
+        await fs.writeFile(targetPath, serializeEventSet(existing), "utf8");
+        nextMetadata.codexEvents[shardKey] = {
+          file: relativeFile,
+          count: existing.size,
+        };
+      }
+    }
+
+    const core = {
+      ...cursors,
+      files: coreFiles,
+    };
+    delete core.codexHashes;
+    await fs.writeFile(
+      path.join(generationDir, nextMetadata.coreFile),
+      `${JSON.stringify(core)}\n`,
+      "utf8",
+    );
+
+    nextMetadata.counts = calculateGenerationCounts(nextMetadata, coreFiles);
+    await fs.writeFile(
+      path.join(generationDir, "generation.json"),
+      `${JSON.stringify(nextMetadata, null, 2)}\n`,
+      "utf8",
+    );
+
+    await maybeInjectFailure(this.failureInjector, "beforeManifestSwap");
+
+    const legacyFingerprint = await fingerprintFile(this.cursorsPath);
+    const nextManifest = {
+      version: STORE_VERSION,
+      current: generationId,
+      previous: this.generation?.id || null,
+      legacyFingerprint: legacyFingerprint || this.manifest?.legacyFingerprint || null,
+      updatedAt: new Date().toISOString(),
+    };
+    await writeJson(path.join(this.storeRoot, MANIFEST_FILENAME), nextManifest);
+
+    this.manifest = nextManifest;
+    this.generation = nextMetadata;
+    this.generationDir = generationDir;
+    this.cursors = core;
+    this.loadedFileShards.clear();
+    this.loadedEventSets.clear();
+    this.pendingEventKeys.clear();
+    this.skipValidationCache.clear();
+    this.materializedCodexHashes = false;
+    await cleanupGenerations(this.storeRoot, new Set([
+      nextManifest.current,
+      nextManifest.previous,
+    ].filter(Boolean)));
+  }
+}
+
+async function migrateLegacyCursorState({
+  cursorsPath,
+  storeRoot,
+  legacyFingerprint,
+  previousManifest,
+  codexRoots,
+  failureInjector,
+}) {
+  const cursors = (await readJson(cursorsPath)) || defaultCursorState();
+  const generationId = newGenerationId();
+  const generationDir = generationDirectory(storeRoot, generationId);
+  await ensureDir(path.join(generationDir, "codex-files"));
+  await ensureDir(path.join(generationDir, "codex-events"));
+
+  const { coreFiles, codexFilesByShard } = partitionCursorFiles(
+    cursors.files || {},
+    codexRoots,
+  );
+  const eventShards = partitionEventHashes(cursors.codexHashes || []);
+  const core = { ...cursors, files: coreFiles };
+  delete core.codexHashes;
+
+  const metadata = {
+    version: STORE_VERSION,
+    id: generationId,
+    createdAt: new Date().toISOString(),
+    coreFile: "core.json",
+    codexFiles: {},
+    codexEvents: {},
+    counts: {},
+  };
+
+  for (const [shardKey, data] of codexFilesByShard.entries()) {
+    const relativeFile = path.join("codex-files", `${safeShardFilename(shardKey)}.json`);
+    await fs.writeFile(
+      path.join(generationDir, relativeFile),
+      `${JSON.stringify(data)}\n`,
+      "utf8",
+    );
+    metadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
+      shardKey,
+      data,
+      relativeFile,
+      dayInventoryCache: cursors.codexDayInventoryCache,
+    });
+  }
+
+  for (const [shardKey, values] of eventShards.entries()) {
+    const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+    await fs.writeFile(
+      path.join(generationDir, relativeFile),
+      serializeEventSet(values),
+      "utf8",
+    );
+    metadata.codexEvents[shardKey] = {
+      file: relativeFile,
+      count: values.size,
+    };
+  }
+
+  await fs.writeFile(
+    path.join(generationDir, metadata.coreFile),
+    `${JSON.stringify(core)}\n`,
+    "utf8",
+  );
+  metadata.counts = calculateGenerationCounts(metadata, coreFiles);
+  await fs.writeFile(
+    path.join(generationDir, "generation.json"),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    "utf8",
+  );
+
+  await maybeInjectFailure(failureInjector, "beforeMigrationManifestSwap");
+  const manifest = {
+    version: STORE_VERSION,
+    current: generationId,
+    previous: isManifest(previousManifest) ? previousManifest.current : null,
+    legacyFingerprint: legacyFingerprint || null,
+    updatedAt: new Date().toISOString(),
+  };
+  await writeJson(path.join(storeRoot, MANIFEST_FILENAME), manifest);
+  await cleanupGenerations(storeRoot, new Set([
+    manifest.current,
+    manifest.previous,
+  ].filter(Boolean)));
+  return manifest;
+}
+
+async function openManifestGeneration({
+  cursorsPath,
+  storeRoot,
+  manifest,
+  codexRoots,
+  failureInjector,
+}) {
+  for (const generationId of [manifest.current, manifest.previous]) {
+    const generation = await readGeneration({ storeRoot, generationId });
+    if (!generation) continue;
+    return new V2CursorStore({
+      cursorsPath,
+      storeRoot,
+      manifest,
+      generation,
+      codexRoots,
+      failureInjector,
+    });
+  }
+  return null;
+}
+
+async function readGeneration({ storeRoot, generationId }) {
+  if (typeof generationId !== "string" || generationId.length === 0) return null;
+  const directory = generationDirectory(storeRoot, generationId);
+  const metadata = await readJson(path.join(directory, "generation.json"));
+  if (!isGenerationMetadata(metadata, generationId)) {
+    return null;
+  }
+  const core = await readJson(path.join(directory, metadata.coreFile));
+  if (
+    !core ||
+    typeof core !== "object" ||
+    Array.isArray(core) ||
+    !core.files ||
+    typeof core.files !== "object" ||
+    Array.isArray(core.files)
+  ) {
+    return null;
+  }
+  if (!(await generationReferencesExist(directory, metadata))) return null;
+  const counts = calculateGenerationCounts(metadata, core.files);
+  if (!sameGenerationCounts(counts, metadata.counts)) return null;
+  return { directory, metadata, core };
+}
+
+function isGenerationMetadata(metadata, generationId) {
+  if (
+    !metadata ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata) ||
+    metadata.version !== STORE_VERSION ||
+    metadata.id !== generationId ||
+    metadata.coreFile !== "core.json" ||
+    !metadata.codexFiles ||
+    typeof metadata.codexFiles !== "object" ||
+    Array.isArray(metadata.codexFiles) ||
+    !metadata.codexEvents ||
+    typeof metadata.codexEvents !== "object" ||
+    Array.isArray(metadata.codexEvents) ||
+    !metadata.counts ||
+    typeof metadata.counts !== "object" ||
+    Array.isArray(metadata.counts)
+  ) {
+    return false;
+  }
+
+  return (
+    validShardMetadataMap(metadata.codexFiles, "codex-files") &&
+    validShardMetadataMap(metadata.codexEvents, "codex-events")
+  );
+}
+
+function validShardMetadataMap(shards, expectedDirectory) {
+  const files = new Set();
+  for (const entry of Object.values(shards)) {
+    const reference = normalizeShardReference(entry?.file, expectedDirectory);
+    const count = Number(entry?.count);
+    if (
+      !reference ||
+      files.has(reference.name) ||
+      !Number.isSafeInteger(count) ||
+      count < 0
+    ) {
+      return false;
+    }
+    files.add(reference.name);
+  }
+  return true;
+}
+
+async function generationReferencesExist(directory, metadata) {
+  for (const [expectedDirectory, shards] of [
+    ["codex-files", metadata.codexFiles],
+    ["codex-events", metadata.codexEvents],
+  ]) {
+    const expectedNames = Object.values(shards)
+      .map((entry) => normalizeShardReference(entry.file, expectedDirectory).name);
+    if (expectedNames.length === 0) continue;
+
+    let entries;
+    try {
+      entries = await fs.readdir(path.join(directory, expectedDirectory), {
+        withFileTypes: true,
+      });
+    } catch (_e) {
+      return false;
+    }
+    const files = new Map(entries.map((entry) => [entry.name, entry]));
+    if (expectedNames.some((name) => !files.get(name)?.isFile())) return false;
+  }
+  return true;
+}
+
+function normalizeShardReference(relativeFile, expectedDirectory) {
+  if (typeof relativeFile !== "string" || relativeFile.length === 0) return null;
+  const normalized = relativeFile.replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  if (
+    parts.length !== 2 ||
+    parts[0] !== expectedDirectory ||
+    !parts[1] ||
+    parts[1] === "." ||
+    parts[1] === ".."
+  ) {
+    return null;
+  }
+  return { directory: expectedDirectory, name: parts[1] };
+}
+
+function sameGenerationCounts(left, right) {
+  return ["nonCodexFiles", "codexFiles", "totalFiles", "codexEvents"]
+    .every((key) => Number(left?.[key]) === Number(right?.[key]));
+}
+
+async function linkGenerationFiles({ fromDirectory, toDirectory, metadata }) {
+  for (const entry of Object.values(metadata.codexFiles || {})) {
+    if (entry?.file) await linkOrCopy(fromDirectory, toDirectory, entry.file);
+  }
+  for (const entry of Object.values(metadata.codexEvents || {})) {
+    if (entry?.file) await linkOrCopy(fromDirectory, toDirectory, entry.file);
+  }
+}
+
+async function linkOrCopy(fromDirectory, toDirectory, relativeFile) {
+  const source = path.join(fromDirectory, relativeFile);
+  const target = path.join(toDirectory, relativeFile);
+  await ensureDir(path.dirname(target));
+  try {
+    await fs.link(source, target);
+  } catch (_e) {
+    await fs.copyFile(source, target);
+  }
+}
+
+async function rebuildEventShards({ generationDir, metadata, hashes }) {
+  for (const entry of Object.values(metadata.codexEvents || {})) {
+    if (entry?.file) await fs.unlink(path.join(generationDir, entry.file)).catch(() => {});
+  }
+  metadata.codexEvents = {};
+  for (const [shardKey, values] of partitionEventHashes(hashes).entries()) {
+    const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+    await fs.writeFile(
+      path.join(generationDir, relativeFile),
+      serializeEventSet(values),
+      "utf8",
+    );
+    metadata.codexEvents[shardKey] = { file: relativeFile, count: values.size };
+  }
+}
+
+function buildCodexFileShardMetadata({
+  shardKey,
+  data,
+  relativeFile,
+  dayInventoryCache,
+}) {
+  const directories = {};
+  const configs = new Map();
+  let absentFreshUntil = null;
+
+  for (const [filePath, cursor] of Object.entries(data || {})) {
+    const dayDir = codexDayDirectory(filePath);
+    if (dayDir) {
+      if (!directories[dayDir]) directories[dayDir] = { paths: [] };
+      directories[dayDir].paths.push(filePath);
+    }
+    const context = cursor?.projectFileContext;
+    if (context?.absent === true) {
+      const checkedAtMs = Number(context.checkedAtMs);
+      if (Number.isFinite(checkedAtMs) && checkedAtMs > 0) {
+        const expiresAt = checkedAtMs + PROJECT_ABSENT_CONTEXT_RESCAN_MS;
+        absentFreshUntil = absentFreshUntil == null
+          ? expiresAt
+          : Math.min(absentFreshUntil, expiresAt);
+      } else {
+        absentFreshUntil = 0;
+      }
+      continue;
+    }
+    for (const config of projectConfigs(context)) {
+      configs.set(config.configPath, config);
+    }
+  }
+
+  for (const [dayDir, value] of Object.entries(directories)) {
+    const inventory = dayInventoryCache?.days?.[dayDir];
+    const inventoryFiles = Array.isArray(inventory?.files) ? inventory.files : [];
+    const complete = Boolean(
+      typeof inventory?.statKey === "string" &&
+      inventoryFiles.length > 0 &&
+      inventoryFiles.every((name) => {
+        const filePath = path.join(dayDir, name);
+        const cursor = data[filePath];
+        const offset = Number(cursor?.offset);
+        const projectOffset = Number(cursor?.projectOffset);
+        return (
+          Number.isFinite(offset) && offset > 0 &&
+          Number.isFinite(projectOffset) && projectOffset >= offset &&
+          cursor?.projectFileContext && typeof cursor.projectFileContext === "object"
+        );
+      })
+    );
+    directories[dayDir] = {
+      statKey: typeof inventory?.statKey === "string" ? inventory.statKey : null,
+      fileCount: inventoryFiles.length,
+      complete,
+    };
+  }
+
+  return {
+    file: relativeFile,
+    shardKey,
+    count: Object.keys(data || {}).length,
+    directories,
+    projectSummary: {
+      configs: Array.from(configs.values()),
+      absentFreshUntil,
+    },
+  };
+}
+
+async function validateProjectSummary(summary, nowMs) {
+  if (!summary || typeof summary !== "object") return false;
+  const absentFreshUntil = Number(summary.absentFreshUntil);
+  if (Number.isFinite(absentFreshUntil) && absentFreshUntil > 0 && nowMs >= absentFreshUntil) {
+    return false;
+  }
+  if (summary.absentFreshUntil === 0) return false;
+  for (const config of Array.isArray(summary.configs) ? summary.configs : []) {
+    const configPath = typeof config?.configPath === "string" ? config.configPath : null;
+    if (!configPath) return false;
+    const stat = await fs.stat(configPath).catch(() => null);
+    if (
+      !stat?.isFile() ||
+      stat.mtimeMs !== config.configMtimeMs ||
+      stat.size !== config.configSize
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function projectConfigs(context) {
+  if (!context || typeof context !== "object") return [];
+  const raw = Array.isArray(context.configs) ? context.configs : [context];
+  const out = [];
+  for (const config of raw) {
+    const configPath = typeof config?.configPath === "string" ? config.configPath : null;
+    if (!configPath) continue;
+    out.push({
+      configPath,
+      configMtimeMs: Number.isFinite(config.configMtimeMs) ? config.configMtimeMs : null,
+      configSize: Number.isFinite(config.configSize) ? config.configSize : null,
+    });
+  }
+  return out;
+}
+
+function partitionCursorFiles(files, codexRoots = []) {
+  const coreFiles = {};
+  const codexFilesByShard = new Map();
+  for (const [filePath, cursor] of Object.entries(files || {})) {
+    if (!isCodexSessionCursorPathForRoots(filePath, codexRoots)) {
+      coreFiles[filePath] = cursor;
+      continue;
+    }
+    const shardKey = codexFileShardKey(filePath);
+    if (!codexFilesByShard.has(shardKey)) codexFilesByShard.set(shardKey, {});
+    codexFilesByShard.get(shardKey)[filePath] = cursor;
+  }
+  return { coreFiles, codexFilesByShard };
+}
+
+function partitionEventHashes(hashes) {
+  const shards = new Map();
+  for (const key of Array.isArray(hashes) ? hashes : []) {
+    if (typeof key !== "string" || key.length === 0) continue;
+    const shardKey = codexEventShardKey(key);
+    if (!shards.has(shardKey)) shards.set(shardKey, new Set());
+    shards.get(shardKey).add(key);
+  }
+  return shards;
+}
+
+function mergeFileShardIntoCursors(data, cursors) {
+  if (!cursors.files || typeof cursors.files !== "object") cursors.files = {};
+  for (const [filePath, cursor] of Object.entries(data || {})) {
+    if (!(filePath in cursors.files)) cursors.files[filePath] = cursor;
+  }
+}
+
+function calculateGenerationCounts(metadata, coreFiles) {
+  const nonCodexFiles = Object.keys(coreFiles || {}).length;
+  const codexFiles = Object.values(metadata.codexFiles || {})
+    .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
+  const codexEvents = Object.values(metadata.codexEvents || {})
+    .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
+  return {
+    nonCodexFiles,
+    codexFiles,
+    totalFiles: nonCodexFiles + codexFiles,
+    codexEvents,
+  };
+}
+
+function isCodexSessionCursorPath(filePath, codexRoots = []) {
+  return isCodexSessionCursorPathForRoots(
+    filePath,
+    normalizeCodexRoots(codexRoots),
+  );
+}
+
+function isCodexSessionCursorPathForRoots(filePath, codexRoots) {
+  if (typeof filePath !== "string") return false;
+  const normalized = filePath.replace(/\\/g, "/");
+  if (/\/\.codex\/(?:archived_)?sessions\//.test(normalized)) return true;
+  return codexRoots.some((root) => (
+    normalized.startsWith(`${root}/sessions/`) ||
+    normalized.startsWith(`${root}/archived_sessions/`)
+  ));
+}
+
+function normalizeCodexRoots(roots) {
+  const values = Array.isArray(roots) ? roots : [roots];
+  return Array.from(new Set(values
+    .filter((root) => typeof root === "string" && root.trim().length > 0)
+    .map((root) => root.replace(/\\/g, "/").replace(/\/+$/, ""))));
+}
+
+function codexFileShardKey(filePath) {
+  if (typeof filePath !== "string") return "misc";
+  const normalized = filePath.replace(/\\/g, "/");
+  const match = normalized.match(/\/(\d{4})\/(\d{2})\/(\d{2})\//);
+  return match ? `${match[1]}-${match[2]}-${match[3]}` : "misc";
+}
+
+function codexDayDirectory(filePath) {
+  if (codexFileShardKey(filePath) === "misc") return null;
+  return path.dirname(filePath);
+}
+
+function codexEventShardKey(key) {
+  if (typeof key !== "string") return "misc";
+  const separator = key.indexOf(":");
+  const day = separator >= 0 ? key.slice(separator + 1, separator + 11) : "";
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day : "misc";
+}
+
+function safeShardFilename(shardKey) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(shardKey) ? shardKey : "misc";
+}
+
+function serializeEventSet(values) {
+  const rows = Array.from(values || []);
+  return rows.length > 0 ? `${rows.join("\n")}\n` : "";
+}
+
+function defaultCursorState() {
+  return { version: 1, files: {}, updatedAt: null };
+}
+
+function newGenerationId() {
+  return `gen-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function generationDirectory(storeRoot, generationId) {
+  return path.join(storeRoot, GENERATIONS_DIRNAME, generationId);
+}
+
+function isManifest(value) {
+  return Boolean(
+    value &&
+    value.version === STORE_VERSION &&
+    typeof value.current === "string" &&
+    value.current.length > 0
+  );
+}
+
+async function fingerprintFile(filePath) {
+  try {
+    const stat = await fs.stat(filePath, { bigint: true });
+    return {
+      dev: String(stat.dev),
+      ino: String(stat.ino),
+      size: String(stat.size),
+      mtimeNs: String(stat.mtimeNs),
+      ctimeNs: String(stat.ctimeNs),
+    };
+  } catch (e) {
+    if (e?.code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+function sameFingerprint(left, right) {
+  if (!left || !right) return left === right;
+  return ["dev", "ino", "size", "mtimeNs", "ctimeNs"]
+    .every((key) => String(left[key]) === String(right[key]));
+}
+
+async function cleanupGenerations(storeRoot, keep) {
+  const root = path.join(storeRoot, GENERATIONS_DIRNAME);
+  let entries = [];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || keep.has(entry.name)) continue;
+    await fs.rm(path.join(root, entry.name), { recursive: true, force: true });
+  }
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function cursorStoreCorruption(message, cause = null) {
+  const error = new Error(message, cause ? { cause } : undefined);
+  error.code = "TOKENTRACKER_CURSOR_STORE_CORRUPT";
+  return error;
+}
+
+async function maybeInjectFailure(injector, stage) {
+  if (typeof injector === "function") await injector(stage);
+}
+
+module.exports = {
+  DEFAULT_ACTIVATION_BYTES,
+  STORE_DIRNAME,
+  STORE_VERSION,
+  codexEventShardKey,
+  codexFileShardKey,
+  isCodexSessionCursorPath,
+  openCursorStore,
+  readCursorStateSummary,
+};

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -16,6 +16,7 @@ const MANIFEST_FILENAME = "manifest.json";
 const GENERATIONS_DIRNAME = "generations";
 const DEFAULT_ACTIVATION_BYTES = 16 * 1024 * 1024;
 const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
+const CURSOR_STORE_RETRY_CODE = "TOKENTRACKER_CURSOR_STORE_RETRY";
 
 async function openCursorStore({
   trackerDir,
@@ -246,9 +247,17 @@ class V2CursorStore {
       if (!isCodexSessionCursorPathForRoots(filePath, this.codexRoots)) continue;
       shardKeys.add(codexFileShardKey(filePath));
     }
-    for (const shardKey of shardKeys) {
-      await this.loadFileShard(shardKey, cursors);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        for (const shardKey of shardKeys) {
+          await this.loadFileShard(shardKey, cursors);
+        }
+        return { restarted: attempt > 0 };
+      } catch (error) {
+        if (!isCursorStoreRetry(error) || attempt > 0) throw error;
+      }
     }
+    return { restarted: false };
   }
 
   async loadFileShard(shardKey, cursors = this.cursors) {
@@ -261,7 +270,7 @@ class V2CursorStore {
       ) {
         throw error;
       }
-      return this.loadFileShardUnchecked(shardKey, cursors);
+      throw cursorStoreRetry(error);
     }
   }
 
@@ -314,19 +323,27 @@ class V2CursorStore {
   }
 
   async materializeAllCodexState(cursors = this.cursors) {
-    for (const shardKey of Object.keys(this.generation?.codexFiles || {})) {
-      await this.loadFileShard(shardKey, cursors);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        for (const shardKey of Object.keys(this.generation?.codexFiles || {})) {
+          await this.loadFileShard(shardKey, cursors);
+        }
+        const hashes = [];
+        for (const shardKey of Object.keys(this.generation?.codexEvents || {})) {
+          const values = this.loadEventSet(shardKey, cursors);
+          for (const key of values) hashes.push(key);
+        }
+        for (const values of this.pendingEventKeys.values()) {
+          for (const key of values) hashes.push(key);
+        }
+        cursors.codexHashes = hashes;
+        this.materializedCodexHashes = true;
+        return { restarted: attempt > 0 };
+      } catch (error) {
+        if (!isCursorStoreRetry(error) || attempt > 0) throw error;
+      }
     }
-    const hashes = [];
-    for (const shardKey of Object.keys(this.generation?.codexEvents || {})) {
-      const values = this.loadEventSet(shardKey);
-      for (const key of values) hashes.push(key);
-    }
-    for (const values of this.pendingEventKeys.values()) {
-      for (const key of values) hashes.push(key);
-    }
-    cursors.codexHashes = hashes;
-    this.materializedCodexHashes = true;
+    return { restarted: false };
   }
 
   async canSkipCodexDay({
@@ -378,17 +395,17 @@ class V2CursorStore {
     if (loaded) loaded.add(key);
   }
 
-  loadEventSet(shardKey) {
+  loadEventSet(shardKey, cursors = this.cursors) {
     try {
       return this.loadEventSetUnchecked(shardKey);
     } catch (error) {
       if (
         error?.code !== "TOKENTRACKER_CURSOR_STORE_CORRUPT" ||
-        !this.activateFallbackGeneration()
+        !this.activateFallbackGeneration(cursors)
       ) {
         throw error;
       }
-      return this.loadEventSetUnchecked(shardKey);
+      throw cursorStoreRetry(error);
     }
   }
 
@@ -453,132 +470,141 @@ class V2CursorStore {
   async commit(cursors = this.cursors) {
     const generationId = newGenerationId();
     const generationDir = generationDirectory(this.storeRoot, generationId);
-    await ensureDir(path.join(generationDir, "codex-files"));
-    await ensureDir(path.join(generationDir, "codex-events"));
+    let published = false;
+    try {
+      await ensureDir(path.join(generationDir, "codex-files"));
+      await ensureDir(path.join(generationDir, "codex-events"));
 
-    const nextMetadata = {
-      version: STORE_VERSION,
-      id: generationId,
-      createdAt: new Date().toISOString(),
-      coreFile: "core.json",
-      codexFiles: cloneJson(this.generation?.codexFiles || {}),
-      codexEvents: cloneJson(this.generation?.codexEvents || {}),
-      counts: { nonCodexFiles: 0, codexFiles: 0, totalFiles: 0, codexEvents: 0 },
-    };
+      const nextMetadata = {
+        version: STORE_VERSION,
+        id: generationId,
+        createdAt: new Date().toISOString(),
+        coreFile: "core.json",
+        codexFiles: cloneJson(this.generation?.codexFiles || {}),
+        codexEvents: cloneJson(this.generation?.codexEvents || {}),
+        counts: { nonCodexFiles: 0, codexFiles: 0, totalFiles: 0, codexEvents: 0 },
+      };
 
-    await linkGenerationFiles({
-      fromDirectory: this.generationDir,
-      toDirectory: generationDir,
-      metadata: nextMetadata,
-    });
-
-    const codexShardKeysPresent = new Set();
-    for (const filePath of Object.keys(cursors.files || {})) {
-      if (isCodexSessionCursorPathForRoots(filePath, this.codexRoots)) {
-        codexShardKeysPresent.add(codexFileShardKey(filePath));
-      }
-    }
-    for (const shardKey of codexShardKeysPresent) {
-      if (!this.loadedFileShards.has(shardKey) && nextMetadata.codexFiles[shardKey]) {
-        await this.loadFileShard(shardKey, cursors);
-      }
-    }
-
-    const { coreFiles, codexFilesByShard } = partitionCursorFiles(
-      cursors.files,
-      this.codexRoots,
-    );
-    const dirtyFileShards = new Set([
-      ...this.loadedFileShards.keys(),
-      ...codexFilesByShard.keys(),
-    ]);
-    for (const shardKey of dirtyFileShards) {
-      const data = codexFilesByShard.get(shardKey) || {};
-      const relativeFile = path.join("codex-files", `${safeShardFilename(shardKey)}.json`);
-      const targetPath = path.join(generationDir, relativeFile);
-      await fs.unlink(targetPath).catch(() => {});
-      if (Object.keys(data).length === 0) {
-        delete nextMetadata.codexFiles[shardKey];
-        continue;
-      }
-      const serialized = `${JSON.stringify(data)}\n`;
-      await fs.writeFile(targetPath, serialized, "utf8");
-      nextMetadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
-        shardKey,
-        data,
-        relativeFile,
-        serialized,
-        dayInventoryCache: cursors.codexDayInventoryCache,
-      });
-    }
-
-    if (this.materializedCodexHashes || Array.isArray(cursors.codexHashes)) {
-      await rebuildEventShards({
-        generationDir,
+      await linkGenerationFiles({
+        fromDirectory: this.generationDir,
+        toDirectory: generationDir,
         metadata: nextMetadata,
-        hashes: Array.isArray(cursors.codexHashes) ? cursors.codexHashes : [],
       });
-    } else {
-      for (const [shardKey, pending] of this.pendingEventKeys.entries()) {
-        if (pending.size === 0) continue;
-        const existing = this.loadEventSet(shardKey);
-        for (const key of pending) existing.add(key);
-        const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+
+      const codexShardKeysPresent = new Set();
+      for (const filePath of Object.keys(cursors.files || {})) {
+        if (isCodexSessionCursorPathForRoots(filePath, this.codexRoots)) {
+          codexShardKeysPresent.add(codexFileShardKey(filePath));
+        }
+      }
+      for (const shardKey of codexShardKeysPresent) {
+        if (!this.loadedFileShards.has(shardKey) && nextMetadata.codexFiles[shardKey]) {
+          await this.loadFileShardUnchecked(shardKey, cursors);
+        }
+      }
+
+      const { coreFiles, codexFilesByShard } = partitionCursorFiles(
+        cursors.files,
+        this.codexRoots,
+      );
+      const dirtyFileShards = new Set([
+        ...this.loadedFileShards.keys(),
+        ...codexFilesByShard.keys(),
+      ]);
+      for (const shardKey of dirtyFileShards) {
+        const data = codexFilesByShard.get(shardKey) || {};
+        const relativeFile = path.join("codex-files", `${safeShardFilename(shardKey)}.json`);
         const targetPath = path.join(generationDir, relativeFile);
         await fs.unlink(targetPath).catch(() => {});
-        const serialized = serializeEventSet(existing);
+        if (Object.keys(data).length === 0) {
+          delete nextMetadata.codexFiles[shardKey];
+          continue;
+        }
+        const serialized = `${JSON.stringify(data)}\n`;
         await fs.writeFile(targetPath, serialized, "utf8");
-        nextMetadata.codexEvents[shardKey] = buildEventShardMetadata({
+        nextMetadata.codexFiles[shardKey] = buildCodexFileShardMetadata({
+          shardKey,
+          data,
           relativeFile,
-          values: existing,
           serialized,
+          dayInventoryCache: cursors.codexDayInventoryCache,
         });
       }
+
+      if (this.materializedCodexHashes || Array.isArray(cursors.codexHashes)) {
+        await rebuildEventShards({
+          generationDir,
+          metadata: nextMetadata,
+          hashes: Array.isArray(cursors.codexHashes) ? cursors.codexHashes : [],
+        });
+      } else {
+        for (const [shardKey, pending] of this.pendingEventKeys.entries()) {
+          if (pending.size === 0) continue;
+          const existing = this.loadEventSetUnchecked(shardKey);
+          for (const key of pending) existing.add(key);
+          const relativeFile = path.join("codex-events", `${safeShardFilename(shardKey)}.txt`);
+          const targetPath = path.join(generationDir, relativeFile);
+          await fs.unlink(targetPath).catch(() => {});
+          const serialized = serializeEventSet(existing);
+          await fs.writeFile(targetPath, serialized, "utf8");
+          nextMetadata.codexEvents[shardKey] = buildEventShardMetadata({
+            relativeFile,
+            values: existing,
+            serialized,
+          });
+        }
+      }
+
+      const core = {
+        ...cursors,
+        files: coreFiles,
+      };
+      delete core.codexHashes;
+      await fs.writeFile(
+        path.join(generationDir, nextMetadata.coreFile),
+        `${JSON.stringify(core)}\n`,
+        "utf8",
+      );
+
+      nextMetadata.counts = calculateGenerationCounts(nextMetadata, coreFiles);
+      await fs.writeFile(
+        path.join(generationDir, "generation.json"),
+        `${JSON.stringify(nextMetadata, null, 2)}\n`,
+        "utf8",
+      );
+
+      await maybeInjectFailure(this.failureInjector, "beforeManifestSwap");
+
+      const legacyFingerprint = await fingerprintFile(this.cursorsPath);
+      const nextManifest = {
+        version: STORE_VERSION,
+        current: generationId,
+        previous: this.generation?.id || null,
+        legacyFingerprint: legacyFingerprint || this.manifest?.legacyFingerprint || null,
+        updatedAt: new Date().toISOString(),
+      };
+      await writeJson(path.join(this.storeRoot, MANIFEST_FILENAME), nextManifest);
+      published = true;
+
+      this.manifest = nextManifest;
+      this.generation = nextMetadata;
+      this.generationDir = generationDir;
+      this.cursors = core;
+      this.loadedFileShards.clear();
+      this.loadedEventSets.clear();
+      this.pendingEventKeys.clear();
+      this.skipValidationCache.clear();
+      this.materializedCodexHashes = false;
+      await cleanupGenerations(this.storeRoot, new Set([
+        nextManifest.current,
+        nextManifest.previous,
+      ].filter(Boolean)));
+    } catch (error) {
+      if (!published) {
+        await fs.rm(generationDir, { recursive: true, force: true }).catch(() => {});
+      }
+      throw error;
     }
-
-    const core = {
-      ...cursors,
-      files: coreFiles,
-    };
-    delete core.codexHashes;
-    await fs.writeFile(
-      path.join(generationDir, nextMetadata.coreFile),
-      `${JSON.stringify(core)}\n`,
-      "utf8",
-    );
-
-    nextMetadata.counts = calculateGenerationCounts(nextMetadata, coreFiles);
-    await fs.writeFile(
-      path.join(generationDir, "generation.json"),
-      `${JSON.stringify(nextMetadata, null, 2)}\n`,
-      "utf8",
-    );
-
-    await maybeInjectFailure(this.failureInjector, "beforeManifestSwap");
-
-    const legacyFingerprint = await fingerprintFile(this.cursorsPath);
-    const nextManifest = {
-      version: STORE_VERSION,
-      current: generationId,
-      previous: this.generation?.id || null,
-      legacyFingerprint: legacyFingerprint || this.manifest?.legacyFingerprint || null,
-      updatedAt: new Date().toISOString(),
-    };
-    await writeJson(path.join(this.storeRoot, MANIFEST_FILENAME), nextManifest);
-
-    this.manifest = nextManifest;
-    this.generation = nextMetadata;
-    this.generationDir = generationDir;
-    this.cursors = core;
-    this.loadedFileShards.clear();
-    this.loadedEventSets.clear();
-    this.pendingEventKeys.clear();
-    this.skipValidationCache.clear();
-    this.materializedCodexHashes = false;
-    await cleanupGenerations(this.storeRoot, new Set([
-      nextManifest.current,
-      nextManifest.previous,
-    ].filter(Boolean)));
   }
 }
 
@@ -1238,6 +1264,19 @@ function cursorStoreCorruption(message, cause = null) {
   return error;
 }
 
+function cursorStoreRetry(cause) {
+  const error = new Error(
+    "Cursor store generation changed; restart the operation",
+    cause ? { cause } : undefined,
+  );
+  error.code = CURSOR_STORE_RETRY_CODE;
+  return error;
+}
+
+function isCursorStoreRetry(error) {
+  return error?.code === CURSOR_STORE_RETRY_CODE;
+}
+
 async function maybeInjectFailure(injector, stage) {
   if (typeof injector === "function") await injector(stage);
 }
@@ -1249,6 +1288,7 @@ module.exports = {
   codexEventShardKey,
   codexFileShardKey,
   isCodexSessionCursorPath,
+  isCursorStoreRetry,
   openCursorStore,
   readCursorStateSummary,
 };

--- a/src/lib/diagnostics.js
+++ b/src/lib/diagnostics.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const fs = require("node:fs/promises");
 
 const { readJson } = require("./fs");
+const { readCursorStateSummary } = require("./cursor-store");
 const { readCodexNotify, readEveryCodeNotify } = require("./codex-config");
 const { areClaudeUsageHooksConfigured, buildClaudeHookCommand } = require("./claude-config");
 const {
@@ -59,7 +60,8 @@ async function collectTrackerDiagnostics({
     path.join(home, ".grok");
 
   const config = await readJson(configPath);
-  const cursors = await readJson(cursorsPath);
+  const cursorSummary = await readCursorStateSummary({ trackerDir, cursorsPath });
+  const cursors = cursorSummary.cursors;
   const queueState = (await readJson(queueStatePath)) || { offset: 0 };
   const uploadThrottle = normalizeUploadState(await readJson(uploadThrottlePath));
   const autoRetry = await readJson(autoRetryPath);
@@ -165,10 +167,11 @@ async function collectTrackerDiagnostics({
     },
     parse: {
       updated_at: typeof cursors?.updatedAt === "string" ? cursors.updatedAt : null,
-      file_count:
-        cursors?.files && typeof cursors.files === "object"
-          ? Object.keys(cursors.files).length
-          : null,
+      file_count: cursorSummary.fileCount,
+      cursor_store: cursorSummary.mode,
+      cursor_store_legacy_drift: cursorSummary.legacyDrift === true,
+      codex_file_count: cursorSummary.codexFileCount,
+      codex_event_count: cursorSummary.codexEventCount,
     },
     queue: {
       size_bytes: queueSize,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -167,6 +167,7 @@ async function listOpencodeMessageFiles(storageDir) {
 async function parseRolloutIncremental({
   rolloutFiles,
   cursors,
+  codexEventStore,
   queuePath,
   projectQueuePath,
   onProgress,
@@ -200,8 +201,16 @@ async function parseRolloutIncremental({
   // the claudeHashes pattern: it makes an inode-changing re-scan idempotent so an
   // external rewrite of a session file (Codex-Manager's atomic provider-patch on
   // account switch, issue #187) cannot re-count already-counted events.
+  const externalCodexEventStore =
+    codexEventStore &&
+    typeof codexEventStore.has === "function" &&
+    typeof codexEventStore.add === "function"
+      ? codexEventStore
+      : null;
   const prevCodexHashes = Array.isArray(cursors?.codexHashes) ? cursors.codexHashes : [];
-  if (!Array.isArray(cursors.codexHashes)) cursors.codexHashes = prevCodexHashes;
+  if (!externalCodexEventStore && !Array.isArray(cursors.codexHashes)) {
+    cursors.codexHashes = prevCodexHashes;
+  }
   let seenCodexEvents = null;
   let newCodexEventKeys = null;
   let newCodexEventKeySet = null;
@@ -229,7 +238,9 @@ async function parseRolloutIncremental({
       hash_set_constructions: 0,
       hash_array_materializations: 0,
       hash_array_materialized_items: 0,
-      codex_hash_count: prevCodexHashes.length,
+      codex_hash_count: externalCodexEventStore
+        ? Number(externalCodexEventStore.size || 0)
+        : prevCodexHashes.length,
     });
   }
   const ensureNewCodexEventKeys = () => {
@@ -242,6 +253,7 @@ async function parseRolloutIncremental({
     newCodexEventKeySet.add(key);
     newCodexEventKeys.push(key);
     if (seenCodexEvents) seenCodexEvents.add(key);
+    externalCodexEventStore?.add(key);
   };
   const getAppendOnlyCodexEvents = () => {
     if (!appendOnlyCodexEvents) {
@@ -258,6 +270,20 @@ async function parseRolloutIncremental({
     return appendOnlyCodexEvents;
   };
   const getHistoricalCodexEvents = () => {
+    if (externalCodexEventStore) {
+      if (!historicalCodexEvents) {
+        historicalCodexEvents = {
+          has(key) {
+            return Boolean(
+              newCodexEventKeySet?.has(key) ||
+              externalCodexEventStore.has(key)
+            );
+          },
+          add: recordNewCodexEvent,
+        };
+      }
+      return historicalCodexEvents;
+    }
     if (!seenCodexEvents) {
       seenCodexEvents = new Set(prevCodexHashes);
       for (const key of newCodexEventKeys || []) seenCodexEvents.add(key);
@@ -470,11 +496,15 @@ async function parseRolloutIncremental({
   const projectBucketsQueued = projectEnabled
     ? await enqueueTouchedProjectBuckets({ projectQueuePath, projectState, projectTouchedBuckets })
     : 0;
-  for (const key of newCodexEventKeys || []) prevCodexHashes.push(key);
+  if (!externalCodexEventStore) {
+    for (const key of newCodexEventKeys || []) prevCodexHashes.push(key);
+  }
   if (syncDiagnostics) {
-    syncDiagnostics.codex_hash_count = Array.isArray(cursors.codexHashes)
-      ? cursors.codexHashes.length
-      : prevCodexHashes.length;
+    syncDiagnostics.codex_hash_count = externalCodexEventStore
+      ? Number(externalCodexEventStore.size || 0)
+      : Array.isArray(cursors.codexHashes)
+        ? cursors.codexHashes.length
+        : prevCodexHashes.length;
   }
   hourlyState.updatedAt = new Date().toISOString();
   cursors.hourly = hourlyState;
@@ -489,6 +519,7 @@ async function parseRolloutIncremental({
 async function filterColdCodexRolloutFiles({
   rolloutFiles,
   cursors,
+  codexCursorStore = null,
   projectEnabled = false,
   auditDue = false,
   nowMs = Date.now(),
@@ -506,18 +537,48 @@ async function filterColdCodexRolloutFiles({
       0,
     );
     syncDiagnostics.discovered_rollouts = discoveredRollouts;
-    syncDiagnostics.cursor_keys = Object.keys(cursors?.files || {}).length;
+    syncDiagnostics.cursor_keys = Number.isFinite(codexCursorStore?.fileCount)
+      ? codexCursorStore.fileCount
+      : Object.keys(cursors?.files || {}).length;
     syncDiagnostics.cold_skipped = 0;
     syncDiagnostics.parse_candidates = discoveredRollouts;
   }
-  if (auditDue || !cursors?.files || typeof cursors.files !== "object") {
+  if (
+    !codexCursorStore &&
+    (auditDue || !cursors?.files || typeof cursors.files !== "object")
+  ) {
     return { rolloutFiles: files, skipped: 0 };
   }
 
   const activeDates = activeCodexRolloutDates(files, { nowMs, recentDays });
   const freshnessCache = new Map();
+  const cursorLoadDirectories = new Set();
+  const coldDaySkipDecisions = new Map();
   const out = [];
   let skipped = 0;
+
+  const loadCodexCursorDirectory = async (filePath) => {
+    if (!codexCursorStore) return;
+    const directory = path.dirname(filePath);
+    if (cursorLoadDirectories.has(directory)) return;
+    cursorLoadDirectories.add(directory);
+    await codexCursorStore.loadCodexFilesForPaths([filePath], cursors);
+  };
+
+  const canSkipCodexDirectory = async (filePath) => {
+    if (!codexCursorStore) return false;
+    const directory = path.dirname(filePath);
+    if (coldDaySkipDecisions.has(directory)) {
+      return coldDaySkipDecisions.get(directory);
+    }
+    const decision = await codexCursorStore.canSkipCodexDay({
+      filePath,
+      dayInventoryCache: cursors?.codexDayInventoryCache,
+      nowMs,
+    });
+    coldDaySkipDecisions.set(directory, decision);
+    return decision;
+  };
 
   for (const entry of files) {
     const filePath = typeof entry === "string" ? entry : entry?.path;
@@ -532,9 +593,23 @@ async function filterColdCodexRolloutFiles({
 
     const rolloutDate = rolloutDateFromPath(filePath);
     if (!rolloutDate || activeDates.has(rolloutDate)) {
+      await loadCodexCursorDirectory(filePath);
       out.push(entry);
       continue;
     }
+
+    if (auditDue) {
+      await loadCodexCursorDirectory(filePath);
+      out.push(entry);
+      continue;
+    }
+
+    if (await canSkipCodexDirectory(filePath)) {
+      skipped += 1;
+      continue;
+    }
+
+    await loadCodexCursorDirectory(filePath);
 
     const prev = cursors.files[filePath];
     const cachedSize = Number(prev?.offset);

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -556,13 +556,15 @@ async function filterColdCodexRolloutFiles({
   const coldDaySkipDecisions = new Map();
   const out = [];
   let skipped = 0;
+  let cursorStoreRestarted = false;
 
   const loadCodexCursorDirectory = async (filePath) => {
     if (!codexCursorStore) return;
     const directory = path.dirname(filePath);
     if (cursorLoadDirectories.has(directory)) return;
     cursorLoadDirectories.add(directory);
-    await codexCursorStore.loadCodexFilesForPaths([filePath], cursors);
+    const result = await codexCursorStore.loadCodexFilesForPaths([filePath], cursors);
+    if (result?.restarted) cursorStoreRestarted = true;
   };
 
   const canSkipCodexDirectory = async (filePath) => {
@@ -594,12 +596,14 @@ async function filterColdCodexRolloutFiles({
     const rolloutDate = rolloutDateFromPath(filePath);
     if (!rolloutDate || activeDates.has(rolloutDate)) {
       await loadCodexCursorDirectory(filePath);
+      if (cursorStoreRestarted) break;
       out.push(entry);
       continue;
     }
 
     if (auditDue) {
       await loadCodexCursorDirectory(filePath);
+      if (cursorStoreRestarted) break;
       out.push(entry);
       continue;
     }
@@ -610,6 +614,7 @@ async function filterColdCodexRolloutFiles({
     }
 
     await loadCodexCursorDirectory(filePath);
+    if (cursorStoreRestarted) break;
 
     const prev = cursors.files[filePath];
     const cachedSize = Number(prev?.offset);
@@ -638,6 +643,18 @@ async function filterColdCodexRolloutFiles({
     skipped += 1;
   }
 
+  if (cursorStoreRestarted) {
+    await codexCursorStore.loadCodexFilesForPaths(files, cursors);
+    if (syncDiagnostics) {
+      syncDiagnostics.cold_skipped = 0;
+      syncDiagnostics.parse_candidates = files.reduce(
+        (count, entry) => count + (isCodexEntry(entry) ? 1 : 0),
+        0,
+      );
+    }
+    return { rolloutFiles: files, skipped: 0, restarted: true };
+  }
+
   if (syncDiagnostics) {
     syncDiagnostics.cold_skipped = skipped;
     syncDiagnostics.parse_candidates = out.reduce(
@@ -645,7 +662,7 @@ async function filterColdCodexRolloutFiles({
       0,
     );
   }
-  return { rolloutFiles: out, skipped };
+  return { rolloutFiles: out, skipped, restarted: false };
 }
 
 function activeCodexRolloutDates(

--- a/test/codex-sync-hot-path.test.js
+++ b/test/codex-sync-hot-path.test.js
@@ -238,6 +238,48 @@ test("v2 cold filtering batches shard decisions and loads by day directory", asy
   assert.deepEqual(calls, { skip: 1, load: 1 });
 });
 
+test("v2 cold filtering discards partial skip decisions after generation fallback", async () => {
+  const oldPath = path.join(
+    "/tmp", ".codex", "sessions", "2029", "01", "01", "rollout-old.jsonl",
+  );
+  const activePath = path.join(
+    "/tmp", ".codex", "sessions", "2030", "06", "02", "rollout-active.jsonl",
+  );
+  const rolloutFiles = [
+    { path: oldPath, source: "codex" },
+    { path: activePath, source: "codex" },
+  ];
+  const calls = [];
+  const codexCursorStore = {
+    fileCount: rolloutFiles.length,
+    async canSkipCodexDay() {
+      return true;
+    },
+    async loadCodexFilesForPaths(files) {
+      calls.push(files);
+      return { restarted: calls.length === 1 };
+    },
+  };
+  const diagnostics = {};
+
+  const filtered = await filterColdCodexRolloutFiles({
+    rolloutFiles,
+    cursors: { version: 1, files: {}, codexDayInventoryCache: { version: 1, days: {} } },
+    codexCursorStore,
+    diagnostics,
+    nowMs: Date.UTC(2030, 5, 2, 12, 0, 0),
+    recentDays: 2,
+  });
+
+  assert.strictEqual(filtered.rolloutFiles, rolloutFiles);
+  assert.equal(filtered.skipped, 0);
+  assert.equal(filtered.restarted, true);
+  assert.equal(calls.length, 2);
+  assert.strictEqual(calls[1], rolloutFiles);
+  assert.equal(diagnostics.cold_skipped, 0);
+  assert.equal(diagnostics.parse_candidates, 2);
+});
+
 test("Codex sync diagnostics keep candidate counts source-scoped after mixed-source parsing", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-sync-mixed-diagnostics-"));
   try {
@@ -866,6 +908,109 @@ test("v2 source-scoped sync deduplicates an inode rewrite from its day event sha
     const store = await openCursorStore({ trackerDir, cursorsPath });
     await store.loadCodexFilesForPaths([rolloutPath]);
     assert.equal(store.cursors.files[rolloutPath].inode, replacementStat.ino);
+  });
+});
+
+test("v2 sync restarts the full Codex parse after an event-shard fallback", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-event-fallback-", async ({ codexHome, trackerDir }) => {
+    const appendSessionId = "aaaaaaaa-bbbb-4ccc-8ddd-111111111111";
+    const rewriteSessionId = "eeeeeeee-ffff-4000-8111-222222222222";
+    const appendBaselineTimestamp = "2030-06-02T01:00:00.000Z";
+    const appendTimestamp = "2030-06-02T01:05:00.000Z";
+    const rewriteBaselineTimestamp = "2030-06-02T01:10:00.000Z";
+    const rewriteTimestamp = "2030-06-02T01:15:00.000Z";
+    const dayDir = path.join(codexHome, "sessions", "2030", "06", "02");
+    const appendRolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T01-00-00-${appendSessionId}.jsonl`,
+    );
+    const rewriteRolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T01-10-00-${rewriteSessionId}.jsonl`,
+    );
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const queuePath = path.join(trackerDir, "queue.jsonl");
+    const appendBaselineLine = `${JSON.stringify(codexTokenEvent(appendBaselineTimestamp, 5))}\n`;
+    const appendLine = `${JSON.stringify(codexTokenEvent(appendTimestamp, 15))}\n`;
+    const rewriteBaselineLine = `${JSON.stringify(codexTokenEvent(rewriteBaselineTimestamp, 10))}\n`;
+    const rewriteLine = `${JSON.stringify(codexTokenEvent(rewriteTimestamp, 20))}\n`;
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(appendRolloutPath, appendBaselineLine, "utf8");
+    await fs.writeFile(rewriteRolloutPath, rewriteBaselineLine, "utf8");
+    await fs.writeFile(
+      cursorsPath,
+      `${JSON.stringify({ version: 1, files: {}, codexHashes: [] })}\n`,
+      "utf8",
+    );
+
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { cursorStoreOptions: { forceV2: true } },
+    );
+    const baselineRows = await readJsonlRows(queuePath);
+    assert.equal(baselineRows.length, 1);
+    assert.equal(baselineRows[0].total_tokens, 15);
+
+    const stableStore = await openCursorStore({ trackerDir, cursorsPath });
+    await stableStore.materializeAllCodexState();
+    await stableStore.commit();
+
+    const storeRoot = path.join(trackerDir, STORE_DIRNAME);
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(storeRoot, "manifest.json"), "utf8"),
+    );
+    const generationDir = path.join(storeRoot, "generations", manifest.current);
+    const metadata = JSON.parse(
+      await fs.readFile(path.join(generationDir, "generation.json"), "utf8"),
+    );
+    const eventShardPath = path.join(
+      generationDir,
+      metadata.codexEvents["2030-06-02"].file,
+    );
+    await fs.appendFile(eventShardPath, "corrupt", "utf8");
+
+    const appendStat = await fs.stat(appendRolloutPath);
+    await fs.appendFile(appendRolloutPath, appendLine, "utf8");
+    assert.equal((await fs.stat(appendRolloutPath)).ino, appendStat.ino);
+
+    const rewriteStat = await fs.stat(rewriteRolloutPath);
+    const replacement = `${rewriteRolloutPath}.replacement`;
+    await fs.writeFile(replacement, `${rewriteBaselineLine}${rewriteLine}`, "utf8");
+    await fs.rename(replacement, rewriteRolloutPath);
+    assert.notEqual((await fs.stat(rewriteRolloutPath)).ino, rewriteStat.ino);
+
+    await cmdSync(["--auto", "--from-retry", "--source=codex"]);
+
+    const rows = await readJsonlRows(queuePath);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1].source, "codex");
+    assert.equal(rows[1].total_tokens, 35);
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.loadCodexFilesForPaths([appendRolloutPath, rewriteRolloutPath]);
+    assert.equal(
+      reopened.cursors.files[appendRolloutPath].offset,
+      (await fs.stat(appendRolloutPath)).size,
+    );
+    assert.equal(
+      reopened.cursors.files[rewriteRolloutPath].offset,
+      (await fs.stat(rewriteRolloutPath)).size,
+    );
+    assert.equal(
+      reopened.codexEventStore.has(`${appendSessionId}:${appendBaselineTimestamp}`),
+      true,
+    );
+    assert.equal(reopened.codexEventStore.has(`${appendSessionId}:${appendTimestamp}`), true);
+    assert.equal(
+      reopened.codexEventStore.has(`${rewriteSessionId}:${rewriteBaselineTimestamp}`),
+      true,
+    );
+    assert.equal(reopened.codexEventStore.has(`${rewriteSessionId}:${rewriteTimestamp}`), true);
+
+    const queueBeforeIdle = await fs.readFile(queuePath, "utf8");
+    await cmdSync(["--auto", "--from-retry", "--source=codex"]);
+    assert.equal(await fs.readFile(queuePath, "utf8"), queueBeforeIdle);
   });
 });
 

--- a/test/codex-sync-hot-path.test.js
+++ b/test/codex-sync-hot-path.test.js
@@ -725,26 +725,23 @@ test("v2 source-scoped sync commits a same-inode append without loading historic
     const baselineTimestamp = "2030-06-02T00:30:00.000Z";
     const appendedTimestamp = "2030-06-02T00:35:00.000Z";
     const baselineLine = `${JSON.stringify(codexTokenEvent(baselineTimestamp, 10))}\n`;
-    await fs.writeFile(rolloutPath, baselineLine, "utf8");
-    const baselineStat = await fs.stat(rolloutPath);
+    const appendedLine = `${JSON.stringify(codexTokenEvent(appendedTimestamp, 25))}\n`;
+    const baselineBytes = Buffer.byteLength(baselineLine);
+    await fs.writeFile(rolloutPath, `${baselineLine}${appendedLine}`, "utf8");
+    const rolloutStat = await fs.stat(rolloutPath);
     await fs.writeFile(cursorsPath, `${JSON.stringify({
       version: 1,
       files: {
         [rolloutPath]: {
-          inode: baselineStat.ino,
-          offset: baselineStat.size,
-          projectOffset: baselineStat.size,
+          inode: rolloutStat.ino,
+          offset: baselineBytes,
+          projectOffset: baselineBytes,
           projectFileContext: { absent: true, checkedAtMs: Date.now() },
           lastTotal: codexUsage(10),
         },
       },
       codexHashes: [`${sessionId}:${baselineTimestamp}`],
     })}\n`, "utf8");
-    await fs.appendFile(
-      rolloutPath,
-      `${JSON.stringify(codexTokenEvent(appendedTimestamp, 25))}\n`,
-      "utf8",
-    );
 
     const diagnostics = {};
     await cmdSync(

--- a/test/codex-sync-hot-path.test.js
+++ b/test/codex-sync-hot-path.test.js
@@ -12,6 +12,11 @@ const {
   filterColdCodexRolloutFiles,
   parseRolloutIncremental,
 } = require("../src/lib/rollout");
+const {
+  STORE_DIRNAME,
+  openCursorStore,
+  readCursorStateSummary,
+} = require("../src/lib/cursor-store");
 const { withHome } = require("./helpers/with-home");
 
 const LARGE_HASH_COUNT = 379_000;
@@ -22,6 +27,53 @@ function buildProductionScaleHashes() {
     { length: LARGE_HASH_COUNT },
     (_, index) => `${index.toString(36).padStart(6, "0")}:${suffix}`,
   );
+}
+
+function codexUsage(totalTokens) {
+  return {
+    input_tokens: totalTokens,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+  };
+}
+
+function codexTokenEvent(timestamp, totalTokens) {
+  return {
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: { total_token_usage: codexUsage(totalTokens) },
+    },
+  };
+}
+
+async function readJsonlRows(filePath) {
+  const raw = await fs.readFile(filePath, "utf8").catch(() => "");
+  return raw.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function withIsolatedCodexHome(prefix, fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const restoreHome = withHome(home);
+  const previousCodexHome = process.env.CODEX_HOME;
+  const codexHome = path.join(home, ".codex");
+  process.env.CODEX_HOME = codexHome;
+  try {
+    await fn({
+      home,
+      codexHome,
+      trackerDir: path.join(home, ".tokentracker", "tracker"),
+    });
+  } finally {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    restoreHome();
+    await fs.rm(home, { recursive: true, force: true });
+  }
 }
 
 function observeWholeArrayReads(values) {
@@ -150,6 +202,40 @@ test("cold filtering distinguishes discovered rollouts, cursor keys, parse candi
   assert.equal(diagnostics.parse_candidates, 1);
   assert.equal(diagnostics.cold_skipped, 1);
   assert.ok(diagnostics.cold_skipped <= diagnostics.discovered_rollouts);
+});
+
+test("v2 cold filtering batches shard decisions and loads by day directory", async () => {
+  const oldDir = path.join("/tmp", ".codex", "sessions", "2029", "01", "01");
+  const activeDir = path.join("/tmp", ".codex", "sessions", "2030", "06", "02");
+  const rolloutFiles = [
+    { path: path.join(oldDir, "rollout-2029-01-01T00-00-00-a.jsonl"), source: "codex" },
+    { path: path.join(oldDir, "rollout-2029-01-01T01-00-00-b.jsonl"), source: "codex" },
+    { path: path.join(activeDir, "rollout-2030-06-02T00-00-00-c.jsonl"), source: "codex" },
+    { path: path.join(activeDir, "rollout-2030-06-02T01-00-00-d.jsonl"), source: "codex" },
+  ];
+  const calls = { skip: 0, load: 0 };
+  const codexCursorStore = {
+    fileCount: rolloutFiles.length,
+    async canSkipCodexDay() {
+      calls.skip += 1;
+      return true;
+    },
+    async loadCodexFilesForPaths() {
+      calls.load += 1;
+    },
+  };
+
+  const filtered = await filterColdCodexRolloutFiles({
+    rolloutFiles,
+    cursors: { version: 1, files: {}, codexDayInventoryCache: { version: 1, days: {} } },
+    codexCursorStore,
+    nowMs: Date.UTC(2030, 5, 2, 12, 0, 0),
+    recentDays: 2,
+  });
+
+  assert.deepEqual(filtered.rolloutFiles, rolloutFiles.slice(2));
+  assert.equal(filtered.skipped, 2);
+  assert.deepEqual(calls, { skip: 1, load: 1 });
 });
 
 test("Codex sync diagnostics keep candidate counts source-scoped after mixed-source parsing", async () => {
@@ -538,11 +624,17 @@ test("source-scoped sync preserves audit state and reports the actual cursor com
 
     const auditState = {
       version: 1,
-      lastFullScanAtMs: Date.UTC(2030, 5, 1),
-      lastFullScanAt: "2030-06-01T00:00:00.000Z",
+      lastFullScanAtMs: fixedNowMs - 60 * 60 * 1000,
+      lastFullScanAt: "2030-06-02T11:34:56.789Z",
       syncsSinceFullScan: 7,
       lastSkippedFiles: 123,
-      updatedAt: "2030-06-01T00:00:00.000Z",
+      updatedAt: "2030-06-02T11:34:56.789Z",
+    };
+    const expectedAuditState = {
+      ...auditState,
+      syncsSinceFullScan: 8,
+      lastSkippedFiles: 0,
+      updatedAt: fixedNow,
     };
     const hashes = buildProductionScaleHashes();
     const initial = {
@@ -551,7 +643,8 @@ test("source-scoped sync preserves audit state and reports the actual cursor com
       codexHashes: hashes,
       codexColdScanAudit: auditState,
     };
-    await fs.writeFile(cursorsPath, `${JSON.stringify(initial)}\n`, "utf8");
+    const initialRaw = `${JSON.stringify(initial)}\n`;
+    await fs.writeFile(cursorsPath, initialRaw, "utf8");
 
     const diagnostics = {};
     await cmdSync(
@@ -559,10 +652,17 @@ test("source-scoped sync preserves audit state and reports the actual cursor com
       { diagnostics },
     );
 
-    const raw = await fs.readFile(cursorsPath, "utf8");
+    assert.equal(
+      await fs.readFile(cursorsPath, "utf8"),
+      initialRaw,
+      "v2 migration must keep the downgrade-compatible legacy snapshot frozen",
+    );
+    const raw = await fs.readFile(diagnostics.cursor_path, "utf8");
     const persisted = JSON.parse(raw);
     assert.deepEqual(persisted, {
-      ...initial,
+      version: 1,
+      files: {},
+      codexColdScanAudit: expectedAuditState,
       codexDayInventoryCache: { version: 1, days: {} },
       hourly: {
         version: 3,
@@ -591,13 +691,321 @@ test("source-scoped sync preserves audit state and reports the actual cursor com
       codex_hash_count: LARGE_HASH_COUNT,
       cursor_commits: 1,
       cursor_bytes: Buffer.byteLength(raw),
-      cursor_path: cursorsPath,
+      cursor_path: diagnostics.cursor_path,
     });
+    assert.notEqual(diagnostics.cursor_path, cursorsPath);
+    assert.ok(
+      diagnostics.cursor_path.includes(`${path.sep}${STORE_DIRNAME}${path.sep}generations${path.sep}`),
+    );
+    const summary = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(summary.mode, "v2");
+    assert.equal(summary.codexEventCount, LARGE_HASH_COUNT);
   } finally {
     global.Date = RealDate;
     if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = previousCodexHome;
     restoreHome();
     await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("v2 source-scoped sync commits a same-inode append without loading historical hashes", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-append-", async ({ codexHome, trackerDir }) => {
+    const sessionId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const dayDir = path.join(codexHome, "sessions", "2030", "06", "02");
+    const rolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T00-00-00-${sessionId}.jsonl`,
+    );
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const queuePath = path.join(trackerDir, "queue.jsonl");
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+
+    const baselineTimestamp = "2030-06-02T00:30:00.000Z";
+    const appendedTimestamp = "2030-06-02T00:35:00.000Z";
+    const baselineLine = `${JSON.stringify(codexTokenEvent(baselineTimestamp, 10))}\n`;
+    await fs.writeFile(rolloutPath, baselineLine, "utf8");
+    const baselineStat = await fs.stat(rolloutPath);
+    await fs.writeFile(cursorsPath, `${JSON.stringify({
+      version: 1,
+      files: {
+        [rolloutPath]: {
+          inode: baselineStat.ino,
+          offset: baselineStat.size,
+          projectOffset: baselineStat.size,
+          projectFileContext: { absent: true, checkedAtMs: Date.now() },
+          lastTotal: codexUsage(10),
+        },
+      },
+      codexHashes: [`${sessionId}:${baselineTimestamp}`],
+    })}\n`, "utf8");
+    await fs.appendFile(
+      rolloutPath,
+      `${JSON.stringify(codexTokenEvent(appendedTimestamp, 25))}\n`,
+      "utf8",
+    );
+
+    const diagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { diagnostics, cursorStoreOptions: { forceV2: true } },
+    );
+
+    assert.equal(diagnostics.content_files_read, 1);
+    assert.equal(diagnostics.hash_set_constructions, 0);
+    assert.equal(diagnostics.hash_array_materializations, 0);
+    assert.equal(diagnostics.codex_hash_count, 2);
+    const rows = await readJsonlRows(queuePath);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].source, "codex");
+    assert.equal(rows[0].total_tokens, 15);
+
+    const store = await openCursorStore({ trackerDir, cursorsPath });
+    await store.loadCodexFilesForPaths([rolloutPath]);
+    assert.equal(store.cursors.files[rolloutPath].offset, (await fs.stat(rolloutPath)).size);
+    assert.equal(store.codexEventStore.has(`${sessionId}:${baselineTimestamp}`), true);
+    assert.equal(store.codexEventStore.has(`${sessionId}:${appendedTimestamp}`), true);
+
+    const queueBeforeIdle = await fs.readFile(queuePath, "utf8");
+    const idleDiagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { diagnostics: idleDiagnostics },
+    );
+    assert.equal(await fs.readFile(queuePath, "utf8"), queueBeforeIdle);
+    assert.equal(idleDiagnostics.content_files_read, 0);
+    assert.equal(idleDiagnostics.hash_set_constructions, 0);
+  });
+});
+
+test("v2 source-scoped sync shards a custom CODEX_HOME outside the default path", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-custom-home-", async ({ home, trackerDir }) => {
+    const customCodexHome = path.join(home, "custom-codex-data");
+    process.env.CODEX_HOME = customCodexHome;
+    const dayDir = path.join(customCodexHome, "sessions", "2030", "06", "02");
+    const rolloutPath = path.join(
+      dayDir,
+      "rollout-2030-06-02T00-00-00-custom-home.jsonl",
+    );
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      rolloutPath,
+      `${JSON.stringify(codexTokenEvent("2030-06-02T00:00:00.000Z", 10))}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      cursorsPath,
+      `${JSON.stringify({ version: 1, files: {}, codexHashes: [] })}\n`,
+      "utf8",
+    );
+
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { cursorStoreOptions: { forceV2: true } },
+    );
+
+    const summary = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(summary.codexFileCount, 1);
+    const store = await openCursorStore({
+      trackerDir,
+      cursorsPath,
+      codexRoots: [customCodexHome],
+    });
+    assert.equal(store.cursors.files[rolloutPath], undefined);
+    await store.loadCodexFilesForPaths([rolloutPath]);
+    assert.ok(store.cursors.files[rolloutPath]);
+  });
+});
+
+test("v2 source-scoped sync deduplicates an inode rewrite from its day event shard", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-rewrite-", async ({ codexHome, trackerDir }) => {
+    const sessionId = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+    const timestamp = "2030-06-02T01:00:00.000Z";
+    const dayDir = path.join(codexHome, "sessions", "2030", "06", "02");
+    const rolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T01-00-00-${sessionId}.jsonl`,
+    );
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const queuePath = path.join(trackerDir, "queue.jsonl");
+    const line = `${JSON.stringify(codexTokenEvent(timestamp, 20))}\n`;
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(rolloutPath, line, "utf8");
+    await fs.writeFile(
+      cursorsPath,
+      `${JSON.stringify({ version: 1, files: {}, codexHashes: [] })}\n`,
+      "utf8",
+    );
+
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { cursorStoreOptions: { forceV2: true } },
+    );
+    const queueBeforeRewrite = await fs.readFile(queuePath, "utf8");
+    const firstStat = await fs.stat(rolloutPath);
+    const replacement = `${rolloutPath}.replacement`;
+    await fs.writeFile(replacement, line, "utf8");
+    await fs.rename(replacement, rolloutPath);
+    const replacementStat = await fs.stat(rolloutPath);
+    assert.notEqual(replacementStat.ino, firstStat.ino);
+
+    const diagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-retry", "--source=codex"],
+      { diagnostics },
+    );
+
+    assert.equal(await fs.readFile(queuePath, "utf8"), queueBeforeRewrite);
+    assert.equal(diagnostics.content_files_read, 1);
+    assert.equal(diagnostics.hash_set_constructions, 0);
+    assert.equal(diagnostics.hash_array_materializations, 0);
+    assert.equal(diagnostics.codex_hash_count, 1);
+    const summary = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(summary.codexEventCount, 1);
+    const store = await openCursorStore({ trackerDir, cursorsPath });
+    await store.loadCodexFilesForPaths([rolloutPath]);
+    assert.equal(store.cursors.files[rolloutPath].inode, replacementStat.ino);
+  });
+});
+
+test("v2 replays a sync after a failed manifest swap without inflating totals", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-replay-", async ({ codexHome, trackerDir }) => {
+    const sessionId = "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa";
+    const timestamp = "2030-06-02T01:30:00.000Z";
+    const dayDir = path.join(codexHome, "sessions", "2030", "06", "02");
+    const rolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T01-30-00-${sessionId}.jsonl`,
+    );
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const queuePath = path.join(trackerDir, "queue.jsonl");
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      rolloutPath,
+      `${JSON.stringify(codexTokenEvent(timestamp, 20))}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      cursorsPath,
+      `${JSON.stringify({ version: 1, files: {}, codexHashes: [] })}\n`,
+      "utf8",
+    );
+
+    await assert.rejects(
+      cmdSync(
+        ["--auto", "--from-retry", "--source=codex"],
+        {
+          cursorStoreOptions: {
+            forceV2: true,
+            failureInjector(stage) {
+              if (stage === "beforeManifestSwap") throw new Error("simulated manifest failure");
+            },
+          },
+        },
+      ),
+      /simulated manifest failure/,
+    );
+    assert.equal((await readJsonlRows(queuePath)).length, 1);
+    const beforeReplay = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(beforeReplay.codexEventCount, 0);
+
+    await cmdSync(["--auto", "--from-retry", "--source=codex"]);
+
+    const rows = await readJsonlRows(queuePath);
+    assert.equal(rows.length, 2);
+    assert.deepEqual(rows[1], rows[0]);
+    const store = await openCursorStore({ trackerDir, cursorsPath });
+    await store.materializeAllCodexState();
+    assert.deepEqual(store.cursors.codexHashes, [`${sessionId}:${timestamp}`]);
+    const total = Object.entries(store.cursors.hourly.buckets)
+      .filter(([key]) => key.startsWith("codex|"))
+      .reduce((sum, [, bucket]) => sum + Number(bucket.totals.total_tokens || 0), 0);
+    assert.equal(total, 20);
+  });
+});
+
+test("v2 cursor shards preserve legacy parser output and event hashes", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-v2-equivalence-"));
+  const RealDate = Date;
+  const fixedNowMs = RealDate.parse("2030-06-02T12:34:56.789Z");
+  global.Date = class FixedDate extends RealDate {
+    constructor(...args) {
+      super(...(args.length > 0 ? args : [fixedNowMs]));
+    }
+
+    static now() {
+      return fixedNowMs;
+    }
+  };
+  try {
+    const sessionId = "dddddddd-eeee-4fff-8aaa-bbbbbbbbbbbb";
+    const rolloutPath = path.join(
+      root,
+      ".codex",
+      "sessions",
+      "2030",
+      "06",
+      "02",
+      `rollout-2030-06-02T02-00-00-${sessionId}.jsonl`,
+    );
+    const events = [
+      codexTokenEvent("2030-06-02T02:00:00.000Z", 10),
+      codexTokenEvent("2030-06-02T02:05:00.000Z", 25),
+    ];
+    await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+    await fs.writeFile(
+      rolloutPath,
+      events.map((event) => JSON.stringify(event)).join("\n") + "\n",
+      "utf8",
+    );
+
+    const legacyTrackerDir = path.join(root, "legacy");
+    const v2TrackerDir = path.join(root, "v2");
+    await fs.mkdir(legacyTrackerDir, { recursive: true });
+    await fs.mkdir(v2TrackerDir, { recursive: true });
+    for (const trackerDir of [legacyTrackerDir, v2TrackerDir]) {
+      await fs.writeFile(
+        path.join(trackerDir, "cursors.json"),
+        `${JSON.stringify({ version: 1, files: {}, codexHashes: [] })}\n`,
+        "utf8",
+      );
+    }
+
+    const legacyStore = await openCursorStore({
+      trackerDir: legacyTrackerDir,
+      activationBytes: Number.MAX_SAFE_INTEGER,
+    });
+    const v2Store = await openCursorStore({ trackerDir: v2TrackerDir, forceV2: true });
+    const parseInto = async (store, trackerDir) => {
+      await parseRolloutIncremental({
+        rolloutFiles: [{ path: rolloutPath, source: "codex" }],
+        cursors: store.cursors,
+        codexEventStore: store.codexEventStore,
+        queuePath: path.join(trackerDir, "queue.jsonl"),
+      });
+      await store.commit();
+    };
+    await parseInto(legacyStore, legacyTrackerDir);
+    await parseInto(v2Store, v2TrackerDir);
+
+    assert.equal(
+      await fs.readFile(path.join(v2TrackerDir, "queue.jsonl"), "utf8"),
+      await fs.readFile(path.join(legacyTrackerDir, "queue.jsonl"), "utf8"),
+    );
+    const reopenedLegacy = await openCursorStore({
+      trackerDir: legacyTrackerDir,
+      activationBytes: Number.MAX_SAFE_INTEGER,
+    });
+    const reopenedV2 = await openCursorStore({ trackerDir: v2TrackerDir });
+    await reopenedV2.materializeAllCodexState();
+    assert.deepEqual(reopenedV2.cursors, reopenedLegacy.cursors);
+  } finally {
+    global.Date = RealDate;
+    await fs.rm(root, { recursive: true, force: true });
   }
 });

--- a/test/codex-sync-hot-path.test.js
+++ b/test/codex-sync-hot-path.test.js
@@ -954,6 +954,7 @@ test("v2 sync restarts the full Codex parse after an event-shard fallback", asyn
 
     const stableStore = await openCursorStore({ trackerDir, cursorsPath });
     await stableStore.materializeAllCodexState();
+    const appendInode = stableStore.cursors.files[appendRolloutPath].inode;
     await stableStore.commit();
 
     const storeRoot = path.join(trackerDir, STORE_DIRNAME);
@@ -970,9 +971,7 @@ test("v2 sync restarts the full Codex parse after an event-shard fallback", asyn
     );
     await fs.appendFile(eventShardPath, "corrupt", "utf8");
 
-    const appendStat = await fs.stat(appendRolloutPath);
     await fs.appendFile(appendRolloutPath, appendLine, "utf8");
-    assert.equal((await fs.stat(appendRolloutPath)).ino, appendStat.ino);
 
     const rewriteStat = await fs.stat(rewriteRolloutPath);
     const replacement = `${rewriteRolloutPath}.replacement`;
@@ -993,6 +992,7 @@ test("v2 sync restarts the full Codex parse after an event-shard fallback", asyn
       reopened.cursors.files[appendRolloutPath].offset,
       (await fs.stat(appendRolloutPath)).size,
     );
+    assert.equal(reopened.cursors.files[appendRolloutPath].inode, appendInode);
     assert.equal(
       reopened.cursors.files[rewriteRolloutPath].offset,
       (await fs.stat(rewriteRolloutPath)).size,

--- a/test/cursor-store.test.js
+++ b/test/cursor-store.test.js
@@ -427,10 +427,83 @@ test("a malformed current event shard lazily falls back to the previous generati
     await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
 
     const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    assert.throws(
+      () => recovered.codexEventStore.has(addedEvent),
+      (error) => (
+        error?.code === "TOKENTRACKER_CURSOR_STORE_RETRY" &&
+        error?.cause?.code === "TOKENTRACKER_CURSOR_STORE_CORRUPT"
+      ),
+    );
     assert.equal(recovered.codexEventStore.has(addedEvent), false);
     assert.equal(recovered.codexEventStore.has(baseEvent), true);
     await recovered.loadCodexFilesForPaths([day17File]);
     assert.equal(recovered.cursors.files[day17File].offset, 10);
+  });
+});
+
+test("materialization restarts every shard after a lazy generation fallback", async () => {
+  await withCursorFixture(async ({
+    trackerDir,
+    cursorsPath,
+    day17File,
+    day16File,
+  }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File, day16File]);
+    migrated.cursors.files[day17File].offset = 44;
+    migrated.cursors.files[day16File].offset = 55;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexFiles["2026-07-16"];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    const result = await recovered.materializeAllCodexState();
+    assert.equal(result.restarted, true);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
+    assert.equal(recovered.cursors.files[day16File].offset, 20);
+  });
+});
+
+test("commit rejects a corrupt required shard without publishing a mixed generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath }) => {
+    const currentOnlyEvent = "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:01.500Z";
+    const newEvent = "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:02.000Z";
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    migrated.codexEventStore.add(currentOnlyEvent);
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexEvents["2026-07-17"];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    const storeRoot = path.join(trackerDir, STORE_DIRNAME);
+    const manifestPath = path.join(storeRoot, "manifest.json");
+    const generationsPath = path.join(storeRoot, "generations");
+    const manifestBefore = await fs.readFile(manifestPath, "utf8");
+    const generationsBefore = (await fs.readdir(generationsPath)).sort();
+
+    const failing = await openCursorStore({ trackerDir, cursorsPath });
+    failing.codexEventStore.add(newEvent);
+    await assert.rejects(
+      failing.commit(),
+      (error) => error?.code === "TOKENTRACKER_CURSOR_STORE_CORRUPT",
+    );
+
+    assert.equal(await fs.readFile(manifestPath, "utf8"), manifestBefore);
+    assert.deepEqual((await fs.readdir(generationsPath)).sort(), generationsBefore);
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    assert.throws(
+      () => reopened.codexEventStore.has(newEvent),
+      (error) => error?.code === "TOKENTRACKER_CURSOR_STORE_RETRY",
+    );
+    assert.equal(reopened.codexEventStore.has(newEvent), false);
   });
 });
 

--- a/test/cursor-store.test.js
+++ b/test/cursor-store.test.js
@@ -120,6 +120,14 @@ async function readCurrentGeneration(trackerDir) {
   return { manifest, directory, metadata };
 }
 
+function corruptShardWithoutChangingLength(raw) {
+  assert.ok(raw.length > 0);
+  const first = raw[0] === "x" ? "y" : "x";
+  const corrupted = `${first}${raw.slice(1)}`;
+  assert.equal(Buffer.byteLength(corrupted), Buffer.byteLength(raw));
+  return corrupted;
+}
+
 test("small cursor states keep the legacy single-file path", async () => {
   await withCursorFixture(async ({ trackerDir, cursorsPath }) => {
     const store = await openCursorStore({
@@ -134,6 +142,23 @@ test("small cursor states keep the legacy single-file path", async () => {
     const persisted = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
     assert.equal(persisted.updatedAt, "2026-07-18T00:00:00.000Z");
     assert.ok(Array.isArray(persisted.codexHashes));
+  });
+});
+
+test("v2 migration rejects malformed legacy cursor state", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath }) => {
+    const malformed = '{"version":1,"files":';
+    await fs.writeFile(cursorsPath, malformed, "utf8");
+
+    await assert.rejects(
+      openCursorStore({ trackerDir, cursorsPath, forceV2: true }),
+      (error) => error?.code === "TOKENTRACKER_CURSOR_STORE_CORRUPT",
+    );
+    assert.equal(await fs.readFile(cursorsPath, "utf8"), malformed);
+    await assert.rejects(
+      fs.access(path.join(trackerDir, STORE_DIRNAME, "manifest.json")),
+      (error) => error?.code === "ENOENT",
+    );
   });
 });
 
@@ -362,6 +387,50 @@ test("a current generation with a missing event shard falls back to the previous
     await recovered.loadCodexFilesForPaths([day17File]);
     assert.equal(recovered.cursors.files[day17File].offset, 10);
     assert.equal(recovered.codexEventStore.has(eventKey), true);
+  });
+});
+
+test("a malformed current file shard lazily falls back to the previous generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexFiles["2026-07-17"];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    await recovered.loadCodexFilesForPaths([day17File]);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
+  });
+});
+
+test("a malformed current event shard lazily falls back to the previous generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const baseEvent = "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:01.000Z";
+    const addedEvent = "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:02.000Z";
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    assert.equal(migrated.codexEventStore.has(baseEvent), true);
+    migrated.codexEventStore.add(addedEvent);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexEvents["2026-07-17"];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    assert.equal(recovered.codexEventStore.has(addedEvent), false);
+    assert.equal(recovered.codexEventStore.has(baseEvent), true);
+    await recovered.loadCodexFilesForPaths([day17File]);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
   });
 });
 

--- a/test/cursor-store.test.js
+++ b/test/cursor-store.test.js
@@ -1,0 +1,445 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const {
+  STORE_DIRNAME,
+  openCursorStore,
+  readCursorStateSummary,
+} = require("../src/lib/cursor-store");
+const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
+
+async function withCursorFixture(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-cursor-store-"));
+  const trackerDir = path.join(home, ".tokentracker", "tracker");
+  const cursorsPath = path.join(trackerDir, "cursors.json");
+  const codexDir = path.join(home, ".codex", "sessions");
+  const configPath = path.join(home, "repo", ".git", "config");
+  await fs.mkdir(trackerDir, { recursive: true });
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, "[remote \"origin\"]\n", "utf8");
+  const configStat = await fs.stat(configPath);
+
+  const day17Dir = path.join(codexDir, "2026", "07", "17");
+  const day16Dir = path.join(codexDir, "2026", "07", "16");
+  await fs.mkdir(day17Dir, { recursive: true });
+  await fs.mkdir(day16Dir, { recursive: true });
+  const day17File = path.join(
+    day17Dir,
+    "rollout-2026-07-17T00-00-00-11111111-1111-4111-8111-111111111111.jsonl",
+  );
+  const day16File = path.join(
+    day16Dir,
+    "rollout-2026-07-16T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+  );
+  await fs.writeFile(day17File, "{}\n", "utf8");
+  await fs.writeFile(day16File, "{}\n", "utf8");
+
+  const context = {
+    configPath,
+    configMtimeMs: configStat.mtimeMs,
+    configSize: configStat.size,
+    configs: [{
+      configPath,
+      configMtimeMs: configStat.mtimeMs,
+      configSize: configStat.size,
+    }],
+  };
+  const cursorFor = (offset) => ({
+    inode: 1,
+    offset,
+    projectOffset: offset,
+    projectFileContext: context,
+    updatedAt: "2026-07-17T00:00:00.000Z",
+  });
+  const day17Stat = await fs.stat(day17Dir);
+  const day16Stat = await fs.stat(day16Dir);
+  const statKey = (stat) => [stat.ino, stat.size, stat.mtimeMs, stat.ctimeMs].join(":");
+  const legacy = {
+    version: 1,
+    updatedAt: "2026-07-17T00:00:00.000Z",
+    files: {
+      [day17File]: cursorFor(10),
+      [day16File]: cursorFor(20),
+      [path.join(home, ".claude", "projects", "one.jsonl")]: {
+        inode: 2,
+        offset: 30,
+      },
+    },
+    codexHashes: [
+      "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:01.000Z",
+      "22222222-2222-4222-8222-222222222222:2026-07-16T00:00:01.000Z",
+    ],
+    codexDayInventoryCache: {
+      version: 1,
+      days: {
+        [day17Dir]: {
+          statKey: statKey(day17Stat),
+          files: [path.basename(day17File)],
+        },
+        [day16Dir]: {
+          statKey: statKey(day16Stat),
+          files: [path.basename(day16File)],
+        },
+      },
+    },
+    hourly: { buckets: {}, groupQueued: {} },
+  };
+  await fs.writeFile(cursorsPath, `${JSON.stringify(legacy, null, 2)}\n`, "utf8");
+  const originalLegacyRaw = await fs.readFile(cursorsPath, "utf8");
+
+  try {
+    await fn({
+      home,
+      trackerDir,
+      cursorsPath,
+      configPath,
+      day17Dir,
+      day16Dir,
+      day17File,
+      day16File,
+      legacy,
+      originalLegacyRaw,
+    });
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+async function readCurrentGeneration(trackerDir) {
+  const storeRoot = path.join(trackerDir, STORE_DIRNAME);
+  const manifest = JSON.parse(
+    await fs.readFile(path.join(storeRoot, "manifest.json"), "utf8"),
+  );
+  const directory = path.join(storeRoot, "generations", manifest.current);
+  const metadata = JSON.parse(
+    await fs.readFile(path.join(directory, "generation.json"), "utf8"),
+  );
+  return { manifest, directory, metadata };
+}
+
+test("small cursor states keep the legacy single-file path", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath }) => {
+    const store = await openCursorStore({
+      trackerDir,
+      cursorsPath,
+      activationBytes: Number.MAX_SAFE_INTEGER,
+    });
+    assert.equal(store.mode, "legacy");
+    store.cursors.updatedAt = "2026-07-18T00:00:00.000Z";
+    await store.commit();
+
+    const persisted = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+    assert.equal(persisted.updatedAt, "2026-07-18T00:00:00.000Z");
+    assert.ok(Array.isArray(persisted.codexHashes));
+  });
+});
+
+test("explicit Codex roots shard custom CODEX_HOME session paths", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-custom-codex-root-"));
+  try {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const codexRoot = path.join(home, "custom-codex-data");
+    const rolloutPath = path.join(
+      codexRoot,
+      "sessions",
+      "2026",
+      "07",
+      "17",
+      "rollout-2026-07-17T00-00-00-custom.jsonl",
+    );
+    await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(rolloutPath, "{}\n", "utf8");
+    await fs.writeFile(cursorsPath, `${JSON.stringify({
+      version: 1,
+      files: { [rolloutPath]: { inode: 1, offset: 3 } },
+      codexHashes: [],
+    })}\n`, "utf8");
+
+    const store = await openCursorStore({
+      trackerDir,
+      cursorsPath,
+      codexRoots: [codexRoot],
+      forceV2: true,
+    });
+    assert.equal(store.cursors.files[rolloutPath], undefined);
+    assert.equal(store.fileCount, 1);
+    await store.loadCodexFilesForPaths([rolloutPath]);
+    assert.equal(store.cursors.files[rolloutPath].offset, 3);
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("v2 migration freezes legacy state and lazily loads Codex day shards", async () => {
+  await withCursorFixture(async ({
+    trackerDir,
+    cursorsPath,
+    day17File,
+    day16File,
+    originalLegacyRaw,
+  }) => {
+    const store = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    assert.equal(store.mode, "v2");
+    assert.equal(store.cursors.files[day17File], undefined);
+    assert.equal(store.cursors.files[day16File], undefined);
+    assert.equal(Object.keys(store.cursors.files).length, 1);
+    assert.equal(await fs.readFile(cursorsPath, "utf8"), originalLegacyRaw);
+
+    await store.loadCodexFilesForPaths([day17File]);
+    assert.equal(store.fileShardLoadCount, 1);
+    assert.equal(store.cursors.files[day17File].offset, 10);
+    assert.equal(store.cursors.files[day16File], undefined);
+    assert.equal(
+      store.codexEventStore.has(
+        "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:01.000Z",
+      ),
+      true,
+    );
+    store.codexEventStore.add(
+      "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:02.000Z",
+    );
+    store.cursors.files[day17File].offset = 11;
+    store.cursors.updatedAt = "2026-07-18T00:00:00.000Z";
+    await store.commit();
+
+    assert.equal(await fs.readFile(cursorsPath, "utf8"), originalLegacyRaw);
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.loadCodexFilesForPaths([day17File]);
+    assert.equal(reopened.cursors.files[day17File].offset, 11);
+    assert.equal(
+      reopened.codexEventStore.has(
+        "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:02.000Z",
+      ),
+      true,
+    );
+
+    const summary = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(summary.mode, "v2");
+    assert.equal(summary.fileCount, 3);
+    assert.equal(summary.codexFileCount, 2);
+    assert.equal(summary.codexEventCount, 3);
+  });
+});
+
+test("unchanged complete cold days skip without loading their cursor shard", async () => {
+  await withCursorFixture(async ({
+    trackerDir,
+    cursorsPath,
+    configPath,
+    day16File,
+  }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    assert.equal(
+      await migrated.canSkipCodexDay({
+        filePath: day16File,
+        dayInventoryCache: migrated.cursors.codexDayInventoryCache,
+      }),
+      true,
+    );
+    assert.equal(migrated.fileShardLoadCount, 0);
+
+    await fs.appendFile(configPath, "# changed\n", "utf8");
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    assert.equal(
+      await reopened.canSkipCodexDay({
+        filePath: day16File,
+        dayInventoryCache: reopened.cursors.codexDayInventoryCache,
+      }),
+      false,
+    );
+  });
+});
+
+test("a failed generation commit leaves the previous manifest authoritative", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 15;
+    await migrated.commit();
+
+    const failing = await openCursorStore({
+      trackerDir,
+      cursorsPath,
+      failureInjector(stage) {
+        if (stage === "beforeManifestSwap") throw new Error("simulated crash");
+      },
+    });
+    await failing.loadCodexFilesForPaths([day17File]);
+    failing.cursors.files[day17File].offset = 99;
+    await assert.rejects(failing.commit(), /simulated crash/);
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.loadCodexFilesForPaths([day17File]);
+    assert.equal(reopened.cursors.files[day17File].offset, 15);
+  });
+});
+
+test("a downgraded legacy writer is detected and remigrated on upgrade", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File, legacy }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 11;
+    await migrated.commit();
+
+    const downgraded = structuredClone(legacy);
+    downgraded.files[day17File].offset = 77;
+    downgraded.codexHashes.push(
+      "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:03.000Z",
+    );
+    await fs.writeFile(cursorsPath, `${JSON.stringify(downgraded, null, 2)}\n`, "utf8");
+
+    const upgraded = await openCursorStore({ trackerDir, cursorsPath });
+    await upgraded.loadCodexFilesForPaths([day17File]);
+    assert.equal(upgraded.cursors.files[day17File].offset, 77);
+    assert.equal(
+      upgraded.codexEventStore.has(
+        "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:03.000Z",
+      ),
+      true,
+    );
+  });
+});
+
+test("a corrupt current generation falls back to the previous generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const manifestPath = path.join(trackerDir, STORE_DIRNAME, "manifest.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+    const corePath = path.join(
+      trackerDir,
+      STORE_DIRNAME,
+      "generations",
+      manifest.current,
+      "core.json",
+    );
+    await fs.writeFile(corePath, "{broken", "utf8");
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    await recovered.loadCodexFilesForPaths([day17File]);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
+  });
+});
+
+test("a current generation with a missing shard falls back to the previous generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexFiles["2026-07-17"];
+    await fs.unlink(path.join(current.directory, shard.file));
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    await recovered.loadCodexFilesForPaths([day17File]);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
+  });
+});
+
+test("a current generation with a missing event shard falls back to the previous generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File }) => {
+    const eventKey = "11111111-1111-4111-8111-111111111111:2026-07-17T00:00:01.000Z";
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.codexEvents["2026-07-17"];
+    await fs.unlink(path.join(current.directory, shard.file));
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    await recovered.loadCodexFilesForPaths([day17File]);
+    assert.equal(recovered.cursors.files[day17File].offset, 10);
+    assert.equal(recovered.codexEventStore.has(eventKey), true);
+  });
+});
+
+test("state summaries prefer a later legacy write over stale v2 state", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File, legacy }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 11;
+    await migrated.commit();
+
+    const downgraded = structuredClone(legacy);
+    downgraded.files[day17File].offset = 77;
+    downgraded.updatedAt = "2026-07-19T00:00:00.000Z";
+    await fs.writeFile(cursorsPath, `${JSON.stringify(downgraded, null, 2)}\n`, "utf8");
+
+    const summary = await readCursorStateSummary({ trackerDir, cursorsPath });
+    assert.equal(summary.mode, "legacy");
+    assert.equal(summary.legacyDrift, true);
+    assert.equal(summary.cursors.files[day17File].offset, 77);
+    assert.equal(summary.codexEventCount, legacy.codexHashes.length);
+  });
+});
+
+test("materializing all Codex shards lets project purge clear frozen historical cursors", async () => {
+  await withCursorFixture(async ({
+    trackerDir,
+    cursorsPath,
+    day17File,
+    day16File,
+    legacy,
+  }) => {
+    const projectKey = "blocked-project";
+    const prepared = structuredClone(legacy);
+    prepared.files[day17File].project = { projectKey };
+    prepared.files[day16File].project = { projectKey };
+    prepared.projectHourly = {
+      version: 2,
+      buckets: {
+        [`${projectKey}|codex|2026-07-17T00:00:00.000Z`]: {
+          totals: { total_tokens: 30 },
+        },
+      },
+      projects: {
+        [projectKey]: { status: "blocked", purge_pending: true },
+      },
+    };
+    await fs.writeFile(cursorsPath, `${JSON.stringify(prepared, null, 2)}\n`, "utf8");
+
+    const projectQueuePath = path.join(trackerDir, "project.queue.jsonl");
+    const projectQueueStatePath = path.join(trackerDir, "project.queue.state.json");
+    const queueRaw = `${JSON.stringify({ project_key: projectKey, total_tokens: 30 })}\n`;
+    await fs.writeFile(projectQueuePath, queueRaw, "utf8");
+    await fs.writeFile(
+      projectQueueStatePath,
+      JSON.stringify({ offset: Buffer.byteLength(queueRaw) }),
+      "utf8",
+    );
+
+    const store = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await store.loadCodexFilesForPaths([day17File]);
+    assert.equal(store.cursors.files[day16File], undefined);
+    await store.materializeAllCodexState();
+    assert.equal(store.fileShardLoadCount, 2);
+
+    const result = await purgeProjectUsage({
+      projectKey,
+      projectQueuePath,
+      projectQueueStatePath,
+      projectState: store.cursors.projectHourly,
+      cursors: store.cursors,
+    });
+    assert.equal(result.removedProjectCursors, 2);
+    await store.commit();
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.materializeAllCodexState();
+    assert.equal(reopened.cursors.files[day17File].project, undefined);
+    assert.equal(reopened.cursors.files[day16File].project, undefined);
+    assert.equal(await fs.readFile(projectQueuePath, "utf8"), "");
+  });
+});

--- a/test/cursor-store.test.js
+++ b/test/cursor-store.test.js
@@ -113,11 +113,19 @@ async function readCurrentGeneration(trackerDir) {
   const manifest = JSON.parse(
     await fs.readFile(path.join(storeRoot, "manifest.json"), "utf8"),
   );
-  const directory = path.join(storeRoot, "generations", manifest.current);
+  return {
+    manifest,
+    ...(await readGenerationFixture(trackerDir, manifest.current)),
+  };
+}
+
+async function readGenerationFixture(trackerDir, generationId) {
+  const storeRoot = path.join(trackerDir, STORE_DIRNAME);
+  const directory = path.join(storeRoot, "generations", generationId);
   const metadata = JSON.parse(
     await fs.readFile(path.join(directory, "generation.json"), "utf8"),
   );
-  return { manifest, directory, metadata };
+  return { directory, metadata };
 }
 
 function corruptShardWithoutChangingLength(raw) {
@@ -304,6 +312,36 @@ test("a failed generation commit leaves the previous manifest authoritative", as
   });
 });
 
+test("ordinary commits keep unchanged fallback shards physically independent", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File, day16File }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.loadCodexFilesForPaths([day17File]);
+    migrated.cursors.files[day17File].offset = 44;
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const previous = await readGenerationFixture(trackerDir, current.manifest.previous);
+    const shard = current.metadata.codexFiles["2026-07-16"];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    for (const [shards, shardKey] of [
+      ["codexFiles", "2026-07-16"],
+      ["codexEvents", "2026-07-16"],
+    ]) {
+      const currentPath = path.join(current.directory, current.metadata[shards][shardKey].file);
+      const previousPath = path.join(previous.directory, previous.metadata[shards][shardKey].file);
+      assert.notEqual((await fs.stat(currentPath)).ino, (await fs.stat(previousPath)).ino);
+    }
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    const result = await recovered.loadCodexFilesForPaths([day16File]);
+    assert.equal(result.restarted, true);
+    assert.equal(recovered.cursors.files[day16File].offset, 20);
+  });
+});
+
 test("a downgraded legacy writer is detected and remigrated on upgrade", async () => {
   await withCursorFixture(async ({ trackerDir, cursorsPath, day17File, legacy }) => {
     const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
@@ -327,6 +365,24 @@ test("a downgraded legacy writer is detected and remigrated on upgrade", async (
       ),
       true,
     );
+  });
+});
+
+test("commit does not acknowledge a concurrent legacy write it did not migrate", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, day17File, legacy }) => {
+    const store = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    const downgraded = structuredClone(legacy);
+    downgraded.files[day17File].offset = 77;
+    downgraded.updatedAt = "2026-07-19T00:00:00.000Z";
+    await fs.writeFile(cursorsPath, `${JSON.stringify(downgraded, null, 2)}\n`, "utf8");
+
+    store.cursors.updatedAt = "2026-07-18T00:00:00.000Z";
+    await store.commit();
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.loadCodexFilesForPaths([day17File]);
+    assert.equal(reopened.cursors.updatedAt, "2026-07-19T00:00:00.000Z");
+    assert.equal(reopened.cursors.files[day17File].offset, 77);
   });
 });
 


### PR DESCRIPTION
## Summary

Reduce steady-state Codex sync CPU and memory for large local histories by moving oversized cursor state from one monolithic JSON document to an atomic, day-sharded store. Cursor files below 16 MiB continue using the existing legacy path.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Problem

Large Codex histories accumulate file cursors, event fingerprints, hourly buckets, and project buckets in `cursors.json`. Before this change, every sync parsed and stringified the full document even when only one recent rollout changed. On a production-sized 64 MiB cursor state, that historical-state cost dominated an otherwise incremental sync.

## What changed

- Activate cursor-store v2 only when the legacy file is at least 16 MiB; smaller installations retain the existing behavior.
- Split Codex file cursors and event fingerprints into daily shards while keeping shared state in a small core file.
- Lazily load only touched day shards and batch cold-day decisions by date directory.
- Clone unchanged shards into the next generation with `COPYFILE_FICLONE`: CoW where supported, independent copy otherwise. Adjacent fallback generations no longer share an inode.
- Commit immutable generations through an atomic manifest swap and retain one previous generation for fallback.
- Validate loaded shards by byte length, SHA-256, and logical count.
- Treat fallback as an operation boundary: file loading, materialization, cold filtering, and Codex parsing restart from the previous snapshot; commit fails closed and removes unpublished generations.
- Keep legacy `cursors.json` frozen for downgrade compatibility. A later legacy write remains detectable and is remigrated on the next open.
- Materialize all Codex shards for operations that require a complete view, including repair and project purge.
- Recognize explicit custom `CODEX_HOME` roots even when the directory is not named `.codex`.
- Teach status and diagnostics to read v2 summaries and report legacy fingerprint drift.

No authentication, public exposure, cloud protocol, dashboard, or native-app UI behavior changes.

## Benchmark

Frozen production-sized snapshot, isolated `HOME`, identical 64 MiB cursor state, empty Codex source to isolate cursor-state overhead, and five steady-state runs after activation. Comparison: `origin/main@8016c1e` vs current head `2128156`.

| Metric | origin/main | Current head | Change |
|---|---:|---:|---:|
| Wall time | 0.31 s | 0.21 s | -32% |
| User CPU | 0.30 s | 0.15 s | -50% |
| Maximum RSS | about 591 MiB | about 168 MiB | -72% |

Fixture inventory:

- 42,072 file cursors, including 28,951 Codex file cursors
- 430,033 Codex event fingerprints
- 6,381 hourly buckets and 2,734 project buckets
- Command: `node bin/tracker.js sync --auto --from-retry --source=codex`

A source-populated semantic comparison also matched file cursors (excluding volatile timestamps), event fingerprints, hourly/project buckets, `queue.jsonl`, and `project.queue.jsonl`.

## Tradeoff

The fixture reports about 173 MiB of logical tracker state after activation: about 64 MiB of frozen legacy state plus about 109 MiB across two retained generations. On APFS, CoW clones share unchanged extents until either copy is written, while still preserving independent fallback semantics. Retention remains bounded to the current and previous generation.

## Verification

- [x] `node --test test/cursor-store.test.js test/codex-sync-hot-path.test.js` - 35 passed
- [x] `npm run ci:local` - 1,628 tests passed
- [x] Copy registry validation
- [x] UI hardcode validation
- [x] Architecture guardrails
- [x] Dashboard production build
- [x] `git diff --check`
- [x] Corruption, ordinary incremental fallback, concurrent legacy drift, and operation-restart regressions

## Release handling

This focused feature PR does not bump versions or commit generated desktop bundles. The `src/` change will ship through the next maintainer release commit, which synchronizes npm, macOS, and Windows versions and builds artifacts from the immutable release tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a more scalable cursor storage system for sync state, including automatic migration from the existing format.
  * Added sharded Codex cursor and event tracking to reduce unnecessary processing during incremental syncs.
  * Added recovery and fallback handling when cursor data is incomplete or corrupted.

* **Improvements**
  * Improved cold-day skipping and sync performance by loading only relevant Codex state.
  * Enhanced diagnostics with cursor-store mode, file/event counts, and migration drift information.
  * Preserved compatibility with existing cursor data and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->