### PR TITLE
fix: refresh daily usage and clarify trend estimates

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -190,8 +190,17 @@ final class StatusBarController: NSObject {
     }
 
     private func selectedMenuBarSummaries() -> MenuBarSummarySelection {
-        guard showStats else { return [] }
-        return MenuBarDisplayPreferences.summarySelection(for: MenuBarDisplayPreferences.read())
+        var summaries = showStats
+            ? MenuBarDisplayPreferences.summarySelection(for: MenuBarDisplayPreferences.read())
+            : MenuBarSummarySelection()
+        // The floating pet is another always-visible consumer of today and
+        // rolling usage. When menu-bar stats are hidden, returning an empty
+        // selection here made queue writes animate the pet but left its usage
+        // numbers stale until the dashboard opened or Sync Now was clicked.
+        if desktopPetController.isVisible {
+            summaries.formUnion([.today, .rolling])
+        }
+        return summaries
     }
 
     /// Single derivation of the animator state from the view model.

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -209,6 +209,7 @@ dashboard.cost_breakdown.close,ui,CostAnalysisModal,CostAnalysisModal,close_labe
 
 
 trend.monitor.label,ui,TrendMonitor,TrendMonitor,label,"Usage Trend",,active
+trend.monitor.predicted,ui,TrendMonitor,TrendMonitor,predicted_label,"Estimated",,active
 trend.zoom.open_aria,ui,TrendMonitor,TrendMonitor,zoom_open_aria,"Expand to full screen",,active
 trend.zoom.close_aria,ui,TrendMonitorZoomModal,TrendMonitorZoomModal,zoom_close_aria,"Close",,active
 trend.zoom.badge,ui,TrendMonitorZoomModal,TrendMonitorZoomModal,zoom_badge,"Trend Insight",,active

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -46,6 +46,7 @@
   "dashboard.cost_breakdown.total_label": "Geschätzte Gesamtkosten",
   "dashboard.cost_breakdown.close": "Schließen",
   "trend.monitor.label": "Nutzungstrend",
+  "trend.monitor.predicted": "Prognose",
   "trend.zoom.open_aria": "Vollbild öffnen",
   "trend.zoom.close_aria": "Schließen",
   "trend.zoom.badge": "Trendanalyse",

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -51,6 +51,7 @@
   "dashboard.cost_breakdown.total_label": "推定総コスト",
   "dashboard.cost_breakdown.close": "閉じる",
   "trend.monitor.label": "使用トレンド",
+  "trend.monitor.predicted": "予測値",
   "trend.zoom.open_aria": "全画面表示",
   "trend.zoom.close_aria": "閉じる",
   "trend.zoom.badge": "トレンド分析",

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -51,6 +51,7 @@
   "dashboard.cost_breakdown.total_label": "예상 총비용",
   "dashboard.cost_breakdown.close": "닫기",
   "trend.monitor.label": "사용 추세",
+  "trend.monitor.predicted": "예측값",
   "trend.zoom.open_aria": "전체 화면으로 확대",
   "trend.zoom.close_aria": "닫기",
   "trend.zoom.badge": "트렌드 인사이트",

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -51,6 +51,7 @@
   "dashboard.cost_breakdown.total_label": "預計總成本",
   "dashboard.cost_breakdown.close": "關閉",
   "trend.monitor.label": "使用趨勢",
+  "trend.monitor.predicted": "預測值",
   "trend.zoom.open_aria": "展開全螢幕",
   "trend.zoom.close_aria": "關閉",
   "trend.zoom.badge": "趨勢洞察",

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -51,6 +51,7 @@
   "dashboard.cost_breakdown.total_label": "预计总成本",
   "dashboard.cost_breakdown.close": "关闭",
   "trend.monitor.label": "使用趋势",
+  "trend.monitor.predicted": "预测值",
   "trend.zoom.open_aria": "展开全屏",
   "trend.zoom.close_aria": "关闭",
   "trend.zoom.badge": "趋势洞察",

