### PR TITLE
fix(dashboard): refresh device names after rename

### DIFF
--- a/dashboard/src/contexts/InsforgeAuthContext.jsx
+++ b/dashboard/src/contexts/InsforgeAuthContext.jsx
@@ -40,15 +40,21 @@ export async function resolveInsforgeClientAccessToken(client, options = {}) {
   const skewMs = Math.max(0, Math.floor(Number(options.skewMs) || 60_000));
   const tm = /** @type {any} */ (client).tokenManager;
   const readToken = () => tm?.getAccessToken?.() ?? tm?.getSession?.()?.accessToken ?? null;
+  const firstUsableToken = (...candidates) =>
+    candidates.find((candidate) => candidate && !isLikelyExpiredAccessToken(candidate, skewMs)) ?? null;
 
   let token = readToken();
   if (!token || isLikelyExpiredAccessToken(token, skewMs)) {
     const { data } = await client.auth.refreshSession();
-    token = readToken() ?? accessTokenFromRefreshPayload(data) ?? null;
+    // Some SDK/storage combinations expose the old token from tokenManager for
+    // a short window after refreshSession resolves. Do not let that stale JWT
+    // mask the fresh token returned in the refresh payload.
+    const refreshedPayloadToken = accessTokenFromRefreshPayload(data);
+    token = firstUsableToken(readToken(), refreshedPayloadToken);
     if (!token && typeof client.auth.getCurrentUser === "function") {
       try {
         await client.auth.getCurrentUser();
-        token = readToken() ?? accessTokenFromRefreshPayload(data) ?? null;
+        token = firstUsableToken(readToken(), refreshedPayloadToken);
       } catch {
         /* ignore */
       }

--- a/dashboard/src/contexts/__tests__/InsforgeAuthContext.test.jsx
+++ b/dashboard/src/contexts/__tests__/InsforgeAuthContext.test.jsx
@@ -66,6 +66,23 @@ describe("resolveInsforgeClientAccessToken", () => {
     expect(client.auth.refreshSession).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the refreshed payload while the token manager still exposes the expired token", async () => {
+    const expiredToken = makeJwt(Math.floor(Date.now() / 1000) - 60);
+    const refreshedToken = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const client = {
+      tokenManager: {
+        getAccessToken: vi.fn(() => expiredToken),
+        getSession: vi.fn(() => ({ accessToken: expiredToken })),
+      },
+      auth: {
+        refreshSession: vi.fn(async () => ({ data: { accessToken: refreshedToken } })),
+      },
+    };
+
+    await expect(resolveInsforgeClientAccessToken(client)).resolves.toBe(refreshedToken);
+    expect(client.auth.refreshSession).toHaveBeenCalledTimes(1);
+  });
+
   it("uses access_token from refresh payload when token manager stays empty", async () => {
     const accessToken = "snake-case-token";
     const client = {

--- a/dashboard/src/lib/api.device.test.ts
+++ b/dashboard/src/lib/api.device.test.ts
@@ -3,6 +3,7 @@ import {
   fetchCloudUsageSummary,
   fetchAccountDevices,
   invalidateAccountResponseCache,
+  renameAccountDevice,
 } from "./api";
 
 vi.mock("./insforge-config", () => ({
@@ -57,5 +58,35 @@ describe("api device filter", () => {
     invalidateAccountResponseCache();
     await fetchCloudUsageSummary(args);
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates cached device data after a successful rename", async () => {
+    let deviceName = "Old name";
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes("tokentracker-device-rename")) {
+        deviceName = "M4";
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({
+        devices: [{ id: "dev-1", device_name: deviceName }],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+
+    const args = { from: "2026-06-01", to: "2026-06-30", accessToken: JWT };
+    const before = await fetchAccountDevices(args);
+    expect(before.devices[0].device_name).toBe("Old name");
+
+    await renameAccountDevice({ deviceId: "dev-1", name: "M4", accessToken: JWT });
+    const after = await fetchAccountDevices(args);
+
+    expect(after.devices[0].device_name).toBe("M4");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -956,9 +956,14 @@ export async function renameAccountDevice({ deviceId, name, accessToken }: AnyRe
     err.status = 401;
     throw err;
   }
-  return fetchInsforgeFunction("tokentracker-device-rename", {
+  const result = await fetchInsforgeFunction("tokentracker-device-rename", {
     accessToken,
     method: "POST",
     body: { device_id: deviceId, device_name: name },
   });
+  // Account GETs are cached briefly to collapse dashboard fan-out. A rename
+  // changes the device list immediately, so the caller's follow-up refresh
+  // must not be satisfied by the pre-mutation snapshot.
+  invalidateAccountResponseCache();
+  return result;
 }


### PR DESCRIPTION
## Summary

- invalidate cached account responses after a successful device rename so the immediate refresh displays the new name
- prefer the fresh refresh-session payload when the SDK token manager temporarily continues exposing an expired JWT
- add regressions for both the stale-name and signed-in-but-401 paths

## Root cause

The production rename mutation returned 200, but the follow-up account-devices read was satisfied by the 30-second client cache. The earlier 401 was a separate stale-token window: signed-in UI state can outlive the access JWT, and the old token manager value could mask the newly refreshed payload.

## Validation

- dashboard tests: 413 passed
- targeted regressions: 11 passed
- dashboard lint
- dashboard typecheck
- dashboard build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in session recovery so refreshed, valid access tokens are selected reliably, even when an older token remains available.
  - Fixed device renaming so updated names appear immediately in account device lists instead of showing cached information.

- **Tests**
  - Added coverage for expired-token recovery and device-list updates after renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->