### PR TITLE
fix(grok): discard failed billing responses

### DIFF
--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -41,8 +41,15 @@ async function runBeforeBillingDeadline(operation, deadlineMs) {
 async function fetchGrokBillingAttempt(fetchImpl, url, headers, deadlineMs) {
   return runBeforeBillingDeadline(async (signal) => {
     const response = await fetchImpl(url, { method: "GET", headers, signal });
-    if (response.status === 401 || response.status === 403) throw grokAuthError();
-    if (!response.ok) return { ok: false, status: response.status };
+    if (!response.ok) {
+      try {
+        await response.body?.cancel?.();
+      } catch (_error) {
+        // The status remains authoritative even if discarding the body fails.
+      }
+      if (response.status === 401 || response.status === 403) throw grokAuthError();
+      return { ok: false, status: response.status };
+    }
     return { ok: true, body: await response.json() };
   }, deadlineMs);
 }

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -9,6 +9,7 @@ const {
   normalizeGrokPeriodType,
   inferGrokPeriodTypeFromDates,
   sumProductUsagePercent,
+  fetchGrokBilling,
   fetchGrokLimits,
   readGrokAccessToken,
   isGrokInstalled,
@@ -310,13 +311,23 @@ describe("fetchGrokLimits", () => {
       );
 
       const urls = [];
+      let canceledBodies = 0;
       const result = await fetchGrokLimits({
         home: tmp,
         env: { GROK_HOME: grokHome },
         fetchImpl: async (url) => {
           urls.push(url);
           if (String(url).includes("format=credits")) {
-            return { ok: false, status: 500, async json() { return {}; } };
+            return {
+              ok: false,
+              status: 500,
+              body: {
+                async cancel() {
+                  canceledBodies += 1;
+                },
+              },
+              async json() { return {}; },
+            };
           }
           return {
             ok: true,
@@ -343,9 +354,31 @@ describe("fetchGrokLimits", () => {
       assert.equal(result.configured, true);
       assert.equal(result.period_type, "monthly");
       assert.equal(result.primary_window.used_percent, 25);
+      assert.equal(canceledBodies, 1);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("cancels an auth-error response body before surfacing reauthentication", async () => {
+    let canceledBodies = 0;
+
+    await assert.rejects(
+      fetchGrokBilling("test-token", {
+        timeoutMs: 100,
+        fetchImpl: async () => ({
+          ok: false,
+          status: 401,
+          body: {
+            async cancel() {
+              canceledBodies += 1;
+            },
+          },
+        }),
+      }),
+      /grok login/i,
+    );
+    assert.equal(canceledBodies, 1);
   });
 
   it("falls back to legacy /v1/billing after a format=credits network error", async () => {


### PR DESCRIPTION
## What changed

- cancel non-success Grok billing response bodies before fallback or authentication errors
- preserve the original HTTP status and successful JSON handling
- add regression coverage for fallback and authentication response cleanup

## Why

Node's fetch implementation may keep an unread response body and its connection occupied. This closes the low-priority follow-up reported on #331 for every non-2xx path, including 401/403.

## Validation

- `node --test test/grok-limits.test.js test/usage-limits.test.js test/usage-limits-singleflight.test.js` (116 passed)
- `npm run validate:guardrails`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed billing requests by properly releasing response data.
  * Authentication errors continue to prompt users to sign in again while preserving the original HTTP status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->