--- a/dashboard/src/hooks/use-trend-data.test.tsx
+++ b/dashboard/src/hooks/use-trend-data.test.tsx
@@ -101,6 +101,45 @@ describe("useTrendData", () => {
     });
   });
 
+  it("keeps future daily buckets as estimates for week and month trends", async () => {
+    vi.mocked(getUsageDaily).mockResolvedValue({
+      from: "2026-05-01",
+      to: "2026-05-31",
+      data: [
+        {
+          day: "2026-05-10",
+          total_tokens: 100,
+          billable_total_tokens: 100,
+        },
+      ],
+    });
+    const now = new Date("2026-05-15T12:15:00Z");
+
+    const { result } = renderHook(() =>
+      useTrendData({
+        baseUrl: "http://localhost:7680",
+        accessToken: "test-token",
+        period: "month",
+        from: "2026-05-01",
+        to: "2026-05-31",
+        timeZone: "UTC",
+        now,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(31));
+
+    expect(result.current.rows.find((row) => row.day === "2026-05-15")).toMatchObject({
+      missing: true,
+      future: false,
+    });
+    expect(result.current.rows.find((row) => row.day === "2026-05-16")).toMatchObject({
+      total_tokens: null,
+      missing: false,
+      future: true,
+    });
+  });
+
   it("fills elapsed half-hour slots with zero observations without touching future slots", async () => {
     vi.mocked(getUsageHourly).mockResolvedValue({
       day: "2026-05-29",

--- a/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
+++ b/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
@@ -240,13 +240,22 @@ function TrendBar({
           /* 占位/预测/真实零：单色背景条 */
           <div
             data-trend-bar="true"
+            data-trend-kind={kind}
             className={cn(
               "h-full w-full group-hover:brightness-110 transition-all",
-              kind === "real" ? "" : "bg-oai-gray-100 dark:bg-oai-gray-800",
+              kind === "real"
+                ? ""
+                : kind === "predicted"
+                  ? "text-oai-gray-400 dark:text-oai-gray-500"
+                  : "bg-oai-gray-100 dark:bg-oai-gray-800",
             )}
             style={{
-              opacity: isPreview ? PREVIEW_OPACITY : 1,
+              opacity: kind === "predicted" ? 0.55 : isPreview ? PREVIEW_OPACITY : 1,
               background: kind === "real" ? "#10b981" : undefined,
+              backgroundImage:
+                kind === "predicted"
+                  ? "repeating-linear-gradient(135deg, currentColor 0 2px, transparent 2px 5px)"
+                  : undefined,
             }}
           />
         ) : (
@@ -387,6 +396,10 @@ export function TrendMonitor({
   const series = React.useMemo(
     () => (Array.isArray(rows) && rows.length ? rows : []),
     [rows],
+  );
+  const hasPredictions = React.useMemo(
+    () => series.some((row) => row?.future),
+    [series],
   );
 
   // rawValues: real observations (incl. 0) pass through; missing/future are null.
@@ -569,6 +582,23 @@ export function TrendMonitor({
           </div>
         )}
 
+        {hasPredictions && (
+          <div
+            className="flex items-center justify-end gap-1.5 text-[10px] font-medium text-oai-gray-400 dark:text-oai-gray-500"
+            data-trend-prediction-legend="true"
+          >
+            <span
+              aria-hidden="true"
+              className="h-2.5 w-3 rounded-[2px] text-oai-gray-400 dark:text-oai-gray-500 opacity-50"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(135deg, currentColor 0 2px, transparent 2px 5px)",
+              }}
+            />
+            <span>~ {copy("trend.monitor.predicted")}</span>
+          </div>
+        )}
+
         {from && to && (
           <div className="flex justify-between text-xs text-oai-gray-500 dark:text-oai-gray-300 font-medium pt-2 border-t border-oai-gray-100 dark:border-oai-gray-800">
             <span>{from === to ? `${from} 00:00` : from}</span>
@@ -603,7 +633,7 @@ export function TrendMonitor({
               </span>
               {hoveredBar.kind === "predicted" && (
                 <span className="text-[9px] font-semibold uppercase tracking-wider text-oai-gray-400 dark:text-oai-gray-500">
-                  Predicted
+                  {copy("trend.monitor.predicted")}
                 </span>
               )}
               {hoveredBar.kind === "unsynced" && (

--- a/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
@@ -58,7 +58,7 @@ describe("TrendMonitor", () => {
     expect(bars[1].parentElement?.style.height).toBe("2px");
   });
 
-  it("renders future bars at faint preview opacity with interpolated heights", () => {
+  it("renders future bars as striped estimates with an always-visible legend", () => {
     const rows = [
       { billable_total_tokens: 100 },
       { billable_total_tokens: 100 },
@@ -69,9 +69,22 @@ describe("TrendMonitor", () => {
     );
     const bars = Array.from(container.querySelectorAll('[data-trend-bar="true"]'));
     const previewBar = bars.at(-1);
-    expect(previewBar?.style.opacity).toBe("0.35");
+    expect(previewBar?.dataset.trendKind).toBe("predicted");
+    expect(previewBar?.style.opacity).toBe("0.55");
+    expect(previewBar?.style.backgroundImage).toContain("repeating-linear-gradient");
+    expect(container.querySelector('[data-trend-prediction-legend="true"]')?.textContent).toContain(
+      "~ Estimated",
+    );
     // Predicted heights are clipped to the y-axis max and rendered as a percentage.
     expect(previewBar?.parentElement?.style.height).toMatch(/%$/);
+  });
+
+  it("does not show the estimate legend when the range has no future rows", () => {
+    const { container } = render(
+      <TrendMonitor rows={[{ billable_total_tokens: 100 }]} showTimeZoneLabel={false} />,
+    );
+
+    expect(container.querySelector('[data-trend-prediction-legend="true"]')).toBeNull();
   });
 
   it("renders X-axis tick labels only in zoom mode (small card unchanged)", () => {

--- a/test/macos-background-sync-source.test.js
+++ b/test/macos-background-sync-source.test.js
@@ -14,6 +14,7 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
   const refreshPolicy = read("TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift");
   const appDelegate = read("TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift");
+  const statusBarController = read("TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift");
 
   assert.match(
     apiClient,
@@ -92,5 +93,10 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
     widgetWriter,
     /func hasConfiguredWidgets\(\) async -> Bool[\s\S]*getCurrentConfigurations[\s\S]*!configurations\.isEmpty[\s\S]*resume\(returning: true\)/,
     "Widget discovery should avoid full hidden loads when unused and fail toward freshness on query errors.",
+  );
+  assert.match(
+    statusBarController,
+    /private func selectedMenuBarSummaries\(\)[\s\S]*desktopPetController\.isVisible[\s\S]*summaries\.formUnion\(\[\.today, \.rolling\]\)/,
+    "Queue writes must refresh the visible pet's today and rolling totals even when menu-bar stats are hidden.",
   );
 });


### PR DESCRIPTION
## Summary

- refresh the visible macOS pet's today and rolling summaries whenever queue usage is published, even when menu-bar stats are hidden
- preserve the intentional future-usage estimates in week and month trends
- distinguish estimated buckets with striped bars and an always-visible localized ~ Estimated legend
- add regression coverage for background refresh, daily forecast buckets, and forecast presentation

## Validation

- Dashboard tests: 74 files, 422 tests passed
- TypeScript typecheck passed
- ESLint passed
- production dashboard build passed
- copy registry and UI hardcode validation passed
- macOS background-sync and trend-layout source guards passed
- visually verified at a 640 x 800 viewport with no overflow or date-label overlap