### PR TITLE
fix: split Pi usage by provider

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -421,6 +421,9 @@ async function fetchGroupedRows(
 }
 
 function computeRowCost(row: GroupedRow): number {
+  // Pi's GitHub Copilot provider is subscription-backed. Keep its token
+  // counts, but do not reprice the recorded Claude model as Anthropic API use.
+  if (row.source === "pi-github-copilot" || row.source === "pi-copilot") return 0;
   // WorkBuddy's auto-router logs model="auto"; price it as its default Hunyuan
   // model (hy3-preview-agent) so it isn't billed as Cursor's composer-1. Mirrors
   // normalizeWorkbuddyModel in src/lib/pricing/matcher.js.

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -554,17 +554,20 @@ export default async function (req: Request): Promise<Response> {
             ? "hy3-preview-agent"
             : m.model;
         const p = getModelPricing(modelForPricing);
+        const subscriptionBacked =
+          s.source === "pi-github-copilot" || s.source === "pi-copilot";
         // Codex / every-code fold reasoning into output_tokens (OpenAI
         // convention), so charging reasoning again double-counts. Mirror the
         // guard in src/lib/pricing/index.js + tokentracker-leaderboard-refresh.ts.
         const reasoningIncludedInOutput = s.source === "codex" || s.source === "every-code";
-        const cost =
-          ((m.totals.input_tokens || 0) * (p.input || 0) +
+        const cost = subscriptionBacked
+          ? 0
+          : ((m.totals.input_tokens || 0) * (p.input || 0) +
             (m.totals.output_tokens || 0) * (p.output || 0) +
             (m.totals.cached_input_tokens || 0) * (p.cache_read || 0) +
             (m.totals.cache_creation_input_tokens || 0) * ((p.cache_write ?? 0)) +
             (reasoningIncludedInOutput ? 0 : (m.totals.reasoning_output_tokens || 0) * (p.output || 0))) /
-          1_000_000;
+            1_000_000;
         return {
           model: m.model,
           model_id: m.model_id,

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -446,6 +446,9 @@ async function fetchGroupedRows(
 }
 
 function computeRowCost(row: GroupedRow): number {
+  // Pi's GitHub Copilot provider is subscription-backed. Keep its token
+  // counts, but do not reprice the recorded Claude model as Anthropic API use.
+  if (row.source === "pi-github-copilot" || row.source === "pi-copilot") return 0;
   // WorkBuddy's auto-router logs model="auto"; price it as its default Hunyuan
   // model (hy3-preview-agent) so it isn't billed as Cursor's composer-1. Mirrors
   // normalizeWorkbuddyModel in src/lib/pricing/matcher.js.

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -345,6 +345,9 @@ interface HourlyRow {
 }
 
 function computeRowCost(row: HourlyRow): number {
+  // Pi's GitHub Copilot provider is subscription-backed. Keep its token
+  // counts, but do not reprice the recorded Claude model as Anthropic API use.
+  if (row.source === "pi-github-copilot" || row.source === "pi-copilot") return 0;
   // WorkBuddy's auto-router logs model="auto"; price it as its default Hunyuan
   // model (hy3-preview-agent) so it isn't billed as Cursor's composer-1. Mirrors
   // normalizeWorkbuddyModel in src/lib/pricing/matcher.js.
@@ -370,7 +373,8 @@ function computeRowCost(row: HourlyRow): number {
 /** Map raw `source` to the canonical bucket used by the modal's by_provider list. */
 const KNOWN_SOURCES = new Set([
   "codex", "claude", "gemini", "cursor", "opencode", "openclaw",
-  "hermes", "kiro", "copilot", "kimi", "droid",
+  "hermes", "kiro", "copilot", "pi-anthropic", "pi-github-copilot",
+  "pi-copilot", "kimi", "droid",
 ]);
 function canonicalSource(s: string) {
   return KNOWN_SOURCES.has(s) ? s : "other";

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -354,6 +354,9 @@ function getModelPricing(model: string) {
 }
 
 function computeRowCost(row: HourlyRow): number {
+  // Pi's GitHub Copilot provider is subscription-backed. Keep its token
+  // counts, but do not reprice the recorded Claude model as Anthropic API use.
+  if (row.source === "pi-github-copilot" || row.source === "pi-copilot") return 0;
   // WorkBuddy's auto-router logs model="auto"; price it as its default Hunyuan
   // model (hy3-preview-agent) so it isn't billed as Cursor's composer-1. Mirrors
   // normalizeWorkbuddyModel in src/lib/pricing/matcher.js.
@@ -392,6 +395,9 @@ const SOURCE_COLUMN_MAP: Record<string, string> = {
   hermes: "hermes_tokens",
   kiro: "kiro_tokens",
   copilot: "copilot_tokens",
+  "pi-github-copilot": "copilot_tokens",
+  "pi-copilot": "copilot_tokens",
+  "pi-anthropic": "claude_tokens",
   kimi: "kimi_tokens",
 };
 

--- a/dashboard/src/lib/provider-display.js
+++ b/dashboard/src/lib/provider-display.js
@@ -1,5 +1,8 @@
 const SPECIAL_PROVIDER_NAMES = {
   anythingllm: "AnythingLLM",
+  pianthropic: "Pi · Anthropic",
+  pigithubcopilot: "Pi · GitHub Copilot",
+  picopilot: "Pi · Copilot",
 };
 
 function normalizedProviderKey(value) {

--- a/dashboard/src/lib/provider-display.test.js
+++ b/dashboard/src/lib/provider-display.test.js
@@ -14,4 +14,9 @@ describe("formatProviderDisplayName", () => {
     expect(formatProviderDisplayName("CODEX")).toBe("CODEX");
     expect(formatProviderDisplayName("")).toBe("");
   });
+
+  it("gives Pi routed providers distinct readable names", () => {
+    expect(formatProviderDisplayName("pi-anthropic")).toBe("Pi · Anthropic");
+    expect(formatProviderDisplayName("PI-GITHUB-COPILOT")).toBe("Pi · GitHub Copilot");
+  });
 });

--- a/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
+++ b/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
@@ -298,6 +298,9 @@ const PROVIDER_ICON_MAP = {
   OPENCODE: OpenCodeIcon,
   OMP: OmpIcon,
   PI: PiIcon,
+  "PI-ANTHROPIC": PiIcon,
+  "PI-GITHUB-COPILOT": PiIcon,
+  "PI-COPILOT": PiIcon,
   ROOCODE: RoocodeIcon,
   ZED: ZedIcon,
 };

--- a/src/lib/pricing/index.js
+++ b/src/lib/pricing/index.js
@@ -15,6 +15,7 @@ const {
 const { loadLitellmData } = require("./litellm-fetcher");
 
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
+const PI_SUBSCRIPTION_SOURCES = new Set(["pi-github-copilot", "pi-copilot"]);
 const SEED_SNAPSHOT_PATH = path.resolve(__dirname, "seed-snapshot.json");
 
 // Sync seed load. Done at require-time so callers that haven't awaited
@@ -115,6 +116,10 @@ function getModelPricing(model, opts = {}) {
 // computeRowCost in src/lib/local-api.js. Moved here so vite mock + local
 // server share one source of truth.
 function computeRowCost(row) {
+  // Pi can route a turn through a subscription-backed Copilot provider. Pi's
+  // usage record reports a zero marginal cost for those turns; do not
+  // reinterpret the Claude model name as an Anthropic API bill.
+  if (PI_SUBSCRIPTION_SOURCES.has(String(row?.source || "").toLowerCase())) return 0;
   const pricing = getModelPricing(row.model, { source: row.source });
   const reasoningIncludedInOutput = row.source === "codex" || row.source === "every-code";
   const reasoningCost = reasoningIncludedInOutput

--- a/src/lib/pricing/matcher.js
+++ b/src/lib/pricing/matcher.js
@@ -141,6 +141,7 @@ function normalizeWorkbuddyModel(model) {
 const SOURCE_MODEL_NORMALIZERS = {
   antigravity: normalizeAntigravityModel,
   claude: normalizeClaudeModel,
+  "pi-anthropic": normalizeClaudeModel,
   zed: normalizeZedModel,
   workbuddy: normalizeWorkbuddyModel,
 };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9657,6 +9657,22 @@ function resolvePiDefaultModel() {
   return "pi-unknown";
 }
 
+// Pi is a router: the same session can send turns to Anthropic, GitHub
+// Copilot, or another backend. Keep provider names in the queue source so
+// those turns cannot collapse into one bucket (or inherit the wrong pricing).
+// Missing providers are deliberately kept on the historical `pi` source for
+// compatibility with older session formats and already-synced data.
+function piSourceForProvider(provider) {
+  if (typeof provider !== "string" || !provider.trim()) return "pi";
+  const slug = provider
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return slug ? `pi-${slug}` : "pi";
+}
+
 async function parsePiIncremental({
   sessionFiles,
   cursors,
@@ -9773,6 +9789,7 @@ async function parsePiIncremental({
           : input + output + cacheRead + cacheWrite + reasoningTokens;
 
       const model = normalizeModelInput(msg.model) || fallbackModel;
+      const source = piSourceForProvider(msg.provider);
 
       const delta = {
         input_tokens: input,
@@ -9784,9 +9801,9 @@ async function parsePiIncremental({
         conversation_count: 1,
       };
 
-      const bucket = getHourlyBucket(hourlyState, "pi", model, bucketStart);
+      const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
       addTotals(bucket.totals, delta);
-      touchedBuckets.add(bucketKey("pi", model, bucketStart));
+      touchedBuckets.add(bucketKey(source, model, bucketStart));
       seenIds.add(entryId);
       eventsAggregated++;
 

--- a/test/edge-pricing-parity.test.js
+++ b/test/edge-pricing-parity.test.js
@@ -83,3 +83,24 @@ test("canonical pricing block retains regression-prone entries and matcher order
   order('lower.includes("kimi-k2.6")', 'lower.includes("kimi")');
   order('lower.includes("mimo-v2.5-pro")', 'lower.includes("mimo-v2.5")');
 });
+
+test("all cloud cost paths keep Pi Copilot subscription rows at zero cost", () => {
+  for (const name of [CANONICAL, ...MIRRORS]) {
+    const source = readEdge(name);
+    assert.ok(source.includes('"pi-github-copilot"'), `${name}: Pi Copilot source missing`);
+    assert.ok(source.includes('"pi-copilot"'), `${name}: Pi Copilot alias missing`);
+    if (name === "tokentracker-account-model-breakdown.ts") {
+      assert.match(
+        source,
+        /const cost = subscriptionBacked\s*\? 0/,
+        `${name}: subscription rows must bypass model pricing`,
+      );
+    } else {
+      assert.match(
+        source,
+        /if \(row\.source === "pi-github-copilot" \|\| row\.source === "pi-copilot"\) return 0;/,
+        `${name}: subscription rows must bypass model pricing`,
+      );
+    }
+  }
+});

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -751,6 +751,22 @@ test("index: computeRowCost on non-Codex source DOES bill reasoning tokens", asy
   assert.ok(w > wo, "reasoning must be billed for non-Codex sources");
 });
 
+test("index: Pi GitHub Copilot rows keep token usage but have zero estimated API cost", () => {
+  pricing.resetPricingForTests();
+  const row = {
+    source: "pi-github-copilot",
+    model: "claude-sonnet-4-6",
+    input_tokens: 100_000,
+    output_tokens: 20_000,
+    cached_input_tokens: 10_000,
+    cache_creation_input_tokens: 5_000,
+    reasoning_output_tokens: 0,
+  };
+  assert.equal(pricing.computeRowCost(row), 0);
+  assert.ok(pricing.computeRowCost({ ...row, source: "pi-anthropic" }) > 0);
+  assert.ok(pricing.getModelPricing("Claude Opus 4.8", { source: "pi-anthropic" }).output > 0);
+});
+
 test("index: getModelPricing returns ZERO for empty/null model", () => {
   pricing.resetPricingForTests();
   assert.equal(pricing.getModelPricing("").input, 0);

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -7874,7 +7874,7 @@ function buildOmpSessionHeader() {
   return JSON.stringify({ type: "session", id: "session-1", timestamp: new Date().toISOString() });
 }
 
-function buildOmpAssistantLine({ id, model, input, output, cacheRead = 0, cacheWrite = 0, timestamp, reasoningTokens = 0, totalTokens }) {
+function buildOmpAssistantLine({ id, model, input, output, cacheRead = 0, cacheWrite = 0, timestamp, reasoningTokens = 0, totalTokens, provider = "anthropic" }) {
   const usage = {
     input,
     output,
@@ -7892,7 +7892,7 @@ function buildOmpAssistantLine({ id, model, input, output, cacheRead = 0, cacheW
     timestamp: new Date(timestamp).toISOString(),
     message: {
       role: "assistant",
-      provider: "anthropic",
+      provider,
       model,
       usage,
       timestamp: Date.parse(new Date(timestamp).toISOString()),
@@ -8220,7 +8220,7 @@ test("parseOmpIncremental dedupes subagent entries across two runs", async () =>
 
 // ─── pi (@mariozechner/pi-coding-agent) tests — same on-disk format as omp ───
 
-test("parsePiIncremental parses a single session and queues with source 'pi'", async () => {
+test("parsePiIncremental preserves the legacy 'pi' source when provider is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
   try {
     const sessionsDir = path.join(tmp, "sessions", "--test--");
@@ -8232,7 +8232,7 @@ test("parsePiIncremental parses a single session and queues with source 'pi'", a
     const ts = Date.UTC(2026, 3, 5, 14, 10, 0);
     const lines = [
       buildOmpSessionHeader(),
-      buildOmpAssistantLine({ id: "msg-1", model: "mimo-v2.5-pro", input: 100, output: 20, cacheRead: 0, cacheWrite: 0, timestamp: ts, totalTokens: 120 }),
+      buildOmpAssistantLine({ id: "msg-1", model: "mimo-v2.5-pro", input: 100, output: 20, cacheRead: 0, cacheWrite: 0, timestamp: ts, totalTokens: 120, provider: null }),
     ];
     await fs.writeFile(filePath, lines.join("\n") + "\n", "utf8");
 
@@ -8247,6 +8247,38 @@ test("parsePiIncremental parses a single session and queues with source 'pi'", a
     assert.equal(queued[0].output_tokens, 20);
     assert.equal(queued[0].total_tokens, 120);
     assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parsePiIncremental splits Anthropic and GitHub Copilot providers into independent sources", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "--test--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, "session.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const ts = Date.UTC(2026, 3, 5, 14, 10, 0);
+    const lines = [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "anthropic-1", provider: "anthropic", model: "claude-sonnet-4-6", input: 100, output: 20, timestamp: ts, totalTokens: 120 }),
+      buildOmpAssistantLine({ id: "copilot-1", provider: "github-copilot", model: "claude-sonnet-4-6", input: 300, output: 40, timestamp: ts, totalTokens: 340 }),
+    ];
+    await fs.writeFile(filePath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parsePiIncremental({ sessionFiles: [filePath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 2);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 2);
+    const bySource = new Map(queued.map((row) => [row.source, row]));
+    assert.equal(bySource.get("pi-anthropic").total_tokens, 120);
+    assert.equal(bySource.get("pi-github-copilot").total_tokens, 340);
+    assert.equal(bySource.get("pi-anthropic").input_tokens, 100);
+    assert.equal(bySource.get("pi-github-copilot").input_tokens, 300);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -8304,7 +8336,7 @@ test("parsePiIncremental counts pure-reasoning rows (only reasoningTokens > 0)",
 
     const queued = await readJsonLines(queuePath);
     assert.equal(queued.length, 1);
-    assert.equal(queued[0].source, "pi");
+    assert.equal(queued[0].source, "pi-anthropic");
     assert.equal(queued[0].reasoning_output_tokens, 7);
     assert.equal(queued[0].total_tokens, 7);
   } finally {


### PR DESCRIPTION
## Summary

- split Pi usage buckets by `message.provider` (`pi-anthropic`, `pi-github-copilot`, and normalized provider aliases)
- preserve the legacy `pi` source when older Pi records do not contain a provider
- keep Copilot subscription usage token-visible while preventing Anthropic API repricing in local and cloud cost paths
- add provider names/icons and regression coverage for parser, pricing, and edge functions

Fixes #319

## Validation

- `node --test test/rollout-parser.test.js test/pricing.test.js test/edge-pricing-parity.test.js`
- `npm --prefix dashboard run test -- --run src/lib/provider-display.test.js`
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run build`
- `npm run validate:copy`
- `npm run validate:ui-hardcode`
- `npm run validate:guardrails`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific tracking for Pi-powered usage, including Anthropic and GitHub Copilot.
  * Added recognizable provider names and icons for Pi-backed services.
  * Improved provider grouping and token attribution in dashboards and leaderboards.
  * Added Claude model pricing support for Pi Anthropic usage.

* **Bug Fixes**
  * Subscription-backed Pi Copilot usage is no longer counted as estimated API cost.

* **Tests**
  * Added coverage for provider attribution, pricing, display names, and zero-cost subscription handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->