### PR TITLE
perf(codex): incrementally parse appended context rollouts

### DIFF
--- a/src/lib/codex-context-breakdown.js
+++ b/src/lib/codex-context-breakdown.js
@@ -266,35 +266,21 @@ function selectAppendHashPaths(candidateGroups) {
 }
 
 async function digestFilePrefix(
-  filePath,
+  sourceHandle,
   endOffset,
   diagnostics = null,
-  sourceHandle = null,
 ) {
   const end = Math.max(0, Number(endOffset) || 0);
   const hash = crypto.createHash("sha256");
   if (end === 0) return hash.digest("hex");
   let bytesRead = 0;
-  if (sourceHandle && typeof sourceHandle.read === "function") {
-    const buffer = Buffer.allocUnsafe(PREFIX_HASH_READ_BYTES);
-    while (bytesRead < end) {
-      const length = Math.min(buffer.length, end - bytesRead);
-      const result = await sourceHandle.read(buffer, 0, length, bytesRead);
-      if (!result.bytesRead) break;
-      hash.update(buffer.subarray(0, result.bytesRead));
-      bytesRead += result.bytesRead;
-    }
-  } else {
-    const stream = fs.createReadStream(filePath, {
-      start: 0,
-      end: end - 1,
-      highWaterMark: PREFIX_HASH_READ_BYTES,
-    });
-    for await (const value of stream) {
-      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
-      bytesRead += chunk.length;
-      hash.update(chunk);
-    }
+  const buffer = Buffer.allocUnsafe(PREFIX_HASH_READ_BYTES);
+  while (bytesRead < end) {
+    const length = Math.min(buffer.length, end - bytesRead);
+    const result = await sourceHandle.read(buffer, 0, length, bytesRead);
+    if (!result.bytesRead) break;
+    hash.update(buffer.subarray(0, result.bytesRead));
+    bytesRead += result.bytesRead;
   }
   if (diagnostics) {
     diagnostics.prefix_validation_bytes =
@@ -338,10 +324,9 @@ async function openValidatedResumeFile(cached, entry, diagnostics = null) {
 
     const expected = cached.contentHashState.copy().digest("hex");
     const actual = await digestFilePrefix(
-      entry.filePath,
+      handle,
       cached.endOffset,
       diagnostics,
-      handle,
     );
     if (actual !== expected) return null;
     if (diagnostics) diagnostics.stat_calls += 1;
@@ -377,15 +362,6 @@ function rememberParsedGroup(key, value) {
 }
 
 function splitCapturedParse(parsed) {
-  if (!parsed || typeof parsed !== "object") {
-    return {
-      parsed,
-      resumeState: null,
-      endOffset: 0,
-      appendable: false,
-      contentHashState: null,
-    };
-  }
   const {
     resumeState = null,
     endOffset = 0,
@@ -537,10 +513,9 @@ async function computeCodexContextBreakdown({
             try {
               const expectedSnapshot = resumed.contentHashState.copy().digest("hex");
               const actualSnapshot = await digestFilePrefix(
-                singleEntry.filePath,
+                resumeHandle,
                 singleEntry.stat.size,
                 diagnostics,
-                resumeHandle,
               );
               stableAfterParse = actualSnapshot === expectedSnapshot;
             } catch {

--- a/src/lib/codex-context-breakdown.js
+++ b/src/lib/codex-context-breakdown.js
@@ -246,24 +246,36 @@ function selectAppendHashPaths(candidateGroups) {
   return newest ? new Set([newest.filePath]) : new Set();
 }
 
-async function digestFilePrefix(filePath, endOffset, diagnostics = null) {
+async function digestFilePrefix(
+  filePath,
+  endOffset,
+  diagnostics = null,
+  sourceHandle = null,
+) {
   const end = Math.max(0, Number(endOffset) || 0);
   const hash = crypto.createHash("sha256");
   if (end === 0) return hash.digest("hex");
-  const stream = fs.createReadStream(filePath, {
-    start: 0,
-    end: end - 1,
-    highWaterMark: PREFIX_HASH_READ_BYTES,
-  });
   let bytesRead = 0;
-  try {
+  if (sourceHandle && typeof sourceHandle.read === "function") {
+    const buffer = Buffer.allocUnsafe(PREFIX_HASH_READ_BYTES);
+    while (bytesRead < end) {
+      const length = Math.min(buffer.length, end - bytesRead);
+      const result = await sourceHandle.read(buffer, 0, length, bytesRead);
+      if (!result.bytesRead) break;
+      hash.update(buffer.subarray(0, result.bytesRead));
+      bytesRead += result.bytesRead;
+    }
+  } else {
+    const stream = fs.createReadStream(filePath, {
+      start: 0,
+      end: end - 1,
+      highWaterMark: PREFIX_HASH_READ_BYTES,
+    });
     for await (const value of stream) {
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
       bytesRead += chunk.length;
       hash.update(chunk);
     }
-  } finally {
-    stream.destroy();
   }
   if (diagnostics) {
     diagnostics.prefix_validation_bytes =
@@ -272,7 +284,7 @@ async function digestFilePrefix(filePath, endOffset, diagnostics = null) {
   return bytesRead === end ? hash.digest("hex") : null;
 }
 
-async function canResumeParsedGroup(cached, entry, diagnostics = null) {
+async function openValidatedResumeFile(cached, entry, diagnostics = null) {
   if (
     !cached?.resumeState ||
     !cached?.stat ||
@@ -280,7 +292,7 @@ async function canResumeParsedGroup(cached, entry, diagnostics = null) {
     typeof cached.contentHashState.copy !== "function" ||
     cached.appendable !== true ||
     cached.filePath !== entry.filePath
-  ) return false;
+  ) return null;
   const previous = cached.stat;
   const current = entry.stat;
   if (
@@ -290,18 +302,47 @@ async function canResumeParsedGroup(cached, entry, diagnostics = null) {
     Number(cached.endOffset) < 0 ||
     Number(cached.endOffset) > Number(previous.size)
   ) {
-    return false;
+    return null;
   }
+  let handle = null;
+  let keepOpen = false;
   try {
-    const expected = cached.contentHashState.copy().digest("hex");
-    const actual = await digestFilePrefix(entry.filePath, cached.endOffset, diagnostics);
-    if (actual !== expected) return false;
+    // Validation and suffix parsing share this handle so a path replacement
+    // cannot splice cached aggregates onto bytes from a different file.
+    handle = await fs.promises.open(entry.filePath, "r");
     if (diagnostics) diagnostics.stat_calls += 1;
-    const afterValidation = fs.statSync(entry.filePath);
-    return statIdentity(entry.filePath, afterValidation) ===
-      statIdentity(entry.filePath, current);
+    const opened = await handle.stat();
+    if (
+      statIdentity(entry.filePath, opened) !==
+      statIdentity(entry.filePath, current)
+    ) return null;
+
+    const expected = cached.contentHashState.copy().digest("hex");
+    const actual = await digestFilePrefix(
+      entry.filePath,
+      cached.endOffset,
+      diagnostics,
+      handle,
+    );
+    if (actual !== expected) return null;
+    if (diagnostics) diagnostics.stat_calls += 1;
+    const afterValidation = await handle.stat();
+    if (
+      statIdentity(entry.filePath, afterValidation) !==
+      statIdentity(entry.filePath, current)
+    ) return null;
+    keepOpen = true;
+    return handle;
   } catch {
-    return false;
+    return null;
+  } finally {
+    if (handle && !keepOpen) {
+      try {
+        await handle.close();
+      } catch {
+        // A failed validation already forces the conservative full parse.
+      }
+    }
   }
 }
 
@@ -439,10 +480,10 @@ async function computeCodexContextBreakdown({
       const appendHashEligible = Boolean(
         singleEntry && appendHashPaths.has(singleEntry.filePath),
       );
-      if (
-        appendHashEligible &&
-        await canResumeParsedGroup(cachedGroup, singleEntry, diagnostics)
-      ) {
+      const resumeHandle = appendHashEligible
+        ? await openValidatedResumeFile(cachedGroup, singleEntry, diagnostics)
+        : null;
+      if (resumeHandle) {
         try {
           const resumed = await parseCodexRolloutFile(singleEntry.filePath, {
             from: fromKey,
@@ -456,37 +497,62 @@ async function computeCodexContextBreakdown({
             captureResumeState: true,
             captureContentHash: true,
             contentHashState: cachedGroup.contentHashState,
+            sourceHandle: resumeHandle,
           });
-          const delta = splitCapturedParse(resumed);
-          captured = {
-            parsed: mergeParsedSessionResults(cachedGroup.parsed, delta.parsed),
-            resumeState: delta.resumeState,
-            endOffset: delta.endOffset,
-            appendable: delta.appendable,
-            contentHashState: delta.contentHashState,
-          };
-          diagnostics.incremental_parse_hits += 1;
+          if (diagnostics) diagnostics.stat_calls += 1;
+          const afterParse = await resumeHandle.stat().catch(() => null);
+          if (
+            afterParse &&
+            statIdentity(singleEntry.filePath, afterParse) ===
+              statIdentity(singleEntry.filePath, singleEntry.stat)
+          ) {
+            const delta = splitCapturedParse(resumed);
+            captured = {
+              parsed: mergeParsedSessionResults(cachedGroup.parsed, delta.parsed),
+              resumeState: delta.resumeState,
+              endOffset: delta.endOffset,
+              appendable: delta.appendable,
+              contentHashState: delta.contentHashState,
+            };
+            diagnostics.incremental_parse_hits += 1;
+          } else {
+            diagnostics.incremental_parse_fallbacks += 1;
+          }
         } catch (error) {
           if (!isCodexResumeInvalidated(error)) throw error;
           diagnostics.incremental_parse_fallbacks += 1;
+        } finally {
+          await resumeHandle.close();
         }
       }
 
       if (!captured) {
-        const fresh = await parseCodexRolloutFile(
-          filePaths.length === 1 ? filePaths[0] : filePaths,
-          {
-            from: fromKey,
-            to: toKey,
-            timeZoneContext,
-            diagnostics,
-            seenTokenEvents: filePaths.length === 1 ? new Set() : seenTokenEvents,
-            endOffset: singleEntry?.stat?.size ?? null,
-            captureResumeState: Boolean(singleEntry),
-            captureContentHash: appendHashEligible,
-          },
-        );
-        captured = splitCapturedParse(fresh);
+        let freshHandle = null;
+        let freshEndOffset = singleEntry?.stat?.size ?? null;
+        try {
+          if (resumeHandle && singleEntry) {
+            freshHandle = await fs.promises.open(singleEntry.filePath, "r");
+            if (diagnostics) diagnostics.stat_calls += 1;
+            freshEndOffset = (await freshHandle.stat()).size;
+          }
+          const fresh = await parseCodexRolloutFile(
+            filePaths.length === 1 ? filePaths[0] : filePaths,
+            {
+              from: fromKey,
+              to: toKey,
+              timeZoneContext,
+              diagnostics,
+              seenTokenEvents: filePaths.length === 1 ? new Set() : seenTokenEvents,
+              endOffset: freshEndOffset,
+              captureResumeState: Boolean(singleEntry),
+              captureContentHash: appendHashEligible,
+              sourceHandle: freshHandle,
+            },
+          );
+          captured = splitCapturedParse(fresh);
+        } finally {
+          await freshHandle?.close();
+        }
       }
 
       parsed = captured.parsed;

--- a/src/lib/codex-context-breakdown.js
+++ b/src/lib/codex-context-breakdown.js
@@ -11,6 +11,7 @@
 "use strict";
 
 const crypto = require("node:crypto");
+const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 
@@ -31,6 +32,7 @@ const {
   finalizeSkillRows,
   finalizeExecRows,
   buildSkillStatsEntry,
+  isCodexResumeInvalidated,
 } = require("./codex-rollout-parser");
 
 // ---------------------------------------------------------------------------
@@ -85,6 +87,50 @@ function mergeExecRows(map, rows) {
   }
 }
 
+function mergeParsedSessionResults(previous, delta) {
+  if (!previous) return delta;
+  if (!delta) return previous;
+
+  const totals = emptyTotals();
+  mergeRollupTotals(totals, previous.totals || {});
+  mergeRollupTotals(totals, delta.totals || {});
+
+  const tools = new Map();
+  mergeRows(tools, previous.toolBreakdown?.tool_rows);
+  mergeRows(tools, delta.toolBreakdown?.tool_rows);
+  const skills = new Map();
+  mergeSkillRows(skills, previous.skillsBreakdown?.skill_rows);
+  mergeSkillRows(skills, delta.skillsBreakdown?.skill_rows);
+
+  const mergeExecGroup = (key) => {
+    const rows = new Map();
+    mergeExecRows(rows, previous.execCommandBreakdown?.[key]);
+    mergeExecRows(rows, delta.execCommandBreakdown?.[key]);
+    return finalizeExecRows(rows);
+  };
+
+  return {
+    sessionId: delta.sessionId || previous.sessionId,
+    cwd: delta.cwd || previous.cwd,
+    model: delta.model || previous.model,
+    provider: delta.provider || previous.provider,
+    version: delta.version || previous.version,
+    filePath: previous.filePath || delta.filePath,
+    turnCount: Number(previous.turnCount || 0) + Number(delta.turnCount || 0),
+    totals,
+    toolBreakdown: { tool_rows: finalizeToolRows(tools) },
+    skillsBreakdown: { skill_rows: finalizeSkillRows(skills) },
+    execCommandBreakdown: {
+      byType: mergeExecGroup("byType"),
+      byExit: mergeExecGroup("byExit"),
+      byExecutable: mergeExecGroup("byExecutable"),
+      byCommand: mergeExecGroup("byCommand"),
+      byDuration: mergeExecGroup("byDuration"),
+      byOutput: mergeExecGroup("byOutput"),
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Period helpers
 // ---------------------------------------------------------------------------
@@ -122,8 +168,9 @@ function buildDateRange({ period, date }) {
 const CACHE = new Map();
 const PARSED_GROUP_CACHE = new Map();
 const CACHE_TTL_MS = 60_000;
-const CACHE_SCHEMA_VERSION = "codex-context-v4";
+const CACHE_SCHEMA_VERSION = "codex-context-v5";
 const MAX_PARSED_GROUP_CACHE_ENTRIES = 4096;
+const APPEND_PREFIX_TAIL_BYTES = 4096;
 
 function cacheTimeZoneKey(timeZoneContext) {
   if (!timeZoneContext) return "";
@@ -131,7 +178,7 @@ function cacheTimeZoneKey(timeZoneContext) {
 }
 
 function statIdentity(filePath, stat) {
-  return JSON.stringify([filePath, stat.size, stat.mtimeMs, stat.ctimeMs, stat.ino]);
+  return JSON.stringify([filePath, stat.dev, stat.ino, stat.size, stat.mtimeMs, stat.ctimeMs]);
 }
 
 function inventorySignature(entries) {
@@ -152,11 +199,69 @@ function parsedGroupCacheKey(entries, { from, to, timeZoneContext }) {
   hash.update(to || "");
   hash.update("\0");
   hash.update(cacheTimeZoneKey(timeZoneContext));
+  for (const { filePath } of entries) {
+    hash.update(filePath);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function parsedGroupSignature(entries) {
+  const hash = crypto.createHash("sha256");
   for (const { filePath, stat } of entries) {
     hash.update(statIdentity(filePath, stat));
     hash.update("\0");
   }
   return hash.digest("hex");
+}
+
+async function inspectParsedPrefix(filePath, endOffset) {
+  const end = Math.max(0, Number(endOffset) || 0);
+  if (end === 0) return { prefixTail: "", appendable: true };
+  const start = Math.max(0, end - APPEND_PREFIX_TAIL_BYTES);
+  const length = end - start;
+  const handle = await fs.open(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, start);
+    if (bytesRead !== length) return null;
+    return {
+      prefixTail: crypto.createHash("sha256").update(buffer).digest("hex"),
+      appendable: buffer[length - 1] === 0x0a,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function prefixTailFingerprint(filePath, endOffset) {
+  return (await inspectParsedPrefix(filePath, endOffset))?.prefixTail ?? null;
+}
+
+async function canResumeParsedGroup(cached, entry) {
+  if (
+    !cached?.resumeState ||
+    !cached?.stat ||
+    cached.appendable !== true ||
+    typeof cached.prefixTail !== "string" ||
+    cached.filePath !== entry.filePath
+  ) return false;
+  const previous = cached.stat;
+  const current = entry.stat;
+  if (
+    Number(previous.dev) !== Number(current.dev) ||
+    Number(previous.ino) !== Number(current.ino) ||
+    Number(current.size) <= Number(previous.size) ||
+    Number(cached.endOffset) < 0 ||
+    Number(cached.endOffset) > Number(previous.size)
+  ) {
+    return false;
+  }
+  try {
+    return await prefixTailFingerprint(entry.filePath, cached.endOffset) === cached.prefixTail;
+  } catch {
+    return false;
+  }
 }
 
 function rememberParsedGroup(key, value) {
@@ -167,6 +272,14 @@ function rememberParsedGroup(key, value) {
     if (!oldest) break;
     PARSED_GROUP_CACHE.delete(oldest);
   }
+}
+
+function splitCapturedParse(parsed) {
+  if (!parsed || typeof parsed !== "object") {
+    return { parsed, resumeState: null, endOffset: 0 };
+  }
+  const { resumeState = null, endOffset = 0, ...result } = parsed;
+  return { parsed: result, resumeState, endOffset };
 }
 
 // ---------------------------------------------------------------------------
@@ -208,6 +321,9 @@ async function computeCodexContextBreakdown({
     opened_files: 0,
     parsed_files: 0,
     parse_cache_hits: 0,
+    incremental_parse_hits: 0,
+    incremental_parse_fallbacks: 0,
+    bytes_read: 0,
     json_parse_calls: 0,
   };
   const discovered = discoverCodexSessionFiles(roots, {
@@ -252,22 +368,77 @@ async function computeCodexContextBreakdown({
     const parsedCacheKey = cacheable
       ? parsedGroupCacheKey(entries, { from: fromKey, to: toKey, timeZoneContext })
       : null;
-    let parsed = parsedCacheKey ? PARSED_GROUP_CACHE.get(parsedCacheKey) : null;
-    if (parsed) {
+    const signature = parsedGroupSignature(entries);
+    const cachedGroup = parsedCacheKey ? PARSED_GROUP_CACHE.get(parsedCacheKey) : null;
+    let parsed = null;
+    if (cachedGroup?.signature === signature) {
       // Cacheable groups are partitioned by rollout UUID, so their token event
       // keys cannot overlap and cache hits need not backfill seenTokenEvents.
       diagnostics.parse_cache_hits += 1;
+      parsed = cachedGroup.parsed;
       PARSED_GROUP_CACHE.delete(parsedCacheKey);
-      PARSED_GROUP_CACHE.set(parsedCacheKey, parsed);
+      PARSED_GROUP_CACHE.set(parsedCacheKey, cachedGroup);
     } else {
-      parsed = await parseCodexRolloutFile(filePaths.length === 1 ? filePaths[0] : filePaths, {
-        from: fromKey,
-        to: toKey,
-        timeZoneContext,
-        diagnostics,
-        seenTokenEvents,
-      });
-      if (parsedCacheKey) rememberParsedGroup(parsedCacheKey, parsed);
+      let captured = null;
+      const singleEntry = entries.length === 1 ? entries[0] : null;
+      if (singleEntry && await canResumeParsedGroup(cachedGroup, singleEntry)) {
+        try {
+          const resumed = await parseCodexRolloutFile(singleEntry.filePath, {
+            from: fromKey,
+            to: toKey,
+            timeZoneContext,
+            diagnostics,
+            seenTokenEvents: new Set(),
+            startOffset: cachedGroup.endOffset,
+            endOffset: singleEntry.stat.size,
+            resumeState: cachedGroup.resumeState,
+            captureResumeState: true,
+          });
+          const delta = splitCapturedParse(resumed);
+          captured = {
+            parsed: mergeParsedSessionResults(cachedGroup.parsed, delta.parsed),
+            resumeState: delta.resumeState,
+            endOffset: delta.endOffset,
+          };
+          diagnostics.incremental_parse_hits += 1;
+        } catch (error) {
+          if (!isCodexResumeInvalidated(error)) throw error;
+          diagnostics.incremental_parse_fallbacks += 1;
+        }
+      }
+
+      if (!captured) {
+        const fresh = await parseCodexRolloutFile(
+          filePaths.length === 1 ? filePaths[0] : filePaths,
+          {
+            from: fromKey,
+            to: toKey,
+            timeZoneContext,
+            diagnostics,
+            seenTokenEvents: filePaths.length === 1 ? new Set() : seenTokenEvents,
+            endOffset: singleEntry?.stat?.size ?? null,
+            captureResumeState: Boolean(singleEntry),
+          },
+        );
+        captured = splitCapturedParse(fresh);
+      }
+
+      parsed = captured.parsed;
+      if (parsedCacheKey) {
+        const parsedPrefix = singleEntry
+          ? await inspectParsedPrefix(singleEntry.filePath, captured.endOffset).catch(() => null)
+          : null;
+        rememberParsedGroup(parsedCacheKey, {
+          signature,
+          parsed,
+          resumeState: captured.resumeState,
+          endOffset: captured.endOffset,
+          prefixTail: parsedPrefix?.prefixTail ?? null,
+          appendable: parsedPrefix?.appendable === true,
+          filePath: singleEntry?.filePath || null,
+          stat: singleEntry?.stat || null,
+        });
+      }
     }
     if (!parsed || !parsed.totals || !parsed.totals.total_tokens) continue;
     sessions.push(parsed);

--- a/src/lib/codex-context-breakdown.js
+++ b/src/lib/codex-context-breakdown.js
@@ -181,6 +181,25 @@ function statIdentity(filePath, stat) {
   return JSON.stringify([filePath, stat.dev, stat.ino, stat.size, stat.mtimeMs, stat.ctimeMs]);
 }
 
+function contentStatIdentity(filePath, stat) {
+  return JSON.stringify([
+    filePath,
+    stat.dev,
+    stat.ino,
+    stat.size,
+    stat.mtimeMs,
+  ]);
+}
+
+function isUnlinkedResumeSnapshot(filePath, before, after) {
+  return Boolean(
+    before &&
+    after &&
+    Number(after.nlink) === 0 &&
+    contentStatIdentity(filePath, before) === contentStatIdentity(filePath, after),
+  );
+}
+
 function inventorySignature(entries) {
   const hash = crypto.createHash("sha256");
   for (const { filePath, stat, candidate } of entries) {
@@ -328,8 +347,9 @@ async function openValidatedResumeFile(cached, entry, diagnostics = null) {
     if (diagnostics) diagnostics.stat_calls += 1;
     const afterValidation = await handle.stat();
     if (
-      statIdentity(entry.filePath, afterValidation) !==
-      statIdentity(entry.filePath, current)
+      statIdentity(entry.filePath, current) !==
+        statIdentity(entry.filePath, afterValidation) &&
+      !isUnlinkedResumeSnapshot(entry.filePath, current, afterValidation)
     ) return null;
     keepOpen = true;
     return handle;
@@ -501,11 +521,33 @@ async function computeCodexContextBreakdown({
           });
           if (diagnostics) diagnostics.stat_calls += 1;
           const afterParse = await resumeHandle.stat().catch(() => null);
-          if (
+          let stableAfterParse = Boolean(
             afterParse &&
             statIdentity(singleEntry.filePath, afterParse) ===
-              statIdentity(singleEntry.filePath, singleEntry.stat)
+              statIdentity(singleEntry.filePath, singleEntry.stat),
+          );
+          if (
+            !stableAfterParse &&
+            isUnlinkedResumeSnapshot(
+              singleEntry.filePath,
+              singleEntry.stat,
+              afterParse,
+            )
           ) {
+            try {
+              const expectedSnapshot = resumed.contentHashState.copy().digest("hex");
+              const actualSnapshot = await digestFilePrefix(
+                singleEntry.filePath,
+                singleEntry.stat.size,
+                diagnostics,
+                resumeHandle,
+              );
+              stableAfterParse = actualSnapshot === expectedSnapshot;
+            } catch {
+              stableAfterParse = false;
+            }
+          }
+          if (stableAfterParse) {
             const delta = splitCapturedParse(resumed);
             captured = {
               parsed: mergeParsedSessionResults(cachedGroup.parsed, delta.parsed),

--- a/src/lib/codex-context-breakdown.js
+++ b/src/lib/codex-context-breakdown.js
@@ -11,7 +11,7 @@
 "use strict";
 
 const crypto = require("node:crypto");
-const fs = require("node:fs/promises");
+const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
@@ -168,9 +168,9 @@ function buildDateRange({ period, date }) {
 const CACHE = new Map();
 const PARSED_GROUP_CACHE = new Map();
 const CACHE_TTL_MS = 60_000;
-const CACHE_SCHEMA_VERSION = "codex-context-v5";
+const CACHE_SCHEMA_VERSION = "codex-context-v6";
 const MAX_PARSED_GROUP_CACHE_ENTRIES = 4096;
-const APPEND_PREFIX_TAIL_BYTES = 4096;
+const PREFIX_HASH_READ_BYTES = 1024 * 1024;
 
 function cacheTimeZoneKey(timeZoneContext) {
   if (!timeZoneContext) return "";
@@ -215,35 +215,70 @@ function parsedGroupSignature(entries) {
   return hash.digest("hex");
 }
 
-async function inspectParsedPrefix(filePath, endOffset) {
-  const end = Math.max(0, Number(endOffset) || 0);
-  if (end === 0) return { prefixTail: "", appendable: true };
-  const start = Math.max(0, end - APPEND_PREFIX_TAIL_BYTES);
-  const length = end - start;
-  const handle = await fs.open(filePath, "r");
-  try {
-    const buffer = Buffer.allocUnsafe(length);
-    const { bytesRead } = await handle.read(buffer, 0, length, start);
-    if (bytesRead !== length) return null;
-    return {
-      prefixTail: crypto.createHash("sha256").update(buffer).digest("hex"),
-      appendable: buffer[length - 1] === 0x0a,
-    };
-  } finally {
-    await handle.close();
+function selectAppendHashPaths(candidateGroups) {
+  // Only the newest single-file group pays the cold hash cost. Any file that
+  // later grows becomes newest, takes one conservative full parse, and keeps
+  // its hash state for subsequent append-only refreshes.
+  let newest = null;
+  for (const entries of candidateGroups.values()) {
+    if (
+      entries.length !== 1 ||
+      !rolloutSessionIdFromPath(entries[0].filePath)
+    ) continue;
+    const entry = entries[0];
+    if (!newest) {
+      newest = entry;
+      continue;
+    }
+    const mtimeDelta = Number(entry.stat?.mtimeMs || 0) -
+      Number(newest.stat?.mtimeMs || 0);
+    const ctimeDelta = Number(entry.stat?.ctimeMs || 0) -
+      Number(newest.stat?.ctimeMs || 0);
+    if (
+      mtimeDelta > 0 ||
+      (mtimeDelta === 0 && ctimeDelta > 0) ||
+      (mtimeDelta === 0 && ctimeDelta === 0 &&
+        entry.filePath.localeCompare(newest.filePath) < 0)
+    ) {
+      newest = entry;
+    }
   }
+  return newest ? new Set([newest.filePath]) : new Set();
 }
 
-async function prefixTailFingerprint(filePath, endOffset) {
-  return (await inspectParsedPrefix(filePath, endOffset))?.prefixTail ?? null;
+async function digestFilePrefix(filePath, endOffset, diagnostics = null) {
+  const end = Math.max(0, Number(endOffset) || 0);
+  const hash = crypto.createHash("sha256");
+  if (end === 0) return hash.digest("hex");
+  const stream = fs.createReadStream(filePath, {
+    start: 0,
+    end: end - 1,
+    highWaterMark: PREFIX_HASH_READ_BYTES,
+  });
+  let bytesRead = 0;
+  try {
+    for await (const value of stream) {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      bytesRead += chunk.length;
+      hash.update(chunk);
+    }
+  } finally {
+    stream.destroy();
+  }
+  if (diagnostics) {
+    diagnostics.prefix_validation_bytes =
+      Number(diagnostics.prefix_validation_bytes || 0) + bytesRead;
+  }
+  return bytesRead === end ? hash.digest("hex") : null;
 }
 
-async function canResumeParsedGroup(cached, entry) {
+async function canResumeParsedGroup(cached, entry, diagnostics = null) {
   if (
     !cached?.resumeState ||
     !cached?.stat ||
+    !cached?.contentHashState ||
+    typeof cached.contentHashState.copy !== "function" ||
     cached.appendable !== true ||
-    typeof cached.prefixTail !== "string" ||
     cached.filePath !== entry.filePath
   ) return false;
   const previous = cached.stat;
@@ -258,7 +293,13 @@ async function canResumeParsedGroup(cached, entry) {
     return false;
   }
   try {
-    return await prefixTailFingerprint(entry.filePath, cached.endOffset) === cached.prefixTail;
+    const expected = cached.contentHashState.copy().digest("hex");
+    const actual = await digestFilePrefix(entry.filePath, cached.endOffset, diagnostics);
+    if (actual !== expected) return false;
+    if (diagnostics) diagnostics.stat_calls += 1;
+    const afterValidation = fs.statSync(entry.filePath);
+    return statIdentity(entry.filePath, afterValidation) ===
+      statIdentity(entry.filePath, current);
   } catch {
     return false;
   }
@@ -276,10 +317,22 @@ function rememberParsedGroup(key, value) {
 
 function splitCapturedParse(parsed) {
   if (!parsed || typeof parsed !== "object") {
-    return { parsed, resumeState: null, endOffset: 0 };
+    return {
+      parsed,
+      resumeState: null,
+      endOffset: 0,
+      appendable: false,
+      contentHashState: null,
+    };
   }
-  const { resumeState = null, endOffset = 0, ...result } = parsed;
-  return { parsed: result, resumeState, endOffset };
+  const {
+    resumeState = null,
+    endOffset = 0,
+    appendable = false,
+    contentHashState = null,
+    ...result
+  } = parsed;
+  return { parsed: result, resumeState, endOffset, appendable, contentHashState };
 }
 
 // ---------------------------------------------------------------------------
@@ -324,6 +377,7 @@ async function computeCodexContextBreakdown({
     incremental_parse_hits: 0,
     incremental_parse_fallbacks: 0,
     bytes_read: 0,
+    prefix_validation_bytes: 0,
     json_parse_calls: 0,
   };
   const discovered = discoverCodexSessionFiles(roots, {
@@ -361,6 +415,7 @@ async function computeCodexContextBreakdown({
     if (!candidateGroups.has(sessionKey)) candidateGroups.set(sessionKey, []);
     candidateGroups.get(sessionKey).push(entry);
   }
+  const appendHashPaths = selectAppendHashPaths(candidateGroups);
 
   for (const entries of candidateGroups.values()) {
     const filePaths = entries.map((entry) => entry.filePath);
@@ -381,7 +436,13 @@ async function computeCodexContextBreakdown({
     } else {
       let captured = null;
       const singleEntry = entries.length === 1 ? entries[0] : null;
-      if (singleEntry && await canResumeParsedGroup(cachedGroup, singleEntry)) {
+      const appendHashEligible = Boolean(
+        singleEntry && appendHashPaths.has(singleEntry.filePath),
+      );
+      if (
+        appendHashEligible &&
+        await canResumeParsedGroup(cachedGroup, singleEntry, diagnostics)
+      ) {
         try {
           const resumed = await parseCodexRolloutFile(singleEntry.filePath, {
             from: fromKey,
@@ -393,12 +454,16 @@ async function computeCodexContextBreakdown({
             endOffset: singleEntry.stat.size,
             resumeState: cachedGroup.resumeState,
             captureResumeState: true,
+            captureContentHash: true,
+            contentHashState: cachedGroup.contentHashState,
           });
           const delta = splitCapturedParse(resumed);
           captured = {
             parsed: mergeParsedSessionResults(cachedGroup.parsed, delta.parsed),
             resumeState: delta.resumeState,
             endOffset: delta.endOffset,
+            appendable: delta.appendable,
+            contentHashState: delta.contentHashState,
           };
           diagnostics.incremental_parse_hits += 1;
         } catch (error) {
@@ -418,6 +483,7 @@ async function computeCodexContextBreakdown({
             seenTokenEvents: filePaths.length === 1 ? new Set() : seenTokenEvents,
             endOffset: singleEntry?.stat?.size ?? null,
             captureResumeState: Boolean(singleEntry),
+            captureContentHash: appendHashEligible,
           },
         );
         captured = splitCapturedParse(fresh);
@@ -425,16 +491,13 @@ async function computeCodexContextBreakdown({
 
       parsed = captured.parsed;
       if (parsedCacheKey) {
-        const parsedPrefix = singleEntry
-          ? await inspectParsedPrefix(singleEntry.filePath, captured.endOffset).catch(() => null)
-          : null;
         rememberParsedGroup(parsedCacheKey, {
           signature,
           parsed,
           resumeState: captured.resumeState,
           endOffset: captured.endOffset,
-          prefixTail: parsedPrefix?.prefixTail ?? null,
-          appendable: parsedPrefix?.appendable === true,
+          appendable: captured.appendable === true,
+          contentHashState: captured.contentHashState,
           filePath: singleEntry?.filePath || null,
           stat: singleEntry?.stat || null,
         });

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -563,6 +563,7 @@ async function parseCodexRolloutFile(filePath, {
   captureResumeState = false,
   captureContentHash = false,
   contentHashState = null,
+  sourceHandle = null,
 } = {}) {
   const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   const primaryFilePath = filePaths[0] || String(filePath || "");
@@ -835,6 +836,7 @@ async function parseCodexRolloutFile(filePath, {
     endOffset,
     readProgress,
     contentHasher,
+    sourceHandle,
   })) {
     const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
     if (!ts) continue;
@@ -960,6 +962,7 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
   endOffset = null,
   readProgress = null,
   contentHasher = null,
+  sourceHandle = null,
 } = {}) {
   const start = Math.max(0, Number(startOffset) || 0);
   const requestedEnd = Number(endOffset);
@@ -971,10 +974,24 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
   }
 
   if (diagnostics) diagnostics.opened_files += 1;
-  const stream = fs.createReadStream(filePath, {
-    start,
-    ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
-  });
+  const stream = sourceHandle && typeof sourceHandle.read === "function"
+    ? null
+    : fs.createReadStream(filePath, {
+        start,
+        ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
+      });
+  const chunks = stream || (async function* readStableHandleChunks() {
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    const limit = hasBoundedEnd ? requestedEnd : Number.MAX_SAFE_INTEGER;
+    let offset = start;
+    while (offset < limit) {
+      const length = Math.min(buffer.length, limit - offset);
+      const result = await sourceHandle.read(buffer, 0, length, offset);
+      if (!result.bytesRead) break;
+      offset += result.bytesRead;
+      yield buffer.subarray(0, result.bytesRead);
+    }
+  })();
   const fragments = [];
   let fragmentsBytes = 0;
   let nextChunkOffset = start;
@@ -982,7 +999,7 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
   let lineIndex = 0;
 
   try {
-    for await (const value of stream) {
+    for await (const value of chunks) {
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
       const chunkStart = nextChunkOffset;
       nextChunkOffset += chunk.length;
@@ -1037,7 +1054,7 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
     }
   } finally {
     if (readProgress) readProgress.endOffset = nextChunkOffset;
-    stream.destroy();
+    stream?.destroy();
     if (diagnostics) diagnostics.parsed_files += 1;
   }
 }
@@ -1103,7 +1120,9 @@ async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
 
 async function* readCodexObjects(filePath, diagnostics, fileIndex, options = {}) {
   const start = Math.max(0, Number(options.startOffset) || 0);
-  const reader = start > 0 ? readCodexObjectsIncremental : readCodexObjectsFull;
+  const reader = start > 0 || options.sourceHandle
+    ? readCodexObjectsIncremental
+    : readCodexObjectsFull;
   yield* reader(filePath, diagnostics, fileIndex, options);
 }
 

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -23,6 +23,7 @@ const DISCOVERY_FULL_AUDIT_INTERVAL_MS = 60 * 1000;
 const MAX_DISCOVERY_INVENTORIES = 32;
 const DISCOVERY_INVENTORIES = new Map();
 const ZONED_DAY_FORMATTERS = new Map();
+const CODEX_RESUME_INVALIDATED = "TOKENTRACKER_CODEX_RESUME_INVALIDATED";
 
 // ---------------------------------------------------------------------------
 // Timezone helpers
@@ -555,20 +556,39 @@ async function parseCodexRolloutFile(filePath, {
   timeZoneContext = null,
   diagnostics = null,
   seenTokenEvents = null,
+  startOffset = 0,
+  endOffset = null,
+  resumeState = null,
+  captureResumeState = false,
 } = {}) {
   const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   const primaryFilePath = filePaths[0] || String(filePath || "");
+  const isResuming = Boolean(resumeState && filePaths.length === 1);
+  const readProgress = { endOffset: Math.max(0, Number(startOffset) || 0) };
 
-  let sessionId = null;
-  let cwd = null;
-  let model = null;
-  let provider = null;
-  let cliVersion = null;
+  let sessionId = isResuming ? resumeState.sessionId || null : null;
+  let cwd = isResuming ? resumeState.cwd || null : null;
+  let model = isResuming ? resumeState.model || null : null;
+  let provider = isResuming ? resumeState.provider || null : null;
+  let cliVersion = isResuming ? resumeState.cliVersion || null : null;
 
-  let prevTotals = null;
-  let pendingCalls = []; // response_item function_call payloads since last token_count
-  let pendingSkills = [];
-  let pendingExecEnds = []; // exec_command_end payloads since last token_count
+  let prevTotals = isResuming ? resumeState.prevTotals || null : null;
+  let pendingToolNames = isResuming
+    ? Array.from(resumeState.pendingToolNames || [])
+    : [];
+  let pendingSkills = isResuming ? Array.from(resumeState.pendingSkills || []) : [];
+  let pendingExecDetails = isResuming
+    ? Array.from(resumeState.pendingExecDetails || [])
+    : [];
+  let lastTokenTimestamp = isResuming
+    ? String(resumeState.lastTokenTimestamp || "") || null
+    : null;
+  let lastTimestampEventSignatures = new Set(
+    isResuming ? resumeState.lastTimestampEventSignatures || [] : [],
+  );
+  let lastTimestampLastUsage = null;
+  let lastTimestampTotalUsage = null;
+  let hasUnmaterializedLastTimestampUsage = false;
 
   const totals = emptyTotals();
   const byTool = new Map(); // tool_name -> {name,calls,totals}
@@ -639,9 +659,7 @@ async function parseCodexRolloutFile(filePath, {
     if (details.failed) row.failures += 1;
   }
 
-  function absorbExecEnd(p) {
-    const details = getExecKeys(p);
-    if (!details) return;
+  function absorbExecEnd(details) {
     absorbExecStats(byExecKind, details.kind, details);
     absorbExecStats(byExecExit, details.exitKey, details);
     absorbExecStats(byExecExecutable, details.executable, details);
@@ -652,18 +670,15 @@ async function parseCodexRolloutFile(filePath, {
 
   function attributeTurn(delta) {
     if (!delta || delta.total_tokens <= 0) {
-      for (const p of pendingExecEnds) absorbExecEnd(p);
-      pendingCalls = [];
+      for (const details of pendingExecDetails) absorbExecEnd(details);
+      pendingToolNames = [];
       pendingSkills = [];
-      pendingExecEnds = [];
+      pendingExecDetails = [];
       return;
     }
     turnCount += 1;
 
-    const toolNames = pendingCalls
-      .map((c) => normalizeToolName(c))
-      .filter(Boolean);
-    const unique = [...new Set(toolNames)];
+    const unique = [...new Set(pendingToolNames.filter(Boolean))];
     const tools = unique.length > 0 ? unique : ["text_response"];
     const share = 1 / tools.length;
 
@@ -710,11 +725,9 @@ async function parseCodexRolloutFile(filePath, {
       total_tokens: delta.total_tokens * execToolShare,
     } : null;
 
-    if (execDelta && pendingExecEnds.length > 0) {
-      const perExecShare = 1 / pendingExecEnds.length;
-      for (const p of pendingExecEnds) {
-        const details = getExecKeys(p);
-        if (!details) continue;
+    if (execDelta && pendingExecDetails.length > 0) {
+      const perExecShare = 1 / pendingExecDetails.length;
+      for (const details of pendingExecDetails) {
         const attributed = {
           input_tokens: execDelta.input_tokens * perExecShare,
           cached_input_tokens: execDelta.cached_input_tokens * perExecShare,
@@ -731,20 +744,74 @@ async function parseCodexRolloutFile(filePath, {
         addInto(ensureExec(byExecDuration, details.duration).totals, attributed);
         addInto(ensureExec(byExecOutput, details.output).totals, attributed);
 
-        absorbExecEnd(p);
+        absorbExecEnd(details);
       }
     } else {
       // Still ingest exec end stats without token attribution so the drill-down works.
-      for (const p of pendingExecEnds) absorbExecEnd(p);
+      for (const details of pendingExecDetails) absorbExecEnd(details);
     }
 
     addInto(totals, delta);
-    pendingCalls = [];
+    pendingToolNames = [];
     pendingSkills = [];
-    pendingExecEnds = [];
+    pendingExecDetails = [];
   }
 
-  for await (const obj of iterateCodexObjects(filePaths, diagnostics)) {
+  function usageEventSignature(lastUsage, totalUsage) {
+    return JSON.stringify({ lastUsage, totalUsage });
+  }
+
+  function materializeLastTimestampSignatures() {
+    if (hasUnmaterializedLastTimestampUsage) {
+      lastTimestampEventSignatures.add(
+        usageEventSignature(lastTimestampLastUsage, lastTimestampTotalUsage),
+      );
+      hasUnmaterializedLastTimestampUsage = false;
+    }
+    return lastTimestampEventSignatures;
+  }
+
+  function noteTokenEvent(timestamp, lastUsage, totalUsage) {
+    if (!isResuming) {
+      if (timestamp !== lastTokenTimestamp) {
+        lastTokenTimestamp = timestamp;
+        lastTimestampEventSignatures = new Set();
+        hasUnmaterializedLastTimestampUsage = false;
+      } else {
+        materializeLastTimestampSignatures();
+      }
+      lastTimestampLastUsage = lastUsage;
+      lastTimestampTotalUsage = totalUsage;
+      hasUnmaterializedLastTimestampUsage = true;
+      return true;
+    }
+    if (isResuming && lastTokenTimestamp && timestamp < lastTokenTimestamp) {
+      const error = new Error("Codex rollout append is not timestamp-monotonic");
+      error.code = CODEX_RESUME_INVALIDATED;
+      throw error;
+    }
+    if (!lastTokenTimestamp || timestamp > lastTokenTimestamp) {
+      lastTokenTimestamp = timestamp;
+      lastTimestampEventSignatures = new Set();
+      lastTimestampLastUsage = lastUsage;
+      lastTimestampTotalUsage = totalUsage;
+      hasUnmaterializedLastTimestampUsage = true;
+      return true;
+    }
+    if (timestamp === lastTokenTimestamp) {
+      const signature = usageEventSignature(lastUsage, totalUsage);
+      const signatures = materializeLastTimestampSignatures();
+      if (signatures.has(signature)) return false;
+      signatures.add(signature);
+    }
+    return true;
+  }
+
+  for await (const obj of iterateCodexObjects(filePaths, diagnostics, {
+    startOffset,
+    endOffset,
+    readProgress,
+  })) {
     const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
     if (!ts) continue;
     const inRequestedRange = isTimestampInRequestedDayRange(ts, { from, to, timeZoneContext });
@@ -765,14 +832,15 @@ async function parseCodexRolloutFile(filePath, {
     }
 
     if (obj.type === "response_item" && obj.payload?.type === "function_call") {
-      pendingCalls.push(obj.payload);
+      pendingToolNames.push(normalizeToolName(obj.payload));
       const skill = extractSkillNameFromFunctionCall(obj.payload, diagnostics);
       if (skill) pendingSkills.push(skill);
       continue;
     }
 
     if (obj.type === "event_msg" && obj.payload?.type === "exec_command_end") {
-      pendingExecEnds.push(obj.payload);
+      const details = getExecKeys(obj.payload);
+      if (details) pendingExecDetails.push(details);
       continue;
     }
 
@@ -783,25 +851,26 @@ async function parseCodexRolloutFile(filePath, {
       const totalUsage = info?.total_token_usage;
       const delta = pickDelta(lastUsage, totalUsage, prevTotals);
       if (totalUsage && typeof totalUsage === "object") prevTotals = totalUsage;
+      const isNewResumeEvent = noteTokenEvent(ts, lastUsage, totalUsage);
       if (inRequestedRange) {
         const eventSessionId = sessionId || rolloutSessionIdFromPath(primaryFilePath) || primaryFilePath;
-        const eventKey = `${eventSessionId}:${ts}:${JSON.stringify({ lastUsage, totalUsage })}`;
-        if (seenTokenEvents && seenTokenEvents.has(eventKey)) {
+        const eventKey = `${eventSessionId}:${ts}:${usageEventSignature(lastUsage, totalUsage)}`;
+        if (!isNewResumeEvent || (seenTokenEvents && seenTokenEvents.has(eventKey))) {
           attributeTurn(null);
         } else {
           if (seenTokenEvents && delta?.total_tokens > 0) seenTokenEvents.add(eventKey);
           attributeTurn(delta);
         }
       } else {
-        pendingCalls = [];
+        pendingToolNames = [];
         pendingSkills = [];
-        pendingExecEnds = [];
+        pendingExecDetails = [];
       }
       continue;
     }
   }
 
-  return {
+  const result = {
     sessionId: sessionId || rolloutSessionIdFromPath(primaryFilePath) || primaryFilePath,
     cwd,
     model: model || provider,
@@ -825,11 +894,140 @@ async function parseCodexRolloutFile(filePath, {
       byOutput: finalizeExecRows(byExecOutput),
     },
   };
+  if (captureResumeState && filePaths.length === 1) {
+    result.resumeState = {
+      sessionId,
+      cwd,
+      model,
+      provider,
+      cliVersion,
+      prevTotals,
+      pendingToolNames,
+      pendingSkills,
+      pendingExecDetails,
+      lastTokenTimestamp,
+      lastTimestampEventSignatures: Array.from(materializeLastTimestampSignatures()),
+    };
+    result.endOffset = readProgress.endOffset;
+  }
+  return result;
 }
 
-async function* readCodexObjects(filePath, diagnostics, fileIndex) {
+function parseCodexLine(lineBuffer, diagnostics) {
+  let content = lineBuffer;
+  if (content.length > 0 && content[content.length - 1] === 0x0d) {
+    content = content.subarray(0, content.length - 1);
+  }
+  if (content.length === 0) return { empty: true, obj: null };
+  try {
+    if (diagnostics) diagnostics.json_parse_calls += 1;
+    return { empty: false, obj: JSON.parse(content.toString("utf8")) };
+  } catch {
+    return { empty: false, obj: null };
+  }
+}
+
+async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
+  startOffset = 0,
+  endOffset = null,
+  readProgress = null,
+} = {}) {
+  const start = Math.max(0, Number(startOffset) || 0);
+  const requestedEnd = Number(endOffset);
+  const hasBoundedEnd = endOffset !== null && endOffset !== undefined &&
+    Number.isFinite(requestedEnd) && requestedEnd >= 0;
+  if (hasBoundedEnd && requestedEnd <= start) {
+    if (readProgress) readProgress.endOffset = start;
+    return;
+  }
+
   if (diagnostics) diagnostics.opened_files += 1;
-  const stream = fs.createReadStream(filePath, { encoding: "utf8" });
+  const stream = fs.createReadStream(filePath, {
+    start,
+    ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
+  });
+  const fragments = [];
+  let fragmentsBytes = 0;
+  let nextChunkOffset = start;
+  let lineStartOffset = start;
+  let lineIndex = 0;
+
+  try {
+    for await (const value of stream) {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      const chunkStart = nextChunkOffset;
+      nextChunkOffset += chunk.length;
+      if (diagnostics) {
+        diagnostics.bytes_read = Number(diagnostics.bytes_read || 0) + chunk.length;
+      }
+
+      let cursor = 0;
+      while (cursor < chunk.length) {
+        const newline = chunk.indexOf(0x0a, cursor);
+        if (newline < 0) {
+          const tail = chunk.subarray(cursor);
+          if (tail.length > 0) {
+            fragments.push(tail);
+            fragmentsBytes += tail.length;
+          }
+          break;
+        }
+
+        const tail = chunk.subarray(cursor, newline);
+        const lineBuffer = fragments.length > 0
+          ? Buffer.concat([...fragments, tail], fragmentsBytes + tail.length)
+          : tail;
+        fragments.length = 0;
+        fragmentsBytes = 0;
+
+        const absoluteEnd = chunkStart + newline + 1;
+        if (readProgress) readProgress.endOffset = absoluteEnd;
+        lineStartOffset = absoluteEnd;
+        const parsed = parseCodexLine(lineBuffer, diagnostics);
+        if (parsed.obj) {
+          yield { obj: parsed.obj, fileIndex, lineIndex };
+          lineIndex += 1;
+        }
+        cursor = newline + 1;
+      }
+    }
+
+    if (fragmentsBytes > 0) {
+      const lineBuffer = fragments.length === 1
+        ? fragments[0]
+        : Buffer.concat(fragments, fragmentsBytes);
+      const parsed = parseCodexLine(lineBuffer, diagnostics);
+      if (parsed.obj) {
+        if (readProgress) readProgress.endOffset = lineStartOffset + fragmentsBytes;
+        yield { obj: parsed.obj, fileIndex, lineIndex };
+      }
+    }
+  } finally {
+    stream.destroy();
+    if (diagnostics) diagnostics.parsed_files += 1;
+  }
+}
+
+async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
+  startOffset = 0,
+  endOffset = null,
+  readProgress = null,
+} = {}) {
+  const start = Math.max(0, Number(startOffset) || 0);
+  const requestedEnd = Number(endOffset);
+  const hasBoundedEnd = endOffset !== null && endOffset !== undefined &&
+    Number.isFinite(requestedEnd) && requestedEnd >= 0;
+  if (hasBoundedEnd && requestedEnd <= start) {
+    if (readProgress) readProgress.endOffset = start;
+    return;
+  }
+
+  if (diagnostics) diagnostics.opened_files += 1;
+  const stream = fs.createReadStream(filePath, {
+    encoding: "utf8",
+    start,
+    ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
+  });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   let lineIndex = 0;
   try {
@@ -846,15 +1044,26 @@ async function* readCodexObjects(filePath, diagnostics, fileIndex) {
       lineIndex += 1;
     }
   } finally {
+    const bytesRead = Number(stream.bytesRead || 0);
+    if (readProgress) readProgress.endOffset = start + bytesRead;
+    if (diagnostics) {
+      diagnostics.bytes_read = Number(diagnostics.bytes_read || 0) + bytesRead;
+      diagnostics.parsed_files += 1;
+    }
     rl.close();
     stream.close?.();
-    if (diagnostics) diagnostics.parsed_files += 1;
   }
 }
 
-async function* iterateCodexObjects(filePaths, diagnostics) {
+async function* readCodexObjects(filePath, diagnostics, fileIndex, options = {}) {
+  const start = Math.max(0, Number(options.startOffset) || 0);
+  const reader = start > 0 ? readCodexObjectsIncremental : readCodexObjectsFull;
+  yield* reader(filePath, diagnostics, fileIndex, options);
+}
+
+async function* iterateCodexObjects(filePaths, diagnostics, options = {}) {
   if (filePaths.length <= 1) {
-    for await (const record of readCodexObjects(filePaths[0], diagnostics, 0)) {
+    for await (const record of readCodexObjects(filePaths[0], diagnostics, 0, options)) {
       yield record.obj;
     }
     return;
@@ -892,6 +1101,10 @@ function rolloutSessionIdFromPath(filePath) {
   return match ? match[1] : null;
 }
 
+function isCodexResumeInvalidated(error) {
+  return error?.code === CODEX_RESUME_INVALIDATED;
+}
+
 module.exports = {
   parseCodexRolloutFile,
   extractTokenCount,
@@ -913,6 +1126,7 @@ module.exports = {
   timestampDayKey,
   isTimestampInRequestedDayRange,
   rolloutSessionIdFromPath,
+  isCodexResumeInvalidated,
   finalizeToolRows,
   finalizeSkillRows,
   finalizeExecRows,

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -948,12 +948,12 @@ function parseCodexLine(lineBuffer, diagnostics) {
   if (content.length > 0 && content[content.length - 1] === 0x0d) {
     content = content.subarray(0, content.length - 1);
   }
-  if (content.length === 0) return { empty: true, obj: null };
+  if (content.length === 0) return null;
   try {
     if (diagnostics) diagnostics.json_parse_calls += 1;
-    return { empty: false, obj: JSON.parse(content.toString("utf8")) };
+    return JSON.parse(content.toString("utf8"));
   } catch {
-    return { empty: false, obj: null };
+    return null;
   }
 }
 
@@ -1017,7 +1017,9 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
         if (newline < 0) {
           const tail = chunk.subarray(cursor);
           if (tail.length > 0) {
-            fragments.push(tail);
+            // Stable-handle reads reuse their buffer, so retained fragments
+            // must own their bytes before the next read overwrites it.
+            fragments.push(Buffer.from(tail));
             fragmentsBytes += tail.length;
           }
           break;
@@ -1033,9 +1035,9 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
         const absoluteEnd = chunkStart + newline + 1;
         if (readProgress) readProgress.endOffset = absoluteEnd;
         lineStartOffset = absoluteEnd;
-        const parsed = parseCodexLine(lineBuffer, diagnostics);
-        if (parsed.obj) {
-          yield { obj: parsed.obj, fileIndex, lineIndex };
+        const obj = parseCodexLine(lineBuffer, diagnostics);
+        if (obj) {
+          yield { obj, fileIndex, lineIndex };
           lineIndex += 1;
         }
         cursor = newline + 1;
@@ -1046,10 +1048,10 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
       const lineBuffer = fragments.length === 1
         ? fragments[0]
         : Buffer.concat(fragments, fragmentsBytes);
-      const parsed = parseCodexLine(lineBuffer, diagnostics);
-      if (parsed.obj) {
+      const obj = parseCodexLine(lineBuffer, diagnostics);
+      if (obj) {
         if (readProgress) readProgress.endOffset = lineStartOffset + fragmentsBytes;
-        yield { obj: parsed.obj, fileIndex, lineIndex };
+        yield { obj, fileIndex, lineIndex };
       }
     }
   } finally {

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const readline = require("node:readline");
@@ -560,11 +561,33 @@ async function parseCodexRolloutFile(filePath, {
   endOffset = null,
   resumeState = null,
   captureResumeState = false,
+  captureContentHash = false,
+  contentHashState = null,
 } = {}) {
   const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   const primaryFilePath = filePaths[0] || String(filePath || "");
   const isResuming = Boolean(resumeState && filePaths.length === 1);
-  const readProgress = { endOffset: Math.max(0, Number(startOffset) || 0) };
+  const initialOffset = Math.max(0, Number(startOffset) || 0);
+  const readProgress = {
+    endOffset: initialOffset,
+    lastByte: initialOffset > 0 ? 0x0a : null,
+  };
+  let contentHasher = null;
+  if (captureResumeState && captureContentHash && filePaths.length === 1) {
+    if (contentHashState && typeof contentHashState.copy === "function") {
+      try {
+        contentHasher = contentHashState.copy();
+      } catch {
+        contentHasher = null;
+      }
+    }
+    if (initialOffset > 0 && !contentHasher) {
+      const error = new Error("Codex rollout append is missing its prefix hash state");
+      error.code = CODEX_RESUME_INVALIDATED;
+      throw error;
+    }
+    if (!contentHasher) contentHasher = crypto.createHash("sha256");
+  }
 
   let sessionId = isResuming ? resumeState.sessionId || null : null;
   let cwd = isResuming ? resumeState.cwd || null : null;
@@ -811,6 +834,7 @@ async function parseCodexRolloutFile(filePath, {
     startOffset,
     endOffset,
     readProgress,
+    contentHasher,
   })) {
     const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
     if (!ts) continue;
@@ -909,6 +933,10 @@ async function parseCodexRolloutFile(filePath, {
       lastTimestampEventSignatures: Array.from(materializeLastTimestampSignatures()),
     };
     result.endOffset = readProgress.endOffset;
+    result.appendable = Boolean(contentHasher) && (
+      readProgress.endOffset === 0 || readProgress.lastByte === 0x0a
+    );
+    result.contentHashState = contentHasher;
   }
   return result;
 }
@@ -931,6 +959,7 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
   startOffset = 0,
   endOffset = null,
   readProgress = null,
+  contentHasher = null,
 } = {}) {
   const start = Math.max(0, Number(startOffset) || 0);
   const requestedEnd = Number(endOffset);
@@ -957,6 +986,10 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
       const chunkStart = nextChunkOffset;
       nextChunkOffset += chunk.length;
+      if (contentHasher) contentHasher.update(chunk);
+      if (readProgress && chunk.length > 0) {
+        readProgress.lastByte = chunk[chunk.length - 1];
+      }
       if (diagnostics) {
         diagnostics.bytes_read = Number(diagnostics.bytes_read || 0) + chunk.length;
       }
@@ -1003,6 +1036,7 @@ async function* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
       }
     }
   } finally {
+    if (readProgress) readProgress.endOffset = nextChunkOffset;
     stream.destroy();
     if (diagnostics) diagnostics.parsed_files += 1;
   }
@@ -1012,6 +1046,7 @@ async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
   startOffset = 0,
   endOffset = null,
   readProgress = null,
+  contentHasher = null,
 } = {}) {
   const start = Math.max(0, Number(startOffset) || 0);
   const requestedEnd = Number(endOffset);
@@ -1024,10 +1059,20 @@ async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
 
   if (diagnostics) diagnostics.opened_files += 1;
   const stream = fs.createReadStream(filePath, {
-    encoding: "utf8",
+    ...(contentHasher ? {} : { encoding: "utf8" }),
     start,
     ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
   });
+  const trackChunk = contentHasher
+    ? (value) => {
+        const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+        contentHasher.update(chunk);
+        if (readProgress && chunk.length > 0) {
+          readProgress.lastByte = chunk[chunk.length - 1];
+        }
+      }
+    : null;
+  if (trackChunk) stream.on("data", trackChunk);
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   let lineIndex = 0;
   try {
@@ -1050,6 +1095,7 @@ async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
       diagnostics.bytes_read = Number(diagnostics.bytes_read || 0) + bytesRead;
       diagnostics.parsed_files += 1;
     }
+    if (trackChunk) stream.off("data", trackChunk);
     rl.close();
     stream.close?.();
   }

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -220,6 +220,7 @@ test("bounded Context prunes an unrelated historical rollout and reports per-cal
       parse_cache_hits: 0,
       incremental_parse_hits: 0,
       incremental_parse_fallbacks: 0,
+      prefix_validation_bytes: 0,
       json_parse_calls: 2,
     });
     const exhaustive = await computeCodexContextBreakdown({ ...args, exhaustive: true });
@@ -729,7 +730,9 @@ test("Context reuses frozen parsed sessions when one active session changes", as
         total_tokens: 35,
       }),
       ],
+      "2030-06-02T13:00:00.000Z",
     );
+    const activePrefixSize = (await fs.stat(activePath)).size;
     const args = {
       from: "2030-06-02",
       to: "2030-06-02",
@@ -758,6 +761,8 @@ test("Context reuses frozen parsed sessions when one active session changes", as
         total_tokens: 54,
       }),
     ].map((event) => JSON.stringify(event)).join("\n") + "\n", "utf8");
+    const activeMtime = new Date("2030-06-02T14:00:00.000Z");
+    await fs.utimes(activePath, activeMtime, activeMtime);
 
     const second = await computeCodexContextBreakdown(args);
     assert.equal(second.diagnostics.opened_files, 1);
@@ -765,6 +770,7 @@ test("Context reuses frozen parsed sessions when one active session changes", as
     assert.equal(second.diagnostics.parse_cache_hits, 1);
     assert.equal(second.diagnostics.incremental_parse_hits, 1);
     assert.equal(second.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(second.diagnostics.prefix_validation_bytes, activePrefixSize);
     assert.equal(second.diagnostics.json_parse_calls, 1);
     assert.ok(second.diagnostics.bytes_read < first.diagnostics.bytes_read);
     assert.ok(stablePath);
@@ -832,6 +838,7 @@ test("Context incrementally parses append-only sessions with pending tools and d
       ],
       "2030-06-02T00:00:00.000Z",
     );
+    const prefixSize = (await fs.stat(filePath)).size;
     const args = {
       from: "2030-06-02",
       to: "2030-06-02",
@@ -864,9 +871,11 @@ test("Context incrementally parses append-only sessions with pending tools and d
     assert.ok(appended.exec_command_breakdown.by_command.length > 0);
     assert.equal(appended.diagnostics.incremental_parse_hits, 1);
     assert.equal(appended.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(appended.diagnostics.prefix_validation_bytes, prefixSize);
     assert.equal(appended.diagnostics.json_parse_calls, 1);
     assert.equal(appended.diagnostics.bytes_read, Buffer.byteLength(appendedLine));
 
+    const firstAppendSize = (await fs.stat(filePath)).size;
     await fs.appendFile(filePath, appendedLine, "utf8");
     await fs.utimes(
       filePath,
@@ -878,6 +887,7 @@ test("Context incrementally parses append-only sessions with pending tools and d
     assert.equal(duplicate.message_count, appended.message_count);
     assert.equal(duplicate.diagnostics.incremental_parse_hits, 1);
     assert.equal(duplicate.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(duplicate.diagnostics.prefix_validation_bytes, firstAppendSize);
     assert.equal(duplicate.diagnostics.json_parse_calls, 1);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
@@ -894,9 +904,27 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
       try {
         const fileName =
           "rollout-2030-06-01T23-50-00-55555555-5555-4555-8555-555555555555.jsonl";
-        const filePath = await writeRollout(root, "2030-06-01", fileName, [
-          tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
-        ], "2030-06-02T00:00:00.000Z");
+        const events = scenario === "prefix rewrite"
+          ? [
+              {
+                timestamp: "2030-06-01T23:40:00.000Z",
+                type: "session_meta",
+                payload: {
+                  id: "55555555-5555-4555-8555-555555555555",
+                  cwd: `/tmp/${"a".repeat(5000)}`,
+                  model_provider: "openai",
+                },
+              },
+              tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
+            ]
+          : [tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE)];
+        const filePath = await writeRollout(
+          root,
+          "2030-06-01",
+          fileName,
+          events,
+          "2030-06-02T00:00:00.000Z",
+        );
         if (scenario === "incomplete record") {
           const stat = await fs.stat(filePath);
           await fs.truncate(filePath, stat.size - 1);
@@ -912,16 +940,19 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
         };
         const primed = await computeCodexContextBreakdown(args);
         assert.equal(primed.totals.total_tokens, 0);
+        const primedSize = (await fs.stat(filePath)).size;
+        if (scenario === "prefix rewrite") assert.ok(primedSize > 4096);
 
         const targetLine = `${JSON.stringify(
           tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
         )}\n`;
         if (scenario === "prefix rewrite") {
           const content = await fs.readFile(filePath, "utf8");
-          assert.match(content, /"input_tokens":100/);
+          const mutationOffset = content.indexOf("/tmp/aaaaaaaa");
+          assert.ok(mutationOffset >= 0 && mutationOffset < 4096);
           await fs.writeFile(
             filePath,
-            `${content.replace('"input_tokens":100', '"input_tokens":101')}${targetLine}`,
+            `${content.replace("/tmp/aaaaaaaa", "/tmp/baaaaaaa")}${targetLine}`,
             "utf8",
           );
         } else {
@@ -941,6 +972,10 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
         assert.equal(guarded.message_count, fresh.message_count);
         assert.equal(guarded.diagnostics.incremental_parse_hits, 0);
         assert.equal(guarded.diagnostics.incremental_parse_fallbacks, 0);
+        assert.equal(
+          guarded.diagnostics.prefix_validation_bytes,
+          scenario === "prefix rewrite" ? primedSize : 0,
+        );
         assert.equal(guarded.diagnostics.opened_files, 1);
         assert.equal(guarded.diagnostics.bytes_read, (await fs.stat(filePath)).size);
       } finally {

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -902,6 +902,113 @@ test("Context incrementally parses append-only sessions with pending tools and d
   }
 });
 
+test("Context preserves appended JSONL records larger than the stable read buffer", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-large-record-"));
+  const freshRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "tt-codex-context-large-record-fresh-"),
+  );
+  try {
+    const fileName =
+      "rollout-2030-06-01T23-40-00-88888888-8888-4888-8888-888888888888.jsonl";
+    const initialEvents = [
+      {
+        timestamp: "2030-06-01T23:40:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "88888888-8888-4888-8888-888888888888",
+          cwd: "/tmp/project",
+          model_provider: "openai",
+        },
+      },
+      tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
+    ];
+    const filePath = await writeRollout(
+      root,
+      "2030-06-01",
+      fileName,
+      initialEvents,
+      "2030-06-02T00:00:00.000Z",
+    );
+    const args = {
+      from: "2030-06-02",
+      to: "2030-06-02",
+      codexDir: root,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    };
+    const primed = await computeCodexContextBreakdown(args);
+    assert.equal(primed.totals.total_tokens, 0);
+
+    const skillCommand =
+      `sed -n '1,120p' /tmp/.codex/skills/large-fixture/SKILL.md ${"x".repeat(90 * 1024)}`;
+    const appendedEvents = [
+      {
+        timestamp: "2030-06-02T00:01:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "exec_command",
+          call_id: "large-exec",
+          arguments: JSON.stringify({ cmd: skillCommand }),
+        },
+      },
+      {
+        timestamp: "2030-06-02T00:02:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "exec_command_end",
+          command: [
+            "bash",
+            "-lc",
+            "sed -n '1,120p' /tmp/.codex/skills/large-fixture/SKILL.md",
+          ],
+          status: "completed",
+          exit_code: 0,
+          duration: { secs: 0, nanos: 10_000_000 },
+          aggregated_output: "skill body\n",
+        },
+      },
+      tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
+    ];
+    const appendedContents = rolloutContents(appendedEvents);
+    assert.ok(Buffer.byteLength(JSON.stringify(appendedEvents[0])) > 64 * 1024);
+    await fs.appendFile(filePath, appendedContents, "utf8");
+    const active = new Date("2030-06-02T00:06:00.000Z");
+    await fs.utimes(filePath, active, active);
+
+    const incremental = await computeCodexContextBreakdown(args);
+    const freshPath = await writeRollout(freshRoot, "2030-06-01", fileName, []);
+    await fs.copyFile(filePath, freshPath);
+    await fs.utimes(freshPath, active, active);
+    const fresh = await computeCodexContextBreakdown({ ...args, codexDir: freshRoot });
+
+    const { diagnostics: incrementalDiagnostics, ...incrementalOutput } = incremental;
+    const { diagnostics: _freshDiagnostics, ...freshOutput } = fresh;
+    assert.deepEqual(incrementalOutput, freshOutput);
+    assertExactTargetDelta(incremental);
+    assert.equal(
+      fresh.tool_calls_breakdown.categories.find((row) => row.name === "Execution")
+        ?.totals.total_tokens,
+      76,
+    );
+    assert.equal(fresh.skills_breakdown.skills[0]?.name, "large-fixture");
+    assert.ok(
+      fresh.exec_command_breakdown.by_command.some(
+        (row) => row.totals.total_tokens === 76,
+      ),
+    );
+    assert.equal(incrementalDiagnostics.incremental_parse_hits, 1);
+    assert.equal(incrementalDiagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(incrementalDiagnostics.json_parse_calls, appendedEvents.length + 1);
+    assert.equal(
+      incrementalDiagnostics.bytes_read,
+      Buffer.byteLength(appendedContents),
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(freshRoot, { recursive: true, force: true });
+  }
+});
+
 test("Context keeps one file handle across prefix validation and suffix parsing", {
   skip: process.platform === "win32",
 }, async () => {

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const fsSync = require("node:fs");
 const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
@@ -12,11 +13,15 @@ function computeCodexContextBreakdown(options = {}) {
   return computeRawCodexContextBreakdown({ ...options, includeDiagnostics: true });
 }
 
+function rolloutContents(events) {
+  return `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+}
+
 async function writeRollout(rootDir, day, name, events, mtime = `${day}T12:00:00.000Z`) {
   const dir = path.join(rootDir, day.slice(0, 4), day.slice(5, 7), day.slice(8, 10));
   await fs.mkdir(dir, { recursive: true });
   const filePath = path.join(dir, name);
-  await fs.writeFile(filePath, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`, "utf8");
+  await fs.writeFile(filePath, rolloutContents(events), "utf8");
   const stamp = new Date(mtime);
   await fs.utimes(filePath, stamp, stamp);
   return filePath;
@@ -716,11 +721,7 @@ test("Context reuses frozen parsed sessions when one active session changes", as
       }),
       ],
     );
-    const activePath = await writeRollout(
-      root,
-      "2030-06-02",
-      "rollout-2030-06-02T02-00-00-22222222-2222-4222-8222-222222222222.jsonl",
-      [
+    const activeEvents = [
       tokenCount("2030-06-02T02:00:00.000Z", {
         input_tokens: 30,
         cached_input_tokens: 5,
@@ -729,10 +730,15 @@ test("Context reuses frozen parsed sessions when one active session changes", as
         reasoning_output_tokens: 1,
         total_tokens: 35,
       }),
-      ],
+    ];
+    const activePath = await writeRollout(
+      root,
+      "2030-06-02",
+      "rollout-2030-06-02T02-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+      activeEvents,
       "2030-06-02T13:00:00.000Z",
     );
-    const activePrefixSize = (await fs.stat(activePath)).size;
+    const activePrefixSize = Buffer.byteLength(rolloutContents(activeEvents));
     const args = {
       from: "2030-06-02",
       to: "2030-06-02",
@@ -786,59 +792,60 @@ test("Context incrementally parses append-only sessions with pending tools and d
   try {
     const fileName =
       "rollout-2030-06-01T23-40-00-33333333-3333-4333-8333-333333333333.jsonl";
+    const initialEvents = [
+      {
+        timestamp: "2030-06-01T23:40:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "33333333-3333-4333-8333-333333333333",
+          cwd: "/tmp/project",
+          model_provider: "openai",
+        },
+      },
+      tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
+      {
+        timestamp: "2030-06-01T23:59:00.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "take_snapshot",
+          call_id: "pending",
+          arguments: "{}",
+        },
+      },
+      {
+        timestamp: "2030-06-01T23:59:10.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "exec_command",
+          call_id: "pending-exec",
+          arguments: JSON.stringify({
+            cmd: "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md",
+          }),
+        },
+      },
+      {
+        timestamp: "2030-06-01T23:59:20.000Z",
+        type: "event_msg",
+        payload: {
+          type: "exec_command_end",
+          command: ["bash", "-lc", "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md"],
+          status: "completed",
+          exit_code: 0,
+          duration: { secs: 0, nanos: 10_000_000 },
+          aggregated_output: "skill body\n",
+        },
+      },
+    ];
     const filePath = await writeRollout(
       root,
       "2030-06-01",
       fileName,
-      [
-        {
-          timestamp: "2030-06-01T23:40:00.000Z",
-          type: "session_meta",
-          payload: {
-            id: "33333333-3333-4333-8333-333333333333",
-            cwd: "/tmp/project",
-            model_provider: "openai",
-          },
-        },
-        tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
-        {
-          timestamp: "2030-06-01T23:59:00.000Z",
-          type: "response_item",
-          payload: {
-            type: "function_call",
-            name: "take_snapshot",
-            call_id: "pending",
-            arguments: "{}",
-          },
-        },
-        {
-          timestamp: "2030-06-01T23:59:10.000Z",
-          type: "response_item",
-          payload: {
-            type: "function_call",
-            name: "exec_command",
-            call_id: "pending-exec",
-            arguments: JSON.stringify({
-              cmd: "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md",
-            }),
-          },
-        },
-        {
-          timestamp: "2030-06-01T23:59:20.000Z",
-          type: "event_msg",
-          payload: {
-            type: "exec_command_end",
-            command: ["bash", "-lc", "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md"],
-            status: "completed",
-            exit_code: 0,
-            duration: { secs: 0, nanos: 10_000_000 },
-            aggregated_output: "skill body\n",
-          },
-        },
-      ],
+      initialEvents,
       "2030-06-02T00:00:00.000Z",
     );
-    const prefixSize = (await fs.stat(filePath)).size;
+    const prefixSize = Buffer.byteLength(rolloutContents(initialEvents));
     const args = {
       from: "2030-06-02",
       to: "2030-06-02",
@@ -875,7 +882,7 @@ test("Context incrementally parses append-only sessions with pending tools and d
     assert.equal(appended.diagnostics.json_parse_calls, 1);
     assert.equal(appended.diagnostics.bytes_read, Buffer.byteLength(appendedLine));
 
-    const firstAppendSize = (await fs.stat(filePath)).size;
+    const firstAppendSize = prefixSize + Buffer.byteLength(appendedLine);
     await fs.appendFile(filePath, appendedLine, "utf8");
     await fs.utimes(
       filePath,
@@ -890,6 +897,125 @@ test("Context incrementally parses append-only sessions with pending tools and d
     assert.equal(duplicate.diagnostics.prefix_validation_bytes, firstAppendSize);
     assert.equal(duplicate.diagnostics.json_parse_calls, 1);
   } finally {
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(freshRoot, { recursive: true, force: true });
+  }
+});
+
+test("Context keeps one file handle across prefix validation and suffix parsing", {
+  skip: process.platform === "win32",
+}, async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-stable-handle-"));
+  const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-stable-handle-fresh-"));
+  const originalOpen = fsSync.promises.open;
+  try {
+    const fileName =
+      "rollout-2030-06-02T00-00-00-77777777-7777-4777-8777-777777777777.jsonl";
+    const initialEvents = [
+      tokenCount("2030-06-02T00:01:00.000Z", BASELINE_USAGE),
+    ];
+    const filePath = await writeRollout(
+      root,
+      "2030-06-02",
+      fileName,
+      initialEvents,
+      "2030-06-02T00:02:00.000Z",
+    );
+    const args = {
+      from: "2030-06-02",
+      to: "2030-06-02",
+      codexDir: root,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    };
+    await computeCodexContextBreakdown(args);
+
+    const appendedLine = `${JSON.stringify(
+      tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
+    )}\n`;
+    await fs.appendFile(filePath, appendedLine, "utf8");
+    const active = new Date("2030-06-02T00:06:00.000Z");
+    await fs.utimes(filePath, active, active);
+
+    const replacementEvents = [
+      {
+        timestamp: "2030-06-02T00:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "77777777-7777-4777-8777-777777777777",
+          cwd: `/tmp/${"replacement".repeat(300)}`,
+          model_provider: "openai",
+        },
+      },
+      tokenCount("2030-06-02T00:01:00.000Z", BASELINE_USAGE),
+      tokenCount("2030-06-02T00:10:00.000Z", {
+        input_tokens: 260,
+        cached_input_tokens: 60,
+        cache_creation_input_tokens: 12,
+        output_tokens: 45,
+        reasoning_output_tokens: 9,
+        total_tokens: 317,
+      }),
+    ];
+    assert.ok(
+      Buffer.byteLength(rolloutContents(replacementEvents)) >
+        Buffer.byteLength(rolloutContents(initialEvents)) +
+          Buffer.byteLength(appendedLine),
+    );
+    const replacementPath = path.join(root, "replacement.tmp");
+    await fs.writeFile(replacementPath, rolloutContents(replacementEvents), "utf8");
+    await fs.utimes(replacementPath, active, active);
+    await writeRollout(
+      freshRoot,
+      "2030-06-02",
+      fileName,
+      replacementEvents,
+      active.toISOString(),
+    );
+
+    let replaced = false;
+    fsSync.promises.open = async function openWithReplacement(...openArgs) {
+      const handle = await originalOpen.apply(this, openArgs);
+      if (openArgs[0] !== filePath) return handle;
+      const originalRead = handle.read.bind(handle);
+      handle.read = async function readWithReplacement(
+        buffer,
+        offset,
+        length,
+        position,
+      ) {
+        // The prefix fits in the position-0 read; replace the path exactly
+        // when the same handle advances to the appended suffix.
+        if (!replaced && Number(position) > 0) {
+          fsSync.renameSync(replacementPath, filePath);
+          replaced = true;
+        }
+        return originalRead(buffer, offset, length, position);
+      };
+      return handle;
+    };
+
+    const stableSnapshot = await computeCodexContextBreakdown(args);
+    const freshSnapshot = await computeCodexContextBreakdown({
+      ...args,
+      codexDir: freshRoot,
+    });
+    assert.equal(replaced, true);
+    assert.deepEqual(stableSnapshot.totals, freshSnapshot.totals);
+    assert.deepEqual(
+      stableSnapshot.tool_calls_breakdown,
+      freshSnapshot.tool_calls_breakdown,
+    );
+    assert.equal(stableSnapshot.diagnostics.incremental_parse_hits, 0);
+    assert.equal(stableSnapshot.diagnostics.incremental_parse_fallbacks, 1);
+    assert.equal(stableSnapshot.diagnostics.opened_files, 2);
+
+    fsSync.promises.open = originalOpen;
+    const replacementSnapshot = await computeCodexContextBreakdown(args);
+    assert.equal(replacementSnapshot.diagnostics.incremental_parse_hits, 0);
+    assert.equal(replacementSnapshot.diagnostics.opened_files, 1);
+    assert.deepEqual(replacementSnapshot.totals, freshSnapshot.totals);
+  } finally {
+    fsSync.promises.open = originalOpen;
     await fs.rm(root, { recursive: true, force: true });
     await fs.rm(freshRoot, { recursive: true, force: true });
   }
@@ -918,6 +1044,7 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
               tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
             ]
           : [tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE)];
+        const primedContent = rolloutContents(events);
         const filePath = await writeRollout(
           root,
           "2030-06-01",
@@ -926,8 +1053,7 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
           "2030-06-02T00:00:00.000Z",
         );
         if (scenario === "incomplete record") {
-          const stat = await fs.stat(filePath);
-          await fs.truncate(filePath, stat.size - 1);
+          await fs.writeFile(filePath, primedContent.slice(0, -1), "utf8");
           const primedAt = new Date("2030-06-02T00:00:00.000Z");
           await fs.utimes(filePath, primedAt, primedAt);
         }
@@ -940,23 +1066,28 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
         };
         const primed = await computeCodexContextBreakdown(args);
         assert.equal(primed.totals.total_tokens, 0);
-        const primedSize = (await fs.stat(filePath)).size;
+        const primedSize = Buffer.byteLength(primedContent) -
+          (scenario === "incomplete record" ? 1 : 0);
         if (scenario === "prefix rewrite") assert.ok(primedSize > 4096);
 
         const targetLine = `${JSON.stringify(
           tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
         )}\n`;
+        let finalContentSize;
         if (scenario === "prefix rewrite") {
-          const content = await fs.readFile(filePath, "utf8");
-          const mutationOffset = content.indexOf("/tmp/aaaaaaaa");
+          const mutationOffset = primedContent.indexOf("/tmp/aaaaaaaa");
           assert.ok(mutationOffset >= 0 && mutationOffset < 4096);
+          const rewritten = primedContent.replace("/tmp/aaaaaaaa", "/tmp/baaaaaaa") +
+            targetLine;
           await fs.writeFile(
             filePath,
-            `${content.replace("/tmp/aaaaaaaa", "/tmp/baaaaaaa")}${targetLine}`,
+            rewritten,
             "utf8",
           );
+          finalContentSize = Buffer.byteLength(rewritten);
         } else {
           await fs.appendFile(filePath, `\n${targetLine}`, "utf8");
+          finalContentSize = primedSize + 1 + Buffer.byteLength(targetLine);
         }
         const active = new Date("2030-06-02T00:06:00.000Z");
         await fs.utimes(filePath, active, active);
@@ -977,7 +1108,7 @@ test("Context requires an unchanged newline-terminated prefix before resuming", 
           scenario === "prefix rewrite" ? primedSize : 0,
         );
         assert.equal(guarded.diagnostics.opened_files, 1);
-        assert.equal(guarded.diagnostics.bytes_read, (await fs.stat(filePath)).size);
+        assert.equal(guarded.diagnostics.bytes_read, finalContentSize);
       } finally {
         await fs.rm(root, { recursive: true, force: true });
         await fs.rm(freshRoot, { recursive: true, force: true });

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -912,7 +912,7 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
     const fileName =
       "rollout-2030-06-02T00-00-00-77777777-7777-4777-8777-777777777777.jsonl";
     const initialEvents = [
-      tokenCount("2030-06-02T00:01:00.000Z", BASELINE_USAGE),
+      tokenCount("2030-06-01T23:59:00.000Z", BASELINE_USAGE),
     ];
     const filePath = await writeRollout(
       root,
@@ -932,6 +932,8 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
     const appendedLine = `${JSON.stringify(
       tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
     )}\n`;
+    const prefixSize = Buffer.byteLength(rolloutContents(initialEvents));
+    const fullSnapshotSize = prefixSize + Buffer.byteLength(appendedLine);
     await fs.appendFile(filePath, appendedLine, "utf8");
     const active = new Date("2030-06-02T00:06:00.000Z");
     await fs.utimes(filePath, active, active);
@@ -946,7 +948,7 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
           model_provider: "openai",
         },
       },
-      tokenCount("2030-06-02T00:01:00.000Z", BASELINE_USAGE),
+      tokenCount("2030-06-01T23:59:00.000Z", BASELINE_USAGE),
       tokenCount("2030-06-02T00:10:00.000Z", {
         input_tokens: 260,
         cached_input_tokens: 60,
@@ -973,9 +975,18 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
     );
 
     let replaced = false;
+    let matchingOpens = 0;
+    let firstHandleReadSuffix = false;
     fsSync.promises.open = async function openWithReplacement(...openArgs) {
+      const isTarget = openArgs[0] === filePath;
+      if (isTarget && matchingOpens > 0 && !replaced) {
+        fsSync.renameSync(replacementPath, filePath);
+        replaced = true;
+      }
       const handle = await originalOpen.apply(this, openArgs);
-      if (openArgs[0] !== filePath) return handle;
+      if (!isTarget) return handle;
+      matchingOpens += 1;
+      const handleIndex = matchingOpens;
       const originalRead = handle.read.bind(handle);
       handle.read = async function readWithReplacement(
         buffer,
@@ -989,6 +1000,9 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
           fsSync.renameSync(replacementPath, filePath);
           replaced = true;
         }
+        if (handleIndex === 1 && Number(position) > 0) {
+          firstHandleReadSuffix = true;
+        }
         return originalRead(buffer, offset, length, position);
       };
       return handle;
@@ -1000,14 +1014,16 @@ test("Context keeps one file handle across prefix validation and suffix parsing"
       codexDir: freshRoot,
     });
     assert.equal(replaced, true);
-    assert.deepEqual(stableSnapshot.totals, freshSnapshot.totals);
-    assert.deepEqual(
-      stableSnapshot.tool_calls_breakdown,
-      freshSnapshot.tool_calls_breakdown,
+    assert.equal(matchingOpens, 1);
+    assert.equal(firstHandleReadSuffix, true);
+    assertExactTargetDelta(stableSnapshot);
+    assert.equal(stableSnapshot.diagnostics.incremental_parse_hits, 1);
+    assert.equal(stableSnapshot.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(stableSnapshot.diagnostics.opened_files, 1);
+    assert.equal(
+      stableSnapshot.diagnostics.prefix_validation_bytes,
+      prefixSize + fullSnapshotSize,
     );
-    assert.equal(stableSnapshot.diagnostics.incremental_parse_hits, 0);
-    assert.equal(stableSnapshot.diagnostics.incremental_parse_fallbacks, 1);
-    assert.equal(stableSnapshot.diagnostics.opened_files, 2);
 
     fsSync.promises.open = originalOpen;
     const replacementSnapshot = await computeCodexContextBreakdown(args);

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -206,7 +206,9 @@ test("bounded Context prunes an unrelated historical rollout and reports per-cal
     assert.equal(result.session_count, 1);
     assert.equal(result.message_count, 1);
     assertExactTextResponseBreakdown(result);
-    assert.deepEqual(result.diagnostics, {
+    const { bytes_read: bytesRead, ...diagnostics } = result.diagnostics;
+    assert.ok(bytesRead > 0);
+    assert.deepEqual(diagnostics, {
       cache_hit: false,
       full_metadata_audit: true,
       discovered_files: 2,
@@ -216,6 +218,8 @@ test("bounded Context prunes an unrelated historical rollout and reports per-cal
       opened_files: 1,
       parsed_files: 1,
       parse_cache_hits: 0,
+      incremental_parse_hits: 0,
+      incremental_parse_fallbacks: 0,
       json_parse_calls: 2,
     });
     const exhaustive = await computeCodexContextBreakdown({ ...args, exhaustive: true });
@@ -759,10 +763,242 @@ test("Context reuses frozen parsed sessions when one active session changes", as
     assert.equal(second.diagnostics.opened_files, 1);
     assert.equal(second.diagnostics.parsed_files, 1);
     assert.equal(second.diagnostics.parse_cache_hits, 1);
+    assert.equal(second.diagnostics.incremental_parse_hits, 1);
+    assert.equal(second.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(second.diagnostics.json_parse_calls, 1);
+    assert.ok(second.diagnostics.bytes_read < first.diagnostics.bytes_read);
     assert.ok(stablePath);
     assert.equal(second.totals.total_tokens, 78);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Context incrementally parses append-only sessions with pending tools and duplicate boundaries", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-incremental-"));
+  const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-incremental-fresh-"));
+  try {
+    const fileName =
+      "rollout-2030-06-01T23-40-00-33333333-3333-4333-8333-333333333333.jsonl";
+    const filePath = await writeRollout(
+      root,
+      "2030-06-01",
+      fileName,
+      [
+        {
+          timestamp: "2030-06-01T23:40:00.000Z",
+          type: "session_meta",
+          payload: {
+            id: "33333333-3333-4333-8333-333333333333",
+            cwd: "/tmp/project",
+            model_provider: "openai",
+          },
+        },
+        tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
+        {
+          timestamp: "2030-06-01T23:59:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "take_snapshot",
+            call_id: "pending",
+            arguments: "{}",
+          },
+        },
+        {
+          timestamp: "2030-06-01T23:59:10.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            call_id: "pending-exec",
+            arguments: JSON.stringify({
+              cmd: "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md",
+            }),
+          },
+        },
+        {
+          timestamp: "2030-06-01T23:59:20.000Z",
+          type: "event_msg",
+          payload: {
+            type: "exec_command_end",
+            command: ["bash", "-lc", "sed -n '1,120p' /tmp/.codex/skills/frontend-design/SKILL.md"],
+            status: "completed",
+            exit_code: 0,
+            duration: { secs: 0, nanos: 10_000_000 },
+            aggregated_output: "skill body\n",
+          },
+        },
+      ],
+      "2030-06-02T00:00:00.000Z",
+    );
+    const args = {
+      from: "2030-06-02",
+      to: "2030-06-02",
+      codexDir: root,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    };
+    const primed = await computeCodexContextBreakdown(args);
+    assert.equal(primed.totals.total_tokens, 0);
+
+    const appendedLine = `${JSON.stringify(
+      tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
+    )}\n`;
+    await fs.appendFile(filePath, appendedLine, "utf8");
+    await fs.utimes(
+      filePath,
+      new Date("2030-06-02T00:06:00.000Z"),
+      new Date("2030-06-02T00:06:00.000Z"),
+    );
+    const appended = await computeCodexContextBreakdown(args);
+    const freshPath = await writeRollout(freshRoot, "2030-06-01", fileName, []);
+    await fs.copyFile(filePath, freshPath);
+    const active = new Date("2030-06-02T00:06:00.000Z");
+    await fs.utimes(freshPath, active, active);
+    const fresh = await computeCodexContextBreakdown({ ...args, codexDir: freshRoot });
+    assertExactTargetDelta(appended);
+    assert.deepEqual(appended.tool_calls_breakdown, fresh.tool_calls_breakdown);
+    assert.deepEqual(appended.skills_breakdown, fresh.skills_breakdown);
+    assert.deepEqual(appended.exec_command_breakdown, fresh.exec_command_breakdown);
+    assert.equal(appended.skills_breakdown.skills[0]?.name, "frontend-design");
+    assert.ok(appended.exec_command_breakdown.by_command.length > 0);
+    assert.equal(appended.diagnostics.incremental_parse_hits, 1);
+    assert.equal(appended.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(appended.diagnostics.json_parse_calls, 1);
+    assert.equal(appended.diagnostics.bytes_read, Buffer.byteLength(appendedLine));
+
+    await fs.appendFile(filePath, appendedLine, "utf8");
+    await fs.utimes(
+      filePath,
+      new Date("2030-06-02T00:07:00.000Z"),
+      new Date("2030-06-02T00:07:00.000Z"),
+    );
+    const duplicate = await computeCodexContextBreakdown(args);
+    assert.deepEqual(duplicate.totals, appended.totals);
+    assert.equal(duplicate.message_count, appended.message_count);
+    assert.equal(duplicate.diagnostics.incremental_parse_hits, 1);
+    assert.equal(duplicate.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(duplicate.diagnostics.json_parse_calls, 1);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(freshRoot, { recursive: true, force: true });
+  }
+});
+
+test("Context requires an unchanged newline-terminated prefix before resuming", async (t) => {
+  const scenarios = ["prefix rewrite", "incomplete record"];
+  for (const scenario of scenarios) {
+    await t.test(scenario, async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-resume-guard-"));
+      const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-resume-guard-fresh-"));
+      try {
+        const fileName =
+          "rollout-2030-06-01T23-50-00-55555555-5555-4555-8555-555555555555.jsonl";
+        const filePath = await writeRollout(root, "2030-06-01", fileName, [
+          tokenCount("2030-06-01T23:50:00.000Z", BASELINE_USAGE),
+        ], "2030-06-02T00:00:00.000Z");
+        if (scenario === "incomplete record") {
+          const stat = await fs.stat(filePath);
+          await fs.truncate(filePath, stat.size - 1);
+          const primedAt = new Date("2030-06-02T00:00:00.000Z");
+          await fs.utimes(filePath, primedAt, primedAt);
+        }
+
+        const args = {
+          from: "2030-06-02",
+          to: "2030-06-02",
+          codexDir: root,
+          timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+        };
+        const primed = await computeCodexContextBreakdown(args);
+        assert.equal(primed.totals.total_tokens, 0);
+
+        const targetLine = `${JSON.stringify(
+          tokenCount("2030-06-02T00:05:00.000Z", TARGET_USAGE),
+        )}\n`;
+        if (scenario === "prefix rewrite") {
+          const content = await fs.readFile(filePath, "utf8");
+          assert.match(content, /"input_tokens":100/);
+          await fs.writeFile(
+            filePath,
+            `${content.replace('"input_tokens":100', '"input_tokens":101')}${targetLine}`,
+            "utf8",
+          );
+        } else {
+          await fs.appendFile(filePath, `\n${targetLine}`, "utf8");
+        }
+        const active = new Date("2030-06-02T00:06:00.000Z");
+        await fs.utimes(filePath, active, active);
+
+        const guarded = await computeCodexContextBreakdown(args);
+        const freshPath = await writeRollout(freshRoot, "2030-06-01", fileName, []);
+        await fs.copyFile(filePath, freshPath);
+        await fs.utimes(freshPath, active, active);
+        const fresh = await computeCodexContextBreakdown({ ...args, codexDir: freshRoot });
+
+        assert.deepEqual(guarded.totals, fresh.totals);
+        assert.deepEqual(guarded.tool_calls_breakdown, fresh.tool_calls_breakdown);
+        assert.equal(guarded.message_count, fresh.message_count);
+        assert.equal(guarded.diagnostics.incremental_parse_hits, 0);
+        assert.equal(guarded.diagnostics.incremental_parse_fallbacks, 0);
+        assert.equal(guarded.diagnostics.opened_files, 1);
+        assert.equal(guarded.diagnostics.bytes_read, (await fs.stat(filePath)).size);
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+        await fs.rm(freshRoot, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("Context abandons an incremental parse when appended token timestamps move backwards", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-resume-fallback-"));
+  const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-resume-fresh-"));
+  try {
+    const fileName =
+      "rollout-2030-06-02T00-00-00-44444444-4444-4444-8444-444444444444.jsonl";
+    const filePath = await writeRollout(root, "2030-06-02", fileName, [
+      tokenCount("2030-06-02T00:05:00.000Z", BASELINE_USAGE),
+      tokenCount("2030-06-02T01:00:00.000Z", TARGET_USAGE),
+    ]);
+    const args = {
+      from: "2030-06-02",
+      to: "2030-06-02",
+      codexDir: root,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    };
+    await computeCodexContextBreakdown(args);
+
+    await fs.appendFile(filePath, `${JSON.stringify(tokenCount(
+      "2030-06-02T00:30:00.000Z",
+      {
+        input_tokens: 200,
+        cached_input_tokens: 40,
+        cache_creation_input_tokens: 8,
+        output_tokens: 30,
+        reasoning_output_tokens: 7,
+        total_tokens: 238,
+      },
+    ))}\n`, "utf8");
+
+    const resumed = await computeCodexContextBreakdown(args);
+    const freshPath = await writeRollout(
+      freshRoot,
+      "2030-06-02",
+      fileName,
+      [],
+    );
+    await fs.copyFile(filePath, freshPath);
+    const fresh = await computeCodexContextBreakdown({ ...args, codexDir: freshRoot });
+
+    assert.deepEqual(resumed.totals, fresh.totals);
+    assert.deepEqual(resumed.tool_calls_breakdown, fresh.tool_calls_breakdown);
+    assert.equal(resumed.diagnostics.incremental_parse_hits, 0);
+    assert.equal(resumed.diagnostics.incremental_parse_fallbacks, 1);
+    assert.equal(resumed.diagnostics.opened_files, 2);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(freshRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

Keep Codex Context Breakdown refreshes current without repeatedly JSON-parsing multi-hundred-megabyte rollout prefixes. Growing single-file sessions validate the complete cached prefix and parse the appended JSONL records through one stable read handle; refresh cadence and API behavior are unchanged.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Why

A machine with about 28,900 Codex rollout files and 16 GB of sessions had roughly 1 GB of candidate data for a current-day Context query. Active 100-200 MiB sessions were fully JSON-parsed after every append, so a small refresh could consume hundreds of milliseconds to seconds of CPU.

This change reduces work per refresh instead of delaying, debouncing, or coalescing refreshes.

## Implementation

- Cache the parsed aggregate and a compact resume state per single-file rollout group.
- Use an O(n) scan to select only the most recently modified eligible single-file rollout for resumable SHA-256 state. Other sessions keep the conservative full-parse path, avoiding cold-path hashing across all sessions.
- On a valid append, open the file once, hash the complete cached prefix `[0, endOffset)`, and parse only the suffix through that same handle. Accept the merge only when metadata is unchanged, or when a concurrently unlinked handle passes a second full-snapshot SHA-256 check.
- Keep full parsing for overlapping live/archive fragments and every unsafe or non-selected state.
- Retain only cumulative token baselines, pending tool/skill names, sanitized exec summaries, metadata, final timestamp signatures, and internal hash state. Raw command arguments and tool output payloads are not cached.
- Add diagnostics for incremental hits, fallbacks, parser bytes read, and prefix-validation bytes.

## Safety invariants

Incremental parsing is allowed only when all of these hold:

- same file path, device, and inode
- file size strictly increased
- the prior parsed snapshot ended at a JSONL newline
- SHA-256 matches across the complete prior prefix `[0, endOffset)`
- prefix validation and suffix parsing use the same open file handle
- the handle metadata is unchanged after suffix parsing, or an unlinked handle's complete parsed snapshot hash still matches
- appended token timestamps do not move backwards

Replacement before validation, truncation, mutation anywhere in the prior prefix, incomplete records, unstable linked handles, timestamp regression, and multi-file overlap groups fall back to a fresh full parse. If the path is atomically replaced after validation, the already-open unlinked handle is rehashed and returned only as a coherent byte-identical snapshot; the new path is picked up on the next refresh.

## Performance

Benchmarked in alternating fresh Node processes against `origin/main` on the same frozen data:

| Case | Baseline median | Candidate median | Result |
| --- | ---: | ---: | --- |
| Cold parse: 64 sessions, 1.059 GB (6 samples each) | 5,788.7 ms | 5,966.1 ms | 3.1% one-time hash-state cost; identical result SHA-256 |
| Append refresh: 194 MiB session + 978,218 B (10 samples each) | 985.1 ms | 124.9 ms | about 7.9x faster / 87.3% lower latency |

The candidate validates 202,992,923 prefix bytes sequentially to prove append safety, but JSON-parses only the 978,218-byte suffix. Baseline and candidate produced identical full-result SHA-256 hashes before and after the append.

## Checklist

- [x] `npm test` passes
- [x] No new user-facing strings
- [x] Commits follow conventional style
- [x] PR description explains why, not just what

## Verification

- `node --check src/lib/codex-rollout-parser.js`
- `node --check src/lib/codex-context-breakdown.js`
- `node --test test/codex-context-breakdown.test.js test/codex-context-hot-path.test.js` (36/36)
- `npm run ci:local` (1,657/1,657 tests, copy/UI/architecture guardrails, production dashboard build)
- Real 1.059 GB cold-result equivalence benchmark
- Real 194 MiB append-result equivalence benchmark
- Regression mutates a prefix larger than 4 KiB near its beginning before appending and confirms the incremental path is rejected
- Regression atomically replaces the path between validation and suffix parsing, asserts exactly one matching open and a first-handle suffix read, then confirms the coherent old snapshot and next-refresh replacement equivalence

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-module parser/cache invariant
- [ ] External gateway / environment constraints

### Rules / invariants

- Never return or cache prompt text, assistant text, command arguments, or tool output payloads.
- Never merge an append into a cache entry unless identity, growth, full-prefix, record-boundary, stable-handle, and timestamp gates pass.
- Preserve synchronous freshness for active sessions; no debounce or polling interval change.

### Boundary matrix

| Boundary | Expected behavior |
| --- | --- |
| Same inode + valid append | Validate prefix and parse suffix on one open handle |
| Replaced before validation / truncated / mutated prefix | Full parse |
| Path replaced after the validated handle opens | Rehash the stable handle; read the new path next refresh |
| Partial final JSONL record | Full parse after completion |
| Timestamp regression | Abort resume and full parse |
| Live/archive overlap | Existing full merge/dedup path |

</details>

<details>
<summary><strong>Codex review context</strong></summary>

- **Intended behavior / invariants:** identical breakdown output with append work proportional to new bytes
- **Edge cases covered:** pending tools/skills/exec attribution, duplicate boundary events, prefix rewrite, incomplete record, concurrent path replacement, replacement/truncation, overlap groups, timestamp regression
- **Tests run:** see Verification
- **Known gaps / out of scope:** cursor-store generation commit cost and the existing 60-second metadata audit for previously pruned historical sessions

### Most likely regression surface

Cross-refresh attribution at the cached byte boundary.

### Verification method

Deterministic targeted tests plus full-result hashes on frozen production-scale fixtures.

### Uncovered scope

No refresh scheduler cadence or live tracker state was changed.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Added safer incremental/resumable parsing for cached Codex contexts, reusing previously parsed results when the file prefix is validated.
  * Improved JSONL incremental reading with byte-offset tracking to reduce hot-path work.

* **Reliability**
  * Strengthened resume safeguards with additional stability and identity checks; automatically falls back to full reparse when invalidated.

* **Diagnostics**
  * Added clearer visibility into incremental parsing behavior, including hit/fallback counters, prefix validation bytes, and bytes read.

* **Tests**
  * Expanded coverage for append-only updates, resume invalidation scenarios, and file-handle stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->