### PR TITLE
fix: localize usage trend dates and times

### DIFF
--- a/dashboard/src/lib/trend-stats.js
+++ b/dashboard/src/lib/trend-stats.js
@@ -83,12 +83,73 @@ function pad2(n) {
   return String(n).padStart(2, "0");
 }
 
+function resolveDateLocale(locale) {
+  return typeof locale === "string" && locale.trim() ? locale : "en-US";
+}
+
+function parseDayKey(value) {
+  const raw = String(value || "");
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+  if (
+    date.getUTCFullYear() !== Number(year)
+    || date.getUTCMonth() + 1 !== Number(month)
+    || date.getUTCDate() !== Number(day)
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function formatDayKey(value, locale, includeYear = true) {
+  const date = parseDayKey(value);
+  if (!date || typeof Intl === "undefined" || !Intl.DateTimeFormat) return String(value || "");
+  try {
+    return new Intl.DateTimeFormat(resolveDateLocale(locale), {
+      ...(includeYear ? { year: "numeric" } : {}),
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    }).format(date);
+  } catch {
+    return String(value || "");
+  }
+}
+
+function formatMonthKey(value, locale) {
+  const raw = String(value || "");
+  const match = /^(\d{4})-(\d{2})(?:-\d{2})?$/.exec(raw);
+  if (!match) return raw;
+  const date = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+  if (date.getUTCFullYear() !== Number(match[1]) || date.getUTCMonth() + 1 !== Number(match[2])) {
+    return raw;
+  }
+  try {
+    return new Intl.DateTimeFormat(resolveDateLocale(locale), {
+      year: "numeric",
+      month: "short",
+      timeZone: "UTC",
+    }).format(date);
+  } catch {
+    return raw;
+  }
+}
+
+function addUtcDays(dayKey, amount) {
+  const date = parseDayKey(dayKey);
+  if (!date) return dayKey;
+  date.setUTCDate(date.getUTCDate() + amount);
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`;
+}
+
 // Precise time RANGE label for a hovered bucket, by granularity:
-//   hourly  "YYYY-MM-DDTHH:MM:00" -> "YYYY-MM-DD HH:MM–HH:MM" (end = start + 30min)
-//   daily   "YYYY-MM-DD"          -> "YYYY-MM-DD"
-//   monthly "YYYY-MM"             -> "YYYY-MM"
+//   hourly  "YYYY-MM-DDTHH:MM:00" -> localized date + "HH:MM–HH:MM"
+//   daily   "YYYY-MM-DD"          -> localized full date
+//   monthly "YYYY-MM"             -> localized month + year
 // Falls back to the raw label (or "") for anything unparseable.
-export function formatBucketRange(row, granularity) {
+export function formatBucketRange(row, granularity, locale) {
   if (!row) return "";
 
   if (granularity === "hourly") {
@@ -100,15 +161,49 @@ export function formatBucketRange(row, granularity) {
     const endMinutes = startMinutes + 30;
     const endH = Math.floor(endMinutes / 60) % 24;
     const endM = endMinutes % 60;
-    return `${date} ${hh}:${mm}–${pad2(endH)}:${pad2(endM)}`;
+    const startDate = formatDayKey(date, locale);
+    if (endMinutes >= 24 * 60) {
+      const endDate = formatDayKey(addUtcDays(date, 1), locale);
+      return `${startDate} ${hh}:${mm}–${endDate} ${pad2(endH)}:${pad2(endM)}`;
+    }
+    return `${startDate} ${hh}:${mm}–${pad2(endH)}:${pad2(endM)}`;
   }
 
   if (granularity === "monthly") {
-    return String(row.month || row.label || "");
+    const raw = String(row.month || row.label || "");
+    return formatMonthKey(raw, locale);
   }
 
   // daily
-  return String(row.day || row.label || "");
+  const raw = String(row.day || row.label || "");
+  return formatDayKey(raw, locale);
+}
+
+// Localized endpoint labels beneath the compact chart. Hourly ranges show the
+// selected date only once so the two endpoints stay legible in narrow cards.
+export function formatTrendRange(from, to, granularity, locale) {
+  if (!from || !to) return null;
+  const rawFrom = String(from);
+  const rawTo = String(to);
+
+  if (granularity === "hourly" && rawFrom === rawTo) {
+    return {
+      start: `${formatDayKey(rawFrom, locale)} · 00:00`,
+      end: "24:00",
+    };
+  }
+
+  if (granularity === "monthly") {
+    return {
+      start: formatMonthKey(rawFrom, locale),
+      end: formatMonthKey(rawTo, locale),
+    };
+  }
+
+  return {
+    start: formatDayKey(rawFrom, locale),
+    end: formatDayKey(rawTo, locale),
+  };
 }
 
 // One-line insight copy key for the zoom stats panel, tiered by total volume so
@@ -123,18 +218,16 @@ export function getTrendInsightKey(stats) {
   return "trend.zoom.insight.massive";
 }
 
-// Short axis-tick label for a bucket (no date noise):
-//   hourly  -> "HH:MM"   daily -> "MM-DD"   monthly -> "YYYY-MM"
-export function formatTickLabel(row, granularity) {
+// Short localized axis-tick label for a bucket (no unnecessary date noise).
+export function formatTickLabel(row, granularity, locale) {
   if (!row) return "";
   if (granularity === "hourly") {
     const m = /T(\d{2}:\d{2})/.exec(String(row.hour || row.label || ""));
     return m ? m[1] : "";
   }
   if (granularity === "monthly") {
-    return String(row.month || row.label || "");
+    return formatMonthKey(String(row.month || row.label || ""), locale);
   }
   const day = String(row.day || row.label || "");
-  const m = /^\d{4}-(\d{2}-\d{2})$/.exec(day);
-  return m ? m[1] : day;
+  return formatDayKey(day, locale, false);
 }

--- a/dashboard/src/lib/trend-stats.test.js
+++ b/dashboard/src/lib/trend-stats.test.js
@@ -3,6 +3,7 @@ import {
   computeZoomStats,
   formatBucketRange,
   formatTickLabel,
+  formatTrendRange,
   getTrendInsightKey,
   granularityFromPeriod,
 } from "./trend-stats";
@@ -59,22 +60,42 @@ describe("computeZoomStats", () => {
 
 describe("formatBucketRange", () => {
   it("hourly -> 30-min range with end = start + 30min", () => {
-    expect(formatBucketRange({ hour: "2026-05-29T14:00:00" }, "hourly")).toBe("2026-05-29 14:00–14:30");
-    expect(formatBucketRange({ hour: "2026-05-29T14:30:00" }, "hourly")).toBe("2026-05-29 14:30–15:00");
+    expect(formatBucketRange({ hour: "2026-05-29T14:00:00" }, "hourly", "en-US")).toBe("May 29, 2026 14:00–14:30");
+    expect(formatBucketRange({ hour: "2026-05-29T14:30:00" }, "hourly", "zh-CN")).toBe("2026年5月29日 14:30–15:00");
   });
 
-  it("hourly wraps 23:30 end to 00:00", () => {
-    expect(formatBucketRange({ hour: "2026-05-29T23:30:00" }, "hourly")).toBe("2026-05-29 23:30–00:00");
+  it("hourly makes a midnight rollover explicit", () => {
+    expect(formatBucketRange({ hour: "2026-05-29T23:30:00" }, "hourly", "en-US")).toBe("May 29, 2026 23:30–May 30, 2026 00:00");
   });
 
-  it("daily and monthly pass through the bucket key", () => {
-    expect(formatBucketRange({ day: "2026-05-29" }, "daily")).toBe("2026-05-29");
-    expect(formatBucketRange({ month: "2026-05" }, "monthly")).toBe("2026-05");
+  it("localizes daily and monthly bucket keys", () => {
+    expect(formatBucketRange({ day: "2026-05-29" }, "daily", "en-US")).toBe("May 29, 2026");
+    expect(formatBucketRange({ month: "2026-05" }, "monthly", "zh-CN")).toBe("2026年5月");
   });
 
   it("falls back to raw label for unparseable / missing input", () => {
     expect(formatBucketRange({ hour: "garbage" }, "hourly")).toBe("garbage");
     expect(formatBucketRange(null, "hourly")).toBe("");
+  });
+});
+
+describe("formatTrendRange", () => {
+  it("shows an hourly day once with readable endpoints", () => {
+    expect(formatTrendRange("2026-05-29", "2026-05-29", "hourly", "zh-CN")).toEqual({
+      start: "2026年5月29日 · 00:00",
+      end: "24:00",
+    });
+  });
+
+  it("localizes daily and monthly range endpoints", () => {
+    expect(formatTrendRange("2026-05-01", "2026-05-29", "daily", "en-US")).toEqual({
+      start: "May 1, 2026",
+      end: "May 29, 2026",
+    });
+    expect(formatTrendRange("2026-01", "2026-05", "monthly", "zh-CN")).toEqual({
+      start: "2026年1月",
+      end: "2026年5月",
+    });
   });
 });
 
@@ -93,10 +114,10 @@ describe("getTrendInsightKey", () => {
 });
 
 describe("formatTickLabel", () => {
-  it("emits short labels per granularity", () => {
-    expect(formatTickLabel({ hour: "2026-05-29T14:30:00" }, "hourly")).toBe("14:30");
-    expect(formatTickLabel({ day: "2026-05-29" }, "daily")).toBe("05-29");
-    expect(formatTickLabel({ month: "2026-05" }, "monthly")).toBe("2026-05");
+  it("emits short localized labels per granularity", () => {
+    expect(formatTickLabel({ hour: "2026-05-29T14:30:00" }, "hourly", "zh-CN")).toBe("14:30");
+    expect(formatTickLabel({ day: "2026-05-29" }, "daily", "zh-CN")).toBe("5月29日");
+    expect(formatTickLabel({ month: "2026-05" }, "monthly", "en-US")).toBe("May 2026");
   });
 
   it("returns empty string for null row", () => {

--- a/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
+++ b/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { Maximize2 } from "lucide-react";
-import { copy } from "../../../lib/copy";
+import { copy, getCopyLocale } from "../../../lib/copy";
 import { cn } from "../../../lib/cn";
 import { useCurrency } from "../../../hooks/useCurrency.js";
 import { useTokenFormat } from "../../../hooks/useTokenFormat.js";
 import { formatUsdCurrency } from "../../../lib/format";
-import { formatBucketRange, formatTickLabel, granularityFromPeriod } from "../../../lib/trend-stats";
+import {
+  formatBucketRange,
+  formatTickLabel,
+  formatTrendRange,
+  granularityFromPeriod,
+} from "../../../lib/trend-stats";
 import { TrendMonitorZoomModal } from "./TrendMonitorZoomModal";
 
 function interpolateQuantile(sortedValues, ratio) {
@@ -413,6 +418,11 @@ export function TrendMonitor({
   const { currency, rate } = useCurrency();
   const { formatTokens, formatTokensTooltip } = useTokenFormat();
   const granularity = granularityFromPeriod(period);
+  const locale = getCopyLocale();
+  const rangeLabels = React.useMemo(
+    () => formatTrendRange(from, to, granularity, locale),
+    [from, granularity, locale, to],
+  );
 
   const [hoveredBar, setHoveredBar] = React.useState(null);
   const [tooltipPos, setTooltipPos] = React.useState({ x: 0, y: 0, shiftX: 0, flipDown: false });
@@ -426,9 +436,7 @@ export function TrendMonitor({
       hideTimeoutRef.current = null;
     }
 
-    const timeLabel = isZoom
-      ? formatBucketRange(row, granularity)
-      : row?.day || row?.hour || row?.month || "";
+    const timeLabel = formatBucketRange(row, granularity, locale);
     setHoveredBar({
       row,
       value,
@@ -468,7 +476,7 @@ export function TrendMonitor({
     const flipDown = y < estTooltipHeight + 12;
 
     setTooltipPos({ x, y, shiftX, flipDown });
-  }, [isZoom, granularity]);
+  }, [isZoom, granularity, locale]);
 
   const handleBarMouseLeave = React.useCallback(() => {
     if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
@@ -567,7 +575,7 @@ export function TrendMonitor({
                 <div key={index} className={cn("flex-1 min-w-0 flex", justify)}>
                   {isTick && (
                     <span className="text-[9px] text-oai-gray-400 dark:text-oai-gray-500 whitespace-nowrap font-mono">
-                      {formatTickLabel(row, granularity)}
+                      {formatTickLabel(row, granularity, locale)}
                     </span>
                   )}
                 </div>
@@ -589,10 +597,10 @@ export function TrendMonitor({
           </div>
         )}
 
-        {from && to && (
+        {rangeLabels && (
           <div className="flex justify-between text-xs text-oai-gray-500 dark:text-oai-gray-300 font-medium pt-2 border-t border-oai-gray-100 dark:border-oai-gray-800">
-            <span>{from === to ? `${from} 00:00` : from}</span>
-            <span>{from === to ? `${to} 24:00` : to}</span>
+            <span>{rangeLabels.start}</span>
+            <span>{rangeLabels.end}</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- localize compact trend range labels instead of exposing raw ISO dates
- show readable localized dates in hover details and zoom-axis ticks
- make half-hour ranges and midnight rollovers explicit

## Validation
- `npm --prefix dashboard test` (75 files, 431 tests)
- `npm --prefix dashboard run typecheck`
- `npm --prefix dashboard run lint -- --quiet`
- copy, UI hardcode, and architecture guardrails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trend charts now display dates, times, months, tooltips, and range labels according to the selected locale.
  * Improved hourly labels correctly handle ranges that cross midnight.
  * Daily and monthly labels use localized formatting across trend views.

* **Bug Fixes**
  * Corrected inconsistent date and time formatting between chart tooltips, axis labels, and range summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->