### PR TITLE
feat: add category navigation to settings

### DIFF
--- a/dashboard/src/components/settings/Controls.jsx
+++ b/dashboard/src/components/settings/Controls.jsx
@@ -28,21 +28,21 @@ export function ToggleSwitch({ checked, onChange, disabled, ariaLabel }) {
 
 export function SettingsRow({ label, hint, control }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-3">
+    <div className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <div className="min-w-0 flex-1">
         <div className="text-sm text-oai-gray-900 dark:text-oai-gray-200">{label}</div>
         {hint ? (
           <div className="mt-0.5 text-xs text-oai-gray-500 dark:text-oai-gray-400">{hint}</div>
         ) : null}
       </div>
-      <div className="shrink-0">{control}</div>
+      <div className="self-end sm:shrink-0 sm:self-auto">{control}</div>
     </div>
   );
 }
 
 export function SectionCard({ title, subtitle, action, children }) {
   return (
-    <Card>
+    <Card className="rounded-lg">
       <div className="mb-3 flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <h2 className="text-sm font-medium text-oai-gray-500 dark:text-oai-gray-300 uppercase tracking-wide">

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -300,6 +300,7 @@
   "settings.page.subtitle": "管理你的账户、外观和显示偏好。",
   "settings.section.appearance": "外观",
   "settings.section.account": "账户",
+  "settings.section.limits": "限额显示",
   "settings.labs.qpd.label": "PR 研发性价比分析",
   "settings.labs.qpd.hint": "基于已合并 PR 与 AI 归因提交，分析各模型的平均交付成本与有效 Token。",
   "settings.labs.qpd.aria": "切换 PR 性价比分析",

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { FlaskConical, Gauge, Monitor, Palette, UserRound } from "lucide-react";
 import { LimitsSettingsPanel } from "../components/LimitsSettingsPanel.jsx";
 import { AccountSection } from "../components/settings/AccountSection.jsx";
 import { AppearanceSection } from "../components/settings/AppearanceSection.jsx";
@@ -6,7 +7,17 @@ import { LabsSection } from "../components/settings/LabsSection.jsx";
 import { SectionCard, SegmentedControl } from "../components/settings/Controls.jsx";
 import { MenuBarSection, NativeAppFooter } from "../components/settings/MenuBarSection.jsx";
 import { LIMIT_DISPLAY_MODES, useLimitsDisplayPrefs } from "../hooks/use-limits-display-prefs.js";
+import { cn } from "../lib/cn";
 import { copy } from "../lib/copy";
+import { isBridgeAvailable, isNativeApp } from "../lib/native-bridge";
+
+const SETTINGS_SECTION_IDS = {
+  APPEARANCE: "appearance",
+  NATIVE_APP: "native-app",
+  ACCOUNT: "account",
+  LIMITS: "limits",
+  LABS: "labs",
+};
 
 function LimitsDisplayModeControl({ prefs }) {
   return (
@@ -23,12 +34,62 @@ function LimitsDisplayModeControl({ prefs }) {
 
 export function SettingsPage() {
   const limitsPrefs = useLimitsDisplayPrefs();
+  const nativeSettingsAvailable = isNativeApp() && isBridgeAvailable();
+  const [activeSection, setActiveSection] = useState(SETTINGS_SECTION_IDS.APPEARANCE);
+
+  const sections = [
+    {
+      id: SETTINGS_SECTION_IDS.APPEARANCE,
+      label: copy("settings.section.appearance"),
+      Icon: Palette,
+      content: <AppearanceSection />,
+    },
+    ...(nativeSettingsAvailable
+      ? [{
+          id: SETTINGS_SECTION_IDS.NATIVE_APP,
+          label: copy("settings.section.menubar"),
+          Icon: Monitor,
+          content: <MenuBarSection />,
+        }]
+      : []),
+    {
+      id: SETTINGS_SECTION_IDS.ACCOUNT,
+      label: copy("settings.section.account"),
+      Icon: UserRound,
+      content: <AccountSection />,
+    },
+    {
+      id: SETTINGS_SECTION_IDS.LIMITS,
+      label: copy("settings.section.limits"),
+      Icon: Gauge,
+      content: (
+        <SectionCard
+          title={copy("settings.section.limits")}
+          action={<LimitsDisplayModeControl prefs={limitsPrefs} />}
+        >
+          <LimitsSettingsPanel prefs={limitsPrefs} />
+        </SectionCard>
+      ),
+    },
+    {
+      id: SETTINGS_SECTION_IDS.LABS,
+      label: copy("settings.section.labs"),
+      Icon: FlaskConical,
+      content: <LabsSection />,
+    },
+  ];
+
+  useEffect(() => {
+    if (activeSection === SETTINGS_SECTION_IDS.NATIVE_APP && !nativeSettingsAvailable) {
+      setActiveSection(SETTINGS_SECTION_IDS.APPEARANCE);
+    }
+  }, [activeSection, nativeSettingsAvailable]);
 
   return (
     <div className="flex flex-1 flex-col font-oai text-oai-black antialiased dark:text-oai-white">
       <main className="flex-1 pb-12 pt-8 sm:pb-16 sm:pt-10">
-        <div className="mx-auto max-w-3xl px-4 sm:px-6">
-          <div className="mb-8">
+        <div className="mx-auto w-full max-w-5xl px-4 sm:px-6">
+          <div className="mb-7">
             <h1 className="text-3xl font-semibold tracking-tight text-oai-black dark:text-white sm:text-4xl">
               {copy("settings.page.title")}
             </h1>
@@ -37,20 +98,60 @@ export function SettingsPage() {
             </p>
           </div>
 
-          <div className="space-y-4">
-            <AppearanceSection />
-            <MenuBarSection />
-            <AccountSection />
-            <LabsSection />
-            <SectionCard
-              title={copy("settings.section.limits")}
-              action={<LimitsDisplayModeControl prefs={limitsPrefs} />}
-            >
-              <LimitsSettingsPanel prefs={limitsPrefs} />
-            </SectionCard>
-          </div>
+          <div className="grid min-w-0 gap-6 md:grid-cols-[12rem_minmax(0,1fr)] md:gap-8 lg:grid-cols-[13.5rem_minmax(0,1fr)]">
+            <aside className="min-w-0 border-b border-oai-gray-200 pb-3 dark:border-oai-gray-800 md:border-b-0 md:border-r md:pb-0 md:pr-5">
+              <nav
+                aria-label={copy("settings.page.title")}
+                className="flex gap-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:sticky md:top-6 md:flex-col md:gap-1 md:overflow-visible"
+              >
+                {sections.map(({ id, label, Icon }) => {
+                  const active = activeSection === id;
+                  return (
+                    <button
+                      key={id}
+                      id={`settings-nav-${id}`}
+                      type="button"
+                      aria-current={active ? "page" : undefined}
+                      aria-controls={`settings-panel-${id}`}
+                      onClick={() => setActiveSection(id)}
+                      className={cn(
+                        "inline-flex min-h-10 min-w-max shrink-0 items-center gap-1.5 rounded-md px-2 py-2 text-left text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-oai-brand-500 md:w-full md:min-w-0 md:gap-2 md:px-3",
+                        active
+                          ? "bg-oai-gray-100 text-oai-black dark:bg-oai-gray-800 dark:text-white"
+                          : "text-oai-gray-500 hover:bg-oai-gray-50 hover:text-oai-gray-900 dark:text-oai-gray-400 dark:hover:bg-oai-gray-900 dark:hover:text-oai-gray-200",
+                      )}
+                    >
+                      <Icon
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          active ? "text-oai-brand-500" : "text-oai-gray-400 dark:text-oai-gray-500",
+                        )}
+                        aria-hidden
+                      />
+                      <span className="truncate">{label}</span>
+                    </button>
+                  );
+                })}
+              </nav>
+            </aside>
 
-          <NativeAppFooter />
+            <div className="min-w-0">
+              {sections.map(({ id, label, content }) => (
+                <section
+                  key={id}
+                  id={`settings-panel-${id}`}
+                  aria-labelledby={`settings-nav-${id}`}
+                  aria-label={label}
+                  data-settings-panel={id}
+                  hidden={activeSection !== id}
+                >
+                  {content}
+                </section>
+              ))}
+
+              <NativeAppFooter />
+            </div>
+          </div>
         </div>
       </main>
     </div>

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -93,9 +93,6 @@ export function SettingsPage() {
             <h1 className="text-3xl font-semibold tracking-tight text-oai-black dark:text-white sm:text-4xl">
               {copy("settings.page.title")}
             </h1>
-            <p className="mt-2 text-sm text-oai-gray-500 dark:text-oai-gray-400">
-              {copy("settings.page.subtitle")}
-            </p>
           </div>
 
           <div className="grid min-w-0 gap-6 md:grid-cols-[12rem_minmax(0,1fr)] md:gap-8 lg:grid-cols-[13.5rem_minmax(0,1fr)]">
@@ -124,7 +121,7 @@ export function SettingsPage() {
                       <Icon
                         className={cn(
                           "h-4 w-4 shrink-0",
-                          active ? "text-oai-brand-500" : "text-oai-gray-400 dark:text-oai-gray-500",
+                          active ? "text-oai-black dark:text-white" : "text-oai-gray-400 dark:text-oai-gray-500",
                         )}
                         aria-hidden
                       />

--- a/dashboard/src/pages/SettingsPage.test.jsx
+++ b/dashboard/src/pages/SettingsPage.test.jsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsPage } from "./SettingsPage.jsx";
+
+const nativeSettingsMock = vi.hoisted(() => ({ available: true }));
+
+const LABELS = {
+  "settings.page.title": "Settings",
+  "settings.page.subtitle": "Manage your preferences",
+  "settings.section.appearance": "Appearance",
+  "settings.section.menubar": "Menu Bar App",
+  "settings.section.account": "Account",
+  "settings.section.limits": "Limits Display",
+  "settings.section.labs": "Labs",
+};
+
+vi.mock("../lib/copy", () => ({
+  copy: (key) => LABELS[key] || key,
+}));
+
+vi.mock("../lib/native-bridge", () => ({
+  isNativeApp: () => true,
+  isBridgeAvailable: () => nativeSettingsMock.available,
+}));
+
+vi.mock("../hooks/use-limits-display-prefs.js", () => ({
+  LIMIT_DISPLAY_MODES: { USED: "used", REMAINING: "remaining" },
+  useLimitsDisplayPrefs: () => ({
+    displayMode: "used",
+    setDisplayMode: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/settings/AppearanceSection.jsx", () => ({
+  AppearanceSection: () => <div data-testid="appearance-content" />,
+}));
+
+vi.mock("../components/settings/MenuBarSection.jsx", () => ({
+  MenuBarSection: () => <div data-testid="native-content" />,
+  NativeAppFooter: () => <footer data-testid="settings-footer" />,
+}));
+
+vi.mock("../components/settings/AccountSection.jsx", () => ({
+  AccountSection: () => <div data-testid="account-content" />,
+}));
+
+vi.mock("../components/settings/LabsSection.jsx", () => ({
+  LabsSection: () => <div data-testid="labs-content" />,
+}));
+
+vi.mock("../components/LimitsSettingsPanel.jsx", () => ({
+  LimitsSettingsPanel: () => <div data-testid="limits-content" />,
+}));
+
+vi.mock("../components/settings/Controls.jsx", () => ({
+  SectionCard: ({ children }) => <div>{children}</div>,
+  SegmentedControl: () => <div data-testid="limits-mode" />,
+}));
+
+describe("SettingsPage category navigation", () => {
+  beforeEach(() => {
+    nativeSettingsMock.available = true;
+  });
+
+  it("switches the visible category while keeping every section mounted", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<SettingsPage />);
+
+    const appearanceButton = screen.getByRole("button", { name: "Appearance" });
+    const accountButton = screen.getByRole("button", { name: "Account" });
+    const appearancePanel = container.querySelector('[data-settings-panel="appearance"]');
+    const accountPanel = container.querySelector('[data-settings-panel="account"]');
+
+    expect(appearanceButton).toHaveAttribute("aria-current", "page");
+    expect(appearancePanel).not.toHaveAttribute("hidden");
+    expect(accountPanel).toHaveAttribute("hidden");
+    expect(screen.getByTestId("appearance-content")).toBeInTheDocument();
+    expect(screen.getByTestId("account-content")).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(accountButton);
+    });
+
+    expect(accountButton).toHaveAttribute("aria-current", "page");
+    expect(appearanceButton).not.toHaveAttribute("aria-current");
+    expect(appearancePanel).toHaveAttribute("hidden");
+    expect(accountPanel).not.toHaveAttribute("hidden");
+  });
+
+  it("omits the native-app category when the native bridge is unavailable", () => {
+    nativeSettingsMock.available = false;
+    const { container } = render(<SettingsPage />);
+
+    expect(screen.queryByRole("button", { name: "Menu Bar App" })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-settings-panel="native-app"]')).toBeNull();
+    expect(screen.getByRole("button", { name: "Appearance" })).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/dashboard/src/ui/components/Card.jsx
+++ b/dashboard/src/ui/components/Card.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "../../lib/cn";
 
 /**
  * Card - 简化版卡片组件
@@ -11,7 +12,7 @@ export function Card({
   bodyClassName = "",
 }) {
   return (
-    <div className={`rounded-xl border border-oai-gray-200 dark:border-oai-gray-800 bg-white dark:bg-oai-gray-900 transition-colors duration-200 ${className}`}>
+    <div className={cn("rounded-xl border border-oai-gray-200 dark:border-oai-gray-800 bg-white dark:bg-oai-gray-900 transition-colors duration-200", className)}>
       {(title || subtitle) && (
         <div className="px-5 py-4 border-b border-oai-gray-200 dark:border-oai-gray-800 transition-colors duration-200">
           {title && (


### PR DESCRIPTION
## Summary

- replace the vertically stacked settings page with a focused category layout: a sticky left navigation on desktop and a compact horizontal category bar on narrow windows
- keep every settings section mounted while switching visibility so unfinished account/profile state is not discarded
- show the native-app category only when the native bridge is available
- stack setting descriptions above their controls on mobile to prevent narrow text columns and control overlap
- add the missing Simplified Chinese translation for the limits display category

## Validation

- SettingsPage category-navigation tests (desktop/native availability behavior)
- dashboard TypeScript and ESLint
- copy, UI hardcode, and architecture guardrails
- production dashboard build
- browser layout checks at 1280x800 and 390x844, including category switching and horizontal-overflow measurements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the Settings page with data-driven section navigation and a two-column layout.
  * Native “Menu Bar App” category now appears only when supported by the app environment.
  * Added a Chinese label for the “limits display” settings section.
* **Accessibility**
  * Improved accessibility wiring between the section navigation and the displayed settings panel.
* **Style**
  * Updated settings control layout to better support small screens.
  * Applied consistent rounded styling to settings cards.
* **Tests**
  * Added a Settings page test suite covering navigation visibility and native-section rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->