### PR TITLE
fix(grok): bound billing fallback retries

### DIFF
--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -3,6 +3,49 @@ const os = require("node:os");
 const path = require("node:path");
 
 const DEFAULT_BILLING_BASE_URL = "https://cli-chat-proxy.grok.com";
+const DEFAULT_BILLING_TIMEOUT_MS = 15_000;
+
+function grokAuthError() {
+  const error = new Error("Not logged in to Grok Build. Run `grok login` in Terminal to authenticate.");
+  error.code = "GROK_AUTH_REQUIRED";
+  return error;
+}
+
+function grokBillingTimeoutError() {
+  const error = new Error("Grok billing request timed out.");
+  error.code = "GROK_BILLING_TIMEOUT";
+  return error;
+}
+
+async function runBeforeBillingDeadline(operation, deadlineMs) {
+  const remainingMs = Math.ceil(deadlineMs - Date.now());
+  if (remainingMs <= 0) throw grokBillingTimeoutError();
+
+  const controller = new AbortController();
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const error = grokBillingTimeoutError();
+      controller.abort(error);
+      reject(error);
+    }, remainingMs);
+  });
+
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchGrokBillingAttempt(fetchImpl, url, headers, deadlineMs) {
+  return runBeforeBillingDeadline(async (signal) => {
+    const response = await fetchImpl(url, { method: "GET", headers, signal });
+    if (response.status === 401 || response.status === 403) throw grokAuthError();
+    if (!response.ok) return { ok: false, status: response.status };
+    return { ok: true, body: await response.json() };
+  }, deadlineMs);
+}
 
 function resolveGrokHome({ home, env = process.env } = {}) {
   if (typeof env.TOKENTRACKER_GROK_HOME === "string" && env.TOKENTRACKER_GROK_HOME.trim()) {
@@ -221,36 +264,60 @@ function normalizeGrokBillingResponse(body) {
  * used by the Grok Build TUI). Fall back to the bare `/v1/billing` payload for
  * older accounts that only expose monthlyLimit/used.
  */
-async function fetchGrokBilling(accessToken, { fetchImpl = fetch, baseUrl, env } = {}) {
+async function fetchGrokBilling(
+  accessToken,
+  { fetchImpl = fetch, baseUrl, env, timeoutMs = DEFAULT_BILLING_TIMEOUT_MS } = {},
+) {
   const root = (baseUrl || resolveGrokBillingBaseUrl(env)).replace(/\/$/, "");
   const headers = {
     Authorization: `Bearer ${accessToken}`,
     Accept: "application/json",
   };
+  const normalizedTimeoutMs =
+    Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_BILLING_TIMEOUT_MS;
+  const deadlineMs = Date.now() + normalizedTimeoutMs;
 
   const creditsUrl = `${root}/v1/billing?format=credits`;
-  const creditsRes = await fetchImpl(creditsUrl, { method: "GET", headers });
-  if (creditsRes.status === 401 || creditsRes.status === 403) {
-    throw new Error("Not logged in to Grok Build. Run `grok login` in Terminal to authenticate.");
-  }
-  if (creditsRes.ok) {
-    return creditsRes.json();
+  let creditsFailure = "request failed";
+  try {
+    const creditsResult = await fetchGrokBillingAttempt(
+      fetchImpl,
+      creditsUrl,
+      headers,
+      deadlineMs,
+    );
+    if (creditsResult.ok) return creditsResult.body;
+    creditsFailure = `HTTP ${creditsResult.status}`;
+  } catch (error) {
+    if (error?.code === "GROK_AUTH_REQUIRED") throw error;
+    if (error?.code === "GROK_BILLING_TIMEOUT") throw error;
   }
 
-  // Non-auth failure on format=credits → try the legacy shape once.
-  const legacyRes = await fetchImpl(`${root}/v1/billing`, { method: "GET", headers });
-  if (legacyRes.status === 401 || legacyRes.status === 403) {
-    throw new Error("Not logged in to Grok Build. Run `grok login` in Terminal to authenticate.");
+  // Non-auth HTTP, network, or response-decoding failure → try the legacy
+  // shape once, while sharing the original request deadline.
+  let legacyResult;
+  try {
+    legacyResult = await fetchGrokBillingAttempt(
+      fetchImpl,
+      `${root}/v1/billing`,
+      headers,
+      deadlineMs,
+    );
+  } catch (error) {
+    if (error?.code === "GROK_AUTH_REQUIRED" || error?.code === "GROK_BILLING_TIMEOUT") throw error;
+    throw new Error(`Grok billing request failed (format=credits: ${creditsFailure})`, {
+      cause: error,
+    });
   }
-  if (!legacyRes.ok) {
+  if (!legacyResult.ok) {
     throw new Error(
-      `Grok billing API returned ${legacyRes.status} (format=credits: ${creditsRes.status})`,
+      `Grok billing API returned ${legacyResult.status} (format=credits: ${creditsFailure})`,
     );
   }
-  return legacyRes.json();
+  return legacyResult.body;
 }
 
-async function fetchGrokLimits({ home, env, fetchImpl = fetch } = {}) {
+async function fetchGrokLimits({ home, env, fetchImpl = fetch, timeoutMs } = {}) {
   if (!isGrokInstalled({ home, env })) {
     return { configured: false };
   }
@@ -259,7 +326,7 @@ async function fetchGrokLimits({ home, env, fetchImpl = fetch } = {}) {
     return { configured: false };
   }
   try {
-    const body = await fetchGrokBilling(accessToken, { fetchImpl, env });
+    const body = await fetchGrokBilling(accessToken, { fetchImpl, env, timeoutMs });
     return {
       configured: true,
       error: null,

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -347,4 +347,95 @@ describe("fetchGrokLimits", () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it("falls back to legacy /v1/billing after a format=credits network error", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-limits-network-fallback-"));
+    try {
+      const grokHome = path.join(tmp, ".grok");
+      fs.mkdirSync(grokHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(grokHome, "auth.json"),
+        JSON.stringify({
+          "https://auth.x.ai::test": { key: "test-token" },
+        }),
+        "utf8",
+      );
+
+      const urls = [];
+      const result = await fetchGrokLimits({
+        home: tmp,
+        env: { GROK_HOME: grokHome },
+        fetchImpl: async (url) => {
+          urls.push(url);
+          if (String(url).includes("format=credits")) {
+            throw new TypeError("fetch failed");
+          }
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                config: {
+                  monthlyLimit: { val: 1000 },
+                  used: { val: 250 },
+                  onDemandCap: { val: 0 },
+                  billingPeriodStart: "2026-07-01T00:00:00Z",
+                  billingPeriodEnd: "2026-08-01T00:00:00Z",
+                },
+              };
+            },
+          };
+        },
+      });
+
+      assert.deepEqual(urls, [
+        "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+        "https://cli-chat-proxy.grok.com/v1/billing",
+      ]);
+      assert.equal(result.configured, true);
+      assert.equal(result.error, null);
+      assert.equal(result.period_type, "monthly");
+      assert.equal(result.primary_window.used_percent, 25);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not start a late fallback after the shared request deadline", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-limits-timeout-"));
+    try {
+      const grokHome = path.join(tmp, ".grok");
+      fs.mkdirSync(grokHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(grokHome, "auth.json"),
+        JSON.stringify({
+          "https://auth.x.ai::test": { key: "test-token" },
+        }),
+        "utf8",
+      );
+
+      const urls = [];
+      const result = await fetchGrokLimits({
+        home: tmp,
+        env: { GROK_HOME: grokHome },
+        timeoutMs: 30,
+        fetchImpl: async (url, options) => {
+          urls.push(url);
+          await new Promise((_, reject) => {
+            options.signal.addEventListener("abort", () => reject(options.signal.reason), {
+              once: true,
+            });
+          });
+        },
+      });
+
+      assert.deepEqual(urls, [
+        "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      ]);
+      assert.equal(result.configured, true);
+      assert.match(result.error, /timed out/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## What changed

- fall back to the legacy Grok billing endpoint after network or response-decoding failures from `format=credits`
- share one 15-second deadline across both billing attempts
- avoid starting a legacy request after the preferred endpoint has consumed the request budget
- add regression coverage for network fallback and deadline exhaustion

## Why

PR #329 added an HTTP-status fallback, but transport failures rejected before reaching it. This keeps older-account compatibility available during transient endpoint failures without doubling the provider timeout.

## Validation

- `node --test test/grok-limits.test.js`
- usage-limits integration tests (102 passed)
- `npm run validate:guardrails`
- `npm test` (1689 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing retrieval reliability by falling back to a legacy billing endpoint when the preferred request encounters a non-authentication failure.
  * Added request timeouts to prevent billing and usage-limit checks from hanging indefinitely.
  * Improved error reporting for authentication, timeout, and billing request failures.
  * Prevented unnecessary fallback requests after a timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->