### PR TITLE
fix(dashboard): resolve small layout regressions

### DIFF
--- a/dashboard/src/lib/__tests__/leaderboard-columns.test.js
+++ b/dashboard/src/lib/__tests__/leaderboard-columns.test.js
@@ -1,10 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { LEADERBOARD_TOKEN_COLUMNS } from "../leaderboard-columns.js";
+import {
+  LEADERBOARD_TOKEN_COLUMNS,
+  lbStickyTdRank,
+  lbStickyTdUser,
+} from "../leaderboard-columns.js";
 
 describe("LEADERBOARD_TOKEN_COLUMNS", () => {
   it("uses the bundled Hermes brand logo for the Hermes leaderboard column", () => {
     const hermesColumn = LEADERBOARD_TOKEN_COLUMNS.find((col) => col.key === "hermes_tokens");
 
     expect(hermesColumn?.icon).toBe("/brand-logos/hermes.svg");
+  });
+});
+
+describe("leaderboard sticky row cells", () => {
+  it("uses opaque dark hover backgrounds so scrolled values cannot bleed through", () => {
+    for (const className of [lbStickyTdRank(false), lbStickyTdUser(false)]) {
+      expect(className).toContain("dark:group-hover:bg-oai-gray-900");
+      expect(className).not.toContain("dark:group-hover:bg-oai-gray-900/60");
+    }
   });
 });

--- a/dashboard/src/lib/leaderboard-columns.js
+++ b/dashboard/src/lib/leaderboard-columns.js
@@ -42,7 +42,7 @@ export function lbStickyTdRank(isMe) {
     "sticky left-0 z-30 w-14 min-w-14 max-w-14 sm:w-[72px] sm:min-w-[72px] sm:max-w-[72px] px-2.5 sm:px-4 py-4 whitespace-nowrap",
     isMe
       ? "bg-oai-brand-50 dark:bg-emerald-950"
-      : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900/60",
+      : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900",
   );
 }
 
