### PR TITLE
fix(i18n): label profile start date correctly

### DIFF
--- a/dashboard/src/content/i18n/de/core.json
+++ b/dashboard/src/content/i18n/de/core.json
@@ -40,7 +40,7 @@
   "error.boundary.hint": "Öffne die Konsole und lade die Seite neu",
   "error.boundary.no_details": "Keine Fehlerdetails verfügbar",
   "error.boundary.action.reload": "Neu laden",
-  "identity_card.rank_label": "Rang",
+  "identity_card.rank_label": "Beginn",
   "identity_card.streak_label": "Aktive Tage",
   "identity_card.rank_placeholder": "—",
   "identity_card.streak_value": "{{days}} Tage",

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -57,7 +57,7 @@
   "error.boundary.hint": "コンソールを開いてから、ページを再読み込みしてください",
   "error.boundary.no_details": "エラーの詳細はありません",
   "error.boundary.action.reload": "再読み込み",
-  "identity_card.rank_label": "ランク",
+  "identity_card.rank_label": "開始日",
   "identity_card.streak_label": "アクティブ日数",
   "identity_card.rank_placeholder": "—",
   "identity_card.streak_value": "{{days}} 日",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -57,7 +57,7 @@
   "error.boundary.hint": "開啟控制台，然後重新載入頁面",
   "error.boundary.no_details": "沒有錯誤詳細資訊",
   "error.boundary.action.reload": "重新載入",
-  "identity_card.rank_label": "排名",
+  "identity_card.rank_label": "開始使用",
   "identity_card.streak_label": "活躍天數",
   "identity_card.rank_placeholder": "—",
   "identity_card.streak_value": "{{days}} 天",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -57,7 +57,7 @@
   "error.boundary.hint": "打开控制台，然后重新加载页面",
   "error.boundary.no_details": "没有错误详细信息",
   "error.boundary.action.reload": "重新加载",
-  "identity_card.rank_label": "排名",
+  "identity_card.rank_label": "开始使用",
   "identity_card.streak_label": "活跃天数",
   "identity_card.rank_placeholder": "—",
   "identity_card.streak_value": "{{days}} 天",

