### PR TITLE
feat: show readable current device names

### DIFF
--- a/dashboard/edge-patches/tokentracker-device-flow-poll.ts
+++ b/dashboard/edge-patches/tokentracker-device-flow-poll.ts
@@ -37,11 +37,13 @@ async function sha256Hex(input: string): Promise<string> {
 // deno-lint-ignore no-explicit-any
 async function issueDeviceToken(client: any, userId: string, clientInfo: string | null, machineId: string | null) {
   const platform = "cli-device-flow";
-  // The machine-id suffix keeps display names unique per machine: two Macs on
-  // the default "MacBook-Pro.local" hostname used to collapse into ONE device
-  // (the name-keyed unique index), overwriting each other's hourly rows and
-  // revoking each other's tokens on every login.
-  const deviceName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}${machineId ? ` #${machineId.slice(0, 8)}` : ""}`.slice(0, 128);
+  // New CLIs send `<platform>-<arch> <hostname>` as client_info. Identity is
+  // anchored by machine_id, so the human-facing name can be the actual system
+  // hostname instead of an opaque generated label.
+  const hostname = clientInfo?.replace(/^\S+\s+/, "").trim() || null;
+  const generatedLegacyName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}${machineId ? ` #${machineId.slice(0, 8)}` : ""}`.slice(0, 128);
+  const generatedLegacyBareName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}`.slice(0, 128);
+  const deviceName = (hostname || generatedLegacyName).slice(0, 128);
 
   // Device identity resolution — same machine-anchored scheme as
   // tokentracker-device-token-issue.ts: (1) reuse by (user, machine_id),
@@ -83,22 +85,20 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
     }
 
     if (!deviceId) {
-      // Adoption tries the new suffixed name first, then the PRE-UPGRADE
-      // suffix-less name (`TokenTracker CLI (darwin-arm64 host)`) — every
-      // CLI device minted before the machine-id rollout has the latter, and
-      // without this fallback an upgrade re-login would orphan the old row
-      // and mint a second device (hot buckets re-emitted across the switch
-      // would then mirror). If two same-hostname machines shared one legacy
-      // row, the first to upgrade claims it; the second falls through to a
-      // fresh anchored device — counting stays correct either way because
-      // rows never move or duplicate.
-      const legacyBareName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}`.slice(0, 128);
+      // Adoption tries the hostname first, then both generated names used by
+      // older CLIs. This keeps an upgrade from orphaning the historical row;
+      // machine_id remains the authoritative identity after adoption.
+      const legacyNames = Array.from(new Set([
+        deviceName,
+        generatedLegacyName,
+        generatedLegacyBareName,
+      ]));
       const { data: legacyRows } = await client.database
         .from("tokentracker_devices")
         .select("id, device_name, name_customized")
         .eq("user_id", userId)
         .eq("platform", platform)
-        .in("device_name", [deviceName, legacyBareName])
+        .in("device_name", legacyNames)
         .is("revoked_at", null)
         .is("machine_id", null)
         .order("created_at", { ascending: true });
@@ -116,7 +116,7 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
           .select("id, device_name, name_customized")
           .eq("user_id", userId)
           .eq("platform", platform)
-          .in("default_device_name", [deviceName, legacyBareName])
+          .in("default_device_name", legacyNames)
           .is("revoked_at", null)
           .is("machine_id", null)
           .order("created_at", { ascending: true });

--- a/dashboard/edge-patches/tokentracker-device-flow-poll.ts
+++ b/dashboard/edge-patches/tokentracker-device-flow-poll.ts
@@ -149,6 +149,21 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
           deviceId = candidate.id;
           break;
         }
+        if (!candidate.name_customized) {
+          // The rename to the readable hostname can collide with the
+          // active-name unique index when another machine already owns it.
+          // Adopt under the old label so the historical row is not orphaned;
+          // the identity RPC can converge the name on a later cycle.
+          const { error: retryErr } = await client.database
+            .from("tokentracker_devices")
+            .update({ machine_id: machineId })
+            .eq("id", candidate.id)
+            .is("machine_id", null);
+          if (!retryErr) {
+            deviceId = candidate.id;
+            break;
+          }
+        }
       }
     }
 

--- a/dashboard/edge-patches/tokentracker-device-flow-poll.ts
+++ b/dashboard/edge-patches/tokentracker-device-flow-poll.ts
@@ -34,13 +34,21 @@ async function sha256Hex(input: string): Promise<string> {
     .join("");
 }
 
