### PR TITLE
fix: prevent macOS Sync Now timeouts on large histories

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/SyncRequestPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/SyncRequestPolicy.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum ManualSyncRequestDisposition: Equatable {
+    case start
+    case queueAfterSilentSync
+    case coalesceWithVisibleSync
+}
+
+enum SyncRequestPolicy {
+    static func manualRequestDisposition(
+        syncInFlight: Bool,
+        isSyncing: Bool
+    ) -> ManualSyncRequestDisposition {
+        guard syncInFlight else { return .start }
+        return isSyncing ? .coalesceWithVisibleSync : .queueAfterSilentSync
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -122,7 +122,11 @@ actor APIClient {
     func triggerSync(drain: Bool = false, auto: Bool = false) async throws -> SyncResponse {
         let body: Data
         if drain {
-            body = Data(#"{"drain":true}"#.utf8)
+            // Sync Now keeps the bounded background scan, while --drain still
+            // flushes the complete cloud backlog and gives the request lock priority.
+            body = Data(
+                #"{"auto":true,"background":true,"allLocalSources":true,"publishAccount":true,"drain":true}"#.utf8
+            )
         } else if auto {
             body = Data(
                 #"{"auto":true,"background":true,"allLocalSources":true,"publishAccount":true}"#.utf8

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -69,6 +69,7 @@ class DashboardViewModel: ObservableObject {
     /// `isSyncing` (which only drives the sync animation), this is also set
     /// during silent syncs so concurrent sync requests are still coalesced.
     private var syncInFlight = false
+    private var pendingManualSync = false
     private var lastBackgroundSyncAt: Date?
     private var lastPopoverOpenSyncAttemptAt: Date?
     private var shouldReloadAfterCurrentLoad = false
@@ -519,6 +520,11 @@ class DashboardViewModel: ObservableObject {
         }
         await loadAll()
         syncInFlight = false
+        if pendingManualSync {
+            pendingManualSync = false
+            await performManualSync()
+            return
+        }
         if !silent { isSyncing = false }
         await runPendingQueueRefreshIfNeeded()
     }
@@ -657,7 +663,21 @@ class DashboardViewModel: ObservableObject {
     }
 
     func triggerSync() async {
-        guard !syncInFlight else { return }
+        switch SyncRequestPolicy.manualRequestDisposition(
+            syncInFlight: syncInFlight,
+            isSyncing: isSyncing
+        ) {
+        case .start:
+            await performManualSync()
+        case .queueAfterSilentSync:
+            pendingManualSync = true
+            isSyncing = true
+        case .coalesceWithVisibleSync:
+            return
+        }
+    }
+
+    private func performManualSync() async {
         syncInFlight = true
         isSyncing = true
         do {

--- a/TokenTrackerBar/TokenTrackerBarTests/SyncRequestPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/SyncRequestPolicyTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+final class SyncRequestPolicyTests: XCTestCase {
+    func testStartsManualSyncWhenIdle() {
+        XCTAssertEqual(
+            SyncRequestPolicy.manualRequestDisposition(
+                syncInFlight: false,
+                isSyncing: false
+            ),
+            .start
+        )
+    }
+
+    func testQueuesManualSyncBehindSilentPopoverSync() {
+        XCTAssertEqual(
+            SyncRequestPolicy.manualRequestDisposition(
+                syncInFlight: true,
+                isSyncing: false
+            ),
+            .queueAfterSilentSync
+        )
+    }
+
+    func testCoalescesManualSyncWithVisibleSync() {
+        XCTAssertEqual(
+            SyncRequestPolicy.manualRequestDisposition(
+                syncInFlight: true,
+                isSyncing: true
+            ),
+            .coalesceWithVisibleSync
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -122,6 +122,7 @@ targets:
       - path: TokenTrackerBar/Models/LimitPace.swift
       - path: TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
       - path: TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
+      - path: TokenTrackerBar/Models/SyncRequestPolicy.swift
       - path: TokenTrackerBar/Models/UsagePublicationPolicy.swift
       - path: TokenTrackerBar/Services/ResumableDownloader.swift
       - path: TokenTrackerBar/Services/QueueActivityMonitor.swift

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -436,7 +436,9 @@ async function cmdSync(argv, context = {}) {
       : null;
 
     const autoSourceScope = resolveAutoSourceScope(opts);
-    const isBackgroundLightweightSync = opts.auto && opts.background && !opts.drain;
+    // --background controls local scan breadth; --drain only controls upload
+    // depth and lock priority. Plain `sync --drain` remains a full source scan.
+    const isBackgroundLightweightSync = opts.auto && opts.background;
     const isBackgroundAllLocalSync = isBackgroundLightweightSync && opts.allLocalSources;
     const isFullSourceScan = !autoSourceScope && !isBackgroundLightweightSync;
     const sourceAllowed = (...sources) => {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1919,7 +1919,9 @@ function createLocalApiHandler({ queuePath }) {
         }
         const extraEnv = {};
         const drain = body.drain === true;
-        const auto = body.auto === true && !drain;
+        // Native Sync Now combines an incremental background scan with a full
+        // cloud drain. A plain {drain:true} request remains an exhaustive sync.
+        const auto = body.auto === true;
         const background =
           auto && (body.background === true || body.lightweight === true);
         // The local server is the trust boundary for cloud-sync preferences.

--- a/test/local-api-background.test.js
+++ b/test/local-api-background.test.js
@@ -177,15 +177,24 @@ test("local-api treats lightweight true as background alias", async () => {
   ]);
 });
 
-test("local-api drain has priority over auto background", async () => {
+test("local-api combines background scan with drain upload", async () => {
   const call = await runLocalSync({
     drain: true,
     auto: true,
     background: true,
-    lightweight: true,
+    allLocalSources: true,
+    publishAccount: true,
   });
   const args = call.args;
-  assert.deepEqual(args.slice(-3), [path.join(process.cwd(), "bin/tracker.js"), "sync", "--drain"]);
+  assert.deepEqual(args.slice(-7), [
+    path.join(process.cwd(), "bin/tracker.js"),
+    "sync",
+    "--auto",
+    "--background",
+    "--publish-account",
+    "--all-local-sources",
+    "--drain",
+  ]);
 });
 
 test("local-api background and lightweight require boolean true", async () => {

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -203,7 +203,7 @@ test("local sync preserves the SYNC_BUSY failure code", async () => {
     const req = createRequest({
       method: "POST",
       headers: { "x-tokentracker-local-auth": localAuthToken },
-      body: JSON.stringify({ drain: true }),
+      body: JSON.stringify({ drain: true, deviceToken: "device-token" }),
     });
     const res = createResponse();
 
@@ -414,7 +414,7 @@ test("local sync lightweight alias forwards background mode", async () => {
   }
 });
 
-test("local sync drain priority suppresses auto background mode", async () => {
+test("local sync combines background scan with drain priority", async () => {
   const calls = [];
   const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
 
@@ -443,9 +443,11 @@ test("local sync drain priority suppresses auto background mode", async () => {
     assert.equal(handled, true);
     assert.equal(res.statusCode, 200);
     assert.equal(calls.length, 1);
-    assert.deepEqual(calls[0].args.slice(-3), [
+    assert.deepEqual(calls[0].args.slice(-5), [
       path.join(process.cwd(), "bin/tracker.js"),
       "sync",
+      "--auto",
+      "--background",
       "--drain",
     ]);
   } finally {

--- a/test/macos-background-sync-source.test.js
+++ b/test/macos-background-sync-source.test.js
@@ -22,7 +22,7 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   );
   assert.match(
     apiClient,
-    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true/,
+    /if drain \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true,"drain":true[\s\S]*\} else if auto \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true/,
   );
   assert.match(
     viewModel,
@@ -55,7 +55,7 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   );
   assert.match(
     viewModel,
-    /func triggerSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
+    /private func performManualSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
   );
   assert.match(refreshPolicy, /static let defaultSyncInterval: TimeInterval = 300/);
   assert.match(

--- a/test/macos-sync-now-drain.test.js
+++ b/test/macos-sync-now-drain.test.js
@@ -9,7 +9,7 @@ function read(relPath) {
   return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
 }
 
-test("macOS manual Sync now requests drain while launch sync stays lightweight", () => {
+test("macOS Sync Now combines a lightweight scan with cloud drain", () => {
   const apiClient = read("TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift");
   const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
   const refreshPolicy = read("TokenTrackerBar/TokenTrackerBar/Models/BackgroundRefreshPolicy.swift");
@@ -21,8 +21,8 @@ test("macOS manual Sync now requests drain while launch sync stays lightweight",
   );
   assert.match(
     apiClient,
-    /if drain \{[\s\S]*Data\(#"\{"drain":true\}"#\.utf8\)[\s\S]*\} else if auto \{[\s\S]*Data\([\s\S]*#"\{"auto":true,"background":true,"allLocalSources":true,"publishAccount":true\}"#\.utf8/,
-    "APIClient should send drain=true for manual sync and publish all local sources for background sync",
+    /if drain \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true,"drain":true[\s\S]*\} else if auto \{[\s\S]*"auto":true,"background":true,"allLocalSources":true,"publishAccount":true/,
+    "Sync Now should keep the bounded all-source scan while draining cloud uploads",
   );
   assert.match(
     viewModel,
@@ -31,8 +31,18 @@ test("macOS manual Sync now requests drain while launch sync stays lightweight",
   );
   assert.match(
     viewModel,
-    /func triggerSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
+    /private func performManualSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
     "manual Sync now should request drain",
+  );
+  assert.match(
+    viewModel,
+    /case \.queueAfterSilentSync:[\s\S]*pendingManualSync = true[\s\S]*isSyncing = true/,
+    "a tap during silent popover sync should stay visible and queue one manual refresh",
+  );
+  assert.match(
+    viewModel,
+    /if pendingManualSync \{[\s\S]*pendingManualSync = false[\s\S]*await performManualSync\(\)/,
+    "the queued manual refresh should run after the silent sync releases ownership",
   );
   assert.match(
     refreshPolicy,

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -158,6 +158,25 @@ test("background auto sync skips deep Codex archives", async () => {
   });
 });
 
+test("background drain skips deep Codex archives while retaining drain semantics", async () => {
+  await withTempSyncEnv(async (home) => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(codexHome, "2026-06-30", "019f16bd-1002-7000-8000-aaaaaaaaaaaa", 53);
+    await writeArchivedCodexRollout(codexHome, "2026-06-30", "019f16bd-1003-7000-8000-aaaaaaaaaaaa", 59);
+
+    const archiveRoot = path.join(codexHome, "archived_sessions");
+    const archiveReads = await countReaddir(
+      () => cmdSync(["--auto", "--background", "--drain"]),
+      (target) => target === archiveRoot || target.startsWith(`${archiveRoot}${path.sep}`),
+    );
+
+    assert.equal(archiveReads, 0);
+    const queue = await readQueue(home);
+    assert.match(queue, /"total_tokens":53/);
+    assert.doesNotMatch(queue, /"total_tokens":59/);
+  });
+});
+
 test("Codex notify sync catches up after an overlapping background sync releases the lock", async () => {
   await withTempSyncEnv(async (home) => {
     const codexHome = process.env.CODEX_HOME;


### PR DESCRIPTION
## Summary

Prevent macOS Sync Now from timing out on large local histories by combining the bounded background scan with drain upload semantics, and preserve taps that arrive during a silent popover sync.

## Why

The native button currently sends only `{ "drain": true }`, which launches an exhaustive `sync --drain`. On a large Codex history (about 25 GB / 29k rollout files), the request reproduced the reported behavior:

- the child ran at high CPU for 120 seconds and exceeded 590 MB observed RSS;
- the embedded server returned `SYNC_TIMEOUT` / HTTP 500;
- queue and v2 cursor evidence did not advance;
- the UI stopped spinning without completing the requested refresh.

The existing bounded all-source path completed against the same data in about 4 seconds, with 218 MB observed RSS, and advanced `queue.jsonl`, the v2 manifest, and the current generation core.

## Changes

- Native Sync Now now requests `--auto --background --all-local-sources --publish-account --drain`.
- Explicit `--background` controls local scan breadth; `--drain` continues to control lock priority and full cloud backlog upload.
- Plain CLI `tracker sync --drain` remains an exhaustive local scan.
- A manual tap during silent popover sync is queued and visibly spins instead of being discarded by `syncInFlight`.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config

## Verification

- `node --test --test-reporter=dot test/*.test.js`: 1731 passed in an isolated HOME.
- `xcodebuild ... -scheme TokenTrackerBarTests ... test`: 104 passed.
- `xcodebuild ... -scheme TokenTrackerBar ... build`: succeeded after XcodeGen + icon project patch.
- Targeted local API, lock, background-drain, and macOS contract tests: 52 passed.
- Live local API comparison confirmed the exhaustive timeout and bounded successful refresh described above.

## Checklist

- [x] `npm test` passes
- [x] No new user-facing strings
- [x] Commits follow conventional style
- [x] PR description explains why, not just what

---

<details open>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

### Rules / invariants

- Plain `sync --drain` remains exhaustive for repair and initial backfill workflows.
- Only explicit `--auto --background` selects the bounded local scan.
- Drain still waits for lock priority, uploads up to the existing drain limit, and surfaces upload failure.
- Concurrent visible syncs coalesce; only a tap hidden behind a silent sync queues one follow-up.

### Boundary matrix

| Request | Local scan | Upload | Lock behavior |
|---|---|---|---|
| `sync --drain` | exhaustive | drain | priority wait |
| `sync --auto --background --drain` | bounded | drain | priority wait |
| `sync --auto --background` | bounded | existing background policy | existing behavior |
| tap during silent popover sync | queued once | manual semantics | starts after owner releases |

</details>

<details open>
<summary><strong>Codex review context</strong></summary>

- **Delta since last Codex review:** New branch from v0.83.5 / current main.
- **Intended behavior / invariants:** Keep user-triggered refresh fast without weakening CLI repair semantics or cloud drain readiness.
- **Edge cases covered:** large Codex histories, deep archives, lock contention, silent popover overlap, cloud-disabled and explicit-token local API paths.
- **Tests run:** full Node suite, full macOS XCTest suite, native App build, targeted integration tests, and live local API timing.
- **Known gaps / out of scope:** No change to the 120-second generic embedded child timeout; exhaustive CLI repair may still exceed it when called through a generic local API drain request.

### Most likely regression surface

- Local API argument forwarding for requests that combine `auto`, `background`, and `drain`.

### Verification method

- Behavioral Node tests assert process arguments and archive traversal.
- Swift policy tests cover all manual-request admission states.
- Full native compilation verifies ViewModel and APIClient integration.

### Uncovered scope

- No Windows UI behavior changed; Windows manual CLI sync remains exhaustive and is covered by the full suite.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved manual sync handling to start, queue, or combine requests based on current sync activity.
  * Sync Now now performs a lightweight local scan while also processing pending cloud uploads.
  * Background sync avoids deep archived-session scans while preserving upload processing.

* **Bug Fixes**
  * Corrected background and drain mode behavior when used together.

* **Tests**
  * Added coverage for sync request queuing, combined sync modes, and archived-session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->