### PR TITLE
fix: recover cloud sync from leaked test config

### DIFF
--- a/src/lib/runtime-config.js
+++ b/src/lib/runtime-config.js
@@ -11,9 +11,14 @@ const DEFAULT_ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3OC0xMjM0LTU2NzgtOTBhYi1jZGVmMTIzNDU2NzgiLCJlbWFpbCI6ImFub25AaW5zZm9yZ2UuY29tIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODExNDU5NDd9.T0auta_IrVIh0uXW1bob5QSnzvsnJmN28r5XkSGEuQY";
 
 function resolveRuntimeConfig({ cli = {}, config = {}, env = process.env, defaults = {} } = {}) {
+  // Older Windows test runs could leak their fixture HOME and persist
+  // https://example.invalid into the user's real config.json. The test
+  // isolation bug is fixed, but existing installs must recover instead of
+  // backing off cloud uploads forever against the reserved placeholder host.
+  const persistedBaseUrl = normalizePersistedBaseUrl(config.baseUrl);
   const baseUrl = pickString(
     cli.baseUrl,
-    config.baseUrl,
+    persistedBaseUrl,
     env?.TOKENTRACKER_INSFORGE_BASE_URL,
     defaults.baseUrl,
     DEFAULT_BASE_URL,
@@ -103,6 +108,19 @@ function normalizeString(value) {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
   return trimmed;
+}
+
+function normalizePersistedBaseUrl(value) {
+  const normalized = normalizeString(value);
+  if (normalized === undefined) return undefined;
+  try {
+    if (new URL(normalized).hostname.toLowerCase() === "example.invalid") {
+      return undefined;
+    }
+  } catch {
+    // Preserve the existing resolver behavior for arbitrary custom values.
+  }
+  return normalized;
 }
 
 function normalizeBoolean(value) {

--- a/test/init-local-runtime-reinstall.test.js
+++ b/test/init-local-runtime-reinstall.test.js
@@ -29,6 +29,7 @@ test("init can rerun from installed local runtime without self-deleting app sour
   const env = {
     ...process.env,
     HOME: tmp,
+    USERPROFILE: tmp,
     CODEX_HOME: path.join(tmp, ".codex"),
     OPENCODE_CONFIG_DIR: path.join(tmp, ".config", "opencode"),
   };

--- a/test/notify-debug-log.test.js
+++ b/test/notify-debug-log.test.js
@@ -54,6 +54,7 @@ async function setupInitEnv() {
   const env = {
     ...process.env,
     HOME: tmp,
+    USERPROFILE: tmp,
     CODEX_HOME: codexHome,
     OPENCODE_CONFIG_DIR: path.join(tmp, ".config", "opencode"),
   };

--- a/test/runtime-config.test.js
+++ b/test/runtime-config.test.js
@@ -29,6 +29,24 @@ test("resolveRuntimeConfig ignores non-TOKENTRACKER env inputs", () => {
   assert.equal(result.sources.deviceToken, "default");
 });
 
+test("resolveRuntimeConfig recovers from the leaked Windows test base URL", () => {
+  const recovered = resolveRuntimeConfig({
+    config: { baseUrl: "https://example.invalid" },
+    env: {},
+  });
+
+  assert.equal(recovered.baseUrl, "https://srctyff5.us-east.insforge.app");
+  assert.equal(recovered.sources.baseUrl, "default");
+
+  const explicit = resolveRuntimeConfig({
+    cli: { baseUrl: "https://example.invalid" },
+    config: { baseUrl: "https://config.example" },
+    env: {},
+  });
+  assert.equal(explicit.baseUrl, "https://example.invalid");
+  assert.equal(explicit.sources.baseUrl, "cli");
+});
+
 test("resolveRuntimeConfig normalizes timeout and flags", () => {
   const result = resolveRuntimeConfig({
     env: {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -17,11 +17,13 @@ function runSql(dbPath, sql) {
 test("status prints last upload timestamps from upload.throttle.json", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-"));
   const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
   const prevCodexHome = process.env.CODEX_HOME;
   const prevWrite = process.stdout.write;
 
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
 
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
@@ -37,7 +39,7 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
     await fs.writeFile(
       path.join(trackerDir, "config.json"),
       JSON.stringify(
-        { baseUrl: "https://example.invalid", deviceToken: "t", deviceId: "d" },
+        { baseUrl: "https://config.example", deviceToken: "t", deviceId: "d" },
         null,
         2,
       ) + "\n",
@@ -81,7 +83,7 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
 
     await cmdStatus();
 
-    assert.match(out, /- Base URL: https:\/\/example\.invalid/);
+    assert.match(out, /- Base URL: https:\/\/config\.example/);
     assert.match(out, /- Last upload: 2025-12-18T10:19:05\.522Z/);
     assert.match(out, /- Last OpenClaw-triggered sync: 2026-02-12T00:00:00.000Z/);
     assert.match(out, /- Next upload after: 2025-12-18T10:19:06\.522Z/);
@@ -89,6 +91,8 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -98,11 +102,13 @@ test("status prints last upload timestamps from upload.throttle.json", async () 
 test("status reports Codex notify unset when config points to another command", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-notify-"));
   const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
   const prevCodexHome = process.env.CODEX_HOME;
   const prevWrite = process.stdout.write;
 
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
 
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
@@ -115,7 +121,7 @@ test("status reports Codex notify unset when config points to another command", 
     );
     await fs.writeFile(
       path.join(trackerDir, "config.json"),
-      JSON.stringify({ baseUrl: "https://example.invalid", deviceToken: "t" }) + "\n",
+      JSON.stringify({ baseUrl: "https://config.example", deviceToken: "t" }) + "\n",
       "utf8",
     );
 
@@ -133,6 +139,8 @@ test("status reports Codex notify unset when config points to another command", 
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -142,11 +150,13 @@ test("status reports Codex notify unset when config points to another command", 
 test("status JSON reports Copilot canonical store diagnostics", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-copilot-"));
   const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
   const prevCodexHome = process.env.CODEX_HOME;
   const prevWrite = process.stdout.write;
 
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
     const trackerDir = path.join(tmp, ".tokentracker", "tracker");
     const copilotHome = path.join(tmp, ".copilot");
@@ -231,6 +241,8 @@ test("status JSON reports Copilot canonical store diagnostics", async () => {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });
@@ -286,11 +298,13 @@ test("status native-only mode does not probe WSL distros", async (t) => {
 test("status does not migrate legacy tracker directory", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-legacy-"));
   const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
   const prevCodexHome = process.env.CODEX_HOME;
   const prevWrite = process.stdout.write;
 
   try {
     process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
     process.env.CODEX_HOME = path.join(tmp, ".codex");
 
     const legacyTrackerDir = path.join(tmp, ".legacy-tracker-root", "tracker");
@@ -354,6 +368,8 @@ test("status does not migrate legacy tracker directory", async () => {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
     if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevCodexHome;
     await fs.rm(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- isolate the remaining Windows init subprocess tests with both HOME and USERPROFILE so they cannot modify the developer's real TokenTracker config
- isolate status tests from the real Windows profile as well
- ignore the reserved https://example.invalid fixture when it appears in persisted runtime config and fall back to the official InsForge endpoint
- preserve explicit CLI overrides for deliberate test and development commands

## Root cause

Two subprocess tests still redirected only HOME. On Windows, os.homedir() reads USERPROFILE, so a local test run could write the fixture base URL into the real config.json. Cloud upload then targeted an unreachable host and entered exponential backoff. PR #309 fixed one fixture, but these two paths remained.

## Validation

- reproduced locally: config changed at the test-run timestamp, cloud upload stopped at the same point, and upload.throttle.json recorded fetch failed with backoff step 7
- repaired the affected Windows install and drained the queue: 7 rows uploaded successfully
- verified the account summary switched from local fallback to cloud account view
- 44 runtime-config and local API cloud-sync tests passed
- init, notify, runtime-config, and isolated status tests passed; the real config SHA-256 remained unchanged after the test run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of the saved base URL so placeholder/invalid values no longer override the correct result.
  * Enhanced recovery behavior so corrupted persisted base URL values fall back to a sensible default.
  * Ensured command-line base URL inputs still take priority over saved settings.
* **Tests**
  * Updated runtime and status-related tests to consistently set and preserve `USERPROFILE` across environments.
  * Adjusted expected `status` output to reflect the corrected base URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->