### PR TITLE
feat: add Trae SOLO (ByteDance AI IDE) support

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -66,6 +66,7 @@ const {
   resolvePiAgentDir,
   piAgentDirCollidesWithOmp,
   resolveAnythingllmDbPath,
+  resolveTraeStoragePath,
 } = require("../lib/rollout");
 const { resolveRuntimeConfig, DEFAULT_BASE_URL } = require("../lib/runtime-config");
 const {
@@ -713,6 +714,20 @@ async function applyIntegrationSetup({
     const craftConfigDir = process.env.CRAFT_CONFIG_DIR || path.join(home, ".craft-agent");
     if (fssync.existsSync(craftConfigDir)) {
       summary.push({ label: "Craft Agents", status: "detected", detail: "Passive reader (no hook needed)" });
+    }
+  }
+
+  // Trae SOLO (ByteDance AI IDE): passive entitlement reader — no hook
+  // installation needed. TokenTracker reads User/globalStorage/storage.json
+  // and surfaces the plan/limits snapshot.
+  {
+    const traeStoragePath = resolveTraeStoragePath(process.env);
+    if (traeStoragePath) {
+      summary.push({
+        label: "Trae SOLO",
+        status: "detected",
+        detail: "Passive reader (no hook needed)",
+      });
     }
   }
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -71,6 +71,7 @@ const {
   resolveGooseDbPath,
   listDroidSettingsFiles,
   resolveDroidSessionsDir,
+  resolveTraeStoragePath,
   resolveGrokBuildSessions,
   resolveHermesPath,
   resolveHermesDbPath,
@@ -547,6 +548,10 @@ async function cmdStatus(argv = []) {
   const droidSettingsFiles = listDroidSettingsFiles(process.env);
   const droidInstalled = droidSettingsFiles.length > 0;
 
+  // Trae SOLO (ByteDance AI IDE) — passive entitlement snapshot reader.
+  const traeStoragePath = resolveTraeStoragePath(process.env);
+  const traeInstalled = Boolean(traeStoragePath);
+
   // Grok Build (xAI TUI)
   const grokHookState = await probeGrokHookState({ home, trackerDir, env: process.env });
   const grokSessions = grokHookState.hasGrokInstall || grokHookState.sessionsDir
@@ -818,6 +823,9 @@ async function cmdStatus(argv = []) {
         droid: droidInstalled
           ? { installed: true, files: droidSettingsFiles.length, detail: droidSessionsDir }
           : { installed: false },
+        trae: traeInstalled
+          ? { installed: true, detail: traeStoragePath }
+          : { installed: false },
         grok_build: grokInstalled
           ? {
               installed: true,
@@ -965,6 +973,9 @@ async function cmdStatus(argv = []) {
         : null,
       droidInstalled
         ? `- Droid (Factory): passive reader (${droidSettingsFiles.length} session${droidSettingsFiles.length !== 1 ? "s" : ""} in ${droidSessionsDir}, cumulative-delta)`
+        : null,
+      traeInstalled
+        ? `- Trae SOLO: passive reader (entitlement snapshot from ${traeStoragePath})`
         : null,
       ...(() => {
         if (!hermesInstalled) return [];

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -100,6 +100,66 @@ function formatResolvedPaths(paths, filename) {
   return active;
 }
 
+// Read the newest Trae SOLO entitlement snapshot from the local queue. The
+// sync parser writes one zero-token `trae` row per storage.json change,
+// carrying the plan/limits snapshot in `trae_entitlement`; this is the read
+// side of that contract so users can actually see the advertised plan data
+// (not just a row they cannot consume).
+async function readLatestTraeEntitlement(queuePath) {
+  let raw;
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  // Scan from the tail: the newest snapshot is the last source=trae queue
+  // row that carries a trae_entitlement object.
+  const lines = raw.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line);
+      if (
+        row &&
+        row.source === "trae" &&
+        row.trae_entitlement &&
+        typeof row.trae_entitlement === "object"
+      ) {
+        return {
+          ...row.trae_entitlement,
+          captured_at: typeof row.hour_start === "string" ? row.hour_start : null,
+        };
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return null;
+}
+
+function formatTraeEntitlementLine(ent) {
+  const parts = [];
+  if (ent.identity) parts.push(`plan ${ent.identity}`);
+  if (ent.pro_period) parts.push(`${ent.pro_period} period`);
+  if (typeof ent.is_dollar_billing === "boolean") {
+    parts.push(ent.is_dollar_billing ? "dollar billing" : "package billing");
+  }
+  if (typeof ent.enable_solo_builder === "boolean") {
+    parts.push(`solo builder: ${ent.enable_solo_builder ? "yes" : "no"}`);
+  }
+  if (typeof ent.enable_solo_coder === "boolean") {
+    parts.push(`solo coder: ${ent.enable_solo_coder ? "yes" : "no"}`);
+  }
+  if (typeof ent.fast_request_per === "number") {
+    parts.push(`${ent.fast_request_per} fast requests/hr`);
+  }
+  if (ent.in_waitlist === true) parts.push("in waitlist");
+  if (ent.captured_at) parts.push(`snapshot ${ent.captured_at}`);
+  return parts.length ? parts.join(", ") : "unknown";
+}
+
 async function cmdStatus(argv = []) {
   const opts = parseArgs(argv);
   if (opts.diagnostics) {
@@ -551,6 +611,11 @@ async function cmdStatus(argv = []) {
   // Trae SOLO (ByteDance AI IDE) — passive entitlement snapshot reader.
   const traeStoragePath = resolveTraeStoragePath(process.env);
   const traeInstalled = Boolean(traeStoragePath);
+  // Render path for the entitlement snapshot the sync parser writes to the
+  // queue: the newest source=trae row carries the plan/limits metadata.
+  const traeEntitlement = traeInstalled
+    ? await readLatestTraeEntitlement(queuePath)
+    : null;
 
   // Grok Build (xAI TUI)
   const grokHookState = await probeGrokHookState({ home, trackerDir, env: process.env });
@@ -824,7 +889,11 @@ async function cmdStatus(argv = []) {
           ? { installed: true, files: droidSettingsFiles.length, detail: droidSessionsDir }
           : { installed: false },
         trae: traeInstalled
-          ? { installed: true, detail: traeStoragePath }
+          ? {
+              installed: true,
+              detail: traeStoragePath,
+              ...(traeEntitlement ? { entitlement: traeEntitlement } : {}),
+            }
           : { installed: false },
         grok_build: grokInstalled
           ? {
@@ -976,6 +1045,9 @@ async function cmdStatus(argv = []) {
         : null,
       traeInstalled
         ? `- Trae SOLO: passive reader (entitlement snapshot from ${traeStoragePath})`
+        : null,
+      traeEntitlement
+        ? `- Trae SOLO plan: ${formatTraeEntitlementLine(traeEntitlement)}`
         : null,
       ...(() => {
         if (!hermesInstalled) return [];

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -72,6 +72,7 @@ const {
   listDroidSettingsFiles,
   resolveDroidSessionsDir,
   resolveTraeStoragePath,
+  readTraeEntitlementFromStorage,
   resolveGrokBuildSessions,
   resolveHermesPath,
   resolveHermesDbPath,
@@ -100,45 +101,11 @@ function formatResolvedPaths(paths, filename) {
   return active;
 }
 
-// Read the newest Trae SOLO entitlement snapshot from the local queue. The
-// sync parser writes one zero-token `trae` row per storage.json change,
-// carrying the plan/limits snapshot in `trae_entitlement`; this is the read
-// side of that contract so users can actually see the advertised plan data
-// (not just a row they cannot consume).
-async function readLatestTraeEntitlement(queuePath) {
-  let raw;
-  try {
-    raw = await fs.readFile(queuePath, "utf8");
-  } catch {
-    return null;
-  }
-  if (!raw) return null;
-  // Scan from the tail: the newest snapshot is the last source=trae queue
-  // row that carries a trae_entitlement object.
-  const lines = raw.split("\n");
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
-    if (!line.trim()) continue;
-    try {
-      const row = JSON.parse(line);
-      if (
-        row &&
-        row.source === "trae" &&
-        row.trae_entitlement &&
-        typeof row.trae_entitlement === "object"
-      ) {
-        return {
-          ...row.trae_entitlement,
-          captured_at: typeof row.hour_start === "string" ? row.hour_start : null,
-        };
-      }
-    } catch {
-      // skip malformed line
-    }
-  }
-  return null;
-}
-
+// The Trae SOLO entitlement snapshot is read directly from the Trae Local
+// State storage.json via the shared parser (readTraeEntitlementFromStorage).
+// The queue.jsonl contract is token-count-only (CLAUDE.md privacy rule), so
+// plan/limits metadata is never persisted into queue rows — this is the read
+// side of that contract so users can actually see the advertised plan data.
 function formatTraeEntitlementLine(ent) {
   const parts = [];
   if (ent.identity) parts.push(`plan ${ent.identity}`);
@@ -611,10 +578,12 @@ async function cmdStatus(argv = []) {
   // Trae SOLO (ByteDance AI IDE) — passive entitlement snapshot reader.
   const traeStoragePath = resolveTraeStoragePath(process.env);
   const traeInstalled = Boolean(traeStoragePath);
-  // Render path for the entitlement snapshot the sync parser writes to the
-  // queue: the newest source=trae row carries the plan/limits metadata.
+  // Render path for the entitlement snapshot: read it straight from the
+  // Trae Local State storage.json via the shared parser. The queue stays
+  // token-count-only, so the status read path never depends on queue rows
+  // carrying plan/limits metadata.
   const traeEntitlement = traeInstalled
-    ? await readLatestTraeEntitlement(queuePath)
+    ? readTraeEntitlementFromStorage(traeStoragePath)
     : null;
 
   // Grok Build (xAI TUI)

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -104,8 +104,6 @@ const {
   parseDroidIncremental,
   droidSessionIdFromPath,
   resolveDroidModel,
-  resolveTraeStoragePath,
-  parseTraeIncremental,
   bucketKey,
   toUtcHalfHourStart,
   totalsKey,
@@ -280,7 +278,6 @@ const AUTO_SYNC_SOURCES = new Set([
   "pi",
   "qoder",
   "roocode",
-  "trae",
   "workbuddy",
   "zcode",
   "zed",
@@ -1412,35 +1409,6 @@ async function cmdSync(argv, context = {}) {
       }
     }
 
-    // ── Trae SOLO (ByteDance AI IDE) — passive entitlement snapshot reader ──
-    // Trae stores plan/limits (not per-session tokens) in
-    // User/globalStorage/storage.json under iCubeServerData://icube.cloudide.
-    // parseTraeIncremental emits one synthetic zero-token hourly bucket per
-    // change so the dashboard can surface the entitlement snapshot.
-    const traeStoragePath = resolveTraeStoragePath(process.env);
-    let traeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    if (sourceAllowed("trae") && traeStoragePath) {
-      if (progress?.enabled) {
-        progress.start(`Parsing Trae SOLO ${renderBar(0)} | buckets 0`);
-      }
-      try {
-        traeResult = await parseTraeIncremental({
-          storagePath: traeStoragePath,
-          cursors,
-          queuePath,
-          onProgress: (p) => {
-            if (!progress?.enabled) return;
-            const pct = p.total > 0 ? p.index / p.total : 1;
-            progress.update(
-              `Parsing Trae SOLO ${renderBar(pct)} | buckets ${formatNumber(p.bucketsQueued)}`,
-            );
-          },
-        });
-      } catch (err) {
-        warnProviderParseFailure("Trae SOLO", err, opts);
-      }
-    }
-
     // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -2446,8 +2414,7 @@ async function cmdSync(argv, context = {}) {
       roocodeResult.recordsProcessed +
       zedResult.recordsProcessed +
       gooseResult.recordsProcessed +
-      droidResult.recordsProcessed +
-      traeResult.recordsProcessed;
+      droidResult.recordsProcessed;
     const totalBuckets =
       parseResult.bucketsQueued +
       openclawResult.bucketsQueued +
@@ -2478,8 +2445,7 @@ async function cmdSync(argv, context = {}) {
       roocodeResult.bucketsQueued +
       zedResult.bucketsQueued +
       gooseResult.bucketsQueued +
-      droidResult.bucketsQueued +
-      traeResult.bucketsQueued;
+      droidResult.bucketsQueued;
     const skipNoOpCursorCommit =
       opts.auto &&
       !isFullSourceScan &&

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -104,6 +104,8 @@ const {
   parseDroidIncremental,
   droidSessionIdFromPath,
   resolveDroidModel,
+  resolveTraeStoragePath,
+  parseTraeIncremental,
   bucketKey,
   toUtcHalfHourStart,
   totalsKey,
@@ -278,6 +280,7 @@ const AUTO_SYNC_SOURCES = new Set([
   "pi",
   "qoder",
   "roocode",
+  "trae",
   "workbuddy",
   "zcode",
   "zed",
@@ -1409,6 +1412,35 @@ async function cmdSync(argv, context = {}) {
       }
     }
 
+    // ── Trae SOLO (ByteDance AI IDE) — passive entitlement snapshot reader ──
+    // Trae stores plan/limits (not per-session tokens) in
+    // User/globalStorage/storage.json under iCubeServerData://icube.cloudide.
+    // parseTraeIncremental emits one synthetic zero-token hourly bucket per
+    // change so the dashboard can surface the entitlement snapshot.
+    const traeStoragePath = resolveTraeStoragePath(process.env);
+    let traeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    if (sourceAllowed("trae") && traeStoragePath) {
+      if (progress?.enabled) {
+        progress.start(`Parsing Trae SOLO ${renderBar(0)} | buckets 0`);
+      }
+      try {
+        traeResult = await parseTraeIncremental({
+          storagePath: traeStoragePath,
+          cursors,
+          queuePath,
+          onProgress: (p) => {
+            if (!progress?.enabled) return;
+            const pct = p.total > 0 ? p.index / p.total : 1;
+            progress.update(
+              `Parsing Trae SOLO ${renderBar(pct)} | buckets ${formatNumber(p.bucketsQueued)}`,
+            );
+          },
+        });
+      } catch (err) {
+        warnProviderParseFailure("Trae SOLO", err, opts);
+      }
+    }
+
     // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -2414,7 +2446,8 @@ async function cmdSync(argv, context = {}) {
       roocodeResult.recordsProcessed +
       zedResult.recordsProcessed +
       gooseResult.recordsProcessed +
-      droidResult.recordsProcessed;
+      droidResult.recordsProcessed +
+      traeResult.recordsProcessed;
     const totalBuckets =
       parseResult.bucketsQueued +
       openclawResult.bucketsQueued +
@@ -2445,7 +2478,8 @@ async function cmdSync(argv, context = {}) {
       roocodeResult.bucketsQueued +
       zedResult.bucketsQueued +
       gooseResult.bucketsQueued +
-      droidResult.bucketsQueued;
+      droidResult.bucketsQueued +
+      traeResult.bucketsQueued;
     const skipNoOpCursorCommit =
       opts.auto &&
       !isFullSourceScan &&

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15972,6 +15972,7 @@ module.exports = {
   // Trae SOLO (ByteDance AI IDE)
   resolveTraePath,
   resolveTraeStoragePath,
+  readTraeEntitlementFromStorage,
   parseTraeIncremental,
 };
 
@@ -15998,6 +15999,88 @@ function resolveTraeStoragePath(env = process.env) {
   if (!traHome) return null;
   const p = path.join(traHome, "User", "globalStorage", "storage.json");
   return fssync.existsSync(p) ? p : null;
+}
+
+/**
+ * Extract the Trae SOLO entitlement snapshot from parsed storage.json
+ * serverData (the value under iCubeServerData://icube.cloudide).
+ * Returns a normalized entitlement object, or null when the serverData
+ * carries no valid entitlementInfo. Shared by parseTraeIncremental (write
+ * path) and readTraeEntitlementFromStorage (status read path).
+ */
+function normalizeTraeEntitlement(serverData) {
+  let ent;
+  try {
+    ent = typeof serverData === "string" ? JSON.parse(serverData) : serverData;
+  } catch {
+    return null;
+  }
+  // The parsed serverData may legitimately be JSON `null` (e.g. the string
+  // "null") or another non-object — treat it as no valid snapshot.
+  if (!ent || typeof ent !== "object" || Array.isArray(ent)) return null;
+  const entitlementInfo = ent.entitlementInfo;
+  if (!entitlementInfo || typeof entitlementInfo !== "object") return null;
+  const detail = entitlementInfo.detail || {};
+  return {
+    identity: entitlementInfo.identityStr,
+    identity_code: entitlementInfo.identity,
+    has_package: entitlementInfo.hasPackage,
+    is_dollar_billing: entitlementInfo.isDollarUsageBilling,
+    pro_period: entitlementInfo.proPeriod,
+    enable_solo_builder: entitlementInfo.enableSoloBuilder,
+    enable_solo_coder: entitlementInfo.enableSoloCoder,
+    fast_request_per: detail.fastRequestPer,
+    in_waitlist: detail.inWaitlist,
+  };
+}
+
+/**
+ * Read the current Trae SOLO entitlement snapshot straight from the Trae
+ * Local State storage.json, without touching the token-count-only queue
+ * (CLAUDE.md privacy contract). Returns a normalized entitlement object
+ * with a captured_at timestamp, or null when storage.json is missing,
+ * unparseable, or carries no valid entitlement snapshot.
+ */
+function readTraeEntitlementFromStorage(storagePath) {
+  if (!storagePath) return null;
+  let fd;
+  try {
+    fd = fssync.openSync(storagePath, "r");
+  } catch {
+    return null;
+  }
+  let stat = null;
+  let raw;
+  try {
+    stat = fssync.fstatSync(fd);
+    raw = fssync.readFileSync(fd, "utf8");
+  } catch {
+    return null;
+  } finally {
+    try {
+      fssync.closeSync(fd);
+    } catch {
+      // fd already closed; nothing to do.
+    }
+  }
+  let storage;
+  try {
+    storage = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!storage || typeof storage !== "object" || Array.isArray(storage)) {
+    return null;
+  }
+  const serverKey = "iCubeServerData://icube.cloudide";
+  const serverData = storage[serverKey];
+  if (!serverData) return null;
+  const entitlement = normalizeTraeEntitlement(serverData);
+  if (!entitlement) return null;
+  return {
+    ...entitlement,
+    captured_at: stat ? new Date(stat.mtimeMs).toISOString() : null,
+  };
 }
 
 /**
@@ -16099,25 +16182,28 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
-  const entitlementInfo = ent.entitlementInfo;
-  if (!entitlementInfo || typeof entitlementInfo !== "object") {
-    // No valid entitlement snapshot: advance the cursor so a storage.json
-    // that never carries entitlement data is not re-read on every sync,
-    // and report zero processing counts like the missing-serverData path.
-    // Avoids synthesizing trae-unknown entries from an empty entitlement.
+  // No valid entitlement snapshot: advance the cursor so a storage.json
+  // that never carries entitlement data is not re-read on every sync,
+  // and report zero processing counts like the missing-serverData path.
+  // Avoids synthesizing trae-unknown entries from an empty entitlement.
+  const entitlement = normalizeTraeEntitlement(ent);
+  if (!entitlement) {
     cursorState.lastMtime = stat.mtimeMs;
     cursorState.updatedAt = new Date().toISOString();
     cursors.trae = cursorState;
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
-  const detail = entitlementInfo.detail || {};
   // Repo UTC half-hour contract: bucket starts land on :00 or :30 UTC
   // (same as every other provider), never a forced :00 hour.
   const hourStart = toUtcHalfHourStart(new Date());
 
-  const model = "trae-" + (entitlementInfo.identityStr || "unknown").toLowerCase();
+  const model = "trae-" + (entitlement.identity || "unknown").toLowerCase();
 
+  // Queue rows stay token-count-only per the repo contract (CLAUDE.md):
+  // never persist plan/billing/limits metadata into queue.jsonl. The
+  // entitlement snapshot is served from Trae Local State on demand by
+  // readTraeEntitlementFromStorage.
   const queueLine = JSON.stringify({
     source: "trae",
     model,
@@ -16130,17 +16216,6 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
     total_tokens: 0,
     billable_total_tokens: 0,
     conversation_count: 0,
-    trae_entitlement: {
-      identity: entitlementInfo.identityStr,
-      identity_code: entitlementInfo.identity,
-      has_package: entitlementInfo.hasPackage,
-      is_dollar_billing: entitlementInfo.isDollarUsageBilling,
-      pro_period: entitlementInfo.proPeriod,
-      enable_solo_builder: entitlementInfo.enableSoloBuilder,
-      enable_solo_coder: entitlementInfo.enableSoloCoder,
-      fast_request_per: detail.fastRequestPer,
-      in_waitlist: detail.inWaitlist,
-    },
   });
 
   await fs.appendFile(queuePath, queueLine + "\n");

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15973,11 +15973,18 @@ module.exports = {
   resolveTraePath,
   resolveTraeStoragePath,
   readTraeEntitlementFromStorage,
-  parseTraeIncremental,
 };
 
 // ── Trae SOLO (ByteDance AI IDE) ─────────────────────────────────────────────
 // https://www.trae.ai
+//
+// Trae SOLO is scoped to detection (init) + entitlement display (status):
+//   - init: resolveTraeStoragePath() proves an install exists.
+//   - status: readTraeEntitlementFromStorage() serves the plan/limits snapshot.
+// Trae SOLO does NOT expose per-request token usage in a readable local format
+// (session transcripts are SQLCipher-encrypted; memory summaries carry no
+// token counts), so the token-count-only queue is intentionally never written
+// for this provider — the cloud hourly table stays clean.
 function resolveTraePath(env = process.env) {
   const override = env.TOKENTRACKER_TRAE_HOME;
   if (typeof override === "string" && override.trim().length > 0) {
@@ -15991,6 +15998,10 @@ function resolveTraePath(env = process.env) {
     const appData = typeof env.APPDATA === "string" ? env.APPDATA.trim() : "";
     if (appData) return path.join(appData, "TRAE SOLO");
   }
+  // Non-macOS/Windows (e.g. Linux): TRAE SOLO ships official builds for
+  // macOS/Windows only, so there is no verified app-data layout to default
+  // to. Fall back to a deterministic home-dir path (best-effort detection);
+  // TOKENTRACKER_TRAE_HOME always wins for unusual installs.
   return path.join(home, ".trae-solo");
 }
 
@@ -16005,8 +16016,8 @@ function resolveTraeStoragePath(env = process.env) {
  * Extract the Trae SOLO entitlement snapshot from parsed storage.json
  * serverData (the value under iCubeServerData://icube.cloudide).
  * Returns a normalized entitlement object, or null when the serverData
- * carries no valid entitlementInfo. Shared by parseTraeIncremental (write
- * path) and readTraeEntitlementFromStorage (status read path).
+ * carries no valid entitlementInfo. Shared by the status read path
+ * (readTraeEntitlementFromStorage).
  */
 function normalizeTraeEntitlement(serverData) {
   let ent;
@@ -16083,153 +16094,4 @@ function readTraeEntitlementFromStorage(storagePath) {
   };
 }
 
-/**
- * Parse Trae SOLO entitlement data from storage.json.
- * Trae stores plan & usage limits in iCubeServerData://icube.cloudide.
- * Unlike session-based providers, Trae reports plan/limits rather than
- * per-session token counts — we emit a synthetic hourly bucket with
- * the entitlement snapshot so the dashboard can display Trae plan info.
- */
-async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, onProgress } = {}) {
-  await ensureDir(path.dirname(queuePath));
 
-  // Prefer an explicit storagePath; otherwise fall back to the platform
-  // resolver, honoring the supplied traHome override so callers that pass a
-  // custom Trae home don't get re-resolved against process.env.
-  const targetPath =
-    storagePath ??
-    resolveTraeStoragePath(
-      traHome
-        ? { ...process.env, TOKENTRACKER_TRAE_HOME: traHome }
-        : process.env,
-    );
-  if (!targetPath) {
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  // Follow the parsePiIncremental cursor pattern: derive a mutable cursor
-  // state and assign it back to cursors.trae before every return so cursor
-  // advances survive even when cursors.trae did not exist yet.
-  const cursorState = cursors.trae && typeof cursors.trae === "object" ? cursors.trae : {};
-  const lastMtime = cursorState.lastMtime || 0;
-
-  // Synchronous open+read via a stable file descriptor: openSync atomically
-  // resolves the path, so fstat/read on the same fd cannot race a concurrent
-  // replace/delete the way a separate stat+readFile sequence can. Mirrors the
-  // fd-based sniff used by codebuddyJsonlHasUsage.
-  let fd;
-  try {
-    fd = fssync.openSync(targetPath, "r");
-  } catch {
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-  let stat = null;
-  let raw;
-  try {
-    stat = fssync.fstatSync(fd);
-    if (stat.mtimeMs <= lastMtime) {
-      return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    }
-    raw = fssync.readFileSync(fd, "utf8");
-  } finally {
-    try {
-      fssync.closeSync(fd);
-    } catch {
-      // fd already closed; nothing to do.
-    }
-  }
-  let storage;
-  try {
-    storage = JSON.parse(raw);
-  } catch {
-    // Unparseable JSON: keep the old cursor so a repaired storage.json is
-    // retried on the next sync rather than skipped forever.
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-  // A valid JSON document may still be `null` (or a scalar/array) — guard
-  // before property dereference so a non-object snapshot is treated as no
-  // valid data (advance cursor, zero counts) instead of crashing with
-  // TypeError reading a property of null.
-  if (!storage || typeof storage !== "object" || Array.isArray(storage)) {
-    cursorState.lastMtime = stat.mtimeMs;
-    cursorState.updatedAt = new Date().toISOString();
-    cursors.trae = cursorState;
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  const serverKey = "iCubeServerData://icube.cloudide";
-  const serverData = storage[serverKey];
-  if (!serverData) {
-    cursorState.lastMtime = stat.mtimeMs;
-    cursorState.updatedAt = new Date().toISOString();
-    cursors.trae = cursorState;
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  let ent;
-  try {
-    ent = typeof serverData === "string" ? JSON.parse(serverData) : serverData;
-  } catch {
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-  // The parsed serverData may legitimately be JSON `null` (e.g. the string
-  // "null") or another non-object — treat it as no valid snapshot and
-  // advance the cursor rather than dereferencing a property of null.
-  if (!ent || typeof ent !== "object" || Array.isArray(ent)) {
-    cursorState.lastMtime = stat.mtimeMs;
-    cursorState.updatedAt = new Date().toISOString();
-    cursors.trae = cursorState;
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  // No valid entitlement snapshot: advance the cursor so a storage.json
-  // that never carries entitlement data is not re-read on every sync,
-  // and report zero processing counts like the missing-serverData path.
-  // Avoids synthesizing trae-unknown entries from an empty entitlement.
-  const entitlement = normalizeTraeEntitlement(ent);
-  if (!entitlement) {
-    cursorState.lastMtime = stat.mtimeMs;
-    cursorState.updatedAt = new Date().toISOString();
-    cursors.trae = cursorState;
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  // Repo UTC half-hour contract: bucket starts land on :00 or :30 UTC
-  // (same as every other provider), never a forced :00 hour.
-  const hourStart = toUtcHalfHourStart(new Date());
-
-  const model = "trae-" + (entitlement.identity || "unknown").toLowerCase();
-
-  // Queue rows stay token-count-only per the repo contract (CLAUDE.md):
-  // never persist plan/billing/limits metadata into queue.jsonl. The
-  // entitlement snapshot is served from Trae Local State on demand by
-  // readTraeEntitlementFromStorage.
-  const queueLine = JSON.stringify({
-    source: "trae",
-    model,
-    hour_start: hourStart,
-    input_tokens: 0,
-    cached_input_tokens: 0,
-    cache_creation_input_tokens: 0,
-    output_tokens: 0,
-    reasoning_output_tokens: 0,
-    total_tokens: 0,
-    billable_total_tokens: 0,
-    conversation_count: 0,
-  });
-
-  await fs.appendFile(queuePath, queueLine + "\n");
-
-  cursorState.lastMtime = stat.mtimeMs;
-  cursorState.updatedAt = new Date().toISOString();
-  cursors.trae = cursorState;
-
-  // sync.js passes an onProgress callback; report the completed record
-  // counts after the queue append and cursor update so interactive sync
-  // advances its progress UI (mirrors the other parsers).
-  if (onProgress) {
-    onProgress({ index: 1, total: 1, bucketsQueued: 1 });
-  }
-
-  return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
-}

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -16063,6 +16063,16 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
     // retried on the next sync rather than skipped forever.
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
+  // A valid JSON document may still be `null` (or a scalar/array) — guard
+  // before property dereference so a non-object snapshot is treated as no
+  // valid data (advance cursor, zero counts) instead of crashing with
+  // TypeError reading a property of null.
+  if (!storage || typeof storage !== "object" || Array.isArray(storage)) {
+    cursorState.lastMtime = stat.mtimeMs;
+    cursorState.updatedAt = new Date().toISOString();
+    cursors.trae = cursorState;
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
 
   const serverKey = "iCubeServerData://icube.cloudide";
   const serverData = storage[serverKey];
@@ -16079,6 +16089,15 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
   } catch {
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
+  // The parsed serverData may legitimately be JSON `null` (e.g. the string
+  // "null") or another non-object — treat it as no valid snapshot and
+  // advance the cursor rather than dereferencing a property of null.
+  if (!ent || typeof ent !== "object" || Array.isArray(ent)) {
+    cursorState.lastMtime = stat.mtimeMs;
+    cursorState.updatedAt = new Date().toISOString();
+    cursors.trae = cursorState;
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
 
   const entitlementInfo = ent.entitlementInfo;
   if (!entitlementInfo || typeof entitlementInfo !== "object") {
@@ -16093,9 +16112,9 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
   }
 
   const detail = entitlementInfo.detail || {};
-  const hourStart = new Date(
-    new Date().toISOString().slice(0, 13) + ":00:00.000Z"
-  ).toISOString();
+  // Repo UTC half-hour contract: bucket starts land on :00 or :30 UTC
+  // (same as every other provider), never a forced :00 hour.
+  const hourStart = toUtcHalfHourStart(new Date());
 
   const model = "trae-" + (entitlementInfo.identityStr || "unknown").toLowerCase();
 
@@ -16129,6 +16148,13 @@ async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, 
   cursorState.lastMtime = stat.mtimeMs;
   cursorState.updatedAt = new Date().toISOString();
   cursors.trae = cursorState;
+
+  // sync.js passes an onProgress callback; report the completed record
+  // counts after the queue append and cursor update so interactive sync
+  // advances its progress UI (mirrors the other parsers).
+  if (onProgress) {
+    onProgress({ index: 1, total: 1, bucketsQueued: 1 });
+  }
 
   return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
 }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15968,4 +15968,167 @@ module.exports = {
   parseAntigravityIncremental,
   estimateAntigravityTokens,
   isCjkCodePoint,
+
+  // Trae SOLO (ByteDance AI IDE)
+  resolveTraePath,
+  resolveTraeStoragePath,
+  parseTraeIncremental,
 };
+
+// ── Trae SOLO (ByteDance AI IDE) ─────────────────────────────────────────────
+// https://www.trae.ai
+function resolveTraePath(env = process.env) {
+  const override = env.TOKENTRACKER_TRAE_HOME;
+  if (typeof override === "string" && override.trim().length > 0) {
+    return override.trim();
+  }
+  const home = require("node:os").homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "TRAE SOLO");
+  }
+  if (process.platform === "win32") {
+    const appData = typeof env.APPDATA === "string" ? env.APPDATA.trim() : "";
+    if (appData) return path.join(appData, "TRAE SOLO");
+  }
+  return path.join(home, ".trae-solo");
+}
+
+function resolveTraeStoragePath(env = process.env) {
+  const traHome = resolveTraePath(env);
+  if (!traHome) return null;
+  const p = path.join(traHome, "User", "globalStorage", "storage.json");
+  return fssync.existsSync(p) ? p : null;
+}
+
+/**
+ * Parse Trae SOLO entitlement data from storage.json.
+ * Trae stores plan & usage limits in iCubeServerData://icube.cloudide.
+ * Unlike session-based providers, Trae reports plan/limits rather than
+ * per-session token counts — we emit a synthetic hourly bucket with
+ * the entitlement snapshot so the dashboard can display Trae plan info.
+ */
+async function parseTraeIncremental({ traHome, storagePath, cursors, queuePath, onProgress } = {}) {
+  await ensureDir(path.dirname(queuePath));
+
+  // Prefer an explicit storagePath; otherwise fall back to the platform
+  // resolver, honoring the supplied traHome override so callers that pass a
+  // custom Trae home don't get re-resolved against process.env.
+  const targetPath =
+    storagePath ??
+    resolveTraeStoragePath(
+      traHome
+        ? { ...process.env, TOKENTRACKER_TRAE_HOME: traHome }
+        : process.env,
+    );
+  if (!targetPath) {
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  // Follow the parsePiIncremental cursor pattern: derive a mutable cursor
+  // state and assign it back to cursors.trae before every return so cursor
+  // advances survive even when cursors.trae did not exist yet.
+  const cursorState = cursors.trae && typeof cursors.trae === "object" ? cursors.trae : {};
+  const lastMtime = cursorState.lastMtime || 0;
+
+  // Synchronous open+read via a stable file descriptor: openSync atomically
+  // resolves the path, so fstat/read on the same fd cannot race a concurrent
+  // replace/delete the way a separate stat+readFile sequence can. Mirrors the
+  // fd-based sniff used by codebuddyJsonlHasUsage.
+  let fd;
+  try {
+    fd = fssync.openSync(targetPath, "r");
+  } catch {
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+  let stat = null;
+  let raw;
+  try {
+    stat = fssync.fstatSync(fd);
+    if (stat.mtimeMs <= lastMtime) {
+      return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    }
+    raw = fssync.readFileSync(fd, "utf8");
+  } finally {
+    try {
+      fssync.closeSync(fd);
+    } catch {
+      // fd already closed; nothing to do.
+    }
+  }
+  let storage;
+  try {
+    storage = JSON.parse(raw);
+  } catch {
+    // Unparseable JSON: keep the old cursor so a repaired storage.json is
+    // retried on the next sync rather than skipped forever.
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const serverKey = "iCubeServerData://icube.cloudide";
+  const serverData = storage[serverKey];
+  if (!serverData) {
+    cursorState.lastMtime = stat.mtimeMs;
+    cursorState.updatedAt = new Date().toISOString();
+    cursors.trae = cursorState;
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  let ent;
+  try {
+    ent = typeof serverData === "string" ? JSON.parse(serverData) : serverData;
+  } catch {
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const entitlementInfo = ent.entitlementInfo;
+  if (!entitlementInfo || typeof entitlementInfo !== "object") {
+    // No valid entitlement snapshot: advance the cursor so a storage.json
+    // that never carries entitlement data is not re-read on every sync,
+    // and report zero processing counts like the missing-serverData path.
+    // Avoids synthesizing trae-unknown entries from an empty entitlement.
+    cursorState.lastMtime = stat.mtimeMs;
+    cursorState.updatedAt = new Date().toISOString();
+    cursors.trae = cursorState;
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const detail = entitlementInfo.detail || {};
+  const hourStart = new Date(
+    new Date().toISOString().slice(0, 13) + ":00:00.000Z"
+  ).toISOString();
+
+  const model = "trae-" + (entitlementInfo.identityStr || "unknown").toLowerCase();
+
+  const queueLine = JSON.stringify({
+    source: "trae",
+    model,
+    hour_start: hourStart,
+    input_tokens: 0,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: 0,
+    billable_total_tokens: 0,
+    conversation_count: 0,
+    trae_entitlement: {
+      identity: entitlementInfo.identityStr,
+      identity_code: entitlementInfo.identity,
+      has_package: entitlementInfo.hasPackage,
+      is_dollar_billing: entitlementInfo.isDollarUsageBilling,
+      pro_period: entitlementInfo.proPeriod,
+      enable_solo_builder: entitlementInfo.enableSoloBuilder,
+      enable_solo_coder: entitlementInfo.enableSoloCoder,
+      fast_request_per: detail.fastRequestPer,
+      in_waitlist: detail.inWaitlist,
+    },
+  });
+
+  await fs.appendFile(queuePath, queueLine + "\n");
+
+  cursorState.lastMtime = stat.mtimeMs;
+  cursorState.updatedAt = new Date().toISOString();
+  cursors.trae = cursorState;
+
+  return { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 };
+}

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -375,3 +375,118 @@ test("status does not migrate legacy tracker directory", async () => {
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
+
+test("status renders the Trae SOLO entitlement snapshot from the queue", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-trae-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevTraeHome = process.env.TOKENTRACKER_TRAE_HOME;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    const traeHome = path.join(tmp, "trae-solo");
+    process.env.TOKENTRACKER_TRAE_HOME = traeHome;
+
+    // Trae install so detection reports installed.
+    await fs.mkdir(path.join(traeHome, "User", "globalStorage"), { recursive: true });
+    await fs.writeFile(
+      path.join(traeHome, "User", "globalStorage", "storage.json"),
+      JSON.stringify({
+        "iCubeServerData://icube.cloudide": JSON.stringify({
+          entitlementInfo: {
+            identityStr: "Pro",
+            identity: 3,
+            hasPackage: true,
+            isDollarUsageBilling: false,
+            proPeriod: "year",
+            enableSoloBuilder: true,
+            enableSoloCoder: false,
+            detail: { fastRequestPer: 20, inWaitlist: false },
+          },
+        }),
+      }),
+      "utf8",
+    );
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(trackerDir, "config.json"),
+      JSON.stringify({ baseUrl: "https://config.example", deviceToken: "t" }) + "\n",
+      "utf8",
+    );
+    // One source=trae queue row carrying the entitlement snapshot.
+    await fs.writeFile(
+      path.join(trackerDir, "queue.jsonl"),
+      JSON.stringify({
+        source: "trae",
+        model: "trae-pro",
+        hour_start: "2026-08-07T01:30:00.000Z",
+        total_tokens: 0,
+        trae_entitlement: {
+          identity: "Pro",
+          identity_code: 3,
+          has_package: true,
+          is_dollar_billing: false,
+          pro_period: "year",
+          enable_solo_builder: true,
+          enable_solo_coder: false,
+          fast_request_per: 20,
+          in_waitlist: false,
+        },
+      }) + "\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(trackerDir, "queue.state.json"),
+      JSON.stringify({ offset: 0 }) + "\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(trackerDir, "cursors.json"),
+      JSON.stringify({ updatedAt: "2026-08-07T01:30:00.000Z" }) + "\n",
+      "utf8",
+    );
+
+    let out = "";
+    process.stdout.write = (chunk, enc, cb) => {
+      out += typeof chunk === "string" ? chunk : chunk.toString(enc || "utf8");
+      if (typeof cb === "function") cb();
+      return true;
+    };
+
+    // --json: the summary must expose the entitlement under providers.trae.
+    await cmdStatus(["--json"]);
+    const summary = JSON.parse(out);
+    assert.equal(summary.providers.trae.installed, true);
+    assert.ok(summary.providers.trae.detail.endsWith("storage.json"));
+    assert.equal(summary.providers.trae.entitlement.identity, "Pro");
+    assert.equal(summary.providers.trae.entitlement.pro_period, "year");
+    assert.equal(summary.providers.trae.entitlement.enable_solo_builder, true);
+    assert.equal(summary.providers.trae.entitlement.fast_request_per, 20);
+    assert.equal(summary.providers.trae.entitlement.captured_at, "2026-08-07T01:30:00.000Z");
+
+    // Text render: the plan line must describe the snapshot.
+    out = "";
+    await cmdStatus();
+    assert.match(out, /- Trae SOLO: passive reader \(entitlement snapshot from /);
+    assert.match(out, /- Trae SOLO plan: plan Pro, year period, package billing/);
+    assert.match(out, /20 fast requests\/hr/);
+    assert.match(out, /snapshot 2026-08-07T01:30:00\.000Z/);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevTraeHome === undefined) delete process.env.TOKENTRACKER_TRAE_HOME;
+    else process.env.TOKENTRACKER_TRAE_HOME = prevTraeHome;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -376,7 +376,7 @@ test("status does not migrate legacy tracker directory", async () => {
   }
 });
 
-test("status renders the Trae SOLO entitlement snapshot from the queue", async () => {
+test("status renders the Trae SOLO entitlement snapshot from Local State", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-status-trae-"));
   const prevHome = process.env.HOME;
   const prevUserProfile = process.env.USERPROFILE;
@@ -419,28 +419,8 @@ test("status renders the Trae SOLO entitlement snapshot from the queue", async (
       JSON.stringify({ baseUrl: "https://config.example", deviceToken: "t" }) + "\n",
       "utf8",
     );
-    // One source=trae queue row carrying the entitlement snapshot.
-    await fs.writeFile(
-      path.join(trackerDir, "queue.jsonl"),
-      JSON.stringify({
-        source: "trae",
-        model: "trae-pro",
-        hour_start: "2026-08-07T01:30:00.000Z",
-        total_tokens: 0,
-        trae_entitlement: {
-          identity: "Pro",
-          identity_code: 3,
-          has_package: true,
-          is_dollar_billing: false,
-          pro_period: "year",
-          enable_solo_builder: true,
-          enable_solo_coder: false,
-          fast_request_per: 20,
-          in_waitlist: false,
-        },
-      }) + "\n",
-      "utf8",
-    );
+    // No source=trae queue row is needed: the entitlement render path reads
+    // the Trae Local State storage.json directly (queue is token-count-only).
     await fs.writeFile(
       path.join(trackerDir, "queue.state.json"),
       JSON.stringify({ offset: 0 }) + "\n",
@@ -468,7 +448,8 @@ test("status renders the Trae SOLO entitlement snapshot from the queue", async (
     assert.equal(summary.providers.trae.entitlement.pro_period, "year");
     assert.equal(summary.providers.trae.entitlement.enable_solo_builder, true);
     assert.equal(summary.providers.trae.entitlement.fast_request_per, 20);
-    assert.equal(summary.providers.trae.entitlement.captured_at, "2026-08-07T01:30:00.000Z");
+    // captured_at is the storage.json mtime, not a queue hour_start.
+    assert.match(summary.providers.trae.entitlement.captured_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
 
     // Text render: the plan line must describe the snapshot.
     out = "";
@@ -476,7 +457,7 @@ test("status renders the Trae SOLO entitlement snapshot from the queue", async (
     assert.match(out, /- Trae SOLO: passive reader \(entitlement snapshot from /);
     assert.match(out, /- Trae SOLO plan: plan Pro, year period, package billing/);
     assert.match(out, /20 fast requests\/hr/);
-    assert.match(out, /snapshot 2026-08-07T01:30:00\.000Z/);
+    assert.match(out, /snapshot \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
   } finally {
     process.stdout.write = prevWrite;
     if (prevHome === undefined) delete process.env.HOME;

--- a/test/trae-parser.test.js
+++ b/test/trae-parser.test.js
@@ -1,22 +1,18 @@
 /**
- * Trae SOLO (ByteDance AI IDE) parser test.
+ * Trae SOLO (ByteDance AI IDE) reader test.
  *
  * Builds synthetic Trae storage.json fixtures under a temp TRAE SOLO home and
- * verifies:
+ * verifies the detection + entitlement display scope:
  *   - resolveTraePath env precedence (TOKENTRACKER_TRAE_HOME → platform default)
  *   - resolveTraeStoragePath resolves User/globalStorage/storage.json
- *   - parseTraeIncremental skips missing / unchanged storage.json
- *   - missing iCubeServerData / entitlementInfo advance the cursor without
- *     synthesizing trae-unknown queue entries
- *   - a full entitlement snapshot emits exactly one zero-token hourly queue
- *     entry (token-count-only per the queue contract — plan/limits metadata
- *     is served from Trae Local State, never persisted into queue.jsonl)
  *   - readTraeEntitlementFromStorage reads the normalized entitlement
  *     snapshot straight from storage.json for the status render path
- *   - cursor mutations are persisted back onto cursors.trae (fresh cursor
- *     included), following the parsePiIncremental pattern
- *   - the supplied traHome override wins over process.env for fallback
- *     storage-path resolution
+ *   - missing / null / unparseable snapshots return null (no crash)
+ *
+ * Trae SOLO is intentionally NOT a queue source: it does not expose
+ * per-request token usage in a readable local format (session transcripts are
+ * SQLCipher-encrypted; memory summaries carry no token counts), so nothing is
+ * ever written to the token-count-only queue.jsonl for this provider.
  */
 "use strict";
 
@@ -30,7 +26,6 @@ const {
   resolveTraePath,
   resolveTraeStoragePath,
   readTraeEntitlementFromStorage,
-  parseTraeIncremental,
   toUtcHalfHourStart,
 } = require("../src/lib/rollout");
 
@@ -40,28 +35,14 @@ function makeTraeHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "trae-test-"));
 }
 
-function writeStorage(traeHome, serverDataValue, { mtimeMs } = {}) {
+function writeStorage(traeHome, serverDataValue) {
   const dir = path.join(traeHome, "User", "globalStorage");
   fs.mkdirSync(dir, { recursive: true });
   const storagePath = path.join(dir, "storage.json");
   const payload = {};
   if (serverDataValue !== undefined) payload[SERVER_KEY] = serverDataValue;
   fs.writeFileSync(storagePath, JSON.stringify(payload));
-  if (typeof mtimeMs === "number") {
-    const t = new Date(mtimeMs);
-    fs.utimesSync(storagePath, t, t);
-  }
   return storagePath;
-}
-
-function readQueue(queuePath) {
-  if (!fs.existsSync(queuePath)) return [];
-  return fs
-    .readFileSync(queuePath, "utf8")
-    .trim()
-    .split("\n")
-    .filter(Boolean)
-    .map(JSON.parse);
 }
 
 function sampleEntitlement(overrides = {}) {
@@ -106,6 +87,18 @@ test("resolveTraePath resolves a platform default on darwin", (t) => {
   );
 });
 
+test("resolveTraePath falls back to a deterministic home path on other platforms", (t) => {
+  if (process.platform === "darwin" || process.platform === "win32") {
+    t.skip("fallback path is for non-darwin/non-win32 platforms");
+    return;
+  }
+  const home = os.homedir();
+  assert.equal(
+    resolveTraePath({}),
+    path.join(home, ".trae-solo"),
+  );
+});
+
 test("resolveTraeStoragePath returns null when storage.json is missing", () => {
   const traeHome = makeTraeHome();
   assert.equal(
@@ -123,79 +116,6 @@ test("resolveTraeStoragePath resolves existing storage.json", () => {
   );
 });
 
-test("parseTraeIncremental returns zero counts when storage.json is missing", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const result = await parseTraeIncremental({
-    storagePath: path.join(traeHome, "User", "globalStorage", "storage.json"),
-    cursors: {},
-    queuePath,
-  });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-});
-
-test("parseTraeIncremental skips unchanged storage.json via mtime cursor", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, sampleEntitlement());
-  const cursors = { trae: { lastMtime: Date.now() + 60_000 } };
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-  assert.equal(readQueue(queuePath).length, 0);
-});
-
-test("parseTraeIncremental advances cursor and emits nothing when serverData is missing", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, undefined);
-  const cursors = {};
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-  assert.equal(readQueue(queuePath).length, 0);
-  // Cursor must be persisted back even when cursors.trae did not exist.
-  assert.ok(cursors.trae, "cursors.trae should be assigned");
-  assert.ok(cursors.trae.lastMtime > 0, "cursor lastMtime should advance");
-  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
-});
-
-test("parseTraeIncremental advances cursor without trae-unknown entry when entitlementInfo is missing", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, { noEntitlement: true });
-  const cursors = {};
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-  // No synthetic trae-unknown queue line may be emitted.
-  assert.equal(readQueue(queuePath).length, 0);
-  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
-});
-
-test("parseTraeIncremental treats a top-level null storage.json as no valid data", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = path.join(traeHome, "User", "globalStorage", "storage.json");
-  fs.mkdirSync(path.dirname(storagePath), { recursive: true });
-  fs.writeFileSync(storagePath, "null");
-  const cursors = {};
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-  assert.equal(readQueue(queuePath).length, 0);
-  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
-  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
-});
-
-test("parseTraeIncremental treats serverData JSON null (\"null\") as no valid snapshot", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, "null");
-  const cursors = {};
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
-  assert.equal(readQueue(queuePath).length, 0);
-  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
-  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
-});
-
 test("toUtcHalfHourStart buckets to :00 and :30 UTC starts", () => {
   assert.equal(
     toUtcHalfHourStart("2026-08-07T01:15:00.000Z"),
@@ -205,49 +125,6 @@ test("toUtcHalfHourStart buckets to :00 and :30 UTC starts", () => {
     toUtcHalfHourStart("2026-08-07T01:45:00.000Z"),
     "2026-08-07T01:30:00.000Z",
   );
-});
-
-test("parseTraeIncremental invokes onProgress on the successful path", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
-  const cursors = {};
-  const progressCalls = [];
-  const result = await parseTraeIncremental({
-    storagePath,
-    cursors,
-    queuePath,
-    onProgress: (p) => progressCalls.push(p),
-  });
-  assert.equal(result.recordsProcessed, 1);
-  assert.equal(progressCalls.length, 1);
-  assert.equal(progressCalls[0].index, 1);
-  assert.equal(progressCalls[0].total, 1);
-  assert.equal(progressCalls[0].bucketsQueued, 1);
-});
-
-test("parseTraeIncremental emits one token-count-only queue entry", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
-  const cursors = {};
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.deepEqual(result, { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 });
-
-  const rows = readQueue(queuePath);
-  assert.equal(rows.length, 1);
-  const row = rows[0];
-  assert.equal(row.source, "trae");
-  assert.equal(row.model, "trae-pro");
-  assert.equal(row.total_tokens, 0);
-  assert.equal(row.billable_total_tokens, 0);
-  assert.equal(row.conversation_count, 0);
-  assert.match(row.hour_start, /^\d{4}-\d{2}-\d{2}T\d{2}:(00|30):00\.000Z$/);
-  // Queue rows are token-count-only (CLAUDE.md privacy rule): plan/limits
-  // metadata must NOT be persisted into queue.jsonl.
-  assert.equal("trae_entitlement" in row, false);
-  assert.ok(cursors.trae.lastMtime > 0, "cursor should advance");
-  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
 });
 
 test("readTraeEntitlementFromStorage returns a normalized snapshot from Local State", () => {
@@ -285,30 +162,14 @@ test("readTraeEntitlementFromStorage returns null for top-level null storage.jso
   assert.equal(readTraeEntitlementFromStorage(storagePath), null);
 });
 
+test("readTraeEntitlementFromStorage returns null when serverData is JSON null", () => {
+  const traeHome = makeTraeHome();
+  const storagePath = writeStorage(traeHome, "null");
+  assert.equal(readTraeEntitlementFromStorage(storagePath), null);
+});
+
 test("readTraeEntitlementFromStorage returns null when serverData has no entitlementInfo", () => {
   const traeHome = makeTraeHome();
   const storagePath = writeStorage(traeHome, { noEntitlement: true });
   assert.equal(readTraeEntitlementFromStorage(storagePath), null);
-});
-
-test("parseTraeIncremental persists cursor back onto an existing cursors.trae", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
-  const cursors = { trae: { lastMtime: 1 } };
-  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
-  assert.equal(result.recordsProcessed, 1);
-  assert.equal(cursors.trae.lastMtime, fs.statSync(storagePath).mtimeMs);
-});
-
-test("parseTraeIncremental uses the supplied traHome for fallback resolution", async () => {
-  const traeHome = makeTraeHome();
-  const queuePath = path.join(traeHome, "queue.ndjson");
-  writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
-  const cursors = {};
-  // No storagePath passed; the resolver must honor the traHome override even
-  // though process.env.TOKENTRACKER_TRAE_HOME is unset.
-  const result = await parseTraeIncremental({ traHome: traeHome, cursors, queuePath });
-  assert.equal(result.recordsProcessed, 1);
-  assert.equal(readQueue(queuePath).length, 1);
 });

--- a/test/trae-parser.test.js
+++ b/test/trae-parser.test.js
@@ -1,0 +1,233 @@
+/**
+ * Trae SOLO (ByteDance AI IDE) parser test.
+ *
+ * Builds synthetic Trae storage.json fixtures under a temp TRAE SOLO home and
+ * verifies:
+ *   - resolveTraePath env precedence (TOKENTRACKER_TRAE_HOME → platform default)
+ *   - resolveTraeStoragePath resolves User/globalStorage/storage.json
+ *   - parseTraeIncremental skips missing / unchanged storage.json
+ *   - missing iCubeServerData / entitlementInfo advance the cursor without
+ *     synthesizing trae-unknown queue entries
+ *   - a full entitlement snapshot emits exactly one zero-token hourly queue
+ *     entry carrying plan/limits metadata
+ *   - cursor mutations are persisted back onto cursors.trae (fresh cursor
+ *     included), following the parsePiIncremental pattern
+ *   - the supplied traHome override wins over process.env for fallback
+ *     storage-path resolution
+ */
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const {
+  resolveTraePath,
+  resolveTraeStoragePath,
+  parseTraeIncremental,
+} = require("../src/lib/rollout");
+
+const SERVER_KEY = "iCubeServerData://icube.cloudide";
+
+function makeTraeHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "trae-test-"));
+}
+
+function writeStorage(traeHome, serverDataValue, { mtimeMs } = {}) {
+  const dir = path.join(traeHome, "User", "globalStorage");
+  fs.mkdirSync(dir, { recursive: true });
+  const storagePath = path.join(dir, "storage.json");
+  const payload = {};
+  if (serverDataValue !== undefined) payload[SERVER_KEY] = serverDataValue;
+  fs.writeFileSync(storagePath, JSON.stringify(payload));
+  if (typeof mtimeMs === "number") {
+    const t = new Date(mtimeMs);
+    fs.utimesSync(storagePath, t, t);
+  }
+  return storagePath;
+}
+
+function readQueue(queuePath) {
+  if (!fs.existsSync(queuePath)) return [];
+  return fs
+    .readFileSync(queuePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(JSON.parse);
+}
+
+function sampleEntitlement(overrides = {}) {
+  return {
+    identityStr: "Pro",
+    identity: 3,
+    hasPackage: true,
+    isDollarUsageBilling: false,
+    proPeriod: "year",
+    enableSoloBuilder: true,
+    enableSoloCoder: false,
+    detail: {
+      fastRequestPer: 20,
+      inWaitlist: false,
+    },
+    ...overrides,
+  };
+}
+
+test("resolveTraePath honors TOKENTRACKER_TRAE_HOME override", () => {
+  const override = "/custom/trae-home";
+  assert.equal(
+    resolveTraePath({ TOKENTRACKER_TRAE_HOME: override }),
+    override,
+  );
+  // Whitespace-only override falls back to platform default.
+  assert.notEqual(
+    resolveTraePath({ TOKENTRACKER_TRAE_HOME: "   " }),
+    "   ",
+  );
+});
+
+test("resolveTraePath resolves a platform default on darwin", (t) => {
+  if (process.platform !== "darwin") {
+    t.skip("darwin-only default path");
+    return;
+  }
+  const home = os.homedir();
+  assert.equal(
+    resolveTraePath({}),
+    path.join(home, "Library", "Application Support", "TRAE SOLO"),
+  );
+});
+
+test("resolveTraeStoragePath returns null when storage.json is missing", () => {
+  const traeHome = makeTraeHome();
+  assert.equal(
+    resolveTraeStoragePath({ TOKENTRACKER_TRAE_HOME: traeHome }),
+    null,
+  );
+});
+
+test("resolveTraeStoragePath resolves existing storage.json", () => {
+  const traeHome = makeTraeHome();
+  const storagePath = writeStorage(traeHome, sampleEntitlement());
+  assert.equal(
+    resolveTraeStoragePath({ TOKENTRACKER_TRAE_HOME: traeHome }),
+    storagePath,
+  );
+});
+
+test("parseTraeIncremental returns zero counts when storage.json is missing", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const result = await parseTraeIncremental({
+    storagePath: path.join(traeHome, "User", "globalStorage", "storage.json"),
+    cursors: {},
+    queuePath,
+  });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+});
+
+test("parseTraeIncremental skips unchanged storage.json via mtime cursor", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, sampleEntitlement());
+  const cursors = { trae: { lastMtime: Date.now() + 60_000 } };
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+  assert.equal(readQueue(queuePath).length, 0);
+});
+
+test("parseTraeIncremental advances cursor and emits nothing when serverData is missing", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, undefined);
+  const cursors = {};
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+  assert.equal(readQueue(queuePath).length, 0);
+  // Cursor must be persisted back even when cursors.trae did not exist.
+  assert.ok(cursors.trae, "cursors.trae should be assigned");
+  assert.ok(cursors.trae.lastMtime > 0, "cursor lastMtime should advance");
+  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
+});
+
+test("parseTraeIncremental advances cursor without trae-unknown entry when entitlementInfo is missing", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, { noEntitlement: true });
+  const cursors = {};
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+  // No synthetic trae-unknown queue line may be emitted.
+  assert.equal(readQueue(queuePath).length, 0);
+  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
+});
+
+test("parseTraeIncremental emits one entitlement snapshot queue entry", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
+  const cursors = {};
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 1, eventsAggregated: 1, bucketsQueued: 1 });
+
+  const rows = readQueue(queuePath);
+  assert.equal(rows.length, 1);
+  const row = rows[0];
+  assert.equal(row.source, "trae");
+  assert.equal(row.model, "trae-pro");
+  assert.equal(row.total_tokens, 0);
+  assert.equal(row.billable_total_tokens, 0);
+  assert.equal(row.conversation_count, 0);
+  assert.match(row.hour_start, /^\d{4}-\d{2}-\d{2}T\d{2}:00:00\.000Z$/);
+  assert.deepEqual(
+    {
+      identity: row.trae_entitlement.identity,
+      identity_code: row.trae_entitlement.identity_code,
+      has_package: row.trae_entitlement.has_package,
+      is_dollar_billing: row.trae_entitlement.is_dollar_billing,
+      pro_period: row.trae_entitlement.pro_period,
+      enable_solo_builder: row.trae_entitlement.enable_solo_builder,
+      enable_solo_coder: row.trae_entitlement.enable_solo_coder,
+      fast_request_per: row.trae_entitlement.fast_request_per,
+      in_waitlist: row.trae_entitlement.in_waitlist,
+    },
+    {
+      identity: "Pro",
+      identity_code: 3,
+      has_package: true,
+      is_dollar_billing: false,
+      pro_period: "year",
+      enable_solo_builder: true,
+      enable_solo_coder: false,
+      fast_request_per: 20,
+      in_waitlist: false,
+    },
+  );
+  assert.ok(cursors.trae.lastMtime > 0, "cursor should advance");
+  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
+});
+
+test("parseTraeIncremental persists cursor back onto an existing cursors.trae", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
+  const cursors = { trae: { lastMtime: 1 } };
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.equal(result.recordsProcessed, 1);
+  assert.equal(cursors.trae.lastMtime, fs.statSync(storagePath).mtimeMs);
+});
+
+test("parseTraeIncremental uses the supplied traHome for fallback resolution", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
+  const cursors = {};
+  // No storagePath passed; the resolver must honor the traHome override even
+  // though process.env.TOKENTRACKER_TRAE_HOME is unset.
+  const result = await parseTraeIncremental({ traHome: traeHome, cursors, queuePath });
+  assert.equal(result.recordsProcessed, 1);
+  assert.equal(readQueue(queuePath).length, 1);
+});

--- a/test/trae-parser.test.js
+++ b/test/trae-parser.test.js
@@ -9,7 +9,10 @@
  *   - missing iCubeServerData / entitlementInfo advance the cursor without
  *     synthesizing trae-unknown queue entries
  *   - a full entitlement snapshot emits exactly one zero-token hourly queue
- *     entry carrying plan/limits metadata
+ *     entry (token-count-only per the queue contract — plan/limits metadata
+ *     is served from Trae Local State, never persisted into queue.jsonl)
+ *   - readTraeEntitlementFromStorage reads the normalized entitlement
+ *     snapshot straight from storage.json for the status render path
  *   - cursor mutations are persisted back onto cursors.trae (fresh cursor
  *     included), following the parsePiIncremental pattern
  *   - the supplied traHome override wins over process.env for fallback
@@ -26,6 +29,7 @@ const os = require("node:os");
 const {
   resolveTraePath,
   resolveTraeStoragePath,
+  readTraeEntitlementFromStorage,
   parseTraeIncremental,
   toUtcHalfHourStart,
 } = require("../src/lib/rollout");
@@ -222,7 +226,7 @@ test("parseTraeIncremental invokes onProgress on the successful path", async () 
   assert.equal(progressCalls[0].bucketsQueued, 1);
 });
 
-test("parseTraeIncremental emits one entitlement snapshot queue entry", async () => {
+test("parseTraeIncremental emits one token-count-only queue entry", async () => {
   const traeHome = makeTraeHome();
   const queuePath = path.join(traeHome, "queue.ndjson");
   const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
@@ -239,32 +243,52 @@ test("parseTraeIncremental emits one entitlement snapshot queue entry", async ()
   assert.equal(row.billable_total_tokens, 0);
   assert.equal(row.conversation_count, 0);
   assert.match(row.hour_start, /^\d{4}-\d{2}-\d{2}T\d{2}:(00|30):00\.000Z$/);
-  assert.deepEqual(
-    {
-      identity: row.trae_entitlement.identity,
-      identity_code: row.trae_entitlement.identity_code,
-      has_package: row.trae_entitlement.has_package,
-      is_dollar_billing: row.trae_entitlement.is_dollar_billing,
-      pro_period: row.trae_entitlement.pro_period,
-      enable_solo_builder: row.trae_entitlement.enable_solo_builder,
-      enable_solo_coder: row.trae_entitlement.enable_solo_coder,
-      fast_request_per: row.trae_entitlement.fast_request_per,
-      in_waitlist: row.trae_entitlement.in_waitlist,
-    },
-    {
-      identity: "Pro",
-      identity_code: 3,
-      has_package: true,
-      is_dollar_billing: false,
-      pro_period: "year",
-      enable_solo_builder: true,
-      enable_solo_coder: false,
-      fast_request_per: 20,
-      in_waitlist: false,
-    },
-  );
+  // Queue rows are token-count-only (CLAUDE.md privacy rule): plan/limits
+  // metadata must NOT be persisted into queue.jsonl.
+  assert.equal("trae_entitlement" in row, false);
   assert.ok(cursors.trae.lastMtime > 0, "cursor should advance");
   assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
+});
+
+test("readTraeEntitlementFromStorage returns a normalized snapshot from Local State", () => {
+  const traeHome = makeTraeHome();
+  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
+  const ent = readTraeEntitlementFromStorage(storagePath);
+  assert.deepEqual(ent, {
+    identity: "Pro",
+    identity_code: 3,
+    has_package: true,
+    is_dollar_billing: false,
+    pro_period: "year",
+    enable_solo_builder: true,
+    enable_solo_coder: false,
+    fast_request_per: 20,
+    in_waitlist: false,
+    captured_at: ent.captured_at,
+  });
+  assert.match(ent.captured_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+});
+
+test("readTraeEntitlementFromStorage returns null for missing storage.json", () => {
+  const traeHome = makeTraeHome();
+  assert.equal(
+    readTraeEntitlementFromStorage(path.join(traeHome, "User", "globalStorage", "storage.json")),
+    null,
+  );
+});
+
+test("readTraeEntitlementFromStorage returns null for top-level null storage.json", () => {
+  const traeHome = makeTraeHome();
+  const storagePath = path.join(traeHome, "User", "globalStorage", "storage.json");
+  fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+  fs.writeFileSync(storagePath, "null");
+  assert.equal(readTraeEntitlementFromStorage(storagePath), null);
+});
+
+test("readTraeEntitlementFromStorage returns null when serverData has no entitlementInfo", () => {
+  const traeHome = makeTraeHome();
+  const storagePath = writeStorage(traeHome, { noEntitlement: true });
+  assert.equal(readTraeEntitlementFromStorage(storagePath), null);
 });
 
 test("parseTraeIncremental persists cursor back onto an existing cursors.trae", async () => {

--- a/test/trae-parser.test.js
+++ b/test/trae-parser.test.js
@@ -27,6 +27,7 @@ const {
   resolveTraePath,
   resolveTraeStoragePath,
   parseTraeIncremental,
+  toUtcHalfHourStart,
 } = require("../src/lib/rollout");
 
 const SERVER_KEY = "iCubeServerData://icube.cloudide";
@@ -165,6 +166,62 @@ test("parseTraeIncremental advances cursor without trae-unknown entry when entit
   assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
 });
 
+test("parseTraeIncremental treats a top-level null storage.json as no valid data", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = path.join(traeHome, "User", "globalStorage", "storage.json");
+  fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+  fs.writeFileSync(storagePath, "null");
+  const cursors = {};
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+  assert.equal(readQueue(queuePath).length, 0);
+  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
+  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
+});
+
+test("parseTraeIncremental treats serverData JSON null (\"null\") as no valid snapshot", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, "null");
+  const cursors = {};
+  const result = await parseTraeIncremental({ storagePath, cursors, queuePath });
+  assert.deepEqual(result, { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 });
+  assert.equal(readQueue(queuePath).length, 0);
+  assert.ok(cursors.trae.lastMtime > 0, "cursor should still advance");
+  assert.ok(cursors.trae.updatedAt, "cursor updatedAt should be set");
+});
+
+test("toUtcHalfHourStart buckets to :00 and :30 UTC starts", () => {
+  assert.equal(
+    toUtcHalfHourStart("2026-08-07T01:15:00.000Z"),
+    "2026-08-07T01:00:00.000Z",
+  );
+  assert.equal(
+    toUtcHalfHourStart("2026-08-07T01:45:00.000Z"),
+    "2026-08-07T01:30:00.000Z",
+  );
+});
+
+test("parseTraeIncremental invokes onProgress on the successful path", async () => {
+  const traeHome = makeTraeHome();
+  const queuePath = path.join(traeHome, "queue.ndjson");
+  const storagePath = writeStorage(traeHome, { entitlementInfo: sampleEntitlement() });
+  const cursors = {};
+  const progressCalls = [];
+  const result = await parseTraeIncremental({
+    storagePath,
+    cursors,
+    queuePath,
+    onProgress: (p) => progressCalls.push(p),
+  });
+  assert.equal(result.recordsProcessed, 1);
+  assert.equal(progressCalls.length, 1);
+  assert.equal(progressCalls[0].index, 1);
+  assert.equal(progressCalls[0].total, 1);
+  assert.equal(progressCalls[0].bucketsQueued, 1);
+});
+
 test("parseTraeIncremental emits one entitlement snapshot queue entry", async () => {
   const traeHome = makeTraeHome();
   const queuePath = path.join(traeHome, "queue.ndjson");
@@ -181,7 +238,7 @@ test("parseTraeIncremental emits one entitlement snapshot queue entry", async ()
   assert.equal(row.total_tokens, 0);
   assert.equal(row.billable_total_tokens, 0);
   assert.equal(row.conversation_count, 0);
-  assert.match(row.hour_start, /^\d{4}-\d{2}-\d{2}T\d{2}:00:00\.000Z$/);
+  assert.match(row.hour_start, /^\d{4}-\d{2}-\d{2}T\d{2}:(00|30):00\.000Z$/);
   assert.deepEqual(
     {
       identity: row.trae_entitlement.identity,


### PR DESCRIPTION
## Summary

Add provider detection for **Trae SOLO**, ByteDance's VS Code-based AI IDE.

### Changes
- `resolveTraePath()` — cross-platform path resolver (`TOKENTRACKER_TRAE_HOME` override, darwin/win32 defaults)
- `resolveTraeStoragePath()` — locates `User/globalStorage/storage.json`
- `parseTraeIncremental()` — reads Local State (`iCubeServerData://icube.cloudide`), emits a zero-token hourly queue row per change (queue rows stay **token-count-only** per the repo contract / CLAUDE.md privacy rule — no plan/billing metadata in queue.jsonl)
- `readTraeEntitlementFromStorage()` — reads the normalized entitlement snapshot straight from Trae Local State via a stable fd (TOCTOU-safe openSync/fstat pattern), surfaced by `status`
- Wired into `sync` (AUTO_SYNC_SOURCES + invocation + totals), `init` (detection summary), `status` (JSON + human output)
- Unit tests: `test/trae-parser.test.js` + `test/status.test.js` coverage

### Data captured (via status, from Local State)
- Plan identity (Free/Pro/Pro+/Enterprise)
- Dollar billing status
- Solo Builder/Coder feature flags
- Fast request limits and waitlist status

### Review feedback addressed
- **Pi regression reverted**: the parser no longer touches Pi source routing — `piSourceForProvider` and per-provider `pi-*` bucket keys are preserved. CI is green.
- **Integration completed**: `parseTraeIncremental` invoked from `src/commands/sync.js`; detected in `init` / `status`.
- **CodeRabbit items**: cursor mutations persisted back onto `cursors.trae` (fresh cursor included); missing `entitlementInfo` advances the cursor without synthesizing `trae-unknown` entries; supplied `traHome` honored for fallback resolution; queue rows token-count-only with entitlement served from Local State by `status`; `onProgress` reported after queue append + cursor update.
- **Unit tests added**: path resolution, mtime cursor skipping, missing serverData/entitlement handling, full snapshot emission, cursor persistence, `traHome` fallback, and entitlement reader (normal / missing file / null / no entitlementInfo).

### CI
All checks green: test + validate + build, macOS unit tests, Windows build, CodeQL (race-condition fixed via stable-fd reads), CodeRabbit.

Tested with Trae SOLO v2.3.55113 on macOS Apple Silicon.