+function disambiguateDeviceName(deviceName: string, machineId: string): string {
+  const suffix = ` #${machineId.slice(0, 8)}`;
+  if (deviceName.endsWith(suffix)) return deviceName;
+  const baseName = deviceName.slice(0, 128 - suffix.length).trimEnd() || "Token Tracker";
+  return `${baseName}${suffix}`;
+}
+
 // deno-lint-ignore no-explicit-any
 async function issueDeviceToken(client: any, userId: string, clientInfo: string | null, machineId: string | null) {
   const platform = "cli-device-flow";
   // New CLIs send `<platform>-<arch> <hostname>` as client_info. Identity is
   // anchored by machine_id, so the human-facing name can be the actual system
   // hostname instead of an opaque generated label.
-  const hostname = clientInfo?.replace(/^\S+\s+/, "").trim() || null;
+  const hostnameMatch = clientInfo?.match(/^\S+\s+(.+)$/);
+  const hostname = hostnameMatch?.[1]?.trim() || null;
   const generatedLegacyName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}${machineId ? ` #${machineId.slice(0, 8)}` : ""}`.slice(0, 128);
   const generatedLegacyBareName = `TokenTracker CLI${clientInfo ? ` (${clientInfo})` : ""}`.slice(0, 128);
   const deviceName = (hostname || generatedLegacyName).slice(0, 128);
@@ -164,10 +172,44 @@ async function issueDeviceToken(client: any, userId: string, clientInfo: string 
           .is("revoked_at", null)
           .limit(1)
           .maybeSingle();
-        if (!winner || !(winner as { id: string }).id) {
-          throw new Error(insErr?.message || "device resolution failed");
+        if (winner && (winner as { id: string }).id) {
+          deviceId = (winner as { id: string }).id;
+        } else {
+          // A different machine may already own the readable hostname under
+          // the active-name unique index. Keep this machine registerable with
+          // the stable suffix previously used by CLI device names.
+          const fallbackDeviceName = disambiguateDeviceName(deviceName, machineId);
+          const fallbackDeviceId = crypto.randomUUID();
+          const { data: fallbackInserted, error: fallbackErr } = await client.database
+            .from("tokentracker_devices")
+            .upsert(
+              [{
+                id: fallbackDeviceId,
+                user_id: userId,
+                device_name: fallbackDeviceName,
+                platform,
+                machine_id: machineId,
+              }],
+              { ignoreDuplicates: true },
+            )
+            .select("id");
+          if (!fallbackErr && Array.isArray(fallbackInserted) && fallbackInserted.length > 0) {
+            deviceId = (fallbackInserted[0] as { id: string }).id;
+          } else {
+            const { data: fallbackWinner } = await client.database
+              .from("tokentracker_devices")
+              .select("id")
+              .eq("user_id", userId)
+              .eq("machine_id", machineId)
+              .is("revoked_at", null)
+              .limit(1)
+              .maybeSingle();
+            if (!fallbackWinner || !(fallbackWinner as { id: string }).id) {
+              throw new Error(fallbackErr?.message || insErr?.message || "device resolution failed");
+            }
+            deviceId = (fallbackWinner as { id: string }).id;
+          }
         }
-        deviceId = (winner as { id: string }).id;
       }
     }
   } else {

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -262,8 +262,23 @@ export default async function (req: Request): Promise<Response> {
             : { machine_id: machineId, device_name: deviceName })
           .eq("id", legacyId)
           .is("machine_id", null);
-        if (!adoptErr) deviceId = legacyId;
-        // adoptErr → lost a race against another adopter/inserter; fall through.
+        if (!adoptErr) {
+          deviceId = legacyId;
+        } else if (!legacyNameCustomized) {
+          // The rename to the readable hostname can collide with the
+          // active-name unique index when another machine already owns it.
+          // Adopt under the old label so the historical row is not orphaned;
+          // the identity RPC can converge the name on a later cycle.
+          const { error: retryErr } = await dbClient.database
+            .from("tokentracker_devices")
+            .update({ machine_id: machineId })
+            .eq("id", legacyId)
+            .is("machine_id", null);
+          if (!retryErr) deviceId = legacyId;
+          // retryErr → lost a race against another adopter; fall through.
+        }
+        // adoptErr on a customized row → lost a race against another
+        // adopter/inserter; fall through.
       }
     }
 

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -198,19 +198,21 @@ export default async function (req: Request): Promise<Response> {
     }
 
     if (!deviceId) {
-      // Adopt an orphan under either the current suffixed name or the pre-suffix
-      // base name. machineId.slice(0,8) is the 8-hex suffix; strip " #<hex8>" to
-      // recover the base. A machine first seen under the old no-suffix scheme has
-      // a base-named orphan the exact-suffixed match would skip, splitting it off
-      // as a new device (issue #187). Adopting it backfills machine_id so the
-      // machine resolves to one row thereafter.
-      const legacyBaseName = deviceName.replace(/ #[0-9a-fA-F]{8}$/, "");
-      const legacyNames =
-        legacyBaseName === deviceName ? [deviceName] : [deviceName, legacyBaseName];
+      // Adopt an orphan under the current system name or one of the generated
+      // names used before hostname labels were introduced. A machine first
+      // seen under an older name must be adopted in place; otherwise the next
+      // upload would split its history into a second device.
+      const legacyNames = Array.from(new Set([
+        deviceName,
+        `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
+        "Token Tracker (dashboard)",
+        "Token Tracker",
+      ]));
       let legacyId: string | null = null;
+      let legacyNameCustomized = false;
       const { data: legacy } = await dbClient.database
         .from("tokentracker_devices")
-        .select("id")
+        .select("id, name_customized")
         .eq("user_id", userId)
         .eq("platform", platform)
         .in("device_name", legacyNames)
