### PR TITLE
fix: prevent stale syncs and reduce idle energy

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/ServerHealthCheckPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/ServerHealthCheckPolicy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum ServerHealthCheckPolicy {
+    enum Ownership {
+        case ownedProcess
+        case externalProcess
+    }
+
+    static let ownedProcessInterval: TimeInterval = 5 * 60
+    static let externalProcessInterval: TimeInterval = 30
+
+    static func interval(for ownership: Ownership) -> TimeInterval {
+        switch ownership {
+        case .ownedProcess:
+            return ownedProcessInterval
+        case .externalProcess:
+            return externalProcessInterval
+        }
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/ServerManager.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/ServerManager.swift
@@ -40,7 +40,7 @@ final class ServerManager: ObservableObject {
         } else if await APIClient.shared.checkServerHealth() {
             // No embedded server, but an external one is already running — reuse it
             status = .running
-            startHealthCheckLoop()
+            startHealthCheckLoop(ownership: .externalProcess)
             return
         } else if let binaryPath = findTokenTrackerBinary() {
             // Fall back to system-installed CLI
@@ -54,7 +54,7 @@ final class ServerManager: ObservableObject {
         let started = await waitForServer(timeout: 15)
         if started {
             status = .running
-            startHealthCheckLoop()
+            startHealthCheckLoop(ownership: .ownedProcess)
         } else {
             status = .failed(Strings.serverNotResponding(port: Constants.serverPort))
         }
@@ -268,11 +268,12 @@ final class ServerManager: ObservableObject {
 
     // MARK: - Health Check Loop
 
-    private func startHealthCheckLoop() {
+    private func startHealthCheckLoop(ownership: ServerHealthCheckPolicy.Ownership) {
         healthCheckTask?.cancel()
+        let interval = ServerHealthCheckPolicy.interval(for: ownership)
         healthCheckTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
                 guard !Task.isCancelled, let self else { break }
                 let healthy = await APIClient.shared.checkServerHealth()
                 if healthy {

--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -51,6 +51,8 @@ struct ClawdCompanionView: View {
     @State private var lastTokens = 0
     @State private var modelStatusText: String? = nil
     @State private var modelStatusTask: Task<Void, Never>? = nil
+    @State private var blinkTask: Task<Void, Never>? = nil
+    @State private var idleVariantTask: Task<Void, Never>? = nil
 
     private let px: CGFloat = 4.0
     private let syncSpinPeriod: TimeInterval = 0.8
@@ -66,9 +68,20 @@ struct ClawdCompanionView: View {
             }
         }
         .onAppear {
-            startBlinkLoop()
-            startIdleVariantLoop()
+            updateDiscreteAnimationLoops(isVisible: isCharacterTimelineVisible)
             lastTokens = viewModel.todayTokens
+        }
+        .onChange(of: isCharacterTimelineVisible) { isVisible in
+            updateDiscreteAnimationLoops(isVisible: isVisible)
+        }
+        .onDisappear {
+            stopDiscreteAnimationLoops()
+            floatingBubbleTask?.cancel()
+            floatingBubbleTask = nil
+            modelStatusTask?.cancel()
+            modelStatusTask = nil
+            syncSpinStopTask?.cancel()
+            syncSpinStopTask = nil
         }
         .onChange(of: viewModel.todayTokens) { newTokens in
             if lastTokens > 0, newTokens > lastTokens {
@@ -1779,37 +1792,73 @@ struct ClawdCompanionView: View {
 
     /// Periodically switches between idle animations for visual variety
     private func startIdleVariantLoop() {
-        let delay = Double.random(in: 12...25)
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            var variants: [ClawdState] = [.idleLiving, .idleLook, .idleLiving, .idleLiving]
-            let tokens = viewModel.todayTokens
-            if tokens >= 200_000 { variants.append(.workingThinking) }
-            if tokens >= 500_000 { variants.append(.workingJuggling) }
-            // .workingOverheated is deliberately excluded: it draws the error visuals
-            // (X-eyes + red pulse), which must stay reserved for a real error state.
-            if tokens >= 2_000_000 { variants.append(.workingUltrathink) }
-            if viewModel.topModels.count >= 3 { variants.append(.workingJuggling) }
-            if (viewModel.heatmap?.streakDays ?? 0) >= 7 { variants.append(.workingWizard) }
-            idleVariant = variants.randomElement() ?? .idleLiving
-            startIdleVariantLoop()
+        guard idleVariantTask == nil else { return }
+        idleVariantTask = Task { @MainActor in
+            while !Task.isCancelled {
+                let delay = Double.random(in: 12...25)
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled else { break }
+
+                var variants: [ClawdState] = [.idleLiving, .idleLook, .idleLiving, .idleLiving]
+                let tokens = viewModel.todayTokens
+                if tokens >= 200_000 { variants.append(.workingThinking) }
+                if tokens >= 500_000 { variants.append(.workingJuggling) }
+                // .workingOverheated is deliberately excluded: it draws the error visuals
+                // (X-eyes + red pulse), which must stay reserved for a real error state.
+                if tokens >= 2_000_000 { variants.append(.workingUltrathink) }
+                if viewModel.topModels.count >= 3 { variants.append(.workingJuggling) }
+                if (viewModel.heatmap?.streakDays ?? 0) >= 7 { variants.append(.workingWizard) }
+                idleVariant = variants.randomElement() ?? .idleLiving
+            }
         }
     }
 
     // MARK: - Idle Blink
 
     private func startBlinkLoop() {
-        let delay = Double.random(in: 2.5...5.0)
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            guard clawdState != .sleeping && clawdState != .idleDoze else {
-                startBlinkLoop()
-                return
-            }
-            eyesClosed = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+        guard blinkTask == nil else { return }
+        blinkTask = Task { @MainActor in
+            while !Task.isCancelled {
+                let delay = Double.random(in: 2.5...5.0)
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled else { break }
+                guard clawdState != .sleeping && clawdState != .idleDoze else { continue }
+
+                eyesClosed = true
+                do {
+                    try await Task.sleep(nanoseconds: 120_000_000)
+                } catch {
+                    eyesClosed = false
+                    break
+                }
                 eyesClosed = false
-                startBlinkLoop()
             }
         }
+    }
+
+    private func updateDiscreteAnimationLoops(isVisible: Bool) {
+        if isVisible {
+            startBlinkLoop()
+            startIdleVariantLoop()
+        } else {
+            stopDiscreteAnimationLoops()
+        }
+    }
+
+    private func stopDiscreteAnimationLoops() {
+        blinkTask?.cancel()
+        blinkTask = nil
+        idleVariantTask?.cancel()
+        idleVariantTask = nil
+        eyesClosed = false
     }
 
     // MARK: - Types

--- a/TokenTrackerBar/TokenTrackerBarTests/ServerHealthCheckPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/ServerHealthCheckPolicyTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+final class ServerHealthCheckPolicyTests: XCTestCase {
+    func testOwnedServerUsesLowFrequencyHealthChecks() {
+        XCTAssertEqual(
+            ServerHealthCheckPolicy.interval(for: .ownedProcess),
+            5 * 60
+        )
+    }
+
+    func testExternalServerRetainsResponsiveHealthChecks() {
+        XCTAssertEqual(
+            ServerHealthCheckPolicy.interval(for: .externalProcess),
+            30
+        )
+    }
+
+    func testOwnedServerChecksAreAtLeastTenTimesLessFrequent() {
+        XCTAssertGreaterThanOrEqual(
+            ServerHealthCheckPolicy.ownedProcessInterval,
+            ServerHealthCheckPolicy.externalProcessInterval * 10
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -126,6 +126,7 @@ targets:
       - path: TokenTrackerBar/Services/ResumableDownloader.swift
       - path: TokenTrackerBar/Services/QueueActivityMonitor.swift
       - path: TokenTrackerBar/Models/CompanionAnimationPolicy.swift
+      - path: TokenTrackerBar/Models/ServerHealthCheckPolicy.swift
       # WeeklyLimitResetDetector's window labels come from Strings, which
       # resolves the locale via Shared/NativeLocalization (Shared is
       # Foundation-only by design, so pulling the whole dir stays cheap).

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -193,6 +193,10 @@ const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
 const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const NOTIFY_LOCK_WAIT_MS = 130_000;
 const NOTIFY_LOCK_POLL_MS = 5_000;
+// Local API sync requests have a 120-second child-process budget. Reserve at
+// least 30 seconds for parsing, persistence, and the response after contention.
+const PRIORITY_LOCK_WAIT_MS = 90_000;
+const PRIORITY_LOCK_POLL_MS = 250;
 const CODEX_COLD_SCAN_AUDIT_MAX_SYNCS = 288;
 // 0.57.0 mis-attributed mimocode's mirrored Claude/claude-mem history to
 // source=mimo (read the whole DB instead of only providerID=mimo rows). This
@@ -302,10 +306,34 @@ async function acquireSyncLock(
   {
     notifyWaitMs = NOTIFY_LOCK_WAIT_MS,
     notifyPollMs = NOTIFY_LOCK_POLL_MS,
+    priorityWaitMs = PRIORITY_LOCK_WAIT_MS,
+    priorityPollMs = PRIORITY_LOCK_POLL_MS,
   } = {},
 ) {
-  let lock = await openLock(lockPath, { quietIfLocked: opts.auto });
-  if (lock || !opts.fromNotify || notifyWaitMs <= 0) return lock;
+  const waitsForPriority = Boolean(opts.drain || opts.publishAccount);
+  let lock = await openLock(lockPath, {
+    quietIfLocked: opts.auto || waitsForPriority,
+  });
+  if (lock) return lock;
+
+  if (waitsForPriority) {
+    const deadline = Date.now() + Math.max(0, priorityWaitMs);
+    while (!lock && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      await sleep(Math.min(Math.max(1, priorityPollMs), remaining));
+      lock = await openLock(lockPath, { quietIfLocked: true });
+    }
+    if (!lock) {
+      const error = new Error(
+        "SYNC_BUSY: another sync is still running; no refresh was performed",
+      );
+      error.code = "SYNC_BUSY";
+      throw error;
+    }
+    return lock;
+  }
+
+  if (!opts.fromNotify || notifyWaitMs <= 0) return null;
 
   // One low-frequency waiter coalesces every notify that lands behind an
   // active native/background sync. This avoids both losing the final Codex
@@ -513,8 +541,11 @@ async function cmdSync(argv, context = {}) {
     }
 
     const codexColdSkipEnabled = opts.auto && sourceAllowed("codex");
+    const deferredCodexAuditSyncs = codexColdSkipEnabled
+      ? await cursorStore.readDeferredCodexAuditSyncs()
+      : 0;
     const codexColdAuditDue = codexColdSkipEnabled
-      ? isCodexColdScanAuditDue(cursors)
+      ? isCodexColdScanAuditDue(cursors, Date.now(), deferredCodexAuditSyncs)
       : false;
     let codexColdFilter = codexColdSkipEnabled
       ? await filterColdCodexRolloutFiles({
@@ -597,10 +628,12 @@ async function cmdSync(argv, context = {}) {
         warnProviderParseFailure("Codex", err, opts);
       }
     }
-    if (codexColdSkipEnabled && codexParseSucceeded) {
+    const codexAuditRecorded = codexColdSkipEnabled && codexParseSucceeded;
+    if (codexAuditRecorded) {
       recordCodexColdScanAudit(cursors, {
         fullAudit: codexColdAuditDue || codexFallbackRetryRan,
         skipped: codexColdFilter.skipped,
+        deferredSyncs: deferredCodexAuditSyncs,
       });
     }
 
@@ -1953,13 +1986,97 @@ async function cmdSync(argv, context = {}) {
       await applyCloudConversationsBackfill({ cursors, queueStatePath });
     }
 
-    cursors.updatedAt = new Date().toISOString();
-    await cursorStore.commit(cursors);
+    const totalParsed =
+      parseResult.filesProcessed +
+      openclawResult.filesProcessed +
+      claudeResult.filesProcessed +
+      geminiResult.filesProcessed +
+      antigravityResult.filesProcessed +
+      opencodeResult.filesProcessed +
+      cursorResult.recordsProcessed +
+      kiroResult.recordsProcessed +
+      kiroCliResult.recordsProcessed +
+      hermesResult.recordsProcessed +
+      kimiResult.recordsProcessed +
+      kimiCodeResult.recordsProcessed +
+      codebuddyResult.recordsProcessed +
+      workbuddyResult.recordsProcessed +
+      ompResult.recordsProcessed +
+      piResult.recordsProcessed +
+      craftResult.recordsProcessed +
+      grokResult.recordsProcessed +
+      copilotResult.recordsProcessed +
+      anythingllmResult.recordsProcessed +
+      kiloResult.recordsProcessed +
+      mimoResult.recordsProcessed +
+      zcodeResult.recordsProcessed +
+      kilocodeResult.recordsProcessed +
+      roocodeResult.recordsProcessed +
+      zedResult.recordsProcessed +
+      gooseResult.recordsProcessed +
+      droidResult.recordsProcessed;
+    const totalBuckets =
+      parseResult.bucketsQueued +
+      openclawResult.bucketsQueued +
+      claudeResult.bucketsQueued +
+      geminiResult.bucketsQueued +
+      antigravityResult.bucketsQueued +
+      opencodeResult.bucketsQueued +
+      cursorResult.bucketsQueued +
+      kiroResult.bucketsQueued +
+      kiroCliResult.bucketsQueued +
+      hermesResult.bucketsQueued +
+      kimiResult.bucketsQueued +
+      kimiCodeResult.bucketsQueued +
+      codebuddyResult.bucketsQueued +
+      workbuddyResult.bucketsQueued +
+      ompResult.bucketsQueued +
+      piResult.bucketsQueued +
+      craftResult.bucketsQueued +
+      grokResult.bucketsQueued +
+      copilotResult.bucketsQueued +
+      anythingllmResult.bucketsQueued +
+      kiloResult.bucketsQueued +
+      mimoResult.bucketsQueued +
+      zcodeResult.bucketsQueued +
+      kilocodeResult.bucketsQueued +
+      roocodeResult.bucketsQueued +
+      zedResult.bucketsQueued +
+      gooseResult.bucketsQueued +
+      droidResult.bucketsQueued;
+    const skipNoOpCursorCommit =
+      opts.auto &&
+      !isFullSourceScan &&
+      cursorStore.mode === "v2" &&
+      cursorStore.requiresCommit !== true &&
+      totalParsed === 0 &&
+      totalBuckets === 0 &&
+      !codexColdAuditDue &&
+      !codexFallbackRetryRan &&
+      !grokHookSignalConsumed &&
+      !opts.repairGrok;
+
     if (syncDiagnostics) {
-      const cursorStat = await fs.stat(cursorStore.currentCorePath);
-      syncDiagnostics.cursor_commits = Number(syncDiagnostics.cursor_commits || 0) + 1;
-      syncDiagnostics.cursor_bytes = Number(syncDiagnostics.cursor_bytes || 0) + cursorStat.size;
+      syncDiagnostics.cursor_commits = Number(syncDiagnostics.cursor_commits || 0);
+      syncDiagnostics.cursor_bytes = Number(syncDiagnostics.cursor_bytes || 0);
       syncDiagnostics.cursor_path = cursorStore.currentCorePath;
+    }
+    if (!skipNoOpCursorCommit) {
+      cursors.updatedAt = new Date().toISOString();
+      await cursorStore.commit(cursors);
+      if (codexAuditRecorded) {
+        await cursorStore.clearDeferredCodexAuditSyncs();
+      }
+      if (syncDiagnostics) {
+        const cursorStat = await fs.stat(cursorStore.currentCorePath);
+        syncDiagnostics.cursor_commits += 1;
+        syncDiagnostics.cursor_bytes += cursorStat.size;
+        syncDiagnostics.cursor_path = cursorStore.currentCorePath;
+      }
+    } else if (codexAuditRecorded) {
+      await cursorStore.writeDeferredCodexAuditSyncs(
+        deferredCodexAuditSyncs + 1,
+      );
     }
     if (grokHookSignalConsumed && grokHookSignalPath) {
       await fs.unlink(grokHookSignalPath).catch(() => {});
@@ -2074,64 +2191,6 @@ async function cmdSync(argv, context = {}) {
     }
 
     if (!opts.auto) {
-      const totalParsed =
-        parseResult.filesProcessed +
-        openclawResult.filesProcessed +
-        claudeResult.filesProcessed +
-        geminiResult.filesProcessed +
-        antigravityResult.filesProcessed +
-        opencodeResult.filesProcessed +
-        cursorResult.recordsProcessed +
-        kiroResult.recordsProcessed +
-        kiroCliResult.recordsProcessed +
-        hermesResult.recordsProcessed +
-        kimiResult.recordsProcessed +
-        kimiCodeResult.recordsProcessed +
-        codebuddyResult.recordsProcessed +
-        workbuddyResult.recordsProcessed +
-        ompResult.recordsProcessed +
-        piResult.recordsProcessed +
-        craftResult.recordsProcessed +
-        grokResult.recordsProcessed +
-        copilotResult.recordsProcessed +
-        anythingllmResult.recordsProcessed +
-        kiloResult.recordsProcessed +
-        mimoResult.recordsProcessed +
-        zcodeResult.recordsProcessed +
-        kilocodeResult.recordsProcessed +
-        roocodeResult.recordsProcessed +
-        zedResult.recordsProcessed +
-        gooseResult.recordsProcessed +
-        droidResult.recordsProcessed;
-      const totalBuckets =
-        parseResult.bucketsQueued +
-        openclawResult.bucketsQueued +
-        claudeResult.bucketsQueued +
-        geminiResult.bucketsQueued +
-        antigravityResult.bucketsQueued +
-        opencodeResult.bucketsQueued +
-        cursorResult.bucketsQueued +
-        kiroResult.bucketsQueued +
-        kiroCliResult.bucketsQueued +
-        hermesResult.bucketsQueued +
-        kimiResult.bucketsQueued +
-        kimiCodeResult.bucketsQueued +
-        codebuddyResult.bucketsQueued +
-        workbuddyResult.bucketsQueued +
-        ompResult.bucketsQueued +
-        piResult.bucketsQueued +
-        craftResult.bucketsQueued +
-        grokResult.bucketsQueued +
-        copilotResult.bucketsQueued +
-        anythingllmResult.bucketsQueued +
-        kiloResult.bucketsQueued +
-        mimoResult.bucketsQueued +
-        zcodeResult.bucketsQueued +
-        kilocodeResult.bucketsQueued +
-        roocodeResult.bucketsQueued +
-        zedResult.bucketsQueued +
-        gooseResult.bucketsQueued +
-        droidResult.bucketsQueued;
       process.stdout.write(
         [
           "Sync finished:",
@@ -2212,7 +2271,11 @@ function normalizeSyncSource(value) {
   return AUTO_SYNC_SOURCES.has(aliased) ? aliased : null;
 }
 
-function isCodexColdScanAuditDue(cursors, nowMs = Date.now()) {
+function isCodexColdScanAuditDue(
+  cursors,
+  nowMs = Date.now(),
+  deferredSyncs = 0,
+) {
   const state = cursors?.codexColdScanAudit;
   if (!state || typeof state !== "object" || state.version !== 1) return true;
   const lastFullScanAtMs = Number(state.lastFullScanAtMs);
@@ -2221,14 +2284,20 @@ function isCodexColdScanAuditDue(cursors, nowMs = Date.now()) {
   if (Number.isFinite(nowMs) && nowMs - lastFullScanAtMs >= CODEX_COLD_SCAN_AUDIT_INTERVAL_MS) {
     return true;
   }
-  const syncsSinceFullScan = Number(state.syncsSinceFullScan || 0);
+  const syncsSinceFullScan =
+    Number(state.syncsSinceFullScan || 0) +
+    Math.max(0, Number(deferredSyncs) || 0);
   return (
     Number.isFinite(syncsSinceFullScan) &&
     syncsSinceFullScan >= CODEX_COLD_SCAN_AUDIT_MAX_SYNCS
   );
 }
 
-function recordCodexColdScanAudit(cursors, { fullAudit = false, skipped = 0 } = {}, nowMs = Date.now()) {
+function recordCodexColdScanAudit(
+  cursors,
+  { fullAudit = false, skipped = 0, deferredSyncs = 0 } = {},
+  nowMs = Date.now(),
+) {
   if (!cursors || typeof cursors !== "object") return;
   const prev =
     cursors.codexColdScanAudit && typeof cursors.codexColdScanAudit === "object"
@@ -2241,9 +2310,9 @@ function recordCodexColdScanAudit(cursors, { fullAudit = false, skipped = 0 } = 
     lastFullScanAtMs: Number.isFinite(lastFullScanAtMs) && lastFullScanAtMs > 0
       ? lastFullScanAtMs
       : nowMs,
-    syncsSinceFullScan: Number.isFinite(previousSyncs) && previousSyncs > 0
-      ? previousSyncs
-      : 0,
+    syncsSinceFullScan:
+      (Number.isFinite(previousSyncs) && previousSyncs > 0 ? previousSyncs : 0) +
+      Math.max(0, Number(deferredSyncs) || 0),
     lastSkippedFiles: Math.max(0, Number(skipped) || 0),
     updatedAt: new Date(nowMs).toISOString(),
   };

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -14,6 +14,7 @@ const STORE_VERSION = 2;
 const STORE_DIRNAME = "cursor-store-v2";
 const MANIFEST_FILENAME = "manifest.json";
 const GENERATIONS_DIRNAME = "generations";
+const DEFERRED_CODEX_AUDIT_FILENAME = "deferred-codex-audit.json";
 const DEFAULT_ACTIVATION_BYTES = 16 * 1024 * 1024;
 const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
 const CURSOR_STORE_RETRY_CODE = "TOKENTRACKER_CURSOR_STORE_RETRY";
@@ -35,6 +36,7 @@ async function openCursorStore({
   const normalizedCodexRoots = normalizeCodexRoots(codexRoots);
   const legacyFingerprint = await fingerprintFile(cursorsPath);
   let manifest = await readJson(manifestPath);
+  let migratedDuringOpen = false;
 
   if (isManifest(manifest)) {
     const legacyChanged = legacyFingerprint
@@ -49,6 +51,7 @@ async function openCursorStore({
         codexRoots: normalizedCodexRoots,
         failureInjector,
       });
+      migratedDuringOpen = true;
     }
 
     const opened = await openManifestGeneration({
@@ -58,7 +61,10 @@ async function openCursorStore({
       codexRoots: normalizedCodexRoots,
       failureInjector,
     });
-    if (opened) return opened;
+    if (opened) {
+      if (migratedDuringOpen) opened.requiresCommit = true;
+      return opened;
+    }
 
     manifest = await migrateLegacyCursorState({
       cursorsPath,
@@ -68,6 +74,7 @@ async function openCursorStore({
       codexRoots: normalizedCodexRoots,
       failureInjector,
     });
+    migratedDuringOpen = true;
     const recovered = await openManifestGeneration({
       cursorsPath,
       storeRoot,
@@ -75,7 +82,10 @@ async function openCursorStore({
       codexRoots: normalizedCodexRoots,
       failureInjector,
     });
-    if (recovered) return recovered;
+    if (recovered) {
+      recovered.requiresCommit = true;
+      return recovered;
+    }
   }
 
   const legacySize = Number(legacyFingerprint?.size || 0);
@@ -97,6 +107,7 @@ async function openCursorStore({
     codexRoots: normalizedCodexRoots,
     failureInjector,
   });
+  migratedDuringOpen = true;
   const opened = await openManifestGeneration({
     cursorsPath,
     storeRoot,
@@ -105,6 +116,7 @@ async function openCursorStore({
     failureInjector,
   });
   if (!opened) throw new Error("Unable to open migrated cursor store");
+  if (migratedDuringOpen) opened.requiresCommit = true;
   return opened;
 }
 
@@ -180,6 +192,14 @@ class LegacyCursorStore {
     return false;
   }
 
+  async readDeferredCodexAuditSyncs() {
+    return 0;
+  }
+
+  async writeDeferredCodexAuditSyncs() {}
+
+  async clearDeferredCodexAuditSyncs() {}
+
   async commit(cursors = this.cursors) {
     await writeJson(this.cursorsPath, cursors);
   }
@@ -205,12 +225,17 @@ class V2CursorStore {
     this.codexRoots = codexRoots;
     this.cursors = generation.core;
     this.failureInjector = failureInjector;
+    this.deferredCodexAuditPath = path.join(
+      storeRoot,
+      DEFERRED_CODEX_AUDIT_FILENAME,
+    );
     this.loadedFileShards = new Map();
     this.loadedEventSets = new Map();
     this.pendingEventKeys = new Map();
     this.skipValidationCache = new Map();
     this.fileShardLoadCount = 0;
     this.materializedCodexHashes = false;
+    this.requiresCommit = generation.metadata.id !== manifest.current;
 
     if (!this.cursors.files || typeof this.cursors.files !== "object") {
       this.cursors.files = {};
@@ -377,6 +402,29 @@ class V2CursorStore {
     return valid;
   }
 
+  async readDeferredCodexAuditSyncs() {
+    const state = await readJson(this.deferredCodexAuditPath);
+    const count = Number(state?.syncsSinceFullScan || 0);
+    return Number.isSafeInteger(count) && count > 0 ? count : 0;
+  }
+
+  async writeDeferredCodexAuditSyncs(count) {
+    const normalized = Math.max(0, Math.floor(Number(count) || 0));
+    if (normalized === 0) {
+      await this.clearDeferredCodexAuditSyncs();
+      return;
+    }
+    await writeJson(this.deferredCodexAuditPath, {
+      version: 1,
+      syncsSinceFullScan: normalized,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async clearDeferredCodexAuditSyncs() {
+    await fs.unlink(this.deferredCodexAuditPath).catch(() => {});
+  }
+
   hasCodexEvent(key) {
     const shardKey = codexEventShardKey(key);
     if (this.pendingEventKeys.get(shardKey)?.has(key)) return true;
@@ -464,6 +512,7 @@ class V2CursorStore {
     this.pendingEventKeys.clear();
     this.skipValidationCache.clear();
     this.materializedCodexHashes = false;
+    this.requiresCommit = true;
     return true;
   }
 
@@ -594,6 +643,7 @@ class V2CursorStore {
       this.pendingEventKeys.clear();
       this.skipValidationCache.clear();
       this.materializedCodexHashes = false;
+      this.requiresCommit = false;
       await cleanupGenerations(this.storeRoot, new Set([
         nextManifest.current,
         nextManifest.previous,

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -802,9 +802,18 @@ function runSyncCommand(extraEnv = {}, opts = {}) {
     });
     child.on("close", (code) => {
       const r = { code: code ?? 1, stdout: trimOutput(stdout), stderr: trimOutput(stderr) };
-      code === 0
-        ? finish(resolve, r)
-        : finish(reject, Object.assign(new Error(r.stderr || r.stdout || `exit ${r.code}`), r));
+      if (code === 0) {
+        finish(resolve, r);
+        return;
+      }
+      const error = Object.assign(
+        new Error(r.stderr || r.stdout || `exit ${r.code}`),
+        r,
+      );
+      if (/\bSYNC_BUSY\b/.test(`${r.stderr}\n${r.stdout}`)) {
+        error.code = "SYNC_BUSY";
+      }
+      finish(reject, error);
     });
   });
 }

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -804,6 +804,16 @@ test("Codex cold scan audit treats future full-scan timestamps as due", () => {
     }, nowMs),
     true,
   );
+  assert.equal(
+    isCodexColdScanAuditDue({
+      codexColdScanAudit: {
+        version: 1,
+        lastFullScanAtMs: nowMs - 60 * 60 * 1000,
+        syncsSinceFullScan: 7,
+      },
+    }, nowMs, 281),
+    true,
+  );
 });
 
 test("Codex day inventory cache reduces repeated old-day readdir", async () => {

--- a/test/codex-sync-hot-path.test.js
+++ b/test/codex-sync-hot-path.test.js
@@ -818,6 +818,72 @@ test("v2 source-scoped sync commits a same-inode append without loading historic
   });
 });
 
+test("v2 source-scoped no-op sync keeps the current generation unchanged", async () => {
+  await withIsolatedCodexHome("tt-codex-v2-no-op-", async ({ codexHome, trackerDir }) => {
+    const sessionId = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+    const dayDir = path.join(codexHome, "sessions", "2030", "06", "02");
+    const rolloutPath = path.join(
+      dayDir,
+      `rollout-2030-06-02T00-00-00-${sessionId}.jsonl`,
+    );
+    await fs.mkdir(dayDir, { recursive: true });
+    await fs.writeFile(
+      rolloutPath,
+      `${JSON.stringify(codexTokenEvent("2030-06-02T00:30:00.000Z", 10))}\n`,
+      "utf8",
+    );
+
+    const firstDiagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-notify", "--source=codex"],
+      { diagnostics: firstDiagnostics, cursorStoreOptions: { forceV2: true } },
+    );
+    assert.equal(firstDiagnostics.cursor_commits, 1);
+
+    const manifestPath = path.join(trackerDir, STORE_DIRNAME, "manifest.json");
+    const manifestBefore = await fs.readFile(manifestPath, "utf8");
+    const coreBefore = await fs.readFile(firstDiagnostics.cursor_path, "utf8");
+
+    const noOpDiagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-notify", "--source=codex"],
+      { diagnostics: noOpDiagnostics, cursorStoreOptions: { forceV2: true } },
+    );
+
+    assert.equal(noOpDiagnostics.cursor_commits, 0);
+    assert.equal(noOpDiagnostics.cursor_bytes, 0);
+    assert.equal(noOpDiagnostics.content_files_read, 0);
+    assert.equal(await fs.readFile(manifestPath, "utf8"), manifestBefore);
+    assert.equal(await fs.readFile(noOpDiagnostics.cursor_path, "utf8"), coreBefore);
+    assert.equal(
+      JSON.parse(
+        await fs.readFile(
+          path.join(trackerDir, STORE_DIRNAME, "deferred-codex-audit.json"),
+          "utf8",
+        ),
+      ).syncsSinceFullScan,
+      1,
+    );
+
+    await fs.appendFile(
+      rolloutPath,
+      `${JSON.stringify(codexTokenEvent("2030-06-02T00:35:00.000Z", 25))}\n`,
+      "utf8",
+    );
+    const appendDiagnostics = {};
+    await cmdSync(
+      ["--auto", "--from-notify", "--source=codex"],
+      { diagnostics: appendDiagnostics, cursorStoreOptions: { forceV2: true } },
+    );
+    assert.equal(appendDiagnostics.cursor_commits, 1);
+    assert.notEqual(await fs.readFile(manifestPath, "utf8"), manifestBefore);
+    await assert.rejects(
+      fs.stat(path.join(trackerDir, STORE_DIRNAME, "deferred-codex-audit.json")),
+      { code: "ENOENT" },
+    );
+  });
+});
+
 test("v2 source-scoped sync shards a custom CODEX_HOME outside the default path", async () => {
   await withIsolatedCodexHome("tt-codex-v2-custom-home-", async ({ home, trackerDir }) => {
     const customCodexHome = path.join(home, "custom-codex-data");

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -80,6 +80,24 @@ function createSuccessfulSpawn(calls) {
   };
 }
 
+function createBusySpawn(calls) {
+  return (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    process.nextTick(() => {
+      child.stderr.emit(
+        "data",
+        "Error: SYNC_BUSY: another sync is still running; no refresh was performed\n",
+      );
+      child.emit("close", 1);
+    });
+    return child;
+  };
+}
+
 function createDeferred() {
   let resolve;
   let reject;
@@ -162,6 +180,42 @@ test("local sync rejects arbitrary insforgeBaseUrl overrides", async () => {
     restore();
     if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
     else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+  }
+});
+
+test("local sync preserves the SYNC_BUSY failure code", async () => {
+  const calls = [];
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-local-sync-busy-"));
+  const { mod, restore } = loadLocalApiWithSpawn(createBusySpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(tempDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({ drain: true }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 500);
+    const body = JSON.parse(res.body.toString("utf8"));
+    assert.equal(body.ok, false);
+    assert.equal(body.code, "SYNC_BUSY");
+    assert.match(body.error, /no refresh was performed/);
+    assert.equal(calls.length, 1);
+  } finally {
+    restore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
 

--- a/test/macos-idle-energy-policy.test.js
+++ b/test/macos-idle-energy-policy.test.js
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const root = path.join(__dirname, "..");
+
+test("hidden companion cancels discrete animation tasks", () => {
+  const source = fs.readFileSync(
+    path.join(root, "TokenTrackerBar", "TokenTrackerBar", "Views", "ClawdCompanionView.swift"),
+    "utf8",
+  );
+
+  assert.match(source, /\.onChange\(of: isCharacterTimelineVisible\)/);
+  assert.match(source, /private func stopDiscreteAnimationLoops\(\)/);
+  assert.match(source, /blinkTask\?\.cancel\(\)/);
+  assert.match(source, /idleVariantTask\?\.cancel\(\)/);
+  assert.doesNotMatch(
+    source,
+    /private func startBlinkLoop\(\)[\s\S]*?DispatchQueue\.main\.asyncAfter[\s\S]*?private func updateDiscreteAnimationLoops/,
+  );
+});
+
+test("owned embedded server uses the low-frequency health-check policy", () => {
+  const manager = fs.readFileSync(
+    path.join(root, "TokenTrackerBar", "TokenTrackerBar", "Services", "ServerManager.swift"),
+    "utf8",
+  );
+  const policy = fs.readFileSync(
+    path.join(root, "TokenTrackerBar", "TokenTrackerBar", "Models", "ServerHealthCheckPolicy.swift"),
+    "utf8",
+  );
+
+  assert.match(manager, /startHealthCheckLoop\(ownership: \.ownedProcess\)/);
+  assert.match(manager, /ServerHealthCheckPolicy\.interval\(for: ownership\)/);
+  assert.match(policy, /ownedProcessInterval: TimeInterval = 5 \* 60/);
+  assert.match(policy, /externalProcessInterval: TimeInterval = 30/);
+});

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -189,6 +189,66 @@ test("Codex notify sync catches up after an overlapping background sync releases
   });
 });
 
+test("native account publication waits for an overlapping sync instead of reporting success", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-1010-7000-8000-aaaaaaaaaaaa",
+      79,
+    );
+
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const active = await openLock(path.join(trackerDir, "sync.lock"), {
+      quietIfLocked: true,
+    });
+    assert.ok(active);
+
+    const publicationSync = cmdSync(
+      ["--auto", "--background", "--publish-account"],
+      { lockWaitOptions: { priorityWaitMs: 500, priorityPollMs: 10 } },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await active.release();
+    await publicationSync;
+
+    const queue = await readQueue(home);
+    assert.match(queue, /"source":"codex"/);
+    assert.match(queue, /"total_tokens":79/);
+  });
+});
+
+test("manual drain fails explicitly when the sync lock stays busy", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const active = await openLock(path.join(trackerDir, "sync.lock"), {
+      quietIfLocked: true,
+    });
+    assert.ok(active);
+
+    try {
+      await assert.rejects(
+        cmdSync(
+          ["--drain"],
+          { lockWaitOptions: { priorityWaitMs: 40, priorityPollMs: 5 } },
+        ),
+        (error) => {
+          assert.equal(error.code, "SYNC_BUSY");
+          assert.match(error.message, /no refresh was performed/);
+          return true;
+        },
+      );
+    } finally {
+      await active.release();
+    }
+
+    await assert.rejects(readQueue(home), { code: "ENOENT" });
+  });
+});
+
 test("Codex notify sync accepts an explicit null context", async () => {
   await withTempSyncEnv(async () => {
     await cmdSync(["--auto", "--from-notify", "--source=codex"], null);


### PR DESCRIPTION
## Summary

Prevent native refreshes from reporting success without acquiring `sync.lock`, eliminate full v2 cursor-generation writes on unchanged incremental syncs, and reduce unnecessary macOS idle wakeups.

## Why

A native drain or account-publication sync that overlapped another sync previously returned from `cmdSync()` without doing any work, but still exited with code 0. The local API therefore returned success and the macOS app advanced `lastBackgroundSyncAt`. Repeated contention could make the five-minute scheduler believe it had refreshed while displayed usage remained stale until a later or manual sync.

Separately, unchanged v2 auto syncs rewrote a full cursor generation (about 9.5 MB on a large local state). The owned embedded server was also health-polled every 30 seconds despite having a termination handler, and hidden companion views retained recursive blink/idle callbacks.

## Changes

- Wait up to 90 seconds for `--drain` and `--publish-account` lock acquisition, preserving at least 30 seconds of the local API's 120-second child budget.
- Return an explicit `SYNC_BUSY` failure when contention does not clear, and preserve that code through the child-process and HTTP boundary.
- Skip v2 generation commits for truly unchanged incremental auto syncs.
- Keep the 24-hour / 288-sync cold-audit invariant through a small deferred counter; migrations, fallbacks, repairs, audits, and parser progress still commit.
- Poll owned embedded servers every five minutes while retaining 30-second checks for reused external servers.
- Replace recursive hidden companion callbacks with cancellable tasks tied to visibility.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config (`TokenTrackerBar/project.yml` test source wiring only)

## Verification

- `npm run ci:local`: passed (`1721/1721` Node tests, copy/UI/architecture guards, TypeScript, and production dashboard build).
- `xcodebuild test -scheme TokenTrackerBarTests -destination platform=macOS`: passed (`101/101`).
- Universal Release build passed with bundled Node/dashboard; app and embedded CLI report `0.83.1`, and both app/Node binaries contain `arm64` and `x86_64` slices.
- SHA-256 of bundled `sync.js`, `cursor-store.js`, and `local-api.js` matches the checked-out source.

Isolated APFS snapshot benchmark with 28,700 Codex sessions:

| Metric | Before | After, 5 steady-state runs |
| --- | ---: | ---: |
| Full cursor-generation writes | 5 x about 9.49 MB | 0 writes / 0 bytes |
| Wall time | 0.30-0.49 s | 0.19-0.25 s |
| Peak RSS | 212-221 MB | 164-171 MB |
| Instructions retired | about 5.0B/run | 3.36-3.60B/run |
| Session content reads | N/A | 0 in all 5 runs |

The manifest/current-core mtimes stayed unchanged across all five steady-state runs. A due 24-hour project-context recheck and the 288-sync audit were separately exercised and still produced required commits.

## Checklist

- [x] `npm test` passes
- [x] No new user-facing UI strings were added
- [x] Commits follow conventional style (`fix:`)
- [x] PR description explains why, not just what

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- A successful native sync means the lock was acquired and refresh work ran.
- An unchanged incremental v2 sync must not publish a new generation.
- Parser progress, migration/recovery, repairs, and due cold audits must still persist.
- Process termination remains immediate for owned servers; only liveness polling becomes less frequent.

### Boundary matrix

| Boundary | Expected result | Coverage |
| --- | --- | --- |
| Priority sync, lock free | Sync runs and succeeds | Existing + focused sync tests |
| Priority sync, lock releases within wait | Waiter acquires lock and catches up | New overlap test |
| Priority sync, lock remains held | `SYNC_BUSY`, no false success | New sync + local API tests |
| v2 incremental sync, no progress | No generation commit; deferred audit increments | New hot-path test + benchmark |
| v2 sync with append/audit/recovery | Generation commit remains mandatory | Existing fallback/append tests + audit benchmark |
| Companion/server hidden or owned | Tasks cancel; health polling uses five-minute policy | New Node source guard + Swift policy tests |

</details>

<details>
<summary><strong>Review context</strong></summary>

### Most likely regression surface

- v2 cursor persistence around deferred cold-audit accounting.
- Timeout behavior when a legitimate foreground sync already runs close to the local API deadline.
- Visibility transitions for companion animation tasks.
- Delayed detection of a live-but-unresponsive owned server; hard process exits still use the termination handler.

### Verification method

- Focused contention, API propagation, cursor-store, and idle-energy regression tests.
- Full repository CI-equivalent suite and Swift unit suite.
- Production-scale isolated snapshot benchmark.
- Universal Release build and bundle-content hash verification.

### Known gaps / out of scope

- The Release app was not launched because its fixed port `7680` startup path would disturb the currently installed app/listener.
- A 12-hour Activity Monitor energy A/B requires installing the patched build and allowing the historical rolling window to expire.
- No version bump or release packaging is included in this PR.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced background server health checks for embedded servers while keeping external-server checks responsive.
  * Companion animations now pause when hidden, reducing unnecessary energy usage.
  * Sync operations handle lock contention more reliably, including clear busy-status reporting.
  * No-op syncs avoid unnecessary cursor updates while preserving deferred audit tracking.

* **Bug Fixes**
  * Improved recovery and persistence of sync state across migrations and fallback scenarios.
  * Local sync errors now retain the appropriate busy status for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->