--- a/dashboard/src/ui/dashboard/components/StatsPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/StatsPanel.jsx
@@ -35,7 +35,7 @@ function buildSubscriptionItems(subscriptions) {
 }
 
 export function StatsPanel({
-  rankLabel,
+  startDate,
   streakDays,
   subscriptions = [],
   periodConversations,
@@ -47,7 +47,7 @@ export function StatsPanel({
   const placeholder = copy("shared.placeholder.short");
   const percentSymbol = copy("shared.unit.percent");
 
-  const rankValue = rankLabel ?? copy("identity_card.rank_placeholder");
+  const startDateValue = startDate ?? copy("identity_card.rank_placeholder");
   const streakDaysNum = Number.isFinite(Number(streakDays)) ? Number(streakDays) : 0;
   const streakValue = streakDaysNum
     ? copy("identity_card.streak_value", { days: streakDaysNum })
@@ -160,7 +160,7 @@ export function StatsPanel({
         <div className="mt-4 pt-3 border-t border-oai-gray-100 dark:border-oai-gray-800 flex items-center justify-between text-xs text-oai-gray-400 dark:text-oai-gray-400">
           <div className="flex items-center gap-1.5">
             <span>{copy("identity_card.rank_label")}</span>
-            <span className="text-oai-gray-500 dark:text-oai-gray-300 tabular-nums">{rankValue}</span>
+            <span className="text-oai-gray-500 dark:text-oai-gray-300 tabular-nums">{startDateValue}</span>
           </div>
           <div className="flex items-center gap-1">
             <span>{copy("identity_card.streak_label")}</span>

--- a/dashboard/src/ui/dashboard/components/__tests__/StatsPanel.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/StatsPanel.test.jsx
@@ -6,7 +6,7 @@ import { StatsPanel } from "../StatsPanel.jsx";
 function renderPanel(props = {}) {
   return render(
     <StatsPanel
-      rankLabel="2026-03-01"
+      startDate="2026-03-01"
       streakDays={12}
       rolling={{
         last_7d: { totals: { billable_total_tokens: 12345 } },
@@ -48,7 +48,7 @@ it("keeps rolling card values compact when the global token format is full", () 
       }}
     >
       <StatsPanel
-        rankLabel="2026-03-01"
+        startDate="2026-03-01"
         streakDays={12}
         periodConversations={30_500}
         rolling={{

--- a/dashboard/src/ui/dashboard/views/DashboardView.jsx
+++ b/dashboard/src/ui/dashboard/views/DashboardView.jsx
@@ -257,7 +257,7 @@ export function DashboardView(props) {
               title={copy("dashboard.identity.title")}
               subtitle={copy("dashboard.identity.subtitle")}
               period={period}
-              rankLabel={identityStartDate ?? copy("identity_card.rank_placeholder")}
+              startDate={identityStartDate ?? copy("identity_card.rank_placeholder")}
               streakDays={activeDays}
               subscriptions={identitySubscriptions}
               periodConversations={summaryConversationsValue}

--- a/test/localization-regressions.test.js
+++ b/test/localization-regressions.test.js
@@ -193,11 +193,26 @@ test("locale PR stays scoped away from silent auto update flags", () => {
   assert.doesNotMatch(project, /TokenTrackerEnableSilentAutoUpdate/);
 });
 
+test("profile footer labels the start date instead of a leaderboard rank", () => {
+  const expectedLabels = {
+    zh: "开始使用",
+    "zh-TW": "開始使用",
+    ja: "開始日",
+    ko: "시작일",
+    de: "Beginn",
+  };
+
+  for (const [locale, expectedLabel] of Object.entries(expectedLabels)) {
+    const core = JSON.parse(read(`dashboard/src/content/i18n/${locale}/core.json`));
+    assert.equal(core["identity_card.rank_label"], expectedLabel);
+  }
+});
+
 test("zh locale uses reviewed natural copy for settings and dashboard", () => {
   const core = read("dashboard/src/content/i18n/zh/core.json");
   const dashboard = read("dashboard/src/content/i18n/zh/dashboard.json");
 
-  assert.match(core, /"identity_card\.rank_label":\s*"排名"/);
+  assert.match(core, /"identity_card\.rank_label":\s*"开始使用"/);
   assert.match(core, /"widgets\.heatmap\.description":\s*"像 GitHub 一样，一眼看清活跃和空闲的日子。"/);
   assert.match(core, /"widgets\.topModels\.name":\s*"热门模型"/);
   assert.match(core, /"daily\.sort\.conversations\.label":\s*"对话数"/);


### PR DESCRIPTION
## Summary

- Correct the dashboard profile footer translations so the displayed date is labeled as the user's start date, not a leaderboard rank.
- Rename the `StatsPanel` prop and local value from `rankLabel`/`rankValue` to `startDate`/`startDateValue` to make the data contract explicit.
- Add regression coverage for Simplified Chinese, Traditional Chinese, Japanese, Korean, and German.

## Why

`DashboardView` passes the earliest usage date into this footer, and the English source copy has always said `Started`. Several translations instead said `Rank`, producing combinations such as `?? 2026-03-01` in both native desktop apps and the web dashboard.

The separately reported dashboard refresh flash in the released `v0.81.2` is already addressed on current `main` by commit `849b4b3` (`fix(dashboard): keep period refreshes in place`), which keeps rendered content mounted after the initial load. This PR does not duplicate that upstream fix.

## Verification

- `node --test test/localization-regressions.test.js test/dashboard-layout-adjustments.test.js`
- `node scripts/validate-copy-registry.cjs`
- `node scripts/ops/validate-ui-hardcode.cjs`
- `vitest run StatsPanel.test.jsx UsageOverview.test.jsx`
- `vite build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the profile footer to display the localized start-date label instead of a ranking label.
  * Corrected German, Japanese, Simplified Chinese, and Traditional Chinese translations for the start-date text.

* **Tests**
  * Added regression coverage across multiple locales to verify the correct localized label and date display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->