### PR TITLE
feat: add combined all-model usage ranking

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -666,6 +666,10 @@ usage.overview.expand,ui,DashboardPage,UsageOverview,expand,"expand",,active
 usage.overview.collapse,ui,DashboardPage,UsageOverview,collapse,"collapse",,active
 usage.overview.model_count,ui,DashboardPage,UsageOverview,model_count,"{{count}} models",,active
 usage.overview.model_details_aria,ui,DashboardPage,UsageOverview,model_details_aria,"{{provider}} model details",,active
+usage.overview.all_tools,ui,DashboardPage,UsageOverview,all_tools,"All",,active
+usage.overview.all_models,ui,DashboardPage,UsageOverview,all_models,"All models",,active
+usage.overview.all_models_note,ui,DashboardPage,UsageOverview,all_models_note,"Models with the same name are combined across tools and ranked by total usage.",,active
+usage.overview.all_tools_card_aria,ui,DashboardPage,UsageOverview,all_tools_card_aria,"All tools: {{tokens}} tokens, {{cost}}, {{count}} models. Show combined model ranking",,active
 usage.overview.cache_hit_rate_label,ui,DashboardPage,UsageOverview,cache_hit_rate_label,"Cache hit rate",,active
 usage.overview.cache_hit_rate_detail,ui,DashboardPage,UsageOverview,cache_hit_rate_detail,"{{reused}} reused / {{input}} input",,active
 usage.overview.antigravity_notice_title,ui,DashboardPage,UsageOverview,antigravity_notice_title,"Estimated tokens",,active

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -1,4 +1,8 @@
 {
+  "usage.overview.all_tools": "Alle",
+  "usage.overview.all_models": "Alle Modelle",
+  "usage.overview.all_models_note": "Gleichnamige Modelle werden werkzeugübergreifend zusammengeführt und nach Gesamtnutzung sortiert.",
+  "usage.overview.all_tools_card_aria": "Alle Werkzeuge: {{tokens}} Token, {{cost}}, {{count}} Modelle. Zusammengeführte Modellrangliste anzeigen",
   "usage.overview.antigravity_notice_title": "Token sind Schätzwerte",
   "usage.overview.antigravity_notice_body": "Antigravity-Lokalprotokolle enthalten keine tatsächlichen Nutzungsdaten, daher werden die Werte hier aus der Zeichenanzahl (ca. 4 Zeichen/Token) geschätzt, ohne Gemini Prompt-Cache-Rabatte. Betrachte diese Werte als grobe Obergrenze und nicht als Rechnungsgrundlage.",
   "stats.period.today": "Heute",

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -1,4 +1,8 @@
 {
+  "usage.overview.all_tools": "すべて",
+  "usage.overview.all_models": "すべてのモデル",
+  "usage.overview.all_models_note": "同じ名前のモデルはツールをまたいで集計され、合計使用量順に表示されます。",
+  "usage.overview.all_tools_card_aria": "すべてのツール：{{tokens}}トークン、{{cost}}、{{count}}モデル。統合モデルランキングを表示",
   "usage.overview.antigravity_notice_title": "トークンは推定値です",
   "usage.overview.cache_hit_rate_label": "キャッシュヒット率",
   "usage.overview.cache_hit_rate_detail": "{{reused}} 再利用 / {{input}} 入力",

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -1,4 +1,8 @@
 {
+  "usage.overview.all_tools": "전체",
+  "usage.overview.all_models": "전체 모델",
+  "usage.overview.all_models_note": "이름이 같은 모델은 도구 전체에서 합산되어 총사용량순으로 표시됩니다.",
+  "usage.overview.all_tools_card_aria": "전체 도구: {{tokens}} 토큰, {{cost}}, 모델 {{count}}개. 통합 모델 순위 표시",
   "usage.overview.antigravity_notice_title": "추정 토큰",
   "usage.overview.cache_hit_rate_label": "캐시 적중률",
   "usage.overview.cache_hit_rate_detail": "{{reused}} 재사용 / {{input}} 입력",

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -1,4 +1,8 @@
 {
+  "usage.overview.all_tools": "全部",
+  "usage.overview.all_models": "全部模型",
+  "usage.overview.all_models_note": "同名模型會跨工具合併，並按總用量排序。",
+  "usage.overview.all_tools_card_aria": "全部工具：{{tokens}} Token，{{cost}}，{{count}} 個模型。顯示合併後的模型排行",
   "usage.overview.antigravity_notice_title": "Token 為估算值",
   "usage.overview.cache_hit_rate_label": "快取命中率",
   "usage.overview.cache_hit_rate_detail": "{{reused}} 重用 / {{input}} 輸入",

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -1,4 +1,8 @@
 {
+  "usage.overview.all_tools": "全部",
+  "usage.overview.all_models": "全部模型",
+  "usage.overview.all_models_note": "同名模型会跨工具合并，并按总用量排序。",
+  "usage.overview.all_tools_card_aria": "全部工具：{{tokens}} Token，{{cost}}，{{count}} 个模型。显示合并后的模型排行",
   "usage.overview.antigravity_notice_title": "Token 为估算值",
   "usage.overview.cache_hit_rate_label": "缓存命中率",
   "usage.overview.cache_hit_rate_detail": "{{reused}} 复用 / {{input}} 输入",

--- a/dashboard/src/lib/model-breakdown.test.ts
+++ b/dashboard/src/lib/model-breakdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildFleetData } from "./model-breakdown";
+import { buildAllModels, buildFleetData } from "./model-breakdown";
 
 describe("buildFleetData", () => {
   it("keeps two decimal places for small provider percentages", () => {
@@ -30,5 +30,32 @@ describe("buildFleetData", () => {
     ]);
     expect(fleet[2].totalPercentValue).toBeGreaterThan(0);
     expect(fleet[2].totalPercentValue).toBeLessThan(0.01);
+  });
+});
+
+describe("buildAllModels", () => {
+  it("combines the same model across tools and ranks every personal model", () => {
+    const models = buildAllModels([
+      {
+        label: "CODEX",
+        models: [
+          { id: "gpt-5.6", name: "GPT-5.6", usage: 70, cost: 0.7 },
+          { id: "gpt-5.5", name: "gpt-5.5", usage: 20, cost: 0.2 },
+        ],
+      },
+      {
+        label: "CURSOR",
+        models: [
+          { id: "gpt-5.6", name: "gpt-5.6", usage: 30, cost: 0.3 },
+          { id: "claude", name: "claude-sonnet", usage: 80, cost: null },
+        ],
+      },
+    ]);
+
+    expect(models).toEqual([
+      { id: "gpt-5.6", name: "GPT-5.6", usage: 100, cost: 1, share: 50 },
+      { id: "claude-sonnet", name: "claude-sonnet", usage: 80, cost: null, share: 40 },
+      { id: "gpt-5.5", name: "gpt-5.5", usage: 20, cost: 0.2, share: 10 },
+    ]);
   });
 });

--- a/dashboard/src/lib/model-breakdown.ts
+++ b/dashboard/src/lib/model-breakdown.ts
@@ -108,6 +108,70 @@ export function buildFleetData(modelBreakdown: any, { copyFn }: AnyRecord = {}) 
     });
 }
 
+/**
+ * Flatten the provider-oriented fleet data into one personal model ranking.
+ * The same model name can be emitted by several tools, so names are matched
+ * case-insensitively and their token/cost totals are combined before ranking.
+ */
+export function buildAllModels(fleetData: any) {
+  const providers: any[] = Array.isArray(fleetData) ? fleetData : [];
+  const byModel = new Map();
+
+  for (const provider of providers) {
+    const models: any[] = Array.isArray(provider?.models) ? provider.models : [];
+    for (const model of models) {
+      const usage = toFiniteNumber(model?.usage);
+      if (usage == null || usage <= 0) continue;
+      const name = typeof model?.name === "string" && model.name.trim()
+        ? model.name.trim()
+        : typeof model?.id === "string" && model.id.trim()
+          ? model.id.trim()
+          : null;
+      const key = normalizeModelId(name);
+      if (!key) continue;
+
+      const current = byModel.get(key) || {
+        id: key,
+        name,
+        usage: 0,
+        cost: 0,
+        hasCost: false,
+        nameWeight: 0,
+      };
+      current.usage += usage;
+      const cost = toFiniteNumber(model?.cost);
+      if (cost != null) {
+        current.cost += cost;
+        current.hasCost = true;
+      }
+      // Preserve the spelling from the source that contributes the most.
+      if (usage >= current.nameWeight) {
+        current.name = name;
+        current.nameWeight = usage;
+      }
+      byModel.set(key, current);
+    }
+  }
+
+  const totalUsage = Array.from(byModel.values())
+    .reduce((sum, model) => sum + model.usage, 0);
+
+  return Array.from(byModel.values())
+    .map((model) => ({
+      id: model.id,
+      name: model.name,
+      usage: model.usage,
+      cost: model.hasCost ? model.cost : null,
+      share: totalUsage > 0
+        ? Math.round((model.usage / totalUsage) * 1000) / 10
+        : 0,
+    }))
+    .sort((a, b) => {
+      if (b.usage !== a.usage) return b.usage - a.usage;
+      return String(a.name).localeCompare(String(b.name));
+    });
+}
+
 export function buildTopModels(modelBreakdown: any, { limit = 3, copyFn }: AnyRecord = {}) {
   const safeCopy = typeof copyFn === "function" ? copyFn : (key: string) => key;
   const sources: any[] = Array.isArray(modelBreakdown?.sources) ? modelBreakdown.sources : [];

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { motion, useReducedMotion } from "motion/react";
-import { Info, Loader2, SquareArrowOutUpRight } from "lucide-react";
+import { Info, Layers3, Loader2, SquareArrowOutUpRight } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { Card, Button, Counter } from "../../components";
 import { Select } from "../../components/Select.jsx";
@@ -13,7 +13,11 @@ import { formatProviderDisplayName } from "../../../lib/provider-display";
 import { DateRangePopover, formatDateShort, getDateFnsLocale } from "./DateRangePopover.jsx";
 import { ProviderIcon } from "./ProviderIcon.jsx";
 import { formatUsdCurrency } from "../../../lib/format";
+import { buildAllModels } from "../../../lib/model-breakdown";
 import { ContextBreakdownPanel } from "./ContextBreakdownPanel.jsx";
+
+const ALL_PROVIDERS_KEY = "__all__";
+const FULL_SHARE_LABEL = `${(100).toFixed(2)}%`;
 
 function formatPositiveTokens(formatter, value) {
   const n = Number(value);
@@ -222,7 +226,7 @@ export function UsageOverview({
       el.scrollIntoView({ block: "nearest", inline: "center" });
     }
   }, [period]);
-  const [expandedProvider, setExpandedProvider] = useState(null);
+  const [expandedProvider, setExpandedProvider] = useState(ALL_PROVIDERS_KEY);
   const { resolvedTheme } = useTheme();
   const { currency, rate } = useCurrency();
   const { formatTokens } = useTokenFormat();
@@ -232,6 +236,12 @@ export function UsageOverview({
 
   const showSummarySkeleton = summaryLoading && !hasSummary;
   const showProviderSkeleton = providersLoading && !fleetData.some(hasProviderModels);
+
+  // A new time/device scope opens on the combined personal model ranking.
+  // Provider drill-down remains available, but is secondary.
+  useEffect(() => {
+    setExpandedProvider(ALL_PROVIDERS_KEY);
+  }, [period, from, to, selectedDevice]);
 
   const handleTablistKeyDown = (event) => {
     if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
@@ -273,6 +283,15 @@ export function UsageOverview({
 
   // FleetData is already grouped by provider.
   const providers = fleetData.filter((f) => f.models?.length > 0);
+  const allModels = useMemo(() => buildAllModels(fleetData), [fleetData]);
+  const allUsage = allModels.reduce((sum, model) => sum + (Number(model.usage) || 0), 0);
+  const allCost = providers.reduce((sum, provider) => sum + (Number(provider.usd) || 0), 0);
+  const activeProvider =
+    expandedProvider === ALL_PROVIDERS_KEY || providers.some(function matchesExpandedProvider(provider) {
+      return provider.label === expandedProvider;
+    })
+      ? expandedProvider
+      : ALL_PROVIDERS_KEY;
 
   return (
     <Card className={className}>
@@ -464,9 +483,38 @@ export function UsageOverview({
             {/* Provider Cards — responsive grid keeps cells equal-width so the
                 last row never stretches when the count doesn't divide evenly. */}
             <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3">
+              <button
+                type="button"
+                aria-expanded={activeProvider === ALL_PROVIDERS_KEY}
+                aria-controls="provider-details-all"
+                aria-label={copy("usage.overview.all_tools_card_aria", {
+                  tokens: formatPositiveTokens(formatTokens, allUsage) || String(0),
+                  cost: formatCost(allCost, currency, rate) || `${getCurrencySymbol(currency)}0`,
+                  count: allModels.length,
+                })}
+                onClick={() => setExpandedProvider(ALL_PROVIDERS_KEY)}
+                className={`min-w-0 text-left p-3 rounded-lg border transition-colors duration-200 ${
+                  activeProvider === ALL_PROVIDERS_KEY
+                    ? "border-oai-gray-300 dark:border-oai-gray-600 bg-oai-gray-50 dark:bg-oai-gray-800"
+                    : "border-oai-gray-200 dark:border-oai-gray-700 hover:border-oai-gray-300 dark:hover:border-oai-gray-600"
+                }`}
+              >
+                <div className="flex items-center gap-1.5 mb-1 min-w-0">
+                  <Layers3 className="size-[15px] shrink-0 text-oai-brand" aria-hidden="true" />
+                  <span className="text-sm font-medium text-oai-black dark:text-oai-white truncate">
+                    {copy("usage.overview.all_tools")}
+                  </span>
+                </div>
+                <div className="text-lg font-semibold text-oai-black dark:text-oai-white tabular-nums">
+                  {FULL_SHARE_LABEL}
+                </div>
+                <div className="mt-0.5 text-[11px] text-oai-gray-400 dark:text-oai-gray-400 tabular-nums">
+                  {copy("usage.overview.model_count", { count: allModels.length })}
+                </div>
+              </button>
               {providers.map((provider, idx) => {
                 const color = getProviderColor(provider.label, idx);
-                const isExpanded = expandedProvider === provider.label;
+                const isExpanded = activeProvider === provider.label;
                 const displayLabel = formatProviderDisplayName(provider.label);
                 const percentLabel = formatProviderPercent(provider);
 
@@ -482,7 +530,7 @@ export function UsageOverview({
                       cost: formatCost(provider.usd, currency, rate) || `${getCurrencySymbol(currency)}0`,
                       action: copy(isExpanded ? "usage.overview.collapse" : "usage.overview.expand"),
                     })}
-                    onClick={() => setExpandedProvider(isExpanded ? null : provider.label)}
+                    onClick={() => setExpandedProvider(isExpanded ? ALL_PROVIDERS_KEY : provider.label)}
                     className={`min-w-0 text-left p-3 rounded-lg border transition-colors duration-200 ${
                       isExpanded
                         ? "border-oai-gray-300 dark:border-oai-gray-600 bg-oai-gray-50 dark:bg-oai-gray-800"
@@ -504,18 +552,27 @@ export function UsageOverview({
               })}
             </div>
 
-            {/* Expanded Provider Details */}
-            {expandedProvider && (
+            {/* The combined model ranking is the default. */}
+            {activeProvider === ALL_PROVIDERS_KEY ? (
               <div
-                id={`provider-details-${expandedProvider}`}
+                id="provider-details-all"
+                role="region"
+                aria-label={copy("usage.overview.all_models")}
+                className="mt-2"
+              >
+                <AllModelsSection models={allModels} />
+              </div>
+            ) : (
+              <div
+                id={`provider-details-${activeProvider}`}
                 role="region"
                 aria-label={copy("usage.overview.model_details_aria", {
-                  provider: expandedProvider,
+                  provider: activeProvider,
                 })}
                 className="mt-2"
               >
                 {providers
-                  .filter((p) => p.label === expandedProvider)
+                  .filter((p) => p.label === activeProvider)
                   .map((provider) => {
                     const color = getProviderColor(provider.label, 0);
                     const contextSource = resolveContextBreakdownSource(provider);
@@ -552,9 +609,80 @@ export function UsageOverview({
 // Renders a single expanded provider section. Hosts loading state for the
 // inline Context Breakdown so the spinner can sit next to the heading instead
 // of taking its own row.
-function ProviderExpandedSection({ provider, color, providerHeading, contextSource, from, to, sortedModels }) {
+function ModelUsageRows({ models, color }) {
   const { currency, rate } = useCurrency();
   const { formatTokens, formatTokensTooltip } = useTokenFormat();
+
+  return (
+    <div className="space-y-3">
+      {models.map((model) => {
+        const tokensLabel = formatPositiveTokens(formatTokens, model.usage);
+        const costLabel = formatCost(model.cost, currency, rate);
+        const clampedShare = Math.max(0, Math.min(100, Number(model.share) || 0));
+        return (
+          <div key={model.id || model.name} data-model-rank-row>
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,max-content)_minmax(5.5rem,max-content)_4rem] items-baseline gap-x-3 mb-1.5">
+              <span
+                className="col-start-1 row-start-1 min-w-0 text-sm text-oai-gray-700 dark:text-oai-gray-300 truncate"
+                title={model.name}
+              >
+                {model.name}
+              </span>
+              <span
+                title={formatTokensTooltip(model.usage)}
+                className="col-start-2 row-start-1 text-right whitespace-nowrap text-sm text-oai-gray-500 dark:text-oai-gray-400 tabular-nums"
+              >
+                {tokensLabel}
+              </span>
+              <span className="col-start-3 row-start-1 text-right whitespace-nowrap text-sm text-oai-gray-500 dark:text-oai-gray-400 tabular-nums">
+                {costLabel}
+              </span>
+              <span className="col-start-4 row-start-1 text-right whitespace-nowrap text-sm text-oai-black dark:text-oai-white tabular-nums">
+                {model.share}%
+              </span>
+            </div>
+            <div
+              className="h-[3px] bg-oai-gray-100 dark:bg-oai-gray-800 rounded-full overflow-hidden"
+              role="progressbar"
+              aria-valuenow={clampedShare}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div
+                className="h-full transition-[width] duration-500 ease-out"
+                style={{
+                  width: `${clampedShare}%`,
+                  backgroundColor: color,
+                  opacity: 0.45,
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function AllModelsSection({ models }) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <Layers3 className="size-3.5 shrink-0 text-oai-brand" aria-hidden="true" />
+        <span className="text-sm font-medium text-oai-black dark:text-oai-white">
+          {copy("usage.overview.all_models")}
+        </span>
+      </div>
+      <p className="mb-4 text-[11px] leading-snug text-oai-gray-500 dark:text-oai-gray-400">
+        {copy("usage.overview.all_models_note")}
+      </p>
+      <ModelUsageRows models={models} color="var(--oai-blue)" />
+    </div>
+  );
+}
+
+function ProviderExpandedSection({ provider, color, providerHeading, contextSource, from, to, sortedModels }) {
+  const { formatTokens } = useTokenFormat();
   const [breakdownLoading, setBreakdownLoading] = useState(false);
   const isAntigravity =
     String(provider?.source || provider?.label || "").trim().toLowerCase() === "antigravity";
@@ -623,53 +751,7 @@ function ProviderExpandedSection({ provider, color, providerHeading, contextSour
                         ) : null}
 
                         {/* Model rows — text line + thin muted bar as visual rhythm */}
-                        <div className="space-y-3">
-                          {sortedModels.map((model) => {
-                            const tokensLabel = formatPositiveTokens(formatTokens, model.usage);
-                            const costLabel = formatCost(model.cost, currency, rate);
-                            const clampedShare = Math.max(0, Math.min(100, Number(model.share) || 0));
-                            return (
-                              <div key={model.id || model.name}>
-                                <div className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,max-content)_minmax(5.5rem,max-content)_4rem] items-baseline gap-x-3 mb-1.5">
-                                  <span
-                                    className="col-start-1 row-start-1 min-w-0 text-sm text-oai-gray-700 dark:text-oai-gray-300 truncate"
-                                    title={model.name}
-                                  >
-                                    {model.name}
-                                  </span>
-                                  <span
-                                    title={formatTokensTooltip(model.usage)}
-                                    className="col-start-2 row-start-1 text-right whitespace-nowrap text-sm text-oai-gray-500 dark:text-oai-gray-400 tabular-nums"
-                                  >
-                                    {tokensLabel}
-                                  </span>
-                                  <span className="col-start-3 row-start-1 text-right whitespace-nowrap text-sm text-oai-gray-500 dark:text-oai-gray-400 tabular-nums">
-                                    {costLabel}
-                                  </span>
-                                  <span className="col-start-4 row-start-1 text-right whitespace-nowrap text-sm text-oai-black dark:text-oai-white tabular-nums">
-                                    {model.share}%
-                                  </span>
-                                </div>
-                                <div
-                                  className="h-[3px] bg-oai-gray-100 dark:bg-oai-gray-800 rounded-full overflow-hidden"
-                                  role="progressbar"
-                                  aria-valuenow={clampedShare}
-                                  aria-valuemin={0}
-                                  aria-valuemax={100}
-                                >
-                                  <div
-                                    className="h-full transition-[width] duration-500 ease-out"
-                                    style={{
-                                      width: `${clampedShare}%`,
-                                      backgroundColor: color,
-                                      opacity: 0.45,
-                                    }}
-                                  />
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
+                        <ModelUsageRows models={sortedModels} color={color} />
                       </div>
   );
 }

--- a/dashboard/src/ui/dashboard/components/__tests__/UsageOverview.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/UsageOverview.test.jsx
@@ -63,7 +63,8 @@ describe("UsageOverview", () => {
     );
 
     expect(screen.getByRole("status")).toHaveTextContent(copy("qpd.card.updating"));
-    expect(screen.getByText("6.7M").closest('[aria-busy="true"]')).toBeTruthy();
+    expect(document.querySelector("[data-counter-root]")).toHaveTextContent("6.7M");
+    expect(document.querySelector("[data-counter-root]").closest('[aria-busy="true"]')).toBeTruthy();
     expect(screen.getByText("CODEX")).toBeVisible();
   });
 
@@ -108,6 +109,72 @@ describe("UsageOverview", () => {
 
     expect(weekTab).toHaveFocus();
     expect(onPeriodChange).toHaveBeenCalledWith("week");
+  });
+
+  it("defaults to an all-tools model ranking and combines matching models", async () => {
+    const user = userEvent.setup();
+    const fleetData = [
+      {
+        source: "codex",
+        label: "CODEX",
+        totalPercent: "60.00",
+        usage: 90,
+        usd: 0.9,
+        models: [
+          { id: "gpt-5.6", name: "GPT-5.6", share: 77.8, usage: 70, cost: 0.7 },
+          { id: "gpt-5.5", name: "gpt-5.5", share: 22.2, usage: 20, cost: 0.2 },
+        ],
+      },
+      {
+        source: "cursor",
+        label: "CURSOR",
+        totalPercent: "40.00",
+        usage: 60,
+        usd: 0.6,
+        models: [
+          { id: "gpt-5.6", name: "gpt-5.6", share: 50, usage: 30, cost: 0.3 },
+          { id: "claude", name: "claude-sonnet", share: 50, usage: 30, cost: 0.3 },
+        ],
+      },
+    ];
+
+    const { container, rerender } = render(
+      <UsageOverview
+        period="month"
+        periods={["month", "total"]}
+        summaryLabel="Total"
+        summaryValue="150"
+        fleetData={fleetData}
+        from="2026-07-01"
+        to="2026-07-31"
+      />,
+    );
+
+    const allButton = screen.getByRole("button", { name: /All tools:/i });
+    const codexButton = screen.getByRole("button", { name: /CODEX:/i });
+    expect(allButton).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelectorAll("[data-model-rank-row]")).toHaveLength(3);
+    expect(screen.getByText("66.7%")).toBeVisible();
+
+    await act(async () => {
+      await user.click(codexButton);
+    });
+    expect(codexButton).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelectorAll("[data-model-rank-row]")).toHaveLength(2);
+
+    rerender(
+      <UsageOverview
+        period="total"
+        periods={["month", "total"]}
+        summaryLabel="Total"
+        summaryValue="150"
+        fleetData={fleetData}
+        from="2025-01-01"
+        to="2026-07-31"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /All tools:/i })).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelectorAll("[data-model-rank-row]")).toHaveLength(3);
   });
 
   it("renders AnythingLLM with its official name, icon, and stable accent", () => {

--- a/test/model-breakdown.test.js
+++ b/test/model-breakdown.test.js
@@ -208,6 +208,32 @@ test("buildTopModels aggregates by model name across sources", async () => {
   assert.equal(topModels[1].percent, "20.0");
 });
 
+test("buildAllModels creates a complete cross-tool personal model ranking", async () => {
+  const mod = await loadDashboardModule("dashboard/src/lib/model-breakdown.ts");
+  const models = mod.buildAllModels([
+    {
+      label: "CODEX",
+      models: [
+        { id: "gpt-5.6", name: "GPT-5.6", usage: 70, cost: 0.7 },
+        { id: "gpt-5.5", name: "gpt-5.5", usage: 20, cost: 0.2 },
+      ],
+    },
+    {
+      label: "CURSOR",
+      models: [
+        { id: "gpt-5.6", name: "gpt-5.6", usage: 30, cost: 0.3 },
+        { id: "claude", name: "claude-sonnet", usage: 80, cost: null },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(models, [
+    { id: "gpt-5.6", name: "GPT-5.6", usage: 100, cost: 1, share: 50 },
+    { id: "claude-sonnet", name: "claude-sonnet", usage: 80, cost: null, share: 40 },
+    { id: "gpt-5.5", name: "gpt-5.5", usage: 20, cost: 0.2, share: 10 },
+  ]);
+});
+
 test("buildTopModels computes percent using billable tokens across all models", async () => {
   const mod = await loadDashboardModule("dashboard/src/lib/model-breakdown.ts");
   const buildTopModels = mod.buildTopModels;


### PR DESCRIPTION
## Summary

- Add an **All** tools card that is selected by default in the usage overview.
- Merge same-named models case-insensitively across tools and rank the complete personal model usage by tokens.
- Keep provider drill-downs available and reset to the combined ranking when the time range, date, or device scope changes.
- Add localized copy for English, Simplified Chinese, Traditional Chinese, Japanese, Korean, and German.

## Verification

- `node --test test/model-breakdown.test.js` (20/20)
- Dashboard Vitest targeted tests (13/13)
- Dashboard typecheck, ESLint, production build, copy validation, and UI hardcode validation
- Local browser check confirms default All view, provider drill-down, Total reset, and no horizontal overflow at 560px/720px

The repository-wide `ci:local` run was also attempted on Windows; unrelated existing environment-sensitive tests fail because this machine lacks sqlite3 and cannot create some symlinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “All tools” view to the usage overview, combining model usage across tools.
  * Added aggregated model rankings with usage share, token totals, costs, and model counts.
  * Added explanatory notes and accessibility labels for the combined view in German, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added coverage for cross-tool model aggregation, cost handling, sorting, percentages, and view switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->