@@ -54,7 +54,7 @@ export function lbStickyTdUser(isMe) {
     "sticky left-[55px] sm:left-[71px] z-30 hover:z-50 min-w-[96px] sm:min-w-[200px] max-w-[170px] sm:max-w-[min(260px,45vw)] border-l border-r border-oai-gray-200 dark:border-oai-gray-800 px-3 sm:px-4 py-4 min-w-0",
     isMe
       ? "bg-oai-brand-50 dark:bg-emerald-950"
-      : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900/60",
+      : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900",
   );
 }
 

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -154,7 +154,7 @@ function LeaderboardTokenCells({ entry, isMe, orderedColumns }) {
     : "text-oai-gray-500 dark:text-oai-gray-400";
   const cellBg = isMe
     ? "bg-oai-brand-50 dark:bg-oai-brand-900/10"
-    : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900/60";
+    : "bg-white dark:bg-oai-gray-950 group-hover:bg-oai-gray-50 dark:group-hover:bg-oai-gray-900";
   return orderedColumns.map((col) => (
     <td
       key={col.key}

--- a/dashboard/src/pages/LeaderboardPage.test.jsx
+++ b/dashboard/src/pages/LeaderboardPage.test.jsx
@@ -125,6 +125,24 @@ describe("LeaderboardPage window-session cache reuse", () => {
     });
   });
 
+  it("keeps normal token-cell hover backgrounds opaque in dark mode", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    const { container } = renderLeaderboard();
+    const tokenCell = container.querySelector('td[data-column-key="gpt_tokens"]');
+
+    expect(tokenCell).not.toBeNull();
+    expect(tokenCell.className).toContain("dark:group-hover:bg-oai-gray-900");
+    expect(tokenCell.className).not.toContain("dark:group-hover:bg-oai-gray-900/60");
+  });
+
   it("keeps the pinned me-row rank cell sticky (twMerge must not drop it, issue 265)", () => {
     const contextKey = getLeaderboardPreloadContextKey({
       accessMode: "cloud",

--- a/dashboard/src/ui/dashboard/components/ActivityHeatmap.jsx
+++ b/dashboard/src/ui/dashboard/components/ActivityHeatmap.jsx
@@ -502,7 +502,7 @@ export function ActivityHeatmap({
       {view === "2d" && (
       <div
         ref={scrollRef}
-        className="overflow-x-auto overflow-y-hidden heatmap-scroll-thin"
+        className={`overflow-x-auto overflow-y-hidden heatmap-scroll-thin${embedded ? "" : " pb-1"}`}
       >
         <div style={{ minWidth: gridCols }}>
           {/* Month labels */}

--- a/dashboard/src/ui/dashboard/components/DataDetails.jsx
+++ b/dashboard/src/ui/dashboard/components/DataDetails.jsx
@@ -124,7 +124,7 @@ export function DataDetails({
   return (
     <Card>
       {/* Tab Switcher + Controls */}
-      <div className="flex items-center justify-between gap-3 mb-4">
+      <div className={`flex items-center justify-between gap-3 ${activeTab === "projects" ? "mb-4" : "mb-0"}`}>
         <div role="tablist" aria-label="Data view" className="flex gap-1">
           <button
             role="tab"

--- a/dashboard/src/ui/dashboard/components/__tests__/ActivityHeatmap.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/ActivityHeatmap.test.jsx
@@ -53,6 +53,15 @@ describe("ActivityHeatmap", () => {
     expect(tooltip.className).not.toContain("pointer-events-auto");
   });
 
+  it("reserves scrollbar clearance only for the standalone 2D view", () => {
+    const standalone = renderHeatmap();
+    expect(standalone.container.querySelector(".heatmap-scroll-thin").className).toContain("pb-1");
+    standalone.unmount();
+
+    const embedded = renderHeatmap({ embedded: true });
+    expect(embedded.container.querySelector(".heatmap-scroll-thin").className).not.toContain("pb-1");
+  });
+
   it("forces 2D when embedded, ignoring the persisted 3D dashboard preference", () => {
     // Reproduces the leaderboard-modal regression: picking 3D on the standalone
     // dashboard persists "3d" to localStorage, which the embedded modal instance

--- a/dashboard/src/ui/dashboard/components/__tests__/DataDetailsProjects.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/DataDetailsProjects.test.jsx
@@ -78,6 +78,33 @@ function renderProjects(props = {}) {
   return result;
 }
 
+it("removes the daily table gap while preserving project spacing", () => {
+  const result = render(
+    <DataDetails
+      projectEntries={[baseEntry]}
+      projectLimit={3}
+      copy={copy}
+      dailyBreakdownRows={[{ day: "2026-04-20", total_tokens: 1000 }]}
+      dailyBreakdownColumns={[{ key: "day", label: "Day" }]}
+      toggleSort={() => {}}
+      renderDetailDate={() => "2026-04-20"}
+      renderDetailCell={() => "1K"}
+      DETAILS_PAGED_PERIODS={new Set()}
+      period="month"
+      detailsPageCount={0}
+      detailsPage={0}
+      setDetailsPage={() => {}}
+    />,
+  );
+  const controls = screen.getByRole("tablist").parentElement;
+
+  expect(controls.className).toContain("mb-0");
+  fireEvent.click(screen.getByRole("tab", { name: copy("dashboard.projects.title") }));
+  expect(controls.className).toContain("mb-4");
+
+  result.unmount();
+});
+
 it("renders project rows without external links", () => {
   renderProjects();
   expect(screen.getByText("alpha")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- reserve bottom clearance for the standalone 2D heatmap scrollbar without changing embedded heatmaps
- remove the gap above the Daily Details table while preserving Project Usage spacing
- use opaque dark-mode leaderboard hover backgrounds so horizontally scrolled values cannot bleed through
- add focused regression coverage for each presentation fix

## Why

The heatmap scrollbar could cover the final row, the shared details controls margin left an unnecessary strip above the daily table, and translucent dark hover backgrounds allowed scrolling leaderboard values to remain visible beneath sticky cells.

## User impact

The affected dashboard surfaces keep their existing behavior and dimensions while avoiding the three small visual regressions.

## Validation

- `npm --prefix dashboard test` (69 files, 389 tests)
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run lint`
- `npm --prefix dashboard run build`
- `npm run ci:local` (1,616 Node tests plus copy, UI hardcode, architecture, and production-build checks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode hover visibility in leaderboard tables by using an opaque background.
  * Adjusted spacing in activity heatmaps and data detail tabs for more consistent layouts.
  * Preserved appropriate spacing across standalone and embedded heatmap views.

* **Tests**
  * Added coverage for leaderboard hover styling, heatmap padding, and project tab spacing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->