### PR TITLE
fix: prevent dashboard stats overlap on narrow Mac windows

### DIFF
--- a/dashboard/src/ui/dashboard/components/StatsPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/StatsPanel.jsx
@@ -76,39 +76,39 @@ export function StatsPanel({
   return (
     <Card className={`h-full ${className}`}>
         {/* Rolling Stats */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-          <div className="flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
+        <div className="grid grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 gap-2">
+          <div className="min-w-0 flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
             <span
               title={formatTokensTooltip(rolling?.last_7d?.totals?.billable_total_tokens)}
-              className="text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
+              className="w-full min-w-0 truncate text-center text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
             >
               {formatCountValue(rolling?.last_7d?.totals?.billable_total_tokens)}
             </span>
-            <span className="text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.last7d}</span>
+            <span className="w-full min-w-0 truncate text-center text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.last7d}</span>
           </div>
-          <div className="flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
+          <div className="min-w-0 flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
             <span
               title={formatTokensTooltip(rolling?.last_30d?.totals?.billable_total_tokens)}
-              className="text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
+              className="w-full min-w-0 truncate text-center text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
             >
               {formatCountValue(rolling?.last_30d?.totals?.billable_total_tokens)}
             </span>
-            <span className="text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.last30d}</span>
+            <span className="w-full min-w-0 truncate text-center text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.last30d}</span>
           </div>
-          <div className="flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
+          <div className="min-w-0 flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
             <span
               title={formatTokensTooltip(rolling?.last_30d?.avg_per_active_day)}
-              className="text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
+              className="w-full min-w-0 truncate text-center text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums"
             >
               {formatCountValue(rolling?.last_30d?.avg_per_active_day)}
             </span>
-            <span className="text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.avg}</span>
+            <span className="w-full min-w-0 truncate text-center text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.avg}</span>
           </div>
-          <div className="flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
-            <span className="text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums">
+          <div className="min-w-0 flex flex-col items-center justify-center px-2 py-2 bg-oai-gray-50 dark:bg-oai-gray-800 rounded-lg">
+            <span className="w-full min-w-0 truncate text-center text-sm font-semibold text-oai-black dark:text-oai-white tabular-nums">
               {formatCountValue(periodConversations)}
             </span>
-            <span className="text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.convs}</span>
+            <span className="w-full min-w-0 truncate text-center text-[10px] text-oai-gray-400 dark:text-oai-gray-400 mt-0.5 whitespace-nowrap">{rollingLabels.convs}</span>
           </div>
         </div>
 

--- a/dashboard/src/ui/dashboard/components/__tests__/StatsPanel.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/StatsPanel.test.jsx
@@ -69,6 +69,18 @@ it("keeps rolling card values compact when the global token format is full", () 
   expect(screen.queryByText("2,800,000,000")).not.toBeInTheDocument();
 });
 
+it("keeps the rolling stats readable in a narrow desktop sidebar", () => {
+  const { container } = renderPanel({ periodConversations: 42 });
+  const grid = container.querySelector(".grid.grid-cols-2");
+
+  expect(grid).toHaveClass("lg:grid-cols-2");
+  expect(grid).toHaveClass("xl:grid-cols-4");
+  expect(grid?.children).toHaveLength(4);
+  for (const tile of Array.from(grid?.children || [])) {
+    expect(tile).toHaveClass("min-w-0");
+  }
+});
+
 it("localizes compact rolling stats labels", () => {
   const cases = [
     ["en", ["7d", "30d", "avg", "convs"]],


### PR DESCRIPTION
## Summary

- keep the rolling 7d/30d stats in two columns while the desktop dashboard sidebar is narrow
- switch back to four columns only at the wide desktop breakpoint
- constrain stat values and labels so long default-format numbers cannot overlap adjacent tiles

## Validation

- `npm --prefix dashboard run test -- --run src/ui/dashboard/components/__tests__/StatsPanel.test.jsx`
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run lint`
- `npm --prefix dashboard run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Rolling Stats layout across different screen sizes.
  * Enhanced stat tile text handling to keep values readable in narrow sidebars.
  * Preserved existing statistics and tooltip information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->