### PR TITLE
fix: prevent stale leaderboard snapshots

### DIFF
--- a/dashboard/edge-patches/tokentracker-leaderboard.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard.ts
@@ -36,7 +36,15 @@ const BLOCKED_LEADERBOARD_USER_IDS = new Set(
 function json(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { ...cors, "Content-Type": "application/json" },
+    headers: {
+      ...cors,
+      "Content-Type": "application/json",
+      // A leaderboard response is a view of a mutable snapshot. Caching the
+      // edge response makes a freshly refreshed snapshot invisible until the
+      // browser/CDN TTL expires.
+      "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+      "CDN-Cache-Control": "no-store",
+    },
   });
 }
 
@@ -207,6 +215,16 @@ export default async function (req: Request): Promise<Response> {
     badges: (e?.user_id && badgeMap[e.user_id]?.badges) || [],
     badge_count: (e?.user_id && badgeMap[e.user_id]?.badge_count) || 0,
   });
+  // `generated_at` belongs to the persisted snapshot, not to this read
+  // request. Returning the request time made stale month/total snapshots look
+  // fresh to both the dashboard and the freshness watchdog. Include `me` as a
+  // fallback because a page beyond the end of the public ranking can have no
+  // rows while the signed-in user's snapshot row still exists.
+  const snapshotGeneratedAt = [...(entries || []), ...(me ? [me] : [])]
+    .map((entry: { generated_at?: unknown }) =>
+      typeof entry.generated_at === "string" ? entry.generated_at : null,
+    )
+    .find((value): value is string => Boolean(value)) ?? null;
 
   return json({
     entries: visibleEntries.map((e: { user_id?: string }) => ({
@@ -219,6 +237,6 @@ export default async function (req: Request): Promise<Response> {
     total_pages: Math.ceil((count || 0) / limit),
     from: from_day,
     to: to_day,
-    generated_at: new Date().toISOString(),
+    generated_at: snapshotGeneratedAt,
   });
 }

--- a/dashboard/src/lib/api.device.test.ts
+++ b/dashboard/src/lib/api.device.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchCloudUsageSummary,
   fetchAccountDevices,
+  getLeaderboard,
   invalidateAccountResponseCache,
 } from "./api";
 
@@ -46,6 +47,12 @@ describe("api device filter", () => {
   it("fetchAccountDevices hits the account-devices slug", async () => {
     await fetchAccountDevices({ from: "2026-06-01", to: "2026-06-30", accessToken: JWT });
     expect(lastFetchUrl().pathname).toContain("tokentracker-account-devices");
+  });
+
+  it("forces leaderboard reads to bypass browser and CDN caches", async () => {
+    await getLeaderboard({ period: "week", limit: 20, offset: 0, userId: "user-1" });
+    const init = (globalThis.fetch as any).mock.calls.at(-1)?.[1];
+    expect(init?.cache).toBe("no-store");
   });
 
   it("reuses a fresh account response and supports explicit invalidation", async () => {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -274,6 +274,7 @@ async function fetchInsforgeFunction(slug: string, options: {
   accessToken?: string;
   params?: AnyRecord;
   body?: unknown;
+  cache?: RequestCache;
 } = {}) {
   const baseUrl = getInsforgeRemoteUrl();
   if (!baseUrl) throw new Error("InsForge base URL not configured");
@@ -302,6 +303,7 @@ async function fetchInsforgeFunction(slug: string, options: {
   const res = await fetch(url.toString(), {
     method: options.method || "GET",
     headers,
+    cache: options.cache,
     ...(options.body != null ? { body: JSON.stringify(options.body) } : {}),
   });
   if (!res.ok) {
@@ -329,6 +331,7 @@ export async function getLeaderboard({
   // param lets the server compute `is_me` without ever touching the
   // Authorization header.
   return fetchInsforgeFunction("tokentracker-leaderboard", {
+    cache: "no-store",
     params: { period, limit, offset, user_id: userId },
   });
 }

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -3,6 +3,7 @@ const KEY_DEVICE = "tokentracker_cloud_device_session_v1";
 const KEY_LAST_SYNC = "tokentracker_cloud_last_sync_ts";
 const KEY_USAGE_READY = "tokentracker_cloud_usage_ready_v1";
 export const CLOUD_USAGE_SYNCED_EVENT = "tt.cloudUsageSynced";
+export const CLOUD_LEADERBOARD_REFRESHED_EVENT = "tt.cloudLeaderboardRefreshed";
 let memoryDeviceSession: CloudDeviceSession | null = null;
 
 export type CloudDeviceSession = {
@@ -121,6 +122,16 @@ export function emitCloudUsageSynced(): void {
     setCloudUsageReady(true);
     if (typeof window !== "undefined") {
       window.dispatchEvent(new Event(CLOUD_USAGE_SYNCED_EVENT));
+    }
+  } catch {
+    /* best-effort invalidation for the active dashboard */
+  }
+}
+
+export function emitCloudLeaderboardRefreshed(): void {
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(CLOUD_LEADERBOARD_REFRESHED_EVENT));
     }
   } catch {
     /* best-effort invalidation for the active dashboard */

--- a/dashboard/src/lib/cloud-sync.test.ts
+++ b/dashboard/src/lib/cloud-sync.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  CLOUD_LEADERBOARD_REFRESHED_EVENT,
   clearCloudDeviceSession,
   getCloudUsageReady,
   setCloudUsageReady,
@@ -23,8 +24,9 @@ function okJson(data: unknown): Response {
   } as Response;
 }
 
-function installFetchMock() {
-  const fetchMock = vi.fn(async (url: string) => {
+function installFetchMock(options: { leaderboardOk?: boolean } = {}) {
+  const leaderboardOk = options.leaderboardOk ?? true;
+  const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
     if (url === "/functions/tokentracker-machine-id") {
       return okJson({ machineId: "machine-abcdef12" });
     }
@@ -39,7 +41,11 @@ function installFetchMock() {
       return okJson({ ok: true });
     }
     if (url === "https://cloud.example/functions/tokentracker-leaderboard-refresh") {
-      return okJson({ ok: true });
+      return {
+        ok: leaderboardOk,
+        status: leaderboardOk ? 200 : 403,
+        json: async () => ({ ok: leaderboardOk }),
+      } as Response;
     }
     throw new Error(`Unexpected fetch: ${url}`);
   });
@@ -91,13 +97,17 @@ describe("cloud usage sync", () => {
       insforgeBaseUrl: "https://cloud.example",
     });
     expect(onSynced).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.find(([url]) => url === "https://cloud.example/functions/tokentracker-leaderboard-refresh")?.[1])
+      .toMatchObject({ cache: "no-store" });
     window.removeEventListener("tt.cloudUsageSynced", onSynced);
   });
 
   it("drains the full queue before the first scheduled cloud view becomes ready", async () => {
     const fetchMock = installFetchMock();
     const onSynced = vi.fn();
+    const onLeaderboardRefresh = vi.fn();
     window.addEventListener("tt.cloudUsageSynced", onSynced);
+    window.addEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, onLeaderboardRefresh);
 
     await runCloudUsageSyncIfDue(async () => "access-token");
 
@@ -107,8 +117,21 @@ describe("cloud usage sync", () => {
       insforgeBaseUrl: "https://cloud.example",
     });
     expect(onSynced).toHaveBeenCalledTimes(1);
+    expect(onLeaderboardRefresh).toHaveBeenCalledTimes(1);
     expect(getCloudUsageReady()).toBe(true);
     window.removeEventListener("tt.cloudUsageSynced", onSynced);
+    window.removeEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, onLeaderboardRefresh);
+  });
+
+  it("does not announce a leaderboard refresh when the refresh endpoint fails", async () => {
+    installFetchMock({ leaderboardOk: false });
+    const onLeaderboardRefresh = vi.fn();
+    window.addEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, onLeaderboardRefresh);
+
+    await runCloudUsageSyncNow(async () => "access-token");
+
+    expect(onLeaderboardRefresh).not.toHaveBeenCalled();
+    window.removeEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, onLeaderboardRefresh);
   });
 
   it("keeps scheduled sync lightweight after cloud usage is ready", async () => {

--- a/dashboard/src/lib/cloud-sync.ts
+++ b/dashboard/src/lib/cloud-sync.ts
@@ -5,6 +5,7 @@ import {
   getCloudUsageReady,
   getLastCloudSyncTs,
   getStoredDeviceSession,
+  emitCloudLeaderboardRefreshed,
   setLastCloudSyncTs,
   setStoredDeviceSession,
   type CloudDeviceSession,
@@ -31,9 +32,9 @@ function shouldRotateStoredDeviceSession(
 async function triggerLeaderboardRefresh(
   accessToken: string,
   source: "cloud-sync-auto" | "cloud-sync-now",
-): Promise<void> {
+): Promise<boolean> {
   const baseUrl = getInsforgeRemoteUrl();
-  if (!isRemoteHttpBase(baseUrl) || !accessToken) return;
+  if (!isRemoteHttpBase(baseUrl) || !accessToken) return false;
   const root = baseUrl.replace(/\/$/, "");
   const anon = getInsforgeAnonKey();
   const headers: Record<string, string> = {
@@ -47,12 +48,16 @@ async function triggerLeaderboardRefresh(
   // every 5 min per active user blew through the 5 GB plan). Server-side
   // schedules own the slower-moving month/total snapshots.
   try {
-    await fetch(`${root}/functions/tokentracker-leaderboard-refresh`, {
+    const response = await fetch(`${root}/functions/tokentracker-leaderboard-refresh`, {
       method: "POST",
       headers,
+      cache: "no-store",
       body: JSON.stringify({ period: "week", source }),
     });
-  } catch { /* best effort */ }
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -223,7 +228,9 @@ export async function runCloudUsageSyncIfDue(getAccessToken: () => Promise<strin
   });
   if (!accessToken) return;
   setLastCloudSyncTs(Date.now());
-  await triggerLeaderboardRefresh(accessToken, "cloud-sync-auto");
+  if (await triggerLeaderboardRefresh(accessToken, "cloud-sync-auto")) {
+    emitCloudLeaderboardRefreshed();
+  }
 }
 
 /** 用户打开「同步到云端」后立即尝试一次（忽略节流） */
@@ -231,5 +238,7 @@ export async function runCloudUsageSyncNow(getAccessToken: () => Promise<string 
   const accessToken = await syncCloudUsageWithRecovery(getAccessToken, { drain: true });
   if (!accessToken) return;
   setLastCloudSyncTs(Date.now());
-  await triggerLeaderboardRefresh(accessToken, "cloud-sync-now");
+  if (await triggerLeaderboardRefresh(accessToken, "cloud-sync-now")) {
+    emitCloudLeaderboardRefreshed();
+  }
 }

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -38,14 +38,17 @@ import { getDashboardEntryPath } from "../lib/host-mode";
 import { isMockEnabled } from "../lib/mock-data";
 import {
   getLeaderboard,
-  refreshLeaderboard,
 } from "../lib/api";
 import {
   getLeaderboardPreloadContextKey,
   publishLeaderboardPreloadState,
   readLeaderboardPreloadState,
 } from "../lib/dashboard-preload.js";
-import { getCloudSyncEnabled, setCloudSyncEnabled } from "../lib/cloud-sync-prefs";
+import {
+  CLOUD_LEADERBOARD_REFRESHED_EVENT,
+  getCloudSyncEnabled,
+  setCloudSyncEnabled,
+} from "../lib/cloud-sync-prefs";
 import { runCloudUsageSyncNow } from "../lib/cloud-sync";
 import { LeaderboardAvatar } from "../components/LeaderboardAvatar.jsx";
 import { LeaderboardProviderColumnHeader } from "../components/LeaderboardProviderColumnHeader.jsx";
@@ -527,6 +530,17 @@ export function LeaderboardPage({
   const [cloudSyncOn, setCloudSyncOn] = useState(() => getCloudSyncEnabled());
   const [syncing, setSyncing] = useState(false);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const handleLeaderboardRefresh = () => {
+      setListReloadToken((value) => value + 1);
+    };
+    window.addEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, handleLeaderboardRefresh);
+    return () => {
+      window.removeEventListener(CLOUD_LEADERBOARD_REFRESHED_EVENT, handleLeaderboardRefresh);
+    };
+  }, []);
+
   const period = useMemo(() => {
     const params = new URLSearchParams(location?.search || "");
     return normalizePeriod(params.get("period")) || "total";
@@ -736,9 +750,6 @@ export function LeaderboardPage({
       setCloudSyncEnabled(true);
       setCloudSyncOn(true);
       await runCloudUsageSyncNow(() => resolveAuthAccessTokenWithRetry(effectiveAuthToken));
-      const token = await resolveAuthAccessTokenWithRetry(effectiveAuthToken);
-      if (token) await refreshLeaderboard({ accessToken: token, period, source: "leaderboard-enable-sync" });
-      setListReloadToken((v) => v + 1);
     } catch (e) {
       console.warn("[tokentracker] sync:", e);
     } finally {

--- a/dashboard/src/pages/LeaderboardPage.test.jsx
+++ b/dashboard/src/pages/LeaderboardPage.test.jsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/dashboard-preload.js";
 import { getLeaderboard } from "../lib/api";
 import { runCloudUsageSyncNow } from "../lib/cloud-sync";
+import { CLOUD_LEADERBOARD_REFRESHED_EVENT } from "../lib/cloud-sync-prefs";
 import { LeaderboardPage } from "./LeaderboardPage.jsx";
 
 const openLoginModalMock = vi.hoisted(() => vi.fn());
@@ -222,6 +223,34 @@ describe("LeaderboardPage window-session cache reuse", () => {
         data: refreshedData,
         source: "page-load",
       });
+    });
+  });
+
+  it("reloads the active page after cloud sync publishes a fresh leaderboard snapshot", async () => {
+    const initialData = {
+      ...preloadedData,
+      entries: [{ ...preloadedData.entries[0], display_name: "Before sync" }],
+    };
+    const refreshedData = {
+      ...preloadedData,
+      entries: [{ ...preloadedData.entries[0], display_name: "After sync" }],
+    };
+    getLeaderboard.mockResolvedValueOnce(initialData).mockResolvedValueOnce(refreshedData);
+
+    renderLeaderboard();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Before sync").length).toBeGreaterThan(0);
+      expect(getLeaderboard).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event(CLOUD_LEADERBOARD_REFRESHED_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(getLeaderboard).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByText("After sync").length).toBeGreaterThan(0);
     });
   });
 

--- a/test/backend-hot-path-guardrails.test.js
+++ b/test/backend-hot-path-guardrails.test.js
@@ -68,6 +68,19 @@ test("signed-in users cannot trigger expensive month, total, or all-period leade
   assert.match(clientSource, /body: JSON\.stringify\(\{ period: "week", source \}\)/u);
 });
 
+test("leaderboard reads expose snapshot freshness and disable response caching", () => {
+  const edgeSource = read("dashboard/edge-patches/tokentracker-leaderboard.ts");
+  const clientSource = read("dashboard/src/lib/api.ts");
+  assert.match(edgeSource, /const snapshotGeneratedAt =/u);
+  assert.match(edgeSource, /generated_at: snapshotGeneratedAt/u);
+  assert.doesNotMatch(edgeSource, /generated_at: new Date\(\)\.toISOString\(\)/u);
+  assert.match(edgeSource, /"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0"/u);
+  assert.match(
+    clientSource,
+    /fetchInsforgeFunction\("tokentracker-leaderboard", \{\s*cache: "no-store"/u,
+  );
+});
+
 test("telemetry heartbeat uses one atomic database upsert RPC", () => {
   const source = read("dashboard/edge-patches/tokentracker-telemetry.ts");
   assert.match(source, /rpc\("upsert_tokentracker_telemetry_daily"/u);


### PR DESCRIPTION
## Summary

- report the persisted leaderboard snapshot timestamp instead of the request time
- disable browser/CDN caching for leaderboard reads and responses
- refresh the active leaderboard view after a successful cloud-sync refresh
- avoid the duplicate signed-in total refresh that is rejected by the server

## Validation

- `npm --prefix dashboard run test` (74 files, 414 tests)
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run lint`
- `npm --prefix dashboard run build`
- `node --test test/backend-hot-path-guardrails.test.js`

The root `npm test` run on Windows still contains unrelated baseline failures involving sqlite3, symlink permissions, WSL paths, and existing platform-specific assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Leaderboard data now avoids browser, CDN, and server caching to show fresher results.
  * Leaderboard timestamps now reflect the underlying snapshot rather than request time.
  * Cloud-sync failures no longer trigger misleading leaderboard refresh notifications.
  * Leaderboard views automatically refresh after a successful cloud synchronization.

* **Tests**
  * Added coverage for cache prevention, snapshot timestamps, sync outcomes, refresh events, and updated leaderboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->