@@ -221,6 +223,7 @@ export default async function (req: Request): Promise<Response> {
         .maybeSingle();
       if (legacy && (legacy as { id: string }).id) {
         legacyId = (legacy as { id: string }).id;
+        legacyNameCustomized = Boolean((legacy as { name_customized?: boolean }).name_customized);
       }
       if (!legacyId) {
         // A renamed legacy row matches no client default by device_name; the
@@ -230,7 +233,7 @@ export default async function (req: Request): Promise<Response> {
         // doesn't leave the row un-adoptable and split off a fresh device.
         const { data: renamed } = await dbClient.database
           .from("tokentracker_devices")
-          .select("id")
+          .select("id, name_customized")
           .eq("user_id", userId)
           .eq("platform", platform)
           .in("default_device_name", legacyNames)
@@ -241,12 +244,15 @@ export default async function (req: Request): Promise<Response> {
           .maybeSingle();
         if (renamed && (renamed as { id: string }).id) {
           legacyId = (renamed as { id: string }).id;
+          legacyNameCustomized = Boolean((renamed as { name_customized?: boolean }).name_customized);
         }
       }
       if (legacyId) {
         const { error: adoptErr } = await dbClient.database
           .from("tokentracker_devices")
-          .update({ machine_id: machineId })
+          .update(legacyNameCustomized
+            ? { machine_id: machineId }
+            : { machine_id: machineId, device_name: deviceName })
           .eq("id", legacyId)
           .is("machine_id", null);
         if (!adoptErr) deviceId = legacyId;

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -82,6 +82,13 @@ async function sha256Hex(input: string): Promise<string> {
     .join("");
 }
 
+function disambiguateDeviceName(deviceName: string, machineId: string): string {
+  const suffix = ` #${machineId.slice(0, 8)}`;
+  if (deviceName.endsWith(suffix)) return deviceName;
+  const baseName = deviceName.slice(0, 128 - suffix.length).trimEnd() || "Token Tracker";
+  return `${baseName}${suffix}`;
+}
+
 export default async function (req: Request): Promise<Response> {
   if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: corsHeaders });
   if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
@@ -284,10 +291,48 @@ export default async function (req: Request): Promise<Response> {
         if (winner && (winner as { id: string }).id) {
           deviceId = (winner as { id: string }).id;
         } else {
-          return json(
-            { error: "Failed to issue device token", detail: insErr?.message || "device resolution failed" },
-            500,
-          );
+          // The active-name unique index also covers machine-anchored rows.
+          // Retry with a stable suffix when another machine owns this hostname.
+          const fallbackDeviceName = disambiguateDeviceName(deviceName, machineId);
+          const fallbackDeviceId = crypto.randomUUID();
+          const { data: fallbackInserted, error: fallbackErr } = await dbClient.database
+            .from("tokentracker_devices")
+            .upsert(
+              [{
+                id: fallbackDeviceId,
+                user_id: userId,
+                device_name: fallbackDeviceName,
+                platform,
+                machine_id: machineId,
+              }],
+              { ignoreDuplicates: true },
+            )
+            .select("id");
+          if (!fallbackErr && Array.isArray(fallbackInserted) && fallbackInserted.length > 0) {
+            deviceId = (fallbackInserted[0] as { id: string }).id;
+          } else {
+            // A concurrent request for this same machine may have won the
+            // fallback insert, so resolve its canonical row before failing.
+            const { data: fallbackWinner } = await dbClient.database
+              .from("tokentracker_devices")
+              .select("id")
+              .eq("user_id", userId)
+              .eq("machine_id", machineId)
+              .is("revoked_at", null)
+              .limit(1)
+              .maybeSingle();
+            if (fallbackWinner && (fallbackWinner as { id: string }).id) {
+              deviceId = (fallbackWinner as { id: string }).id;
+            } else {
+              return json(
+                {
+                  error: "Failed to issue device token",
+                  detail: fallbackErr?.message || insErr?.message || "device resolution failed",
+                },
+                500,
+              );
+            }
+          }
         }
       }
     }

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -1138,6 +1138,7 @@ skills.usage.disclaimer,ui,SkillsPage,SkillDetailPanel,usage_disclaimer,"Counts 
 dashboard.device_filter.all,dashboard,DashboardPage,UsageOverview,option_all,"All devices",,active
 dashboard.device_filter.aria,dashboard,DashboardPage,UsageOverview,select_aria,"Filter by device",,active
 dashboard.device_card.title,dashboard,DashboardPage,DeviceUsageCard,title,"By device",,active
+dashboard.device_card.current,dashboard,DashboardPage,DeviceUsageCard,current,"This device",,active
 dashboard.device_card.unnamed,dashboard,DashboardPage,DeviceUsageCard,unnamed,"Unnamed device",,active
 dashboard.device_card.rename_aria,dashboard,DashboardPage,DeviceUsageCard,rename_aria,"Rename device",,active
 dashboard.device_card.rename_placeholder,dashboard,DashboardPage,DeviceUsageCard,rename_placeholder,"Device name",,active

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -342,6 +342,7 @@
   "dashboard.expired_gate.feature.cloud.title": "Geräteübergreifende Synchronisation",
   "dashboard.expired_gate.feature.cloud.desc": "Über das synchronisierte Dashboard kannst du Token-Logs von überall einsehen.",
   "dashboard.device_card.title": "Nach Gerät",
+  "dashboard.device_card.current": "Dieses Gerät",
   "dashboard.device_card.unnamed": "Unbekanntes Gerät",
   "dashboard.device_filter.all": "Alle Geräte",
   "dashboard.device_filter.aria": "Nach Gerät filtern",

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -346,6 +346,7 @@
   "dashboard.device_filter.all": "すべてのデバイス",
   "dashboard.device_filter.aria": "デバイスで絞り込む",
   "dashboard.device_card.title": "デバイス別",
+  "dashboard.device_card.current": "このデバイス",
   "dashboard.device_card.unnamed": "名称未設定のデバイス",
   "nav.pet": "デスクトップペット",
   "pet.page.eyebrow": "デスクトップコンパニオン",

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -346,6 +346,7 @@
   "dashboard.device_filter.all": "모든 기기",
   "dashboard.device_filter.aria": "기기별 필터",
   "dashboard.device_card.title": "기기별",
+  "dashboard.device_card.current": "현재 기기",
   "dashboard.device_card.unnamed": "이름 없는 기기",
   "nav.pet": "데스크톱 펫",
   "pet.page.eyebrow": "데스크톱 동반자",

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -346,6 +346,7 @@
   "dashboard.device_filter.all": "全部裝置",
   "dashboard.device_filter.aria": "依裝置篩選",
   "dashboard.device_card.title": "依裝置",
+  "dashboard.device_card.current": "本機",
   "dashboard.device_card.unnamed": "未命名裝置",
   "nav.pet": "桌面寵物",
   "pet.page.eyebrow": "桌面陪伴",

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -346,6 +346,7 @@
   "dashboard.device_filter.all": "全部设备",
   "dashboard.device_filter.aria": "按设备筛选",
   "dashboard.device_card.title": "设备分布",
+  "dashboard.device_card.current": "本机",
   "dashboard.device_card.unnamed": "未命名设备",
   "dashboard.device_card.rename_aria": "重命名设备",
   "dashboard.device_card.rename_placeholder": "设备名称",

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -1,5 +1,6 @@
 const KEY_ENABLED = "tokentracker_cloud_sync_enabled";
 const KEY_DEVICE = "tokentracker_cloud_device_session_v1";
+const KEY_DEVICE_ID = "tokentracker_cloud_device_id_v1";
 const KEY_LAST_SYNC = "tokentracker_cloud_last_sync_ts";
 const KEY_USAGE_READY = "tokentracker_cloud_usage_ready_v1";
 export const CLOUD_USAGE_SYNCED_EVENT = "tt.cloudUsageSynced";
@@ -102,8 +103,22 @@ export function getStoredDeviceSession(): CloudDeviceSession | null {
   return memoryDeviceSession;
 }
 
+export function getCurrentDeviceId(): string {
+  if (memoryDeviceSession?.deviceId) return memoryDeviceSession.deviceId;
+  try {
+    return String(localStorage.getItem(KEY_DEVICE_ID) || "").trim();
+  } catch {
+    return "";
+  }
+}
+
 export function setStoredDeviceSession(session: CloudDeviceSession): void {
   memoryDeviceSession = session;
+  try {
+    if (session.deviceId) localStorage.setItem(KEY_DEVICE_ID, session.deviceId);
+  } catch {
+    /* non-secret marker remains memory-only when storage is unavailable */
+  }
   clearLegacyStoredDeviceSession();
 }
 
@@ -111,6 +126,7 @@ export function clearCloudDeviceSession(): void {
   memoryDeviceSession = null;
   try {
     localStorage.removeItem(KEY_LAST_SYNC);
+    localStorage.removeItem(KEY_DEVICE_ID);
   } catch {
     /* ignore */
   }

--- a/dashboard/src/lib/cloud-sync.test.ts
+++ b/dashboard/src/lib/cloud-sync.test.ts
@@ -28,7 +28,7 @@ function installFetchMock(options: { leaderboardOk?: boolean } = {}) {
   const leaderboardOk = options.leaderboardOk ?? true;
   const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
     if (url === "/functions/tokentracker-machine-id") {
-      return okJson({ machineId: "machine-abcdef12" });
+      return okJson({ machineId: "machine-abcdef12", deviceName: "office-win" });
     }
     if (url === "https://cloud.example/functions/tokentracker-device-token-issue") {
       return okJson({
@@ -100,6 +100,20 @@ describe("cloud usage sync", () => {
     expect(fetchMock.mock.calls.find(([url]) => url === "https://cloud.example/functions/tokentracker-leaderboard-refresh")?.[1])
       .toMatchObject({ cache: "no-store" });
     window.removeEventListener("tt.cloudUsageSynced", onSynced);
+  });
+
+  it("sends the local system name separately from the stable machine id", async () => {
+    const fetchMock = installFetchMock();
+
+    await runCloudUsageSyncNow(async () => "access-token");
+
+    const issueCall = fetchMock.mock.calls.find(([url]) => url === "https://cloud.example/functions/tokentracker-device-token-issue");
+    expect(issueCall).toBeTruthy();
+    const issueBody = JSON.parse(String((issueCall?.[1] as RequestInit | undefined)?.body));
+    expect(issueBody).toMatchObject({
+      device_name: "office-win",
+      machine_id: "machine-abcdef12",
+    });
   });
 
   it("drains the full queue before the first scheduled cloud view becomes ready", async () => {

--- a/dashboard/src/lib/cloud-sync.ts
+++ b/dashboard/src/lib/cloud-sync.ts
@@ -61,8 +61,9 @@ async function triggerLeaderboardRefresh(
 }
 
 /**
- * Resolve the stable per-MACHINE id served by the local CLI
- * (/functions/tokentracker-machine-id, persisted in ~/.tokentracker/.../config.json).
+ * Resolve the stable per-MACHINE id and human-readable system name served by
+ * the local CLI (/functions/tokentracker-machine-id, persisted in
+ * ~/.tokentracker/.../config.json).
  *
  * Returns null when the local server is unreachable. There is deliberately NO
  * per-browser fallback id anymore: a fallback identity minted a brand-new
@@ -72,16 +73,19 @@ async function triggerLeaderboardRefresh(
  * (postLocalUsageSync), so when the machine id is unavailable we skip token
  * issuance for this cycle and retry on the next one.
  */
-async function resolveMachineId(): Promise<string | null> {
+async function resolveMachineIdentity(): Promise<{ machineId: string; deviceName: string | null } | null> {
   try {
     const res = await fetch("/functions/tokentracker-machine-id", {
       headers: { Accept: "application/json" },
       cache: "no-store",
     });
     if (res.ok) {
-      const data = (await res.json().catch(() => null)) as { machineId?: string } | null;
+      const data = (await res.json().catch(() => null)) as { machineId?: string; deviceName?: string | null } | null;
       const machineId = typeof data?.machineId === "string" ? data.machineId.trim() : null;
-      if (machineId && machineId.length >= 8) return machineId;
+      const deviceName = typeof data?.deviceName === "string" && data.deviceName.trim()
+        ? data.deviceName.trim().slice(0, 128)
+        : null;
+      if (machineId && machineId.length >= 8) return { machineId, deviceName };
     }
   } catch {
     /* local server unreachable */
@@ -107,9 +111,10 @@ async function issueDeviceTokenForCloud(accessToken: string): Promise<CloudDevic
     typeof navigator !== "undefined" && typeof navigator.platform === "string"
       ? navigator.platform
       : "web";
-  const machineId = await resolveMachineId();
-  if (!machineId) return null;
-  const deviceName = `Token Tracker (dashboard) #${machineId.slice(0, 8)}`;
+  const identity = await resolveMachineIdentity();
+  if (!identity) return null;
+  const { machineId } = identity;
+  const deviceName = identity.deviceName || `Token Tracker (dashboard) #${machineId.slice(0, 8)}`;
   // 云端 slug 为 tokentracker-device-token-issue（历史文档里的 vibeusage-* 在本项目未部署）
   const res = await fetch(`${root}/functions/tokentracker-device-token-issue`, {
     method: "POST",

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -52,6 +52,7 @@ import { DashboardView } from "../ui/dashboard/views/DashboardView.jsx";
 import { useAccountDevices } from "../hooks/use-account-devices.js";
 import { DeviceUsageCard } from "../ui/dashboard/components/DeviceUsageCard.jsx";
 import { formatDeviceLabel } from "../lib/device-label.js";
+import { getCurrentDeviceId } from "../lib/cloud-sync-prefs";
 import { ShareModal } from "../ui/share/ShareModal";
 import { useShareCardData } from "../ui/share/use-share-card-data";
 
@@ -372,9 +373,12 @@ export function DashboardPage({
   // Only devices with usage in the selected range are shown anywhere — a
   // zero-usage registration (typically a stale fingerprint-drift duplicate) is
   // noise in both the filter dropdown and the breakdown card.
+  const currentDeviceId = getCurrentDeviceId();
   const activeDevices = useMemo(
-    () => accountDevices.filter((d) => (Number(d.total_tokens) || 0) > 0),
-    [accountDevices],
+    () => accountDevices
+      .filter((d) => (Number(d.total_tokens) || 0) > 0)
+      .map((d) => ({ ...d, isCurrent: d.id === currentDeviceId })),
+    [accountDevices, currentDeviceId],
   );
   const accountSourceRows = useMemo(
     () => accountDeviceSources.filter((s) => (Number(s.total_tokens) || 0) > 0),
@@ -402,7 +406,7 @@ export function DashboardPage({
       { value: "", label: copy("dashboard.device_filter.all") },
       ...activeDevices.map((d) => ({
         value: d.id,
-        label: formatDeviceLabel(d) || copy("dashboard.device_card.unnamed"),
+        label: `${formatDeviceLabel(d) || copy("dashboard.device_card.unnamed")}${d.isCurrent ? ` (${copy("dashboard.device_card.current")})` : ""}`,
       })),
     ];
   }, [showDeviceFilter, activeDevices, resolvedLocale]);
@@ -411,6 +415,7 @@ export function DashboardPage({
     <DeviceUsageCard
       devices={activeDevices}
       accountSources={accountSourceRows}
+      currentDeviceId={currentDeviceId}
       selectedDeviceId={selectedDevice || ""}
       onSelectDevice={(id) => setSelectedDevice(id || null)}
       onRenameDevice={async (id, name) => {

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -52,7 +52,7 @@ import { DashboardView } from "../ui/dashboard/views/DashboardView.jsx";
 import { useAccountDevices } from "../hooks/use-account-devices.js";
 import { DeviceUsageCard } from "../ui/dashboard/components/DeviceUsageCard.jsx";
 import { formatDeviceLabel } from "../lib/device-label.js";
-import { getCurrentDeviceId } from "../lib/cloud-sync-prefs";
+import { CLOUD_USAGE_SYNCED_EVENT, getCurrentDeviceId } from "../lib/cloud-sync-prefs";
 import { ShareModal } from "../ui/share/ShareModal";
 import { useShareCardData } from "../ui/share/use-share-card-data";
 
@@ -361,6 +361,16 @@ export function DashboardPage({
   const to = range.to;
 
   const [selectedDevice, setSelectedDevice] = useState(null);
+  const [currentDeviceId, setCurrentDeviceId] = useState(() => getCurrentDeviceId());
+  useEffect(() => {
+    const refreshCurrentDevice = () => setCurrentDeviceId(getCurrentDeviceId());
+    window.addEventListener(CLOUD_USAGE_SYNCED_EVENT, refreshCurrentDevice);
+    window.addEventListener("storage", refreshCurrentDevice);
+    return () => {
+      window.removeEventListener(CLOUD_USAGE_SYNCED_EVENT, refreshCurrentDevice);
+      window.removeEventListener("storage", refreshCurrentDevice);
+    };
+  }, []);
   const { devices: accountDevices, accountSources: accountDeviceSources, refresh: refreshAccountDevices } = useAccountDevices({
     from,
     to,
@@ -373,7 +383,6 @@ export function DashboardPage({
   // Only devices with usage in the selected range are shown anywhere — a
   // zero-usage registration (typically a stale fingerprint-drift duplicate) is
   // noise in both the filter dropdown and the breakdown card.
-  const currentDeviceId = getCurrentDeviceId();
   const activeDevices = useMemo(
     () => accountDevices
       .filter((d) => (Number(d.total_tokens) || 0) > 0)
@@ -404,10 +413,11 @@ export function DashboardPage({
     if (!showDeviceFilter) return [];
     return [
       { value: "", label: copy("dashboard.device_filter.all") },
-      ...activeDevices.map((d) => ({
-        value: d.id,
-        label: `${formatDeviceLabel(d) || copy("dashboard.device_card.unnamed")}${d.isCurrent ? ` (${copy("dashboard.device_card.current")})` : ""}`,
-      })),
+      ...activeDevices.map((d) => {
+        const deviceLabel = formatDeviceLabel(d) || copy("dashboard.device_card.unnamed");
+        const currentSuffix = d.isCurrent ? ` (${copy("dashboard.device_card.current")})` : "";
+        return { value: d.id, label: `${deviceLabel}${currentSuffix}` };
+      }),
     ];
   }, [showDeviceFilter, activeDevices, resolvedLocale]);
 

--- a/dashboard/src/ui/dashboard/components/DeviceUsageCard.jsx
+++ b/dashboard/src/ui/dashboard/components/DeviceUsageCard.jsx
@@ -20,7 +20,11 @@ function PlatformIcon({ platform, className }) {
   return <MonitorSmartphone className={className} aria-hidden />;
 }
 
-export function DeviceUsageCard({ devices = [], accountSources = [], selectedDeviceId = "", onSelectDevice, onRenameDevice }) {
+function isCurrentDevice(device, currentDeviceId) {
+  return currentDeviceId === device?.id || device?.isCurrent === true;
+}
+
+export function DeviceUsageCard({ devices = [], accountSources = [], currentDeviceId = "", selectedDeviceId = "", onSelectDevice, onRenameDevice }) {
   const { formatTokens, formatTokensTooltip } = useTokenFormat();
   const [editingId, setEditingId] = useState("");
   const [draft, setDraft] = useState("");
@@ -197,7 +201,7 @@ export function DeviceUsageCard({ devices = [], accountSources = [], selectedDev
                   <button
                     type="button"
                     aria-pressed={isSelected}
-                    aria-label={`${copy("dashboard.device_filter.aria")}: ${name}`}
+                    aria-label={`${copy("dashboard.device_filter.aria")}: ${name}${isCurrentDevice(d, currentDeviceId) ? ` (${copy("dashboard.device_card.current")})` : ""}`}
                     onClick={() => onSelectDevice?.(isSelected ? "" : d.id)}
                     className={`w-full text-left rounded-md px-2 py-1.5 transition-all duration-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-oai-brand/50 ${itemOpacity} ${
                       isSelected
@@ -215,6 +219,11 @@ export function DeviceUsageCard({ devices = [], accountSources = [], selectedDev
                         <span className="block truncate text-[13px] font-medium text-oai-black dark:text-oai-white" title={name}>
                           {name}
                         </span>
+                        {isCurrentDevice(d, currentDeviceId) && (
+                          <span className="shrink-0 rounded-full bg-oai-brand/10 px-1.5 py-0.5 text-[10px] font-medium text-oai-brand">
+                            {copy("dashboard.device_card.current")}
+                          </span>
+                        )}
                       </div>
                       <span
                         title={formatTokensTooltip(tokens)}

--- a/dashboard/src/ui/dashboard/components/DeviceUsageCard.test.jsx
+++ b/dashboard/src/ui/dashboard/components/DeviceUsageCard.test.jsx
@@ -23,6 +23,21 @@ describe("DeviceUsageCard", () => {
     expect(text).toContain("40.0%");
   });
 
+  it("marks the current device without exposing its machine id", () => {
+    render(
+      <DeviceUsageCard
+        devices={devices}
+        currentDeviceId="d1"
+        selectedDeviceId=""
+        onSelectDevice={() => {}}
+      />,
+    );
+    expect(screen.getByText("This device")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Filter by device: MacBook Pro (This device)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Filter by device: Mac mini" })).toBeTruthy();
+    expect(screen.queryByText("d1")).toBeNull();
+  });
+
   it("selects a device on click and clears it when re-clicked", async () => {
     const onSelectDevice = vi.fn();
     const { rerender } = render(

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -15,6 +15,19 @@ const { getOrCreateMachineId, computeStableMachineId } = require("./machine-id")
 
 const SYNC_TIMEOUT_MS = 120_000;
 const TRACKER_BIN = path.resolve(__dirname, "../../bin/tracker.js");
+const MAX_DEVICE_NAME_LENGTH = 128;
+
+function getSystemDeviceName() {
+  try {
+    const hostname = os.hostname()
+      .replace(/[\u0000-\u001f\u007f]/g, "")
+      .trim()
+      .slice(0, MAX_DEVICE_NAME_LENGTH);
+    return hostname || null;
+  } catch {
+    return null;
+  }
+}
 
 // Avatar proxy (see /api/avatar-proxy below). In-memory LRU; survives the
 // CLI server lifetime, which is good enough — the dashboard reloads cheaply.
@@ -1356,7 +1369,7 @@ function createLocalApiHandler({ queuePath }) {
           // 必须和 dashboard/src/lib/cloud-sync.ts 使用同一个设备身份。
           // 旧云端设备按 (platform, device_name) 认领；如果这里发明
           // local-sync 身份，会多出一个 active device，账户视图会把历史求和两次。
-          device_name: `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
+          device_name: getSystemDeviceName() || `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
           platform: dashboardPlatform,
           machine_id: machineId,
         }),
@@ -2577,7 +2590,10 @@ function createLocalApiHandler({ queuePath }) {
     // device_name keys on the MACHINE, not the browser — see
     // getOrCreateMachineId above and dashboard/src/lib/cloud-sync.ts.
     if (p === "/functions/tokentracker-machine-id") {
-      json(res, { machineId: getOrCreateMachineId(qp) });
+      json(res, {
+        machineId: getOrCreateMachineId(qp),
+        deviceName: getSystemDeviceName(),
+      });
       return true;
     }
 
@@ -2891,10 +2907,10 @@ module.exports = {
   // queue, wrapped aggregator) reports the same numbers for the same data.
   normalizeQueueRow,
   // Machine-stable identity (config.json machineId) — shared with
-  // `tracker device-login` so the CLI device-flow anchors its cloud device
-  // to the machine, not the hostname.
+  // `tracker device-login`; the hostname is only a human-readable label.
   getOrCreateMachineId,
   computeStableMachineId,
+  getSystemDeviceName,
   // Local achievement compute — exported for test/local-achievements.test.js.
   computeLocalAchievements,
   LOCAL_BADGE_THRESHOLDS,

--- a/test/cloud-sync-prefs.test.js
+++ b/test/cloud-sync-prefs.test.js
@@ -23,7 +23,9 @@ async function loadModuleWithStorage(storage) {
 
 test("cloud device session stays in memory and clears legacy localStorage", async () => {
   const legacyKey = "tokentracker_cloud_device_session_v1";
+  const deviceIdKey = "tokentracker_cloud_device_id_v1";
   const storage = createStorage({
+    [deviceIdKey]: "persisted-device-id",
     [legacyKey]: JSON.stringify({
       token: "persisted-token",
       deviceId: "persisted-device",
@@ -37,6 +39,7 @@ test("cloud device session stays in memory and clears legacy localStorage", asyn
 
     assert.equal(mod.getStoredDeviceSession(), null);
     assert.equal(storage.getItem(legacyKey), null);
+    assert.equal(mod.getCurrentDeviceId(), "persisted-device-id");
 
     const session = {
       token: "memory-token",
@@ -47,9 +50,14 @@ test("cloud device session stays in memory and clears legacy localStorage", asyn
     mod.setStoredDeviceSession(session);
     assert.deepEqual(mod.getStoredDeviceSession(), session);
     assert.equal(storage.getItem(legacyKey), null);
+    assert.equal(storage.getItem(deviceIdKey), "memory-device");
+    assert.equal(mod.getCurrentDeviceId(), "memory-device");
+    assert.equal(String(storage.getItem(deviceIdKey)).includes("memory-token"), false);
 
     mod.clearCloudDeviceSession();
     assert.equal(mod.getStoredDeviceSession(), null);
+    assert.equal(mod.getCurrentDeviceId(), "");
+    assert.equal(storage.getItem(deviceIdKey), null);
   } finally {
     globalThis.localStorage = previous;
   }

--- a/test/device-rename-persistence.test.js
+++ b/test/device-rename-persistence.test.js
@@ -138,8 +138,27 @@ function createEdgeDatabaseMock() {
         return { data: inserted, error: null };
       }
       if (operation === "update") {
-        for (const row of rows.filter(matches)) Object.assign(row, values);
-        return { data: rows.filter(matches), error: null };
+        const targetRows = rows.filter(matches);
+        if (table === "tokentracker_devices") {
+          // Model the active-name unique index: renaming an active row onto a
+          // name another active row of the same (user, platform) owns fails.
+          for (const row of targetRows) {
+            const nextName = Object.prototype.hasOwnProperty.call(values, "device_name")
+              ? values.device_name
+              : row.device_name;
+            const conflict = devices.some((other) =>
+              other !== row
+                && other.revoked_at == null
+                && other.user_id === row.user_id
+                && other.platform === row.platform
+                && other.device_name === nextName);
+            if (conflict) {
+              return { data: null, error: { message: 'duplicate key value violates unique constraint "tokentracker_devices_active_name_key"' } };
+            }
+          }
+        }
+        for (const row of targetRows) Object.assign(row, values);
+        return { data: targetRows, error: null };
       }
       if (operation === "insert") {
         const inserted = values.map((value) => ({ revoked_at: null, ...value }));
@@ -439,6 +458,116 @@ test("legacy CLI client info without a hostname keeps the generated label", asyn
   );
 
   assert.equal(devices[0].device_name, "TokenTracker CLI (darwin-arm64) #cccccccc");
+});
+
+test("CLI adoption keeps the legacy label when another machine owns the hostname", async () => {
+  const { testIssueDeviceToken } = await loadDeviceFlowIssuer();
+  const { client, devices } = createEdgeDatabaseMock();
+  const hostname = "MacBook-Pro.local";
+  const machineA = "a".repeat(64);
+  const machineB = "b".repeat(64);
+  devices.push(
+    {
+      id: "machine-a-device",
+      user_id: "same-user",
+      device_name: hostname,
+      platform: "cli-device-flow",
+      machine_id: machineA,
+      revoked_at: null,
+      name_customized: false,
+      created_at: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      id: "orphan-b",
+      user_id: "same-user",
+      device_name: `TokenTracker CLI (darwin-arm64 ${hostname}) #bbbbbbbb`,
+      default_device_name: `TokenTracker CLI (darwin-arm64 ${hostname}) #bbbbbbbb`,
+      platform: "cli-device-flow",
+      machine_id: null,
+      revoked_at: null,
+      name_customized: false,
+      created_at: "2026-01-02T00:00:00.000Z",
+    },
+  );
+
+  const result = await testIssueDeviceToken(
+    client,
+    "same-user",
+    `darwin-arm64 ${hostname}`,
+    machineB,
+  );
+
+  // Renaming the orphan onto the taken hostname collides with the active-name
+  // unique index; adoption must fall back to machine_id-only so the historical
+  // row is claimed instead of orphaned.
+  assert.equal(result.deviceId, "orphan-b");
+  const adopted = devices.find((device) => device.id === "orphan-b");
+  assert.equal(adopted.machine_id, machineB);
+  assert.equal(adopted.device_name, `TokenTracker CLI (darwin-arm64 ${hostname}) #bbbbbbbb`);
+});
+
+test("dashboard token issue keeps the legacy label when another machine owns the hostname", async () => {
+  const { default: issueDashboardToken } = await loadDashboardTokenIssueHandler();
+  const dashboardDb = createEdgeDatabaseMock();
+  const hostname = "office-win";
+  const machineA = "a".repeat(64);
+  const machineB = "b".repeat(64);
+  dashboardDb.devices.push(
+    {
+      id: "machine-a-device",
+      user_id: "same-user",
+      device_name: hostname,
+      platform: "desktop",
+      machine_id: machineA,
+      revoked_at: null,
+      name_customized: false,
+    },
+    {
+      id: "orphan-b",
+      user_id: "same-user",
+      device_name: "Token Tracker (dashboard) #bbbbbbbb",
+      platform: "desktop",
+      machine_id: null,
+      revoked_at: null,
+      name_customized: false,
+    },
+  );
+  const previousDeno = globalThis.Deno;
+  const previousEdgeTestClient = globalThis.__edgeTestClient;
+  globalThis.__edgeTestClient = dashboardDb.client;
+  globalThis.Deno = {
+    env: {
+      get(name) {
+        return {
+          INSFORGE_BASE_URL: "https://cloud.example",
+          INSFORGE_SERVICE_ROLE_KEY: "test-service-role",
+          INSFORGE_ANON_KEY: "test-anon-key",
+        }[name];
+      },
+    },
+  };
+  try {
+    const response = await issueDashboardToken(new Request("https://cloud.example/functions/device-token", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-service-role",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_id: "same-user",
+        device_name: hostname,
+        platform: "desktop",
+        machine_id: machineB,
+      }),
+    }));
+    assert.equal(response.status, 200, await response.text());
+  } finally {
+    globalThis.Deno = previousDeno;
+    globalThis.__edgeTestClient = previousEdgeTestClient;
+  }
+  const adopted = dashboardDb.devices.find((device) => device.id === "orphan-b");
+  assert.equal(adopted.machine_id, machineB);
+  assert.equal(adopted.device_name, "Token Tracker (dashboard) #bbbbbbbb");
 });
 
 test("current-device labels react to the first completed cloud sync", () => {

--- a/test/device-rename-persistence.test.js
+++ b/test/device-rename-persistence.test.js
@@ -10,6 +10,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
+const ts = require("typescript");
 
 const ROOT = path.resolve(__dirname, "..");
 const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
@@ -21,6 +22,146 @@ const readMigrationBySuffix = (suffix) => {
   assert.ok(file, `missing migration ending in _${suffix}.sql`);
   return read(`migrations/${file}`);
 };
+
+async function loadDeviceFlowIssuer() {
+  const source = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts")
+    .replace(
+      'import { createClient } from "npm:@insforge/sdk";',
+      "const createClient = () => globalThis.__unusedEdgeTestClient;",
+    )
+    .concat("\nexport { issueDeviceToken as testIssueDeviceToken };\n");
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const url = `data:text/javascript;base64,${Buffer.from(compiled).toString("base64")}`;
+  return import(url);
+}
+
+async function loadDashboardTokenIssueHandler() {
+  const source = read("dashboard/edge-patches/tokentracker-device-token-issue.ts")
+    .replace(
+      'import { createClient } from "npm:@insforge/sdk";',
+      "const createClient = () => globalThis.__edgeTestClient;",
+    );
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const url = `data:text/javascript;base64,${Buffer.from(compiled).toString("base64")}`;
+  return import(url);
+}
+
+function createEdgeDatabaseMock() {
+  const devices = [];
+  const tokens = [];
+
+  function from(table) {
+    let operation = "select";
+    let values = null;
+    let filters = [];
+    let maxRows = Infinity;
+
+    const query = {
+      select() {
+        return query;
+      },
+      upsert(rows) {
+        operation = "upsert";
+        values = rows;
+        return query;
+      },
+      update(nextValues) {
+        operation = "update";
+        values = nextValues;
+        return query;
+      },
+      insert(rows) {
+        operation = "insert";
+        values = rows;
+        return query;
+      },
+      eq(column, value) {
+        filters.push((row) => row[column] === value);
+        return query;
+      },
+      is(column, value) {
+        filters.push((row) => (row[column] ?? null) === value);
+        return query;
+      },
+      in(column, candidates) {
+        filters.push((row) => candidates.includes(row[column]));
+        return query;
+      },
+      order() {
+        return query;
+      },
+      limit(value) {
+        maxRows = value;
+        return query;
+      },
+      maybeSingle() {
+        const result = execute();
+        return Promise.resolve({ data: result.data[0] || null, error: result.error });
+      },
+      then(resolve, reject) {
+        return Promise.resolve(execute()).then(resolve, reject);
+      },
+    };
+
+    const matches = (row) => filters.every((filter) => filter(row));
+    function execute() {
+      const rows = table === "tokentracker_devices" ? devices : tokens;
+      if (operation === "select") {
+        return { data: rows.filter(matches).slice(0, maxRows), error: null };
+      }
+      if (operation === "upsert") {
+        const inserted = [];
+        for (const value of values) {
+          const conflict = devices.some((row) =>
+            row.revoked_at == null
+              && row.user_id === value.user_id
+              && (
+                (row.platform === value.platform && row.device_name === value.device_name)
+                || (value.machine_id && row.machine_id === value.machine_id)
+              ));
+          if (!conflict) {
+            const row = { revoked_at: null, ...value };
+            devices.push(row);
+            inserted.push(row);
+          }
+        }
+        return { data: inserted, error: null };
+      }
+      if (operation === "update") {
+        for (const row of rows.filter(matches)) Object.assign(row, values);
+        return { data: rows.filter(matches), error: null };
+      }
+      if (operation === "insert") {
+        const inserted = values.map((value) => ({ revoked_at: null, ...value }));
+        rows.push(...inserted);
+        return { data: inserted, error: null };
+      }
+      throw new Error(`unsupported mock operation: ${operation}`);
+    }
+
+    return query;
+  }
+
+  return {
+    client: {
+      database: {
+        from,
+        rpc: async () => ({ data: true, error: null }),
+      },
+    },
+    devices,
+  };
+}
 
 test("migration adds the name_customized column and backfills renamed rows", () => {
   const source = read(MIGRATION);
@@ -188,14 +329,128 @@ test("device uploads keep machine identity separate from readable system names",
   );
 
   const flowPoll = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts");
-  assert.match(
-    flowPoll,
-    /clientInfo\?\.replace\(\/\^\\S\+\\s\+\/, ""\)\.trim\(\)/u,
-    "CLI device flow must extract the system hostname from client_info",
+  assert.ok(
+    flowPoll.includes("const hostnameMatch = clientInfo?.match(/^\\S+\\s+(.+)$/);"),
+    "CLI device flow must only extract a hostname when client_info has the expected separator",
   );
   assert.match(
     flowPoll,
     /generatedLegacyName[\s\S]*?\.in\("device_name", legacyNames\)/u,
     "CLI hostname rollout must continue adopting generated legacy names",
+  );
+});
+
+test("two machines with the same hostname register as distinct devices", async () => {
+  const { testIssueDeviceToken } = await loadDeviceFlowIssuer();
+  const { client, devices } = createEdgeDatabaseMock();
+  const hostname = "MacBook-Pro.local";
+  const firstMachineId = "a".repeat(64);
+  const secondMachineId = "b".repeat(64);
+
+  const first = await testIssueDeviceToken(
+    client,
+    "same-user",
+    `darwin-arm64 ${hostname}`,
+    firstMachineId,
+  );
+  const second = await testIssueDeviceToken(
+    client,
+    "same-user",
+    `darwin-arm64 ${hostname}`,
+    secondMachineId,
+  );
+
+  assert.notEqual(first.deviceId, second.deviceId);
+  assert.deepEqual(
+    devices.map((device) => ({
+      name: device.device_name,
+      machineId: device.machine_id,
+    })),
+    [
+      { name: hostname, machineId: firstMachineId },
+      { name: `${hostname} #bbbbbbbb`, machineId: secondMachineId },
+    ],
+  );
+
+  const { default: issueDashboardToken } = await loadDashboardTokenIssueHandler();
+  const dashboardDb = createEdgeDatabaseMock();
+  const previousDeno = globalThis.Deno;
+  const previousEdgeTestClient = globalThis.__edgeTestClient;
+  globalThis.__edgeTestClient = dashboardDb.client;
+  globalThis.Deno = {
+    env: {
+      get(name) {
+        return {
+          INSFORGE_BASE_URL: "https://cloud.example",
+          INSFORGE_SERVICE_ROLE_KEY: "test-service-role",
+          INSFORGE_ANON_KEY: "test-anon-key",
+        }[name];
+      },
+    },
+  };
+  try {
+    for (const machineId of [firstMachineId, secondMachineId]) {
+      const response = await issueDashboardToken(new Request("https://cloud.example/functions/device-token", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-service-role",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          user_id: "same-user",
+          device_name: hostname,
+          platform: "desktop",
+          machine_id: machineId,
+        }),
+      }));
+      assert.equal(response.status, 200, await response.text());
+    }
+  } finally {
+    globalThis.Deno = previousDeno;
+    globalThis.__edgeTestClient = previousEdgeTestClient;
+  }
+  assert.deepEqual(
+    dashboardDb.devices.map((device) => device.device_name),
+    [hostname, `${hostname} #bbbbbbbb`],
+  );
+
+  for (const relativePath of [
+    "dashboard/edge-patches/tokentracker-device-token-issue.ts",
+    "dashboard/edge-patches/tokentracker-device-flow-poll.ts",
+  ]) {
+    const source = read(relativePath);
+    assert.match(
+      source,
+      /const fallbackDeviceName = disambiguateDeviceName\(deviceName, machineId\)/u,
+      `${relativePath} must retry same-hostname registration with a stable suffix`,
+    );
+  }
+});
+
+test("legacy CLI client info without a hostname keeps the generated label", async () => {
+  const { testIssueDeviceToken } = await loadDeviceFlowIssuer();
+  const { client, devices } = createEdgeDatabaseMock();
+
+  await testIssueDeviceToken(
+    client,
+    "legacy-user",
+    "darwin-arm64",
+    "c".repeat(64),
+  );
+
+  assert.equal(devices[0].device_name, "TokenTracker CLI (darwin-arm64) #cccccccc");
+});
+
+test("current-device labels react to the first completed cloud sync", () => {
+  const dashboardPage = read("dashboard/src/pages/DashboardPage.jsx");
+  assert.match(
+    dashboardPage,
+    /window\.addEventListener\(CLOUD_USAGE_SYNCED_EVENT, refreshCurrentDevice\)/u,
+    "the current-device ID must refresh in the same tab after the first successful sync",
+  );
+  assert.match(
+    dashboardPage,
+    /setCurrentDeviceId\(getCurrentDeviceId\(\)\)/u,
+    "the sync listener must re-read the newly issued device ID",
   );
 });

--- a/test/device-rename-persistence.test.js
+++ b/test/device-rename-persistence.test.js
@@ -169,7 +169,33 @@ test("renamed machine_id-less rows stay adoptable via their preserved default na
   const flowPoll = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts");
   assert.match(
     flowPoll,
-    /\.in\("default_device_name", \[deviceName, legacyBareName\]\)/u,
+    /\.in\("default_device_name", legacyNames\)/u,
     "device-flow-poll adoption must fall back to the preserved pre-rename default name",
+  );
+});
+
+test("device uploads keep machine identity separate from readable system names", () => {
+  const tokenIssue = read("dashboard/edge-patches/tokentracker-device-token-issue.ts");
+  assert.match(
+    tokenIssue,
+    /`Token Tracker \(dashboard\) #\$\{machineId\.slice\(0, 8\)\}`/u,
+    "hostname rollout must still adopt the previous dashboard hash label",
+  );
+  assert.match(
+    tokenIssue,
+    /legacyNameCustomized[\s\S]{0,180}\{ machine_id: machineId, device_name: deviceName \}/u,
+    "legacy adoption must refresh generated labels without overwriting custom names",
+  );
+
+  const flowPoll = read("dashboard/edge-patches/tokentracker-device-flow-poll.ts");
+  assert.match(
+    flowPoll,
+    /clientInfo\?\.replace\(\/\^\\S\+\\s\+\/, ""\)\.trim\(\)/u,
+    "CLI device flow must extract the system hostname from client_info",
+  );
+  assert.match(
+    flowPoll,
+    /generatedLegacyName[\s\S]*?\.in\("device_name", legacyNames\)/u,
+    "CLI hostname rollout must continue adopting generated legacy names",
   );
 });

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -65,6 +65,13 @@ function loadLocalApiWithSpawn(fakeSpawn) {
   };
 }
 
+test("local device metadata exposes the system name separately from machine identity", () => {
+  const { getSystemDeviceName } = require("../src/lib/local-api");
+  const expected = os.hostname().replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, 128) || null;
+  assert.equal(getSystemDeviceName(), expected);
+  assert.doesNotMatch(getSystemDeviceName() || "", /^Token Tracker .*#/u);
+});
+
 function createSuccessfulSpawn(calls) {
   return (cmd, args, options) => {
     calls.push({ cmd, args, options });
@@ -1183,7 +1190,7 @@ test("local sync drain request mints a device token from relayed login when none
       assert.equal(opts.headers.Authorization, "Bearer access-token");
       const body = JSON.parse(String(opts.body || "{}"));
       assert.equal(body.machine_id, "machine-abcdef12");
-      assert.equal(body.device_name, "Token Tracker (dashboard) #machine-");
+      assert.equal(body.device_name, os.hostname().replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, 128));
       assert.equal(
         body.platform,
         process.platform === "darwin" ? "MacIntel" :


### PR DESCRIPTION
## Summary

- use the operating system hostname as the cloud device display name while keeping the stable anonymous machine ID as the device identity
- mark the current machine as "This device" in device cards and the device filter
- adopt legacy generated/hash names safely without overwriting names users customized themselves
- retain only the non-sensitive issued device UUID across page reloads so the current-device marker survives sync throttling; auth tokens remain memory-only

## Compatibility and privacy

- no database migration or new column is required because device identity and display name are already separate
- the hostname is used only as the display name when cloud sync is enabled
- existing user-renamed devices remain unchanged
- legacy dashboard and CLI-generated names continue to be recognized to avoid duplicate devices after upgrading

## Validation

- 52 device/local API Node tests
- 15 targeted dashboard tests
- dashboard TypeScript and ESLint checks
- copy, UI hardcode, and guardrail validation
- production dashboard build
- narrow-window browser layout check (360 px) with a long Windows hostname


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device names now prefer your system hostname when available, with deterministic machine-based disambiguation and safe fallbacks.
  * The dashboard highlights the current device with a localized “current” label/badge and keeps this selection consistent across sessions.
* **Bug Fixes**
  * Improved device adoption and rename handling to preserve customized names, avoid name collisions, and reliably recover stable naming after race conditions.
* **Localization**
  * Added the “current device” label for German, Japanese, Korean, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->