### PR TITLE
fix: stop token issuance from reverting user device renames

### DIFF
--- a/dashboard/edge-patches/tokentracker-device-flow-poll.ts
+++ b/dashboard/edge-patches/tokentracker-device-flow-poll.ts
@@ -53,17 +53,21 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
   if (machineId) {
     const { data: byMachine } = await client.database
       .from("tokentracker_devices")
-      .select("id")
+      .select("id, name_customized")
       .eq("user_id", userId)
       .eq("machine_id", machineId)
       .is("revoked_at", null)
       .limit(1)
       .maybeSingle();
     if (byMachine && (byMachine as { id: string }).id) {
-      deviceId = (byMachine as { id: string }).id;
+      const row = byMachine as { id: string; name_customized?: boolean };
+      deviceId = row.id;
+      // Keep the display name fresh unless the user renamed the device
+      // (name_customized) — this write runs on every CLI re-login and used
+      // to revert renames to the default hostname-derived name.
       await client.database
         .from("tokentracker_devices")
-        .update({ device_name: deviceName, platform })
+        .update(row.name_customized ? { platform } : { device_name: deviceName, platform })
         .eq("id", deviceId);
     }
 
@@ -80,14 +84,16 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
       const legacyBareName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}`.slice(0, 128);
       const { data: legacyRows } = await client.database
         .from("tokentracker_devices")
-        .select("id, device_name")
+        .select("id, device_name, name_customized")
         .eq("user_id", userId)
         .eq("platform", platform)
         .in("device_name", [deviceName, legacyBareName])
         .is("revoked_at", null)
         .is("machine_id", null)
         .order("created_at", { ascending: true });
-      const candidates = Array.isArray(legacyRows) ? (legacyRows as Array<{ id: string; device_name: string }>) : [];
+      const candidates = Array.isArray(legacyRows)
+        ? (legacyRows as Array<{ id: string; device_name: string; name_customized?: boolean }>)
+        : [];
       // Prefer an exact new-name match, then the bare legacy name.
       const ordered = [
         ...candidates.filter((r) => r.device_name === deviceName),
@@ -96,7 +102,9 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
       for (const candidate of ordered) {
         const { error: adoptErr } = await client.database
           .from("tokentracker_devices")
-          .update({ machine_id: machineId, device_name: deviceName })
+          .update(candidate.name_customized
+            ? { machine_id: machineId }
+            : { machine_id: machineId, device_name: deviceName })
           .eq("id", candidate.id)
           .is("machine_id", null);
         if (!adoptErr) {

--- a/dashboard/edge-patches/tokentracker-device-flow-poll.ts
+++ b/dashboard/edge-patches/tokentracker-device-flow-poll.ts
@@ -91,9 +91,28 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
         .is("revoked_at", null)
         .is("machine_id", null)
         .order("created_at", { ascending: true });
-      const candidates = Array.isArray(legacyRows)
+      let candidates = Array.isArray(legacyRows)
         ? (legacyRows as Array<{ id: string; device_name: string; name_customized?: boolean }>)
         : [];
+      if (candidates.length === 0) {
+        // A renamed legacy row matches no client default by device_name; the
+        // rename endpoint preserved its pre-rename default in
+        // default_device_name — match that as a fallback, with the exact same
+        // (user, platform, active, machine_id IS NULL) scope, so a rename
+        // doesn't leave the row un-adoptable and split off a fresh device.
+        const { data: renamedRows } = await client.database
+          .from("tokentracker_devices")
+          .select("id, device_name, name_customized")
+          .eq("user_id", userId)
+          .eq("platform", platform)
+          .in("default_device_name", [deviceName, legacyBareName])
+          .is("revoked_at", null)
+          .is("machine_id", null)
+          .order("created_at", { ascending: true });
+        candidates = Array.isArray(renamedRows)
+          ? (renamedRows as Array<{ id: string; device_name: string; name_customized?: boolean }>)
+          : [];
+      }
       // Prefer an exact new-name match, then the bare legacy name.
       const ordered = [
         ...candidates.filter((r) => r.device_name === deviceName),

--- a/dashboard/edge-patches/tokentracker-device-rename.ts
+++ b/dashboard/edge-patches/tokentracker-device-rename.ts
@@ -15,7 +15,11 @@
  *
  * Renaming also sets name_customized = true, which tells the token-issue /
  * device-flow-poll keep-fresh writes to stop refreshing device_name from the
- * client default (those writes used to revert every rename within ~12h).
+ * client default (those writes used to revert every rename within ~12h). A
+ * row's FIRST rename additionally preserves its pre-rename client-default
+ * name in default_device_name, which legacy adoption matches as a fallback —
+ * without it, renaming a machine_id-less row would make it un-adoptable and
+ * split off a fresh device on the next client-upgrade login.
  */
 import { createClient } from "npm:@insforge/sdk";
 
@@ -104,14 +108,32 @@ export default async function (req: Request): Promise<Response> {
   });
 
   try {
+    // A row's first rename captures its current (client-default) name so
+    // legacy adoption can still match the row afterwards. Once
+    // name_customized is set the capture is frozen — repeated renames must
+    // not overwrite the original default with a previous custom name.
+    let priorName: string | null = null;
+    const { data: current, error: readErr } = await client.database
+      .from("tokentracker_devices")
+      .select("id, device_name, name_customized")
+      .eq("id", deviceId)
+      .eq("user_id", userId)
+      .is("revoked_at", null)
+      .maybeSingle();
+    if (!readErr && current && !(current as { name_customized?: boolean }).name_customized) {
+      priorName = (current as { device_name?: string | null }).device_name ?? null;
+    }
+
     let { data, error } = await client.database
       .from("tokentracker_devices")
-      .update({ device_name: name, name_customized: true })
+      .update(priorName
+        ? { device_name: name, name_customized: true, default_device_name: priorName }
+        : { device_name: name, name_customized: true })
       .eq("id", deviceId)
       .eq("user_id", userId)
       .is("revoked_at", null)
       .select("id, device_name, platform");
-    if (error && /name_customized/i.test(error.message || "")) {
+    if (error && /name_customized|default_device_name/i.test(error.message || "")) {
       // Deploy-order safety net: this function is live but the
       // name_customized migration has not run yet. Fall back to the legacy
       // update so rename keeps working (unprotected) instead of 500ing.

--- a/dashboard/edge-patches/tokentracker-device-rename.ts
+++ b/dashboard/edge-patches/tokentracker-device-rename.ts
@@ -12,6 +12,10 @@
  * `tokentracker_devices_active_unique` on (user_id, platform, device_name)
  * means renaming to a name already held by another active device on the same
  * platform raises a unique violation → surfaced as 409 (name_taken).
+ *
+ * Renaming also sets name_customized = true, which tells the token-issue /
+ * device-flow-poll keep-fresh writes to stop refreshing device_name from the
+ * client default (those writes used to revert every rename within ~12h).
  */
 import { createClient } from "npm:@insforge/sdk";
 
@@ -100,13 +104,25 @@ export default async function (req: Request): Promise<Response> {
   });
 
   try {
-    const { data, error } = await client.database
+    let { data, error } = await client.database
       .from("tokentracker_devices")
-      .update({ device_name: name })
+      .update({ device_name: name, name_customized: true })
       .eq("id", deviceId)
       .eq("user_id", userId)
       .is("revoked_at", null)
       .select("id, device_name, platform");
+    if (error && /name_customized/i.test(error.message || "")) {
+      // Deploy-order safety net: this function is live but the
+      // name_customized migration has not run yet. Fall back to the legacy
+      // update so rename keeps working (unprotected) instead of 500ing.
+      ({ data, error } = await client.database
+        .from("tokentracker_devices")
+        .update({ device_name: name })
+        .eq("id", deviceId)
+        .eq("user_id", userId)
+        .is("revoked_at", null)
+        .select("id, device_name, platform"));
+    }
     if (error) {
       const msg = error.message || "";
       if (/unique|duplicate|conflict|already exists/i.test(msg))

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -195,6 +195,7 @@ export default async function (req: Request): Promise<Response> {
       const legacyBaseName = deviceName.replace(/ #[0-9a-fA-F]{8}$/, "");
       const legacyNames =
         legacyBaseName === deviceName ? [deviceName] : [deviceName, legacyBaseName];
+      let legacyId: string | null = null;
       const { data: legacy } = await dbClient.database
         .from("tokentracker_devices")
         .select("id")
@@ -207,7 +208,30 @@ export default async function (req: Request): Promise<Response> {
         .limit(1)
         .maybeSingle();
       if (legacy && (legacy as { id: string }).id) {
-        const legacyId = (legacy as { id: string }).id;
+        legacyId = (legacy as { id: string }).id;
+      }
+      if (!legacyId) {
+        // A renamed legacy row matches no client default by device_name; the
+        // rename endpoint preserved its pre-rename default in
+        // default_device_name — match that as a fallback, with the exact same
+        // (user, platform, active, machine_id IS NULL) scope, so a rename
+        // doesn't leave the row un-adoptable and split off a fresh device.
+        const { data: renamed } = await dbClient.database
+          .from("tokentracker_devices")
+          .select("id")
+          .eq("user_id", userId)
+          .eq("platform", platform)
+          .in("default_device_name", legacyNames)
+          .is("revoked_at", null)
+          .is("machine_id", null)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle();
+        if (renamed && (renamed as { id: string }).id) {
+          legacyId = (renamed as { id: string }).id;
+        }
+      }
+      if (legacyId) {
         const { error: adoptErr } = await dbClient.database
           .from("tokentracker_devices")
           .update({ machine_id: machineId })

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -167,18 +167,21 @@ export default async function (req: Request): Promise<Response> {
   if (machineId) {
     const { data: byMachine } = await dbClient.database
       .from("tokentracker_devices")
-      .select("id")
+      .select("id, name_customized")
       .eq("user_id", userId)
       .eq("machine_id", machineId)
       .is("revoked_at", null)
       .limit(1)
       .maybeSingle();
     if (byMachine && (byMachine as { id: string }).id) {
-      deviceId = (byMachine as { id: string }).id;
-      // Keep the display name fresh; identity is the machine_id, not the name.
+      const row = byMachine as { id: string; name_customized?: boolean };
+      deviceId = row.id;
+      // Keep the display name fresh — identity is the machine_id, not the
+      // name — UNLESS the user renamed the device (name_customized): this
+      // write runs on every 12h token rotation and used to revert renames.
       await dbClient.database
         .from("tokentracker_devices")
-        .update({ device_name: deviceName, platform })
+        .update(row.name_customized ? { platform } : { device_name: deviceName, platform })
         .eq("id", deviceId);
     }
 

--- a/migrations/20260717060000_add-device-name-customized.sql
+++ b/migrations/20260717060000_add-device-name-customized.sql
@@ -6,12 +6,25 @@
 ALTER TABLE public.tokentracker_devices
   ADD COLUMN IF NOT EXISTS name_customized boolean NOT NULL DEFAULT false;
 
--- One-time backfill: any active name that does not look like a client default
--- ("Token Tracker", "Token Tracker (dashboard) #hex8", "TokenTracker CLI
--- (<clientInfo>) #hex8", with or without the legacy-era suffixes) must have
--- come from the rename endpoint. Pattern matching is acceptable here as a
--- migration-time heuristic; runtime protection relies only on the flag.
+-- Captured by the rename endpoint on a row's FIRST rename: the pre-rename
+-- client-default name. Legacy adoption (token-issue / device-flow-poll)
+-- matches on it as a fallback, so renaming a machine_id-less row does not
+-- make it un-adoptable (which would split off a fresh device on the next
+-- client-upgrade login). NULL for rows renamed before this migration shipped
+-- — their original default is unrecoverable, matching today's behavior.
+ALTER TABLE public.tokentracker_devices
+  ADD COLUMN IF NOT EXISTS default_device_name text;
+
+-- One-time backfill, scoped to ACTIVE rows: revoked devices never receive
+-- keep-fresh writes (every writer filters revoked_at IS NULL), so flagging
+-- them would only blur the column's meaning. Any active name that does not
+-- look like a client default ("Token Tracker", "Token Tracker (dashboard)
+-- #hex8", "TokenTracker CLI (<clientInfo>) #hex8", with or without the
+-- legacy-era suffixes) must have come from the rename endpoint. Pattern
+-- matching is acceptable here as a migration-time heuristic; runtime
+-- protection relies only on the flag.
 UPDATE public.tokentracker_devices
 SET name_customized = true
-WHERE device_name !~ '^Token Tracker( \(dashboard\))?( #[0-9a-fA-F]{8})?$'
+WHERE revoked_at IS NULL
+  AND device_name !~ '^Token Tracker( \(dashboard\))?( #[0-9a-fA-F]{8})?$'
   AND device_name !~ '^TokenTracker CLI( \(.*\))?( #[0-9a-fA-F]{8})?$';

--- a/migrations/20260717060000_add-device-name-customized.sql
+++ b/migrations/20260717060000_add-device-name-customized.sql
@@ -1,0 +1,17 @@
+-- User device renames kept reverting to the client default name: every device
+-- token issuance (12h dashboard rotation, CLI device-flow login) refreshed
+-- device_name from the client-computed default. Record "the user renamed this
+-- device" so those keep-fresh writes can skip protected rows.
+
+ALTER TABLE public.tokentracker_devices
+  ADD COLUMN IF NOT EXISTS name_customized boolean NOT NULL DEFAULT false;
+
+-- One-time backfill: any active name that does not look like a client default
+-- ("Token Tracker", "Token Tracker (dashboard) #hex8", "TokenTracker CLI
+-- (<clientInfo>) #hex8", with or without the legacy-era suffixes) must have
+-- come from the rename endpoint. Pattern matching is acceptable here as a
+-- migration-time heuristic; runtime protection relies only on the flag.
+UPDATE public.tokentracker_devices
+SET name_customized = true
+WHERE device_name !~ '^Token Tracker( \(dashboard\))?( #[0-9a-fA-F]{8})?$'
+  AND device_name !~ '^TokenTracker CLI( \(.*\))?( #[0-9a-fA-F]{8})?$';

--- a/test/device-rename-persistence.test.js
+++ b/test/device-rename-persistence.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+// User device renames must survive token issuance (issue: rename reverted to
+// the default name on every 12h dashboard token rotation / CLI re-login).
+// The `name_customized` flag is set by the rename endpoint; every edge write
+// that refreshes device_name from a client-computed default must skip rows
+// where the user customized the name.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const ROOT = path.resolve(__dirname, "..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+
+const MIGRATION = "migrations/20260717060000_add-device-name-customized.sql";
+
+test("migration adds the name_customized column and backfills renamed rows", () => {
+  const source = read(MIGRATION);
+  assert.match(
+    source,
+    /ADD COLUMN IF NOT EXISTS name_customized boolean NOT NULL DEFAULT false/u,
+    "devices table must gain the name_customized flag",
+  );
+  assert.match(
+    source,
+    /SET name_customized = true/u,
+    "existing user-renamed rows must be backfilled so they are protected immediately",
+  );
+});
+
+test("rename endpoint marks the device name as user-customized", () => {
+  const source = read("dashboard/edge-patches/tokentracker-device-rename.ts");
+  assert.match(
+    source,
+    /\.update\(\{ device_name: name, name_customized: true \}\)/u,
+    "rename must set name_customized so token issuance stops refreshing the name",
+  );
+});
+
+test("rename endpoint survives being deployed before the migration", () => {
+  const source = read("dashboard/edge-patches/tokentracker-device-rename.ts");
+  assert.match(
+    source,
+    /\/name_customized\/i\.test\(error\.message/u,
+    "rename must fall back to the legacy update when the column is missing (deploy-order safety net)",
+  );
+});
+
+test("token issuance never overwrites a user-customized device name", () => {
+  const tokenIssue = read("dashboard/edge-patches/tokentracker-device-token-issue.ts");
+  assert.match(
+    tokenIssue,
+    /\.select\("id, name_customized"\)/u,
+    "token-issue must read name_customized when resolving the device by machine_id",
+  );
+  assert.match(
+    tokenIssue,
+    /name_customized \? \{ platform \} : \{ device_name: deviceName, platform \}/u,
+    "token-issue keep-fresh update must skip device_name on customized rows",
+  );
+  assert.doesNotMatch(
+    tokenIssue,
+    /\.update\(\{ device_name: deviceName, platform \}\)/u,
+    "token-issue must not unconditionally overwrite device_name",
+  );
+
+  const flowPoll = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts");
+  assert.match(
+    flowPoll,
+    /name_customized \? \{ platform \} : \{ device_name: deviceName, platform \}/u,
+    "device-flow-poll keep-fresh update must skip device_name on customized rows",
+  );
+  assert.doesNotMatch(
+    flowPoll,
+    /\.update\(\{ device_name: deviceName, platform \}\)/u,
+    "device-flow-poll must not unconditionally overwrite device_name",
+  );
+  assert.match(
+    flowPoll,
+    /name_customized[\s\S]{0,120}\{ machine_id: machineId \}[\s\S]{0,120}\{ machine_id: machineId, device_name: deviceName \}/u,
+    "legacy adoption must not rename a row the user customized",
+  );
+});

--- a/test/device-rename-persistence.test.js
+++ b/test/device-rename-persistence.test.js
@@ -25,8 +25,13 @@ test("migration adds the name_customized column and backfills renamed rows", () 
   );
   assert.match(
     source,
-    /SET name_customized = true/u,
-    "existing user-renamed rows must be backfilled so they are protected immediately",
+    /ADD COLUMN IF NOT EXISTS default_device_name text/u,
+    "devices table must gain default_device_name so renamed legacy rows stay adoptable",
+  );
+  assert.match(
+    source,
+    /SET name_customized = true\s*\nWHERE revoked_at IS NULL/u,
+    "backfill must be scoped to active rows — revoked devices never receive keep-fresh writes",
   );
 });
 
@@ -34,8 +39,18 @@ test("rename endpoint marks the device name as user-customized", () => {
   const source = read("dashboard/edge-patches/tokentracker-device-rename.ts");
   assert.match(
     source,
-    /\.update\(\{ device_name: name, name_customized: true \}\)/u,
-    "rename must set name_customized so token issuance stops refreshing the name",
+    /\{ device_name: name, name_customized: true, default_device_name: priorName \}/u,
+    "rename must set name_customized and preserve the pre-rename client default",
+  );
+  assert.match(
+    source,
+    /: \{ device_name: name, name_customized: true \}/u,
+    "repeated renames must not overwrite the captured default with a custom name",
+  );
+  assert.match(
+    source,
+    /\.select\("id, device_name, name_customized"\)/u,
+    "rename must read the row's prior state to know whether to capture the default name",
   );
 });
 
@@ -43,8 +58,8 @@ test("rename endpoint survives being deployed before the migration", () => {
   const source = read("dashboard/edge-patches/tokentracker-device-rename.ts");
   assert.match(
     source,
-    /\/name_customized\/i\.test\(error\.message/u,
-    "rename must fall back to the legacy update when the column is missing (deploy-order safety net)",
+    /\/name_customized\|default_device_name\/i\.test\(error\.message/u,
+    "rename must fall back to the legacy update when the columns are missing (deploy-order safety net)",
   );
 });
 
@@ -81,5 +96,26 @@ test("token issuance never overwrites a user-customized device name", () => {
     flowPoll,
     /name_customized[\s\S]{0,120}\{ machine_id: machineId \}[\s\S]{0,120}\{ machine_id: machineId, device_name: deviceName \}/u,
     "legacy adoption must not rename a row the user customized",
+  );
+});
+
+test("renamed machine_id-less rows stay adoptable via their preserved default name", () => {
+  // A rename removes the row from the client-default name space, so adoption
+  // by device_name can no longer find it — without a fallback the next
+  // client-upgrade login would mint a fresh device and split the history
+  // (issue #187 class). Both adoption paths must retry the match against
+  // default_device_name, which the rename endpoint captured.
+  const tokenIssue = read("dashboard/edge-patches/tokentracker-device-token-issue.ts");
+  assert.match(
+    tokenIssue,
+    /\.in\("default_device_name", legacyNames\)/u,
+    "token-issue adoption must fall back to the preserved pre-rename default name",
+  );
+
+  const flowPoll = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts");
+  assert.match(
+    flowPoll,
+    /\.in\("default_device_name", \[deviceName, legacyBareName\]\)/u,
+    "device-flow-poll adoption must fall back to the preserved pre-rename default name",
   );
 });


### PR DESCRIPTION
## Summary

Renaming a device kept reverting to the default name — every device-token issuance ran a "keep the display name fresh" write that unconditionally overwrote `device_name` with the client-computed default. This PR records user renames in a new `tokentracker_devices.name_customized` flag and makes those writes skip protected rows, so renames finally stick while default-named devices keep following hostname changes.

**Why renames reverted on a schedule:** the dashboard rotates its device token every 12h (`DEVICE_TOKEN_ROTATE_AFTER_MS` in `dashboard/src/lib/cloud-sync.ts`), and the CLI local server's issued-token cache is in-memory (`src/lib/local-api.js`), so every `tokentracker serve` / menu-bar app / Windows app restart re-issues a token. Each issuance hit one of the unconditional overwrites:

- `tokentracker-device-token-issue.ts` — keep-fresh update on the machine-anchored row
- `tokentracker-device-flow-poll.ts` — same write on CLI device-flow login, plus the legacy-adoption rename

So a rename survived only until the next app restart or at most ~12h ("half a day").

## What changed

- **`migrations/20260717060000_add-device-name-customized.sql`** — adds `name_customized boolean NOT NULL DEFAULT false` plus `default_device_name text`; backfills `name_customized = true` for **active** (`revoked_at IS NULL`) names that don't match any client default pattern, so already-renamed devices are protected the moment this ships. Pattern matching is a migration-time heuristic only; runtime protection relies solely on the flag.
- **`tokentracker-device-rename.ts`** — rename now sets `name_customized: true`, and a row's **first** rename captures its pre-rename client-default name into `default_device_name` (repeated renames never overwrite the capture). Includes a deploy-order safety net: if the columns don't exist yet (function deployed before the migration ran), it retries the legacy update, so rename degrades to today's unprotected behavior instead of 500ing.
- **`tokentracker-device-token-issue.ts`** — the keep-fresh update sends `{ platform }` only for customized rows, `{ device_name, platform }` otherwise. Legacy adoption falls back to matching `default_device_name` when no row matches by `device_name`, with the identical `(user, platform, revoked_at IS NULL, machine_id IS NULL)` scope — so renaming a machine_id-less row no longer makes it un-adoptable.
- **`tokentracker-device-flow-poll.ts`** — same for the CLI-login keep-fresh write and the same `default_device_name` adoption fallback; legacy adoption still backfills `machine_id` but no longer renames a customized row.
- **`test/device-rename-persistence.test.js`** — static guardrails (house style of `backend-hot-path-guardrails.test.js`) pinning all of the above so an unconditional overwrite can't quietly come back.

## Deployment (order matters)

> [!IMPORTANT]
> Merging this PR does **not** activate the fix by itself. Both steps below are **manual operations against the production InsForge project** (run the SQL migration, then redeploy the edge functions) — nothing in CI performs them. Until both are done, renames keep reverting.

1. **Apply the migration first** — old function code ignores the new column, so this step is safe standalone.
2. **Then redeploy** `tokentracker-device-rename`, `tokentracker-device-token-issue`, `tokentracker-device-flow-poll`.

Reversed order is non-fatal (rename falls back to the legacy update; token issuance for already-anchored machines converges via insert-conflict → winner re-select), but legacy adoption is degraded while functions run ahead of the schema — one more reason to keep migration-first. The fix isn't active until both steps are done.

## Known trade-offs

- A renamed device stops following hostname changes — that's the point of renaming; renaming back is always possible via the same endpoint.
- Rows renamed **after** this ships stay adoptable: the rename captures the pre-rename client default into `default_device_name` and both adoption paths fall back to matching on it. Rows renamed **before** this ships have no recoverable original default (`default_device_name` stays NULL) and remain un-adoptable — exactly as they are on `main` today, so no regression. After the migration runs, that residual class is precisely enumerable (`revoked_at IS NULL AND machine_id IS NULL AND name_customized`) for an optional one-off cleanup, and any splits it produces stay compensated by the `tokentracker_device_machine` cluster branch in account aggregation (replayed hourly rows dedupe there as before).

## Scope

- [ ] CLI (`src/`)
- [x] Dashboard (`dashboard/`) — edge-patches only
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config — migration + guardrail test

No `src/` or `dashboard/src/` changes → release-neutral per the version-bump matrix (no version bump included).

## Checklist

- [x] `npm test` passes — new guardrail test + `backend-hot-path-guardrails` + device/local-api suites green locally; the only local failures are this machine's known pre-existing env baseline (verified identical on a clean `main` checkout), CI is authoritative
- [x] No new user-facing strings
- [x] Conventional commit style
- [x] PR description explains *why*

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth / session / token handling — token-issue path touched, but auth/verification logic is unchanged; only the update payload varies
- [x] Cross-endpoint invariants or shared logic — `name_customized` must be honored by all three functions; enforced by the static guardrail test
- [ ] External gateway / environment constraints

### Rules / invariants

- The rename endpoint is the ONLY writer that sets `name_customized = true`; token issuance never clears it.
- The rename endpoint is also the ONLY writer of `default_device_name`, and only on a row's first rename (`name_customized` still false) — the capture is frozen thereafter, so it always holds a client-computed default, never a custom name.
- Keep-fresh writes may update `device_name` only where `name_customized` is false; `platform` refresh is unconditional.
- Adoption's `default_device_name` fallback uses the identical filter scope as the existing name match (`user_id`, `platform`, `revoked_at IS NULL`, `machine_id IS NULL`, same `created_at` ordering) and the same client-computed candidate names — the same deterministic key class, so it cannot claim any row that today's name matching could not.
- Device identity resolution order (machine_id → adoption by name → adoption by preserved default → insert) only appends a step; existing steps are unchanged.

### Boundary matrix

- Rename deployed before migration → column-missing error detected → falls back to legacy update (rename works, unprotected)
- Token issue for a customized row → `{ platform }`-only update, name preserved
- Token issue for a default-named row → `{ device_name, platform }` refresh (behavior unchanged)
- Adoption of a customized machine_id-less row (renamed post-ship) → matched via `default_device_name`, `machine_id` backfilled, custom name preserved
- Adoption of a machine_id-less row renamed pre-ship → `default_device_name` is NULL → no match, fresh insert (same as `main` today; enumerable + cluster-compensated, see Known trade-offs)
- Rename to a name held by another active device → unique index still surfaces 409 `name_taken` (unchanged, including on the fallback path)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
