### PR TITLE
fix(grok): use format=credits weekly billing for usage limits

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
@@ -60,7 +60,9 @@ enum MenuBarDisplayMetric: String, CaseIterable {
         case .kimiTotal: return "Km Tot"
         case .kiroMonth: return "Kr Mo"
         case .kiroBonus: return "Kr Bn"
-        case .grokMonth: return "Gk Mo"
+        // Preference id stays `grokMonth` for storage stability; label is period-agnostic
+        // because SuperGrok accounts use a weekly pool while legacy is monthly.
+        case .grokMonth: return "Gk"
         case .grokOndemand: return "Gk OD"
         case .copilotPremium: return "Co Prem"
         case .copilotChat: return "Co Chat"
@@ -98,7 +100,7 @@ enum MenuBarDisplayMetric: String, CaseIterable {
         case .kimiTotal: return "Kimi Total Limit"
         case .kiroMonth: return "Kiro Monthly Limit"
         case .kiroBonus: return "Kiro Bonus Limit"
-        case .grokMonth: return "Grok Build Monthly Limit"
+        case .grokMonth: return "Grok Build Limit"
         case .grokOndemand: return "Grok Build On-demand Limit"
         case .copilotPremium: return "Copilot Premium Limit"
         case .copilotChat: return "Copilot Chat Limit"

--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -303,12 +303,15 @@ struct GrokLimits: Codable, Equatable {
     let configured: Bool
     let error: String?
     let planLabel: String?
+    /// "weekly" | "monthly" | "daily" | "hourly" from the billing API period type.
+    let periodType: String?
     let primaryWindow: GenericLimitWindow?
     let secondaryWindow: GenericLimitWindow?
 
     enum CodingKeys: String, CodingKey {
         case configured, error
         case planLabel = "plan_label"
+        case periodType = "period_type"
         case primaryWindow = "primary_window"
         case secondaryWindow = "secondary_window"
     }

--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -303,7 +303,7 @@ struct GrokLimits: Codable, Equatable {
     let configured: Bool
     let error: String?
     let planLabel: String?
-    /// "weekly" | "monthly" | "daily" | "hourly" from the billing API period type.
+    /// "weekly" | "monthly" | "daily" from the billing API period type (null if unknown).
     let periodType: String?
     let primaryWindow: GenericLimitWindow?
     let secondaryWindow: GenericLimitWindow?

--- a/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
@@ -191,7 +191,7 @@ extension UsageLimitsResponse {
         addGeneric("kiro", kiro.configured, kiro.error, [("primary", Strings.kiroMonthLabel, kiro.primaryWindow), ("secondary", Strings.kiroBonusLabel, kiro.secondaryWindow)])
         addGeneric("antigravity", antigravity.configured, antigravity.error, [("primary", "Claude 7d", antigravity.primaryWindow), ("secondary", "Claude 5h", antigravity.secondaryWindow), ("tertiary", "Gemini 7d", antigravity.tertiaryWindow), ("quaternary", "Gemini 5h", antigravity.quaternaryWindow)])
         if let kimi { addGeneric("kimi", kimi.configured, kimi.error, [("primary", Strings.kimiWeeklyLabel, kimi.primaryWindow), ("secondary", Strings.kimiFiveHourLabel, kimi.secondaryWindow), ("tertiary", Strings.kimiTotalLabel, kimi.tertiaryWindow)]) }
-        if let grok { addGeneric("grok", grok.configured, grok.error, [("primary", Strings.grokMonthLabel, grok.primaryWindow), ("secondary", Strings.grokOndemandLabel, grok.secondaryWindow)]) }
+        if let grok { addGeneric("grok", grok.configured, grok.error, [("primary", Strings.grokPrimaryLabel(periodType: grok.periodType), grok.primaryWindow), ("secondary", Strings.grokOndemandLabel, grok.secondaryWindow)]) }
         if let copilot { addGeneric("copilot", copilot.configured, copilot.error, [("primary", "Premium", copilot.primaryWindow), ("secondary", "Chat", copilot.secondaryWindow)]) }
 
         return out

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -334,7 +334,13 @@ enum WidgetSnapshotWriter {
         // Grok Build
         if let grok = limits.grok, grok.configured {
             if let w = grok.primaryWindow {
-                out.append(LimitProvider(source: "grok", label: "Grok Build · Month",
+                let periodLabel: String
+                switch grok.periodType {
+                case "weekly": periodLabel = "Weekly"
+                case "daily": periodLabel = "Daily"
+                default: periodLabel = "Month"
+                }
+                out.append(LimitProvider(source: "grok", label: "Grok Build · \(periodLabel)",
                                          fraction: w.usedPercent / 100.0,
                                          resetsAt: parseISO(w.resetAt)))
             }

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -68,7 +68,18 @@ enum Strings {
     static var kiroMonthLabel: String { t("Month", "本月", "本月", "今月", "이번 달") }
     static var kiroBonusLabel: String { t("Bonus", "奖励", "獎勵", "ボーナス", "보너스") }
     static var grokMonthLabel: String { t("Month", "月度", "月度", "月間", "월간") }
+    static var grokWeekLabel: String { t("Weekly", "周", "週", "週間", "주간") }
+    static var grokDayLabel: String { t("Daily", "日", "日", "日", "일") }
     static var grokOndemandLabel: String { t("On-demand", "按需", "按需", "オンデマンド", "온디맨드") }
+
+    /// Primary Grok Build window label, driven by `period_type` from the billing API.
+    static func grokPrimaryLabel(periodType: String?) -> String {
+        switch periodType {
+        case "weekly": return grokWeekLabel
+        case "daily": return grokDayLabel
+        default: return grokMonthLabel
+        }
+    }
     static var limitResetNow: String { t("now", "现在", "現在", "今", "지금") }
     static func kimiParallelLabel(_ count: Int) -> String {
         t("Parallel: \(count)", "并发：\(count)", "併發：\(count)", "並列：\(count)", "병렬: \(count)")

--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -1497,7 +1497,7 @@ struct ClawdCompanionView: View {
         ])
         if let grok = limits.grok {
             generic("grok", configured: grok.configured, error: grok.error, windows: [
-                (Strings.grokMonthLabel, grok.primaryWindow), (Strings.grokOndemandLabel, grok.secondaryWindow)
+                (Strings.grokPrimaryLabel(periodType: grok.periodType), grok.primaryWindow), (Strings.grokOndemandLabel, grok.secondaryWindow)
             ])
         }
         if let copilot = limits.copilot {

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -272,7 +272,10 @@ struct UsageLimitsView: View {
 
     private func grokSpecs(_ g: GrokLimits) -> [LimitWindowSpec] {
         var s: [LimitWindowSpec] = []
-        if let w = g.primaryWindow { s.append(makeSpec(Strings.grokMonthLabel, w.usedPercent, iso: w.resetAt)) }
+        if let w = g.primaryWindow {
+            let windowSeconds: Double? = g.periodType == "weekly" ? 7 * 86400 : (g.periodType == "daily" ? 86400 : nil)
+            s.append(makeSpec(Strings.grokPrimaryLabel(periodType: g.periodType), w.usedPercent, windowSeconds: windowSeconds, iso: w.resetAt))
+        }
         if let w = g.secondaryWindow { s.append(makeSpec(Strings.grokOndemandLabel, w.usedPercent, iso: w.resetAt)) }
         return s
     }

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -641,6 +641,8 @@ limits.reset_bank.hover_detail_today,ui,LimitsPage,UsageLimitsPanel,reset_bank_h
 limits.label.copilot_premium,ui,LimitsPage,UsageLimitsPanel,copilot_premium,"Premium",,active
 limits.label.copilot_chat,ui,LimitsPage,UsageLimitsPanel,copilot_chat,"Chat",,active
 limits.label.grok_month,ui,LimitsPage,UsageLimitsPanel,grok_month,"Month",,active
+limits.label.grok_week,ui,LimitsPage,UsageLimitsPanel,grok_week,"Weekly",,active
+limits.label.grok_day,ui,LimitsPage,UsageLimitsPanel,grok_day,"Daily",,active
 limits.label.grok_ondemand,ui,LimitsPage,UsageLimitsPanel,grok_ondemand,"On-demand",,active
 limits.provider.claude,ui,LimitsPage,UsageLimitsPanel,provider_claude,"Claude",,active
 limits.provider.codex,ui,LimitsPage,UsageLimitsPanel,provider_codex,"Codex",,active

--- a/dashboard/src/content/i18n/de/core.json
+++ b/dashboard/src/content/i18n/de/core.json
@@ -322,6 +322,8 @@
   "limits.label.gemini_lite": "Lite",
   "limits.label.gemini_pro": "Pro",
   "limits.label.grok_month": "Monat",
+  "limits.label.grok_week": "Woche",
+  "limits.label.grok_day": "Tag",
   "limits.label.grok_ondemand": "On-Demand",
   "limits.label.opencode_go_5h": "5h",
   "limits.label.opencode_go_monthly": "Monatlich",

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -140,6 +140,8 @@
   "limits.label.copilot_premium": "プレミアム",
   "limits.label.copilot_chat": "チャット",
   "limits.label.grok_month": "月間",
+  "limits.label.grok_week": "週間",
+  "limits.label.grok_day": "日",
   "limits.label.grok_ondemand": "オンデマンド",
   "limits.provider.claude": "Claude",
   "limits.provider.codex": "Codex",

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -140,6 +140,8 @@
   "limits.label.copilot_premium": "프리미엄",
   "limits.label.copilot_chat": "채팅",
   "limits.label.grok_month": "월간",
+  "limits.label.grok_week": "주간",
+  "limits.label.grok_day": "일",
   "limits.label.grok_ondemand": "온디맨드",
   "limits.provider.claude": "Claude",
   "limits.provider.codex": "Codex",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -140,6 +140,8 @@
   "limits.label.copilot_premium": "高階",
   "limits.label.copilot_chat": "對話",
   "limits.label.grok_month": "月度",
+  "limits.label.grok_week": "週",
+  "limits.label.grok_day": "日",
   "limits.label.grok_ondemand": "按需",
   "limits.provider.claude": "Claude",
   "limits.provider.codex": "Codex",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -140,6 +140,8 @@
   "limits.label.copilot_premium": "高级",
   "limits.label.copilot_chat": "对话",
   "limits.label.grok_month": "月度",
+  "limits.label.grok_week": "周",
+  "limits.label.grok_day": "日",
   "limits.label.grok_ondemand": "按需",
   "limits.provider.claude": "Claude",
   "limits.provider.codex": "Codex",

--- a/dashboard/src/ui/dashboard/components/usage-limits-provider-specs.js
+++ b/dashboard/src/ui/dashboard/components/usage-limits-provider-specs.js
@@ -74,9 +74,26 @@ export const PROVIDER_LIMIT_SPECS = {
     },
   },
   grok: {
+    // Grok unified billing is weekly for SuperGrok / free-tier accounts and
+    // monthly for legacy credit counters. period_type comes from the billing
+    // API (USAGE_PERIOD_TYPE_WEEKLY / MONTHLY) via grok-limits.js.
     windows(data) {
+      const period = typeof data.period_type === "string" ? data.period_type : null;
+      const primaryLabelKey =
+        period === "weekly"
+          ? "limits.label.grok_week"
+          : period === "daily"
+            ? "limits.label.grok_day"
+            : "limits.label.grok_month";
+      const windowSeconds =
+        period === "weekly" ? 7 * 86400 : period === "daily" ? 86400 : undefined;
       return [
-        { key: "month", labelKey: "limits.label.grok_month", window: data.primary_window },
+        {
+          key: period === "weekly" ? "week" : period === "daily" ? "day" : "month",
+          labelKey: primaryLabelKey,
+          window: data.primary_window,
+          windowSeconds,
+        },
         { key: "ondemand", labelKey: "limits.label.grok_ondemand", window: data.secondary_window },
       ];
     },
@@ -157,6 +174,8 @@ export function usageLimitsLabelCopyAnchor() {
     copy("limits.label.kiro_month"),
     copy("limits.label.kiro_bonus"),
     copy("limits.label.grok_month"),
+    copy("limits.label.grok_week"),
+    copy("limits.label.grok_day"),
     copy("limits.label.grok_ondemand"),
     copy("limits.label.antigravity_claude_weekly"),
     copy("limits.label.antigravity_claude_5h"),

--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -58,6 +58,35 @@ function buildWindow({ usedPercent, resetAt }) {
   };
 }
 
+/**
+ * Map Grok's USAGE_PERIOD_TYPE_* enum (or a bare "weekly"/"monthly" string)
+ * into a short period key the UI can switch labels on.
+ */
+function normalizeGrokPeriodType(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const upper = value.trim().toUpperCase();
+  if (upper.includes("WEEK")) return "weekly";
+  if (upper.includes("MONTH")) return "monthly";
+  if (upper.includes("DAY") || upper.includes("DAILY")) return "daily";
+  if (upper.includes("HOUR")) return "hourly";
+  return null;
+}
+
+/**
+ * Infer weekly vs monthly from period length when the API omits `currentPeriod.type`
+ * (legacy monthly payloads only expose start/end dates).
+ */
+function inferGrokPeriodTypeFromDates(startIso, endIso) {
+  if (!startIso || !endIso) return null;
+  const startMs = Date.parse(startIso);
+  const endMs = Date.parse(endIso);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return null;
+  const days = (endMs - startMs) / 86_400_000;
+  if (days <= 8) return "weekly";
+  if (days >= 25 && days <= 35) return "monthly";
+  return null;
+}
+
 function isGrokInstalled({ home, env } = {}) {
   const grokHome = resolveGrokHome({ home, env });
   const authPath = path.join(grokHome, "auth.json");
@@ -88,25 +117,53 @@ function readGrokAccessToken({ home, env } = {}) {
   return key || null;
 }
 
+/**
+ * Parse either:
+ *   - Unified billing (`?format=credits`): weekly/monthly period + creditUsagePercent
+ *   - Legacy monthly credits: monthlyLimit / used + calendar-month billingPeriod*
+ *
+ * Prefer the unified shape; legacy remains as a fallback for older accounts.
+ */
 function normalizeGrokBillingResponse(body) {
   const config = body?.config;
   if (!config || typeof config !== "object") {
     throw new Error("Could not parse Grok billing: missing config");
   }
 
+  const currentPeriod =
+    config.currentPeriod && typeof config.currentPeriod === "object" ? config.currentPeriod : null;
+
+  const periodStart =
+    grokIsoReset(currentPeriod?.start) || grokIsoReset(config.billingPeriodStart);
+  const resetAt = grokIsoReset(currentPeriod?.end) || grokIsoReset(config.billingPeriodEnd);
+
+  let periodType = normalizeGrokPeriodType(currentPeriod?.type);
+  if (!periodType) {
+    periodType = inferGrokPeriodTypeFromDates(periodStart, resetAt);
+  }
+
+  // Unified billing: overall pool percent is what gates "You hit your weekly limit".
+  // productUsage is attribution only (GrokBuild vs GrokChat), not a separate cap.
+  let usedPercent = clampPercent(config.creditUsagePercent);
+  if (usedPercent === null && Array.isArray(config.productUsage)) {
+    const buildEntry = config.productUsage.find(
+      (entry) => entry && typeof entry === "object" && entry.product === "GrokBuild",
+    );
+    if (buildEntry) usedPercent = clampPercent(buildEntry.usagePercent);
+  }
+
+  // Legacy monthly credit counters (pre-unified / non-format=credits responses).
   const monthlyLimit = grokValNumber(config.monthlyLimit);
   const used = grokValNumber(config.used);
+  if (usedPercent === null && Number.isFinite(monthlyLimit) && monthlyLimit > 0 && Number.isFinite(used)) {
+    usedPercent = (used / monthlyLimit) * 100;
+    if (!periodType) periodType = "monthly";
+  }
+
   const onDemandCap = grokValNumber(config.onDemandCap);
   const onDemandUsed = grokValNumber(config.onDemandUsed);
-  const resetAt = grokIsoReset(config.billingPeriodEnd);
 
-  let primaryWindow = null;
-  if (Number.isFinite(monthlyLimit) && monthlyLimit > 0 && Number.isFinite(used)) {
-    primaryWindow = buildWindow({
-      usedPercent: (used / monthlyLimit) * 100,
-      resetAt,
-    });
-  }
+  const primaryWindow = buildWindow({ usedPercent, resetAt });
 
   let secondaryWindow = null;
   if (Number.isFinite(onDemandCap) && onDemandCap > 0 && Number.isFinite(onDemandUsed)) {
@@ -121,32 +178,50 @@ function normalizeGrokBillingResponse(body) {
   }
 
   return {
+    period_type: periodType,
     monthly_credits_limit: monthlyLimit,
     monthly_credits_used: used,
+    credit_usage_percent: clampPercent(config.creditUsagePercent),
     on_demand_cap: onDemandCap,
     on_demand_used: onDemandUsed,
-    billing_period_start: grokIsoReset(config.billingPeriodStart),
+    billing_period_start: periodStart,
     primary_window: primaryWindow,
     secondary_window: secondaryWindow,
   };
 }
 
+/**
+ * Fetch Grok billing. Prefer `?format=credits` (unified weekly/monthly pool
+ * used by the Grok Build TUI). Fall back to the bare `/v1/billing` payload for
+ * older accounts that only expose monthlyLimit/used.
+ */
 async function fetchGrokBilling(accessToken, { fetchImpl = fetch, baseUrl, env } = {}) {
   const root = (baseUrl || resolveGrokBillingBaseUrl(env)).replace(/\/$/, "");
-  const res = await fetchImpl(`${root}/v1/billing`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/json",
-    },
-  });
-  if (res.status === 401 || res.status === 403) {
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/json",
+  };
+
+  const creditsUrl = `${root}/v1/billing?format=credits`;
+  const creditsRes = await fetchImpl(creditsUrl, { method: "GET", headers });
+  if (creditsRes.status === 401 || creditsRes.status === 403) {
     throw new Error("Not logged in to Grok Build. Run `grok login` in Terminal to authenticate.");
   }
-  if (!res.ok) {
-    throw new Error(`Grok billing API returned ${res.status}`);
+  if (creditsRes.ok) {
+    return creditsRes.json();
   }
-  return res.json();
+
+  // Non-auth failure on format=credits → try the legacy shape once.
+  const legacyRes = await fetchImpl(`${root}/v1/billing`, { method: "GET", headers });
+  if (legacyRes.status === 401 || legacyRes.status === 403) {
+    throw new Error("Not logged in to Grok Build. Run `grok login` in Terminal to authenticate.");
+  }
+  if (!legacyRes.ok) {
+    throw new Error(
+      `Grok billing API returned ${legacyRes.status} (format=credits: ${creditsRes.status})`,
+    );
+  }
+  return legacyRes.json();
 }
 
 async function fetchGrokLimits({ home, env, fetchImpl = fetch } = {}) {
@@ -178,6 +253,7 @@ module.exports = {
   isGrokInstalled,
   loadGrokAuthEntry,
   readGrokAccessToken,
+  normalizeGrokPeriodType,
   normalizeGrokBillingResponse,
   fetchGrokBilling,
   fetchGrokLimits,

--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -181,7 +181,9 @@ function normalizeGrokBillingResponse(body) {
     period_type: periodType,
     monthly_credits_limit: monthlyLimit,
     monthly_credits_used: used,
-    credit_usage_percent: clampPercent(config.creditUsagePercent),
+    // Effective percent used for the primary bar (API creditUsagePercent, or
+    // productUsage / legacy monthly counters when the raw field is absent).
+    credit_usage_percent: usedPercent == null ? null : clampPercent(usedPercent),
     on_demand_cap: onDemandCap,
     on_demand_used: onDemandUsed,
     billing_period_start: periodStart,

--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -61,20 +61,27 @@ function buildWindow({ usedPercent, resetAt }) {
 /**
  * Map Grok's USAGE_PERIOD_TYPE_* enum (or a bare "weekly"/"monthly" string)
  * into a short period key the UI can switch labels on.
+ *
+ * Only daily / weekly / monthly are recognized end-to-end (dashboard + macOS).
+ * Hourly (and other unknown) types return null so UIs fall back to the generic
+ * Month label rather than inventing an unsupported period key.
  */
 function normalizeGrokPeriodType(value) {
   if (typeof value !== "string" || !value.trim()) return null;
   const upper = value.trim().toUpperCase();
   if (upper.includes("WEEK")) return "weekly";
   if (upper.includes("MONTH")) return "monthly";
-  if (upper.includes("DAY") || upper.includes("DAILY")) return "daily";
-  if (upper.includes("HOUR")) return "hourly";
+  // Prefer explicit DAILY / DAY over accidental "HOUR_OF_DAY" style matches.
+  if (upper.includes("DAILY") || /(^|_)DAY($|_)/.test(upper) || upper === "DAY") return "daily";
   return null;
 }
 
 /**
- * Infer weekly vs monthly from period length when the API omits `currentPeriod.type`
- * (legacy monthly payloads only expose start/end dates).
+ * Infer daily / weekly / monthly from period length when the API omits
+ * `currentPeriod.type` (legacy payloads only expose start/end dates).
+ *
+ * Windows used by Grok today: ~1d, ~7d, ~calendar month. Boundaries leave
+ * gaps for odd lengths (e.g. 12d, 2h) so we do not mislabel them.
  */
 function inferGrokPeriodTypeFromDates(startIso, endIso) {
   if (!startIso || !endIso) return null;
@@ -82,9 +89,29 @@ function inferGrokPeriodTypeFromDates(startIso, endIso) {
   const endMs = Date.parse(endIso);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return null;
   const days = (endMs - startMs) / 86_400_000;
-  if (days <= 8) return "weekly";
+  if (days > 0.5 && days <= 1.5) return "daily";
+  if (days > 1.5 && days <= 8) return "weekly";
   if (days >= 25 && days <= 35) return "monthly";
   return null;
+}
+
+/**
+ * Sum per-product attribution percentages into the shared pool total.
+ * productUsage breaks down the same cap (GrokBuild + GrokChat + …), not
+ * independent quotas — a single product entry undercounts the pool.
+ */
+function sumProductUsagePercent(productUsage) {
+  if (!Array.isArray(productUsage)) return null;
+  let sum = 0;
+  let sawAny = false;
+  for (const entry of productUsage) {
+    if (!entry || typeof entry !== "object") continue;
+    const pct = clampPercent(entry.usagePercent);
+    if (pct === null) continue;
+    sawAny = true;
+    sum += pct;
+  }
+  return sawAny ? clampPercent(sum) : null;
 }
 
 function isGrokInstalled({ home, env } = {}) {
@@ -143,13 +170,10 @@ function normalizeGrokBillingResponse(body) {
   }
 
   // Unified billing: overall pool percent is what gates "You hit your weekly limit".
-  // productUsage is attribution only (GrokBuild vs GrokChat), not a separate cap.
+  // productUsage is attribution across products that share the same pool — sum it.
   let usedPercent = clampPercent(config.creditUsagePercent);
-  if (usedPercent === null && Array.isArray(config.productUsage)) {
-    const buildEntry = config.productUsage.find(
-      (entry) => entry && typeof entry === "object" && entry.product === "GrokBuild",
-    );
-    if (buildEntry) usedPercent = clampPercent(buildEntry.usagePercent);
+  if (usedPercent === null) {
+    usedPercent = sumProductUsagePercent(config.productUsage);
   }
 
   // Legacy monthly credit counters (pre-unified / non-format=credits responses).
@@ -256,6 +280,8 @@ module.exports = {
   loadGrokAuthEntry,
   readGrokAccessToken,
   normalizeGrokPeriodType,
+  inferGrokPeriodTypeFromDates,
+  sumProductUsagePercent,
   normalizeGrokBillingResponse,
   fetchGrokBilling,
   fetchGrokLimits,

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -6,13 +6,56 @@ const path = require("node:path");
 
 const {
   normalizeGrokBillingResponse,
+  normalizeGrokPeriodType,
   fetchGrokLimits,
   readGrokAccessToken,
   isGrokInstalled,
 } = require("../src/lib/grok-limits");
 
+describe("normalizeGrokPeriodType", () => {
+  it("maps USAGE_PERIOD_TYPE_* enums", () => {
+    assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_WEEKLY"), "weekly");
+    assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_MONTHLY"), "monthly");
+    assert.equal(normalizeGrokPeriodType("weekly"), "weekly");
+    assert.equal(normalizeGrokPeriodType(""), null);
+    assert.equal(normalizeGrokPeriodType(null), null);
+  });
+});
+
 describe("normalizeGrokBillingResponse", () => {
-  it("maps monthly credits and billing period reset", () => {
+  it("maps unified format=credits weekly pool", () => {
+    const result = normalizeGrokBillingResponse({
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-07-13T09:23:37.846092+00:00",
+          end: "2026-07-20T09:23:37.846092+00:00",
+        },
+        creditUsagePercent: 18.0,
+        onDemandCap: { val: 0 },
+        onDemandUsed: { val: 0 },
+        productUsage: [
+          { product: "GrokBuild", usagePercent: 17.0 },
+          { product: "GrokChat", usagePercent: 1.0 },
+        ],
+        isUnifiedBillingUser: true,
+        billingPeriodStart: "2026-07-13T09:23:37.846092+00:00",
+        billingPeriodEnd: "2026-07-20T09:23:37.846092+00:00",
+      },
+    });
+
+    assert.equal(result.period_type, "weekly");
+    assert.equal(result.credit_usage_percent, 18);
+    // Overall pool percent (not GrokBuild-only attribution) is the quota bar.
+    assert.deepEqual(result.primary_window, {
+      used_percent: 18,
+      reset_at: "2026-07-20T09:23:37.846Z",
+    });
+    assert.equal(result.secondary_window, null);
+    assert.equal(result.billing_period_start, "2026-07-13T09:23:37.846Z");
+  });
+
+  it("maps legacy monthly credits and billing period reset", () => {
     const result = normalizeGrokBillingResponse({
       config: {
         monthlyLimit: { val: 150_000 },
@@ -24,6 +67,7 @@ describe("normalizeGrokBillingResponse", () => {
       },
     });
 
+    assert.equal(result.period_type, "monthly");
     assert.equal(result.monthly_credits_limit, 150_000);
     assert.equal(result.monthly_credits_used, 4_625);
     assert.deepEqual(result.primary_window, {
@@ -49,6 +93,34 @@ describe("normalizeGrokBillingResponse", () => {
       reset_at: "2026-07-01T00:00:00.000Z",
     });
   });
+
+  it("falls back to GrokBuild productUsage when creditUsagePercent is missing", () => {
+    const result = normalizeGrokBillingResponse({
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-07-13T00:00:00Z",
+          end: "2026-07-20T00:00:00Z",
+        },
+        productUsage: [{ product: "GrokBuild", usagePercent: 42 }],
+        billingPeriodEnd: "2026-07-20T00:00:00Z",
+      },
+    });
+
+    assert.equal(result.period_type, "weekly");
+    assert.equal(result.primary_window.used_percent, 42);
+  });
+
+  it("infers weekly from period length when type is omitted", () => {
+    const result = normalizeGrokBillingResponse({
+      config: {
+        creditUsagePercent: 5,
+        billingPeriodStart: "2026-07-13T00:00:00Z",
+        billingPeriodEnd: "2026-07-20T00:00:00Z",
+      },
+    });
+    assert.equal(result.period_type, "weekly");
+  });
 });
 
 describe("fetchGrokLimits", () => {
@@ -62,7 +134,7 @@ describe("fetchGrokLimits", () => {
     }
   });
 
-  it("fetches billing via cli-chat-proxy with stored token", async () => {
+  it("fetches format=credits billing via cli-chat-proxy with stored token", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-limits-fetch-"));
     try {
       const grokHome = path.join(tmp, ".grok");
@@ -77,12 +149,67 @@ describe("fetchGrokLimits", () => {
 
       assert.equal(readGrokAccessToken({ home: tmp, env: { GROK_HOME: grokHome } }), "test-token");
 
+      const urls = [];
       const result = await fetchGrokLimits({
         home: tmp,
         env: { GROK_HOME: grokHome },
         fetchImpl: async (url, options) => {
-          assert.equal(url, "https://cli-chat-proxy.grok.com/v1/billing");
+          urls.push(url);
           assert.equal(options.headers.Authorization, "Bearer test-token");
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                config: {
+                  currentPeriod: {
+                    type: "USAGE_PERIOD_TYPE_WEEKLY",
+                    start: "2026-07-13T09:23:37.846092+00:00",
+                    end: "2026-07-20T09:23:37.846092+00:00",
+                  },
+                  creditUsagePercent: 25,
+                  onDemandCap: { val: 0 },
+                  billingPeriodEnd: "2026-07-20T09:23:37.846092+00:00",
+                },
+              };
+            },
+          };
+        },
+      });
+
+      assert.equal(urls[0], "https://cli-chat-proxy.grok.com/v1/billing?format=credits");
+      assert.equal(result.configured, true);
+      assert.equal(result.error, null);
+      assert.equal(result.period_type, "weekly");
+      assert.equal(result.primary_window.used_percent, 25);
+      assert.equal(result.primary_window.reset_at, "2026-07-20T09:23:37.846Z");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to legacy /v1/billing when format=credits fails", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-limits-fallback-"));
+    try {
+      const grokHome = path.join(tmp, ".grok");
+      fs.mkdirSync(grokHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(grokHome, "auth.json"),
+        JSON.stringify({
+          "https://auth.x.ai::test": { key: "test-token" },
+        }),
+        "utf8",
+      );
+
+      const urls = [];
+      const result = await fetchGrokLimits({
+        home: tmp,
+        env: { GROK_HOME: grokHome },
+        fetchImpl: async (url) => {
+          urls.push(url);
+          if (String(url).includes("format=credits")) {
+            return { ok: false, status: 500, async json() { return {}; } };
+          }
           return {
             ok: true,
             status: 200,
@@ -92,7 +219,8 @@ describe("fetchGrokLimits", () => {
                   monthlyLimit: { val: 1000 },
                   used: { val: 250 },
                   onDemandCap: { val: 0 },
-                  billingPeriodEnd: "2026-07-01T00:00:00Z",
+                  billingPeriodStart: "2026-07-01T00:00:00Z",
+                  billingPeriodEnd: "2026-08-01T00:00:00Z",
                 },
               };
             },
@@ -100,8 +228,12 @@ describe("fetchGrokLimits", () => {
         },
       });
 
+      assert.deepEqual(urls, [
+        "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+        "https://cli-chat-proxy.grok.com/v1/billing",
+      ]);
       assert.equal(result.configured, true);
-      assert.equal(result.error, null);
+      assert.equal(result.period_type, "monthly");
       assert.equal(result.primary_window.used_percent, 25);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -109,6 +109,7 @@ describe("normalizeGrokBillingResponse", () => {
 
     assert.equal(result.period_type, "weekly");
     assert.equal(result.primary_window.used_percent, 42);
+    assert.equal(result.credit_usage_percent, 42);
   });
 
   it("infers weekly from period length when type is omitted", () => {

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -7,18 +7,65 @@ const path = require("node:path");
 const {
   normalizeGrokBillingResponse,
   normalizeGrokPeriodType,
+  inferGrokPeriodTypeFromDates,
+  sumProductUsagePercent,
   fetchGrokLimits,
   readGrokAccessToken,
   isGrokInstalled,
 } = require("../src/lib/grok-limits");
 
 describe("normalizeGrokPeriodType", () => {
-  it("maps USAGE_PERIOD_TYPE_* enums", () => {
+  it("maps USAGE_PERIOD_TYPE_* enums for daily/weekly/monthly only", () => {
     assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_WEEKLY"), "weekly");
     assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_MONTHLY"), "monthly");
+    assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_DAILY"), "daily");
     assert.equal(normalizeGrokPeriodType("weekly"), "weekly");
+    // Hourly is not a recognized end-to-end period — do not emit it.
+    assert.equal(normalizeGrokPeriodType("USAGE_PERIOD_TYPE_HOURLY"), null);
+    assert.equal(normalizeGrokPeriodType("hourly"), null);
     assert.equal(normalizeGrokPeriodType(""), null);
     assert.equal(normalizeGrokPeriodType(null), null);
+  });
+});
+
+describe("inferGrokPeriodTypeFromDates", () => {
+  it("classifies daily / weekly / monthly windows and leaves gaps null", () => {
+    assert.equal(
+      inferGrokPeriodTypeFromDates("2026-07-13T00:00:00Z", "2026-07-14T00:00:00Z"),
+      "daily",
+    );
+    assert.equal(
+      inferGrokPeriodTypeFromDates("2026-07-13T00:00:00Z", "2026-07-20T00:00:00Z"),
+      "weekly",
+    );
+    assert.equal(
+      inferGrokPeriodTypeFromDates("2026-07-01T00:00:00Z", "2026-08-01T00:00:00Z"),
+      "monthly",
+    );
+    // Sub-day and odd mid lengths must not be mislabeled as weekly.
+    assert.equal(
+      inferGrokPeriodTypeFromDates("2026-07-13T00:00:00Z", "2026-07-13T02:00:00Z"),
+      null,
+    );
+    assert.equal(
+      inferGrokPeriodTypeFromDates("2026-07-01T00:00:00Z", "2026-07-13T00:00:00Z"),
+      null,
+    );
+  });
+});
+
+describe("sumProductUsagePercent", () => {
+  it("sums shared-pool product attribution percentages", () => {
+    assert.equal(
+      sumProductUsagePercent([
+        { product: "GrokBuild", usagePercent: 17 },
+        { product: "GrokChat", usagePercent: 1 },
+      ]),
+      18,
+    );
+    assert.equal(sumProductUsagePercent([{ product: "GrokBuild", usagePercent: 42 }]), 42);
+    assert.equal(sumProductUsagePercent([]), null);
+    assert.equal(sumProductUsagePercent(null), null);
   });
 });
 
@@ -94,7 +141,29 @@ describe("normalizeGrokBillingResponse", () => {
     });
   });
 
-  it("falls back to GrokBuild productUsage when creditUsagePercent is missing", () => {
+  it("sums all productUsage entries when creditUsagePercent is missing", () => {
+    const result = normalizeGrokBillingResponse({
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-07-13T00:00:00Z",
+          end: "2026-07-20T00:00:00Z",
+        },
+        productUsage: [
+          { product: "GrokBuild", usagePercent: 17 },
+          { product: "GrokChat", usagePercent: 1 },
+        ],
+        billingPeriodEnd: "2026-07-20T00:00:00Z",
+      },
+    });
+
+    assert.equal(result.period_type, "weekly");
+    // Shared pool: 17 + 1 = 18, not GrokBuild-only 17.
+    assert.equal(result.primary_window.used_percent, 18);
+    assert.equal(result.credit_usage_percent, 18);
+  });
+
+  it("falls back to a single productUsage entry when only one is present", () => {
     const result = normalizeGrokBillingResponse({
       config: {
         currentPeriod: {
@@ -112,15 +181,53 @@ describe("normalizeGrokBillingResponse", () => {
     assert.equal(result.credit_usage_percent, 42);
   });
 
-  it("infers weekly from period length when type is omitted", () => {
+  it("infers daily / weekly / monthly from period length when type is omitted", () => {
+    assert.equal(
+      normalizeGrokBillingResponse({
+        config: {
+          creditUsagePercent: 5,
+          billingPeriodStart: "2026-07-13T00:00:00Z",
+          billingPeriodEnd: "2026-07-14T00:00:00Z",
+        },
+      }).period_type,
+      "daily",
+    );
+    assert.equal(
+      normalizeGrokBillingResponse({
+        config: {
+          creditUsagePercent: 5,
+          billingPeriodStart: "2026-07-13T00:00:00Z",
+          billingPeriodEnd: "2026-07-20T00:00:00Z",
+        },
+      }).period_type,
+      "weekly",
+    );
+    assert.equal(
+      normalizeGrokBillingResponse({
+        config: {
+          creditUsagePercent: 5,
+          billingPeriodStart: "2026-07-01T00:00:00Z",
+          billingPeriodEnd: "2026-08-01T00:00:00Z",
+        },
+      }).period_type,
+      "monthly",
+    );
+  });
+
+  it("does not emit hourly as a recognized period_type", () => {
     const result = normalizeGrokBillingResponse({
       config: {
-        creditUsagePercent: 5,
-        billingPeriodStart: "2026-07-13T00:00:00Z",
-        billingPeriodEnd: "2026-07-20T00:00:00Z",
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_HOURLY",
+          start: "2026-07-13T00:00:00Z",
+          end: "2026-07-13T01:00:00Z",
+        },
+        creditUsagePercent: 10,
       },
     });
-    assert.equal(result.period_type, "weekly");
+    // Type ignored; sub-day length also does not infer weekly/daily.
+    assert.equal(result.period_type, null);
+    assert.equal(result.primary_window.used_percent, 10);
   });
 });
 

--- a/test/localization-regressions.test.js
+++ b/test/localization-regressions.test.js
@@ -70,10 +70,18 @@ test("native macOS strings are wired through the Swift localization helpers", ()
   assert.ok(!dateHelpers.includes('NativeLocalization.usesChinese ? "日" : "Day"'));
 
   assert.ok(usageLimitsView.includes("Strings.kiroBonusLabel"));
-  assert.ok(usageLimitsView.includes("Strings.grokMonthLabel"));
+  assert.ok(usageLimitsView.includes("Strings.grokPrimaryLabel"));
   assert.ok(usageLimitsView.includes('case "grok"'));
   assert.ok(usageLimitsView.includes("Strings.limitResetNow"));
   assert.ok(!usageLimitsView.includes('NativeLocalization.usesChinese ? "奖励" : "Bonus"'));
+
+  assert.ok(strings.includes("static var grokWeekLabel"));
+  assert.ok(strings.includes("static func grokPrimaryLabel"));
+  assert.ok(strings.includes('case "weekly": return grokWeekLabel'));
+
+  const grokLimitsModel = read("TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift");
+  assert.ok(grokLimitsModel.includes("periodType"));
+  assert.ok(grokLimitsModel.includes('case periodType = "period_type"'));
 
   const limitsSettingsStore = read("TokenTrackerBar/TokenTrackerBar/Models/LimitsSettingsStore.swift");
   assert.ok(limitsSettingsStore.includes('"grok"'));


### PR DESCRIPTION
## Summary

Grok Build usage limits were shown as **monthly** with the wrong percent and reset countdown because TokenTracker called `/v1/billing` without `format=credits`. Grok's unified billing returns `USAGE_PERIOD_TYPE_WEEKLY` (and `creditUsagePercent`) on `?format=credits`, which is what the Grok TUI itself uses.

This PR:
- Prefers `/v1/billing?format=credits`, falls back to legacy monthly `/v1/billing`
- Exposes `period_type` (`weekly` / `monthly` / …) for UI labels
- Updates dashboard + macOS menubar/limits/widget copy to show **Weekly** when applicable
- Adds regression tests for the credits payload, legacy path, and HTTP fallback

## Scope

- [x] CLI (`src/`)
- [x] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`) — uses the same local API + web limits UI; no native Swift-style label layer to change
- [ ] Docs / CI / config

## Checklist

- [x] `node --test test/grok-limits.test.js test/localization-regressions.test.js` passes
- [x] New strings via `copy.csv` + i18n locales
- [x] Conventional commit
- [x] Explains *why* (API shape change), not just *what*

## Test plan

- [x] Local `fetchGrokLimits` / `curl` on dev server: `period_type: "weekly"`, ~20%, reset ~7d window end
- [x] Dashboard Limits page: label **周** / Weekly, correct percent and countdown
- [x] Debug macOS menubar Limits panel: same weekly label/numbers
- [x] Unit tests for credits normalize + legacy fallback + format=credits URL
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added period-aware Grok primary window labels and titles across the app (menu bar, widgets, companion view, and usage limits).
  * Introduced Grok weekly/daily time-window labels in supported languages, alongside improved handling of Grok billing periods.
* **Bug Fixes**
  * Improved Grok billing parsing for the newer credits format, with automatic fallback to legacy billing when needed.
  * Enhanced period detection when period metadata is missing, ensuring correct window labeling and reset/usage values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->