### PR TITLE
fix(grok): bill from turn_completed.usage instead of context totalTokens

### DIFF
--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -5,111 +5,546 @@
     "deepseek_v4_pro_pricing_note": "The 2026-05-31 promotional-expiry warning is obsolete: api-docs.deepseek.com/quick_start/pricing verified on 2026-06-10 still lists input $0.435/M, output $0.87/M, cache_read $0.003625/M as the official v4-pro rates (the discount became the list price). Do NOT 'restore' the old 4x rates; re-verify against the official page before any change."
   },
   "exact": {
-    "claude-fable-5":   { "input": 10,   "output": 50,   "cache_read": 1,     "cache_write": 12.5, "note": "Fable 5 — Anthropic's top tier above Opus. Not yet in LiteLLM. $10/$50 per MTok; cache_read 0.1x, cache_write 1.25x. Remove once LiteLLM carries it." },
-    "claude-opus-5":     { "input": 5,    "output": 25,   "cache_read": 0.5,   "cache_write": 6.25, "note": "Opus 5 (public 2026-07). Standard Opus tier, unchanged from 4.6/4.7/4.8: $5/$25 per MTok, cache_read 0.1x, cache_write 1.25x. Not yet in LiteLLM. Fast mode is billed at $10/$50 — see claude-opus-5-fast. Remove once LiteLLM carries it." },
-    "claude-opus-5-fast":{ "input": 10,   "output": 50,   "cache_read": 1,     "cache_write": 12.5, "note": "Opus 5 fast mode (speed=\"fast\", beta fast-mode-2026-02-01) is priced at $10/$50 per MTok — 2x standard Opus. Kept separate so a -fast model id is not silently priced at the standard tier. See claude-opus-5." },
-    "claude-opus-4-8":  { "input": 5,    "output": 25,   "cache_read": 0.5,   "cache_write": 6.25, "note": "Opus 4.8 not yet in LiteLLM. Pin to the standard Opus tier (same as 4.6/4.7); remove once LiteLLM carries it." },
-    "claude-sonnet-5":  { "input": 3,    "output": 15,   "cache_read": 0.3,   "cache_write": 3.75, "note": "Sonnet 5. LiteLLM added this model on ~2026-06-30 with matching rates, but pin explicitly so pricing is correct immediately rather than depending on the 24h local pricing-cache refresh cycle." },
-    "claude-haiku-4-5": { "input": 1,    "output": 5,    "cache_read": 0.1,   "cache_write": 1.25, "note": "Canonical undated alias emitted by Cursor. Pin to the same rates as claude-haiku-4-5-20251001 so local cost does not depend on which dated LiteLLM aliases are present in the current cache." },
-    "gpt-5.6-sol":      { "input": 5,    "output": 30,   "cache_read": 0.5,   "cache_write": 6.25,  "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it." },
-    "gpt-5.6-terra":    { "input": 2.5,  "output": 15,   "cache_read": 0.25,  "cache_write": 3.125, "note": "GPT-5.6 balanced default tier. See gpt-5.6-sol." },
-    "gpt-5.6-luna":     { "input": 1,    "output": 6,    "cache_read": 0.1,   "cache_write": 1.25,  "note": "GPT-5.6 lightweight/cost-efficient tier. See gpt-5.6-sol." },
-    "kiro-agent":       { "input": 3,    "output": 15,   "cache_read": 0.3,   "cache_write": 3.75 },
-    "kiro-cli-agent":   { "input": 3,    "output": 15,   "cache_read": 0.3,   "cache_write": 3.75 },
-    "hy3-preview-agent":{ "input": 0.167, "output": 0.556, "cache_read": 0.056, "cache_write": 0.167, "note": "Tencent Hunyuan Hy3 preview (CodeBuddy/WorkBuddy backend). Official TokenHub rate: 1.2 / 0.4 (cache hit) / 4.0 RMB per MTok in/read/out, converted at ~7.2 RMB/USD. DeepSeek-style cache: no write surcharge, so cache_write = input." },
-    "hy3-preview":      { "input": 0.167, "output": 0.556, "cache_read": 0.056, "cache_write": 0.167, "note": "See hy3-preview-agent." },
-    "composer-1":       { "input": 1.25, "output": 10,   "cache_read": 0.125 },
-    "composer-1.5":     { "input": 3.5,  "output": 17.5, "cache_read": 0.35 },
-    "composer-2":       { "input": 0.5,  "output": 2.5,  "cache_read": 0.2 },
-    "composer-2-fast":  { "input": 1.5,  "output": 7.5,  "cache_read": 0.15 },
-    "MiniMax-M2.7":     { "input": 0.3,  "output": 1.2,  "cache_read": 0.06,  "cache_write": 0.375 },
-    "MiniMax-M2.7-highspeed":{ "input": 0.6, "output": 2.4, "cache_read": 0.06, "cache_write": 0.375 },
-    "minimax-m3":       { "input": 0.3,  "output": 1.2,  "cache_read": 0.06,  "cache_write": 0 },
-    "deepseek-v4-flash":{ "input": 0.14, "output": 0.28, "cache_read": 0.0028, "cache_write": 0.14 },
-    "deepseek-v4-pro":  { "input": 0.435,"output": 0.87, "cache_read": 0.003625, "cache_write": 0.435 },
-    "deepseek-chat":    { "input": 0.14, "output": 0.28, "cache_read": 0.0028, "cache_write": 0.14 },
-    "grok-build":       { "input": 1.25, "output": 2.50, "cache_read": 0.20, "note": "Grok Build TUI estimate. Local telemetry currently exposes totalTokens without a stable prompt/output/cache split, so TokenTracker estimates input/output split until Grok exposes per-call usage details." },
-    "cursor-grok-4.5":  { "input": 2.00, "output": 6.00, "cache_read": 0.50, "cache_write": 0, "note": "Cursor Grok 4.5 base rate. Cursor Models & Pricing: $2/M input, $0.50/M cached input, $6/M output; no cache-write rate is published." },
-    "cursor-grok-4.5-fast": { "input": 4.00, "output": 18.00, "cache_read": 1.00, "cache_write": 0, "note": "Cursor Grok 4.5 Fast rate. Cursor publishes $4/M input and $18/M output; the Cursor usage breakdown reports $1/M cached input. Kept separate from the cheaper base SKU." },
-    "grok-4-0709":      { "input": 3.00, "output": 15.00, "cache_read": 0.75 },
-    "grok-4":           { "input": 3.00, "output": 15.00, "cache_read": 0.75 },
-    "grok-4-latest":    { "input": 3.00, "output": 15.00, "cache_read": 0.75 },
-    "grok-4-fast":      { "input": 0.20, "output": 0.50, "cache_read": 0.05 },
-    "grok-4-fast-reasoning": { "input": 0.20, "output": 0.50, "cache_read": 0.05 },
-    "grok-4-fast-non-reasoning": { "input": 0.20, "output": 0.50, "cache_read": 0.05 },
-    "grok-4-1-fast-non-reasoning": { "input": 0.20, "output": 0.50, "cache_read": 0.05 },
-    "deepseek-reasoner":{ "input": 0.14, "output": 0.28, "cache_read": 0.0028, "cache_write": 0.14 },
-    "kimi-for-coding":  { "input": 0.6,  "output": 2,    "cache_read": 0.15 },
-    "kimi-k2.5":        { "input": 0.6,  "output": 2,    "cache_read": 0.15 },
-    "kimi-k2.5-free":   { "input": 0,    "output": 0,    "cache_read": 0 },
-    "kimi-k2.6":        { "input": 0.95, "output": 4,    "cache_read": 0.16 },
-    "kimi-k2.7-code":   { "input": 0.95, "output": 4,    "cache_read": 0.19 },
-    "kimi-k3":          { "input": 3,    "output": 15,   "cache_read": 0.3,  "note": "Kimi K3 (released 2026-07-16). Reported API rates: $3/M input, $15/M output, $0.30/M cached input (0.1x). Not yet in LiteLLM; remove once it carries k3. Kimi Code records the alias as bare \"k3\" (kimi-code/k3), hence the separate exact key below." },
-    "k3":               { "input": 3,    "output": 15,   "cache_read": 0.3,  "note": "Bare alias emitted by Kimi Code (modelAlias \"kimi-code/k3\" -> \"k3\"). Same rates as kimi-k3." },
-    "glm-5.2":          { "input": 1.4,  "output": 4.4,  "cache_read": 0.26 },
-    "glm-5.1":          { "input": 1.4,  "output": 4.4,  "cache_read": 0.26 },
-    "glm-5":            { "input": 1.0,  "output": 3.2,  "cache_read": 0.2 },
-    "glm-5-turbo":      { "input": 1.2,  "output": 4.0,  "cache_read": 0.24 },
-    "glm-4.7":          { "input": 0.6,  "output": 2.2,  "cache_read": 0.11 },
-    "glm-4.7-flashx":   { "input": 0.07, "output": 0.4,  "cache_read": 0.01 },
-    "glm-4.7-flash":    { "input": 0,    "output": 0,    "cache_read": 0 },
-    "glm-4.6":          { "input": 0.6,  "output": 2.2,  "cache_read": 0.11 },
-    "glm-4.5":          { "input": 0.6,  "output": 2.2,  "cache_read": 0.11 },
-    "glm-4.5-x":        { "input": 2.2,  "output": 8.9,  "cache_read": 0.45 },
-    "glm-4.5-air":      { "input": 0.2,  "output": 1.1,  "cache_read": 0.03 },
-    "glm-4.5-airx":     { "input": 1.1,  "output": 4.5,  "cache_read": 0.22 },
-    "glm-4.5-flash":    { "input": 0,    "output": 0,    "cache_read": 0 },
-    "glm-4.7-free":     { "input": 0,    "output": 0,    "cache_read": 0 },
-    "nemotron-3-super-free":{ "input": 0, "output": 0,   "cache_read": 0 },
-    "mimo-v2-pro-free": { "input": 0,    "output": 0,    "cache_read": 0 },
-    "minimax-m2.1-free":{ "input": 0,    "output": 0,    "cache_read": 0 },
-    "MiniMax-M2.1":     { "input": 0.5,  "output": 3,    "cache_read": 0.05 },
-    "antigravity-gpt-oss-120b": { "input": 2.5, "output": 10, "cache_read": 0, "note": "Antigravity bridge alias. Approximate with GPT-4o-class pricing until Google exposes route-specific billing metadata." },
-    "sakana/fugu-ultra": { "input": 5,    "output": 30,   "cache_read": 0.5,   "cache_write": 5,    "note": "Sakana Fugu Ultra — multi-agent orchestration via an OpenAI-compatible API (sakana.ai PAYG + OpenRouter), used through Codex/Cursor/Cline/ZCode etc. OpenRouter rates: $5/$30 per MTok in/out, cache_read $0.5/M; no published cache-write surcharge, so cache_write = input. Subscriptions ($20/$100/$200) bill against this token-equivalent rate." },
-    "longcat-2.0":      { "input": 0.278, "output": 1.111, "cache_read": 0.00556, "cache_write": 0.278, "note": "Meituan LongCat-2.0, seen via ZCode custom-provider routing (issue #276). Official longcat.chat/platform launch-promo rate: RMB 2 / 0.04 (cache hit) / 8 per MTok in/read/out, converted at ~7.2 RMB/USD. Standard list price is RMB 5/0.10/20 (2.5x) once the promo ends — re-verify against longcat.chat/platform/docs/zh/Pricing/LongCat-2.0.html before assuming either is permanent. DeepSeek-style cache: no write surcharge, so cache_write = input." },
-    "step-3.7-flash":   { "input": 0.2,  "output": 1.15, "cache_read": 0.04, "cache_write": 0.2, "note": "StepFun Step 3.7 Flash (issue #283). Official platform.stepfun.ai pricing: $0.20 / $0.04 (cache hit) / $1.15 per MTok in/read/out. No published cache-write surcharge, so cache_write = input." },
-    "step-3.5-flash":   { "input": 0.1,  "output": 0.3,  "cache_read": 0.02, "cache_write": 0.1, "note": "StepFun Step 3.5 Flash incl. dated snapshots like step-3.5-flash-2603 (issue #283). Official platform.stepfun.ai pricing: $0.10 / $0.02 (cache hit) / $0.30 per MTok in/read/out. No published cache-write surcharge, so cache_write = input." }
+    "claude-fable-5": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5,
+      "note": "Fable 5 \u2014 Anthropic's top tier above Opus. Not yet in LiteLLM. $10/$50 per MTok; cache_read 0.1x, cache_write 1.25x. Remove once LiteLLM carries it."
+    },
+    "claude-opus-5": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25,
+      "note": "Opus 5 (public 2026-07). Standard Opus tier, unchanged from 4.6/4.7/4.8: $5/$25 per MTok, cache_read 0.1x, cache_write 1.25x. Not yet in LiteLLM. Fast mode is billed at $10/$50 \u2014 see claude-opus-5-fast. Remove once LiteLLM carries it."
+    },
+    "claude-opus-5-fast": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5,
+      "note": "Opus 5 fast mode (speed=\"fast\", beta fast-mode-2026-02-01) is priced at $10/$50 per MTok \u2014 2x standard Opus. Kept separate so a -fast model id is not silently priced at the standard tier. See claude-opus-5."
+    },
+    "claude-opus-4-8": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25,
+      "note": "Opus 4.8 not yet in LiteLLM. Pin to the standard Opus tier (same as 4.6/4.7); remove once LiteLLM carries it."
+    },
+    "claude-sonnet-5": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75,
+      "note": "Sonnet 5. LiteLLM added this model on ~2026-06-30 with matching rates, but pin explicitly so pricing is correct immediately rather than depending on the 24h local pricing-cache refresh cycle."
+    },
+    "claude-haiku-4-5": {
+      "input": 1,
+      "output": 5,
+      "cache_read": 0.1,
+      "cache_write": 1.25,
+      "note": "Canonical undated alias emitted by Cursor. Pin to the same rates as claude-haiku-4-5-20251001 so local cost does not depend on which dated LiteLLM aliases are present in the current cache."
+    },
+    "gpt-5.6-sol": {
+      "input": 5,
+      "output": 30,
+      "cache_read": 0.5,
+      "cache_write": 6.25,
+      "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it."
+    },
+    "gpt-5.6-terra": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25,
+      "cache_write": 3.125,
+      "note": "GPT-5.6 balanced default tier. See gpt-5.6-sol."
+    },
+    "gpt-5.6-luna": {
+      "input": 1,
+      "output": 6,
+      "cache_read": 0.1,
+      "cache_write": 1.25,
+      "note": "GPT-5.6 lightweight/cost-efficient tier. See gpt-5.6-sol."
+    },
+    "kiro-agent": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "kiro-cli-agent": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "hy3-preview-agent": {
+      "input": 0.167,
+      "output": 0.556,
+      "cache_read": 0.056,
+      "cache_write": 0.167,
+      "note": "Tencent Hunyuan Hy3 preview (CodeBuddy/WorkBuddy backend). Official TokenHub rate: 1.2 / 0.4 (cache hit) / 4.0 RMB per MTok in/read/out, converted at ~7.2 RMB/USD. DeepSeek-style cache: no write surcharge, so cache_write = input."
+    },
+    "hy3-preview": {
+      "input": 0.167,
+      "output": 0.556,
+      "cache_read": 0.056,
+      "cache_write": 0.167,
+      "note": "See hy3-preview-agent."
+    },
+    "composer-1": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "composer-1.5": {
+      "input": 3.5,
+      "output": 17.5,
+      "cache_read": 0.35
+    },
+    "composer-2": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "composer-2-fast": {
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 0.15
+    },
+    "MiniMax-M2.7": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "MiniMax-M2.7-highspeed": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "minimax-m3": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0
+    },
+    "deepseek-v4-flash": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028,
+      "cache_write": 0.14
+    },
+    "deepseek-v4-pro": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625,
+      "cache_write": 0.435
+    },
+    "deepseek-chat": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028,
+      "cache_write": 0.14
+    },
+    "grok-build": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2,
+      "note": "Grok Build TUI fallback estimate for sessions without turn_completed.usage. Preferred path is turn_completed usage with per-model modelUsage splits."
+    },
+    "cursor-grok-4.5": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5,
+      "cache_write": 0,
+      "note": "Cursor Grok 4.5 base rate. Cursor Models & Pricing: $2/M input, $0.50/M cached input, $6/M output; no cache-write rate is published."
+    },
+    "cursor-grok-4.5-fast": {
+      "input": 4.0,
+      "output": 18.0,
+      "cache_read": 1.0,
+      "cache_write": 0,
+      "note": "Cursor Grok 4.5 Fast rate. Cursor publishes $4/M input and $18/M output; the Cursor usage breakdown reports $1/M cached input. Kept separate from the cheaper base SKU."
+    },
+    "grok-4-0709": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.75
+    },
+    "grok-4": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.75
+    },
+    "grok-4-latest": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.75
+    },
+    "grok-4-fast": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "grok-4-fast-reasoning": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "grok-4-fast-non-reasoning": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "grok-4-1-fast-non-reasoning": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "deepseek-reasoner": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028,
+      "cache_write": 0.14
+    },
+    "kimi-for-coding": {
+      "input": 0.6,
+      "output": 2,
+      "cache_read": 0.15
+    },
+    "kimi-k2.5": {
+      "input": 0.6,
+      "output": 2,
+      "cache_read": 0.15
+    },
+    "kimi-k2.5-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "kimi-k2.6": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.16
+    },
+    "kimi-k2.7-code": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.19
+    },
+    "kimi-k3": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "note": "Kimi K3 (released 2026-07-16). Reported API rates: $3/M input, $15/M output, $0.30/M cached input (0.1x). Not yet in LiteLLM; remove once it carries k3. Kimi Code records the alias as bare \"k3\" (kimi-code/k3), hence the separate exact key below."
+    },
+    "k3": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "note": "Bare alias emitted by Kimi Code (modelAlias \"kimi-code/k3\" -> \"k3\"). Same rates as kimi-k3."
+    },
+    "glm-5.2": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "glm-5.1": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "glm-5": {
+      "input": 1.0,
+      "output": 3.2,
+      "cache_read": 0.2
+    },
+    "glm-5-turbo": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
+    "glm-4.7": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "glm-4.7-flashx": {
+      "input": 0.07,
+      "output": 0.4,
+      "cache_read": 0.01
+    },
+    "glm-4.7-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "glm-4.6": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "glm-4.5": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "glm-4.5-x": {
+      "input": 2.2,
+      "output": 8.9,
+      "cache_read": 0.45
+    },
+    "glm-4.5-air": {
+      "input": 0.2,
+      "output": 1.1,
+      "cache_read": 0.03
+    },
+    "glm-4.5-airx": {
+      "input": 1.1,
+      "output": 4.5,
+      "cache_read": 0.22
+    },
+    "glm-4.5-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "glm-4.7-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "nemotron-3-super-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "mimo-v2-pro-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "minimax-m2.1-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
+    },
+    "MiniMax-M2.1": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.05
+    },
+    "antigravity-gpt-oss-120b": {
+      "input": 2.5,
+      "output": 10,
+      "cache_read": 0,
+      "note": "Antigravity bridge alias. Approximate with GPT-4o-class pricing until Google exposes route-specific billing metadata."
+    },
+    "sakana/fugu-ultra": {
+      "input": 5,
+      "output": 30,
+      "cache_read": 0.5,
+      "cache_write": 5,
+      "note": "Sakana Fugu Ultra \u2014 multi-agent orchestration via an OpenAI-compatible API (sakana.ai PAYG + OpenRouter), used through Codex/Cursor/Cline/ZCode etc. OpenRouter rates: $5/$30 per MTok in/out, cache_read $0.5/M; no published cache-write surcharge, so cache_write = input. Subscriptions ($20/$100/$200) bill against this token-equivalent rate."
+    },
+    "longcat-2.0": {
+      "input": 0.278,
+      "output": 1.111,
+      "cache_read": 0.00556,
+      "cache_write": 0.278,
+      "note": "Meituan LongCat-2.0, seen via ZCode custom-provider routing (issue #276). Official longcat.chat/platform launch-promo rate: RMB 2 / 0.04 (cache hit) / 8 per MTok in/read/out, converted at ~7.2 RMB/USD. Standard list price is RMB 5/0.10/20 (2.5x) once the promo ends \u2014 re-verify against longcat.chat/platform/docs/zh/Pricing/LongCat-2.0.html before assuming either is permanent. DeepSeek-style cache: no write surcharge, so cache_write = input."
+    },
+    "step-3.7-flash": {
+      "input": 0.2,
+      "output": 1.15,
+      "cache_read": 0.04,
+      "cache_write": 0.2,
+      "note": "StepFun Step 3.7 Flash (issue #283). Official platform.stepfun.ai pricing: $0.20 / $0.04 (cache hit) / $1.15 per MTok in/read/out. No published cache-write surcharge, so cache_write = input."
+    },
+    "step-3.5-flash": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.02,
+      "cache_write": 0.1,
+      "note": "StepFun Step 3.5 Flash incl. dated snapshots like step-3.5-flash-2603 (issue #283). Official platform.stepfun.ai pricing: $0.10 / $0.02 (cache hit) / $0.30 per MTok in/read/out. No published cache-write surcharge, so cache_write = input."
+    },
+    "grok-4.5-build": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5,
+      "cache_write": 0,
+      "note": "Grok Build paid SKU (grok-4.5-build from turn_completed.modelUsage). Rates aligned with xAI/Cursor Grok 4.5 until a dedicated Build price list is published."
+    },
+    "grok-build-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0,
+      "note": "Grok Build free tier (canonical model id). $0 marginal cost. Prefer this over grok-4.5-build-free so pricing lookup cannot fuzzy-match paid grok-4.5."
+    },
+    "grok-4.5-build-free": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0,
+      "note": "Alias for free Build SKU as labeled in Grok updates.jsonl modelUsage. Canonical storage id is grok-build-free."
+    }
   },
   "alias": {
     "auto": "composer-1"
   },
   "fuzzy": [
-    { "match": "gpt-5.6-sol",            "ref": "gpt-5.6-sol" },
-    { "match": "gpt-5.6-terra",          "ref": "gpt-5.6-terra" },
-    { "match": "gpt-5.6-luna",           "ref": "gpt-5.6-luna" },
-    { "match": "gpt-5.6",                "ref": "gpt-5.6-terra" },
-    { "match": "kiro",                   "ref": "kiro-cli-agent" },
-    { "match": "hy3",                    "ref": "hy3-preview-agent" },
-    { "match": "composer",               "ref": "composer-1" },
-    { "match": "claude-opus-5-fast",      "ref": "claude-opus-5-fast" },
-    { "match": "claude-opus-5",           "ref": "claude-opus-5" },
-    { "match": "claude-opus-4-8",         "ref": "claude-opus-4-8" },
-    { "match": "minimax-m3",            "ref": "minimax-m3" },
-    { "match": "minimax-m2.7-highspeed", "ref": "MiniMax-M2.7-highspeed" },
-    { "match": "minimax-m2.7",           "ref": "MiniMax-M2.7" },
-    { "match": "deepseek-v4-flash",      "ref": "deepseek-v4-flash" },
-    { "match": "deepseek-v4-pro",        "ref": "deepseek-v4-pro" },
-    { "match": "kimi-k2.7-code",        "ref": "kimi-k2.7-code" },
-    { "match": "kimi-k3",                "ref": "kimi-k3" },
-    { "match": "kimi-k2.6",              "ref": "kimi-k2.6" },
-    { "match": "kimi",                   "ref": "kimi-k2.5" },
-    { "match": "glm-4.5-airx",           "ref": "glm-4.5-airx" },
-    { "match": "glm-4.5-air",            "ref": "glm-4.5-air" },
-    { "match": "glm-4.5-x",              "ref": "glm-4.5-x" },
-    { "match": "glm-4.5-flash",          "ref": "glm-4.5-flash" },
-    { "match": "glm-4.5",                "ref": "glm-4.5" },
-    { "match": "glm-4.7-flashx",         "ref": "glm-4.7-flashx" },
-    { "match": "glm-4.7-flash",          "ref": "glm-4.7-flash" },
-    { "match": "glm-4.7",                "ref": "glm-4.7" },
-    { "match": "glm-4.6",                "ref": "glm-4.6" },
-    { "match": "glm-5-turbo",            "ref": "glm-5-turbo" },
-    { "match": "glm-5.2",                "ref": "glm-5.2" },
-    { "match": "glm-5.1",                "ref": "glm-5.1" },
-    { "match": "glm-5",                  "ref": "glm-5" },
-    { "match": "fugu",                   "ref": "sakana/fugu-ultra" },
-    { "match": "longcat",                "ref": "longcat-2.0" },
-    { "match": "step-3.7-flash",         "ref": "step-3.7-flash" },
-    { "match": "step-3.5-flash",         "ref": "step-3.5-flash" },
-    { "match": "stepfun",                "ref": "step-3.7-flash" }
+    {
+      "match": "gpt-5.6-sol",
+      "ref": "gpt-5.6-sol"
+    },
+    {
+      "match": "gpt-5.6-terra",
+      "ref": "gpt-5.6-terra"
+    },
+    {
+      "match": "gpt-5.6-luna",
+      "ref": "gpt-5.6-luna"
+    },
+    {
+      "match": "gpt-5.6",
+      "ref": "gpt-5.6-terra"
+    },
+    {
+      "match": "kiro",
+      "ref": "kiro-cli-agent"
+    },
+    {
+      "match": "hy3",
+      "ref": "hy3-preview-agent"
+    },
+    {
+      "match": "composer",
+      "ref": "composer-1"
+    },
+    {
+      "match": "claude-opus-5-fast",
+      "ref": "claude-opus-5-fast"
+    },
+    {
+      "match": "claude-opus-5",
+      "ref": "claude-opus-5"
+    },
+    {
+      "match": "claude-opus-4-8",
+      "ref": "claude-opus-4-8"
+    },
+    {
+      "match": "minimax-m3",
+      "ref": "minimax-m3"
+    },
+    {
+      "match": "minimax-m2.7-highspeed",
+      "ref": "MiniMax-M2.7-highspeed"
+    },
+    {
+      "match": "minimax-m2.7",
+      "ref": "MiniMax-M2.7"
+    },
+    {
+      "match": "deepseek-v4-flash",
+      "ref": "deepseek-v4-flash"
+    },
+    {
+      "match": "deepseek-v4-pro",
+      "ref": "deepseek-v4-pro"
+    },
+    {
+      "match": "kimi-k2.7-code",
+      "ref": "kimi-k2.7-code"
+    },
+    {
+      "match": "kimi-k3",
+      "ref": "kimi-k3"
+    },
+    {
+      "match": "kimi-k2.6",
+      "ref": "kimi-k2.6"
+    },
+    {
+      "match": "kimi",
+      "ref": "kimi-k2.5"
+    },
+    {
+      "match": "glm-4.5-airx",
+      "ref": "glm-4.5-airx"
+    },
+    {
+      "match": "glm-4.5-air",
+      "ref": "glm-4.5-air"
+    },
+    {
+      "match": "glm-4.5-x",
+      "ref": "glm-4.5-x"
+    },
+    {
+      "match": "glm-4.5-flash",
+      "ref": "glm-4.5-flash"
+    },
+    {
+      "match": "glm-4.5",
+      "ref": "glm-4.5"
+    },
+    {
+      "match": "glm-4.7-flashx",
+      "ref": "glm-4.7-flashx"
+    },
+    {
+      "match": "glm-4.7-flash",
+      "ref": "glm-4.7-flash"
+    },
+    {
+      "match": "glm-4.7",
+      "ref": "glm-4.7"
+    },
+    {
+      "match": "glm-4.6",
+      "ref": "glm-4.6"
+    },
+    {
+      "match": "glm-5-turbo",
+      "ref": "glm-5-turbo"
+    },
+    {
+      "match": "glm-5.2",
+      "ref": "glm-5.2"
+    },
+    {
+      "match": "glm-5.1",
+      "ref": "glm-5.1"
+    },
+    {
+      "match": "glm-5",
+      "ref": "glm-5"
+    },
+    {
+      "match": "fugu",
+      "ref": "sakana/fugu-ultra"
+    },
+    {
+      "match": "longcat",
+      "ref": "longcat-2.0"
+    },
+    {
+      "match": "step-3.7-flash",
+      "ref": "step-3.7-flash"
+    },
+    {
+      "match": "step-3.5-flash",
+      "ref": "step-3.5-flash"
+    },
+    {
+      "match": "stepfun",
+      "ref": "step-3.7-flash"
+    }
   ]
 }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6204,7 +6204,7 @@ async function parseKimiCodeIncremental({ wireFiles, cursors, queuePath, onProgr
 // each sync (passive scan only, same shape as Kimi's wire.jsonl reader).
 //
 // Per-line record types: message, reasoning, topic, file-history-snapshot.
-// Only `type=="message" && role=="assistant"` carry token usage. The shape:
+// Only `type=="message" and role=="assistant"` carry token usage. The shape:
 //
 //   providerData.rawUsage = {
 //     prompt_tokens: 22223,           // OpenAI-style — INCLUDES cached
@@ -6734,7 +6734,7 @@ async function parseCodebuddyIncremental({
 // (each verified against real ~/.workbuddy logs, NOT assumed from CodeBuddy):
 //
 //   1. Usage lives on `function_call` records too — not only on
-//      `type=="message" && role=="assistant"`. Each LLM round-trip (whether it
+//      `type=="message" and role=="assistant"`. Each LLM round-trip (whether it
 //      ends in a tool call or a text reply) carries its own providerData.rawUsage.
 //      We therefore aggregate EVERY record that has providerData.rawUsage and
 //      dedup per response id, instead of filtering by record type.
@@ -12795,7 +12795,7 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOff
 
   // When the file does not end on a newline, the final emitted line is a
   // partial tail still being written. Exclude its bytes so the committed offset
-  // stays on a complete-line boundary && the line is re-read once finished.
+  // stays on a complete-line boundary and the line is re-read once finished.
   const trailingPartialBytes = endsWithNewline ? 0 : Buffer.byteLength(lastLine, "utf8");
   const committedSize = Math.max(startOffset, stat.size - trailingPartialBytes);
   return {
@@ -12901,22 +12901,43 @@ async function parseGrokBuildIncremental({
   const prevVersion = Number(grokState.version) || 0;
   const needsTurnUsageMigration = prevVersion < GROK_CURSOR_VERSION;
 
-  // v3 && earlier treated context-window totalTokens as cumulative spend, which
-  // undercounts heavily (often 10-50x) && mis-splits input/output. Rebuild from
+  // v3 and earlier treated context-window totalTokens as cumulative spend, which
+  // undercounts heavily (often 10-50x) and mis-splits input/output. Rebuild from
   // turn_completed.usage when migrating to v4.
-  let sessionSnapshots = needsTurnUsageMigration ? {} : normalizeGrokSessionSnapshots(grokState);
+  //
+  // Drop prior watermark totals / updateOffsets so files are re-read from byte 0,
+  // but keep legacySeen markers from seenSessions so the one-shot baseline
+  // (sessions already counted under the old scanner) still applies.
+  let sessionSnapshots;
+  if (needsTurnUsageMigration) {
+    const normalized = normalizeGrokSessionSnapshots(grokState);
+    sessionSnapshots = {};
+    for (const [sessionId, snapshot] of Object.entries(normalized)) {
+      if (!snapshot?.legacySeen) continue;
+      sessionSnapshots[sessionId] = {
+        totalTokens: 0,
+        messageCount: 0,
+        model: null,
+        source: null,
+        lastEventId: null,
+        lastEventTimestamp: null,
+        updatedAt: snapshot.updatedAt || null,
+        legacySeen: true,
+      };
+    }
+    clearGrokHourlyBuckets(hourlyState);
+  } else {
+    sessionSnapshots = normalizeGrokSessionSnapshots(grokState);
+  }
   const prevUpdateOffsets =
     !needsTurnUsageMigration &&
     grokState.updateOffsets &&
     typeof grokState.updateOffsets === "object"
       ? grokState.updateOffsets
       : {};
-  if (needsTurnUsageMigration) {
-    clearGrokHourlyBuckets(hourlyState);
-  }
 
   // Rebuilt from the sessions seen this scan, so entries for deleted session
-  // dirs are pruned && the cursor stays bounded by the on-disk session count.
+  // dirs are pruned and the cursor stays bounded by the on-disk session count.
   const updateOffsets = {};
   const touchedBuckets = new Set();
 
@@ -12957,6 +12978,9 @@ async function parseGrokBuildIncremental({
     let lastEventTimestamp = previous.lastEventTimestamp || null;
     let lastModel = previous.model || model;
     let sawTurnUsage = source === "turn_usage" || previous.source === "turn_usage";
+    // Defer bucket writes until after we know whether this is a legacy baseline
+    // pass (first sighting of a session already counted under an older scanner).
+    const pendingBucketDeltas = [];
 
     const updatesPath = grokUpdatesPathForSession(sess);
     const updates = await readGrokUpdateTokenEvents(
@@ -12986,10 +13010,7 @@ async function parseGrokBuildIncremental({
         billable_total_tokens: event.billable_total_tokens,
         conversation_count: event.conversation_count || 1,
       };
-      const bucket = getHourlyBucket(hourlyState, "grok", eventModel, hourStartStr);
-      addTotals(bucket.totals, delta);
-      touchedBuckets.add(bucketKey("grok", eventModel, hourStartStr));
-      eventsAggregated++;
+      pendingBucketDeltas.push({ model: eventModel, hourStartStr, delta });
       cumulativeTotal += event.total_tokens;
       tokenDeltaForSession += event.total_tokens;
       finalTouchedHourStart = hourStartStr;
@@ -13001,7 +13022,7 @@ async function parseGrokBuildIncremental({
 
     // Fallback only when this session never emitted turn_completed usage
     // (older logs / partial sessions). Context watermark is a lower-bound
-    // estimate && must not run on top of turn usage.
+    // estimate and must not run on top of turn usage.
     if (!sawTurnUsage) {
       let highWatermark = previousTotal;
       for (const event of updates.contextEvents) {
@@ -13016,13 +13037,10 @@ async function parseGrokBuildIncremental({
           toUtcHalfHourStart(Date.now());
         if (!hourStartStr) continue;
         const delta = estimateGrokTokenDelta(deltaTokens, 0, { allowZeroConversationCount: true });
-        const bucket = getHourlyBucket(hourlyState, "grok", model, hourStartStr);
-        addTotals(bucket.totals, delta);
-        touchedBuckets.add(bucketKey("grok", model, hourStartStr));
-        eventsAggregated++;
+        pendingBucketDeltas.push({ model, hourStartStr, delta });
         tokenDeltaForSession += deltaTokens;
         finalTouchedHourStart = hourStartStr;
-        source = "context_fallback";
+        source = "updates";
       }
 
       const effectiveSignalTotal = grokEffectiveTotalFromSignals(safeSignals);
@@ -13032,34 +13050,37 @@ async function parseGrokBuildIncremental({
         const hourStartStr = toUtcHalfHourStart(lastActive) || toUtcHalfHourStart(Date.now());
         if (hourStartStr) {
           const delta = estimateGrokTokenDelta(deltaTokens, 0, { allowZeroConversationCount: true });
-          const bucket = getHourlyBucket(hourlyState, "grok", model, hourStartStr);
-          addTotals(bucket.totals, delta);
-          touchedBuckets.add(bucketKey("grok", model, hourStartStr));
-          eventsAggregated++;
+          pendingBucketDeltas.push({ model, hourStartStr, delta });
           tokenDeltaForSession += deltaTokens;
           finalTouchedHourStart = hourStartStr;
-          source = "signals_fallback";
+          source = "signals";
         }
       }
       cumulativeTotal = Math.max(previousTotal, highWatermark);
     }
 
     const finalTotal = Math.max(previousTotal, cumulativeTotal);
+    // Sessions already observed under an older scanner must establish a watermark
+    // without backfilling historical tokens as brand-new usage.
     const legacyBaselineOnly = previous.legacySeen && previousTotal === 0 && finalTotal > 0;
 
-    // Message/conversation count for fallback-only sessions (turn path already
-    // counts each turn_completed as one conversation).
-    if (
-      !legacyBaselineOnly &&
-      !sawTurnUsage &&
-      tokenDeltaForSession > 0 &&
-      finalTouchedHourStart
-    ) {
-      const deltaMessageCount =
-        messageCount > previousMessageCount ? messageCount - previousMessageCount : 1;
-      const bucket = getHourlyBucket(hourlyState, "grok", lastModel || model, finalTouchedHourStart);
-      addTotals(bucket.totals, { conversation_count: deltaMessageCount });
-      touchedBuckets.add(bucketKey("grok", lastModel || model, finalTouchedHourStart));
+    if (!legacyBaselineOnly) {
+      for (const pending of pendingBucketDeltas) {
+        const bucket = getHourlyBucket(hourlyState, "grok", pending.model, pending.hourStartStr);
+        addTotals(bucket.totals, pending.delta);
+        touchedBuckets.add(bucketKey("grok", pending.model, pending.hourStartStr));
+        eventsAggregated++;
+      }
+
+      // Message/conversation count for fallback-only sessions (turn path already
+      // counts each turn_completed as one conversation).
+      if (!sawTurnUsage && tokenDeltaForSession > 0 && finalTouchedHourStart) {
+        const deltaMessageCount =
+          messageCount > previousMessageCount ? messageCount - previousMessageCount : 1;
+        const bucket = getHourlyBucket(hourlyState, "grok", lastModel || model, finalTouchedHourStart);
+        addTotals(bucket.totals, { conversation_count: deltaMessageCount });
+        touchedBuckets.add(bucketKey("grok", lastModel || model, finalTouchedHourStart));
+      }
     }
 
     if (finalTotal > 0 && (tokenDeltaForSession > 0 || previousTotal > 0 || legacyBaselineOnly)) {
@@ -13071,6 +13092,19 @@ async function parseGrokBuildIncremental({
         lastEventId,
         lastEventTimestamp,
         updatedAt: new Date().toISOString(),
+      };
+    } else if (previous.legacySeen && finalTotal === 0) {
+      // Keep the baseline marker across empty syncs so later growth is still
+      // baselined once instead of backfilled as brand-new usage.
+      sessionSnapshots[sessionId] = {
+        totalTokens: 0,
+        messageCount: Math.max(previousMessageCount, messageCount),
+        model: lastModel || model,
+        source: previous.source || null,
+        lastEventId: lastEventId || previous.lastEventId || null,
+        lastEventTimestamp: lastEventTimestamp || previous.lastEventTimestamp || null,
+        updatedAt: new Date().toISOString(),
+        legacySeen: true,
       };
     }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -12387,7 +12387,8 @@ async function parseCopilotAppDbIncremental({
 // ─────────────────────────────────────────────────────────────────────────────
 
 const GROK_ESTIMATED_INPUT_RATIO = 0.8;
-const GROK_CURSOR_VERSION = 3;
+// v4: bill from turn_completed.usage (true cumulative API usage), not context-window totalTokens.
+const GROK_CURSOR_VERSION = 4;
 
 function resolveGrokBuildHome(env = process.env) {
   if (env.TOKENTRACKER_GROK_HOME) return env.TOKENTRACKER_GROK_HOME;
@@ -12540,6 +12541,9 @@ function grokMessageCountFromSignals(signals) {
   );
 }
 
+// Context-window telemetry only. Prefer turn_completed.usage when available —
+// signals.totalTokens / contextTokensUsed track the live window, not billable
+// cumulative spend across a session (especially after compaction).
 function grokEffectiveTotalFromSignals(signals) {
   if (!signals || typeof signals !== "object") return 0;
   const beforeCompaction = normalizeNonNegativeNumber(signals.totalTokensBeforeCompaction);
@@ -12612,28 +12616,135 @@ function grokFileEndsWithNewline(filePath, size) {
   }
 }
 
-async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOffsetEntry) {
-  if (!updatesPath) return { events: [], offsetEntry: null };
+
+function canonicalizeGrokUsageModel(model) {
+  const raw = normalizeModelInput(model) || "grok-build";
+  const lower = raw.toLowerCase();
+  // Free Build SKU must not fuzzy-match paid grok-4.5 rates in native clients.
+  if (lower.includes("build-free") || lower.endsWith("-free") || lower.includes("free-tier")) {
+    return "grok-build-free";
+  }
+  if (lower === "grok-4.5-build" || lower === "grok-4-5-build") {
+    return "grok-4.5-build";
+  }
+  return raw;
+}
+
+function normalizeGrokTurnUsage(usage, model, timestamp, eventId) {
+  if (!usage || typeof usage !== "object") return null;
+  const inputRaw = normalizeNonNegativeNumber(
+    usage.inputTokens ?? usage.input_tokens,
+  );
+  const output = normalizeNonNegativeNumber(
+    usage.outputTokens ?? usage.output_tokens,
+  );
+  const cached = normalizeNonNegativeNumber(
+    usage.cachedReadTokens ??
+      usage.cache_read_input_tokens ??
+      usage.cached_input_tokens,
+  );
+  const reasoning = normalizeNonNegativeNumber(
+    usage.reasoningTokens ?? usage.reasoning_output_tokens,
+  );
+  // Grok reports inputTokens as the full prompt (including cache hits). Split
+  // so pricing can apply cache_read rates correctly.
+  const nonCachedInput = Math.max(0, inputRaw - cached);
+  let total = normalizeNonNegativeNumber(usage.totalTokens ?? usage.total_tokens);
+  if (total <= 0) {
+    total = inputRaw + output;
+  }
+  if (total <= 0 && nonCachedInput <= 0 && cached <= 0 && output <= 0) return null;
+  return {
+    input_tokens: nonCachedInput,
+    cached_input_tokens: cached,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: reasoning,
+    total_tokens: total > 0 ? total : nonCachedInput + cached + output,
+    billable_total_tokens: total > 0 ? total : nonCachedInput + cached + output,
+    conversation_count: 1,
+    model: canonicalizeGrokUsageModel(model),
+    timestamp,
+    eventId,
+  };
+}
+
+function extractGrokTurnUsageEvents(record, fallbackTimestamp, fallbackModel, lineIndex) {
+  const update = record?.params?.update;
+  if (!update || typeof update !== "object") return [];
+  if (update.sessionUpdate !== "turn_completed") return [];
+  const usage = update.usage;
+  if (!usage || typeof usage !== "object") return [];
+
+  const meta = record?.params?._meta || record?._meta || {};
+  const timestamp = grokTimestampFromUpdate(meta, record, fallbackTimestamp);
+  const baseEventId = grokEventId(
+    meta.eventId ?? record?.eventId ?? record?.id ?? update.prompt_id,
+    String(lineIndex),
+  );
+
+  const modelUsage =
+    usage.modelUsage && typeof usage.modelUsage === "object" ? usage.modelUsage : null;
+  const events = [];
+  if (modelUsage && Object.keys(modelUsage).length > 0) {
+    for (const [modelName, modelUsageEntry] of Object.entries(modelUsage)) {
+      if (!modelUsageEntry || typeof modelUsageEntry !== "object") continue;
+      const event = normalizeGrokTurnUsage(
+        modelUsageEntry,
+        modelName,
+        timestamp,
+        `${baseEventId}|${modelName}`,
+      );
+      if (event) events.push(event);
+    }
+  }
+  if (events.length === 0) {
+    const event = normalizeGrokTurnUsage(usage, fallbackModel, timestamp, baseEventId);
+    if (event) events.push(event);
+  }
+  return events;
+}
+
+// Context-window watermark events (legacy / fallback only).
+function extractGrokContextTokenEvent(record, fallbackTimestamp, lineIndex) {
+  const meta = record?.params?._meta || record?._meta;
+  if (!meta || typeof meta !== "object") return null;
+  const totalTokens = normalizeNonNegativeNumber(meta.totalTokens);
+  if (totalTokens <= 0) return null;
+  return {
+    totalTokens,
+    timestamp: grokTimestampFromUpdate(meta, record, fallbackTimestamp),
+    eventId: grokEventId(meta.eventId ?? record?.eventId ?? record?.id, String(lineIndex)),
+  };
+}
+
+async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOffsetEntry, options = {}) {
+  const fallbackModel = options.fallbackModel || "grok-build";
+  if (!updatesPath) {
+    return { turnEvents: [], contextEvents: [], offsetEntry: null };
+  }
   let stat;
   try {
     stat = fssync.statSync(updatesPath);
-    if (!stat.isFile()) return { events: [], offsetEntry: null };
+    if (!stat.isFile()) return { turnEvents: [], contextEvents: [], offsetEntry: null };
   } catch {
-    return { events: [], offsetEntry: null };
+    return { turnEvents: [], contextEvents: [], offsetEntry: null };
   }
 
-  // updates.jsonl is append-only and carries cumulative totalTokens, deduped
-  // by the session high-watermark, so resuming from the last consumed byte is
-  // safe: re-read events stay below the watermark (no double count), and any
-  // bytes a write race leaves unparsed are covered by the next event's
-  // cumulative total. Re-read from 0 on truncation or inode change.
+  // updates.jsonl is append-only. Turn usage is additive per turn_completed, so
+  // resuming from the last consumed byte is safe. Re-read from 0 on truncation
+  // or inode change.
   const prevSize = Number(prevOffsetEntry?.size) || 0;
   const prevIno = prevOffsetEntry?.ino;
   const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
   const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
   const baseOffset = { mtimeMs: stat.mtimeMs, ino: stat.ino };
   if (stat.size <= startOffset) {
-    return { events: [], offsetEntry: { size: startOffset, ...baseOffset } };
+    return {
+      turnEvents: [],
+      contextEvents: [],
+      offsetEntry: { size: startOffset, ...baseOffset },
+    };
   }
 
   // Only advance the stored offset to the end of the last newline-terminated
@@ -12642,7 +12753,8 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOff
   // complete instead of skipping it forever (which would undercount tokens).
   const endsWithNewline = grokFileEndsWithNewline(updatesPath, stat.size);
 
-  const events = [];
+  const turnEvents = [];
+  const contextEvents = [];
   let lineIndex = 0;
   let lastLine = "";
   const input = fssync.createReadStream(updatesPath, {
@@ -12662,29 +12774,35 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOff
       } catch {
         continue;
       }
-      const meta = record?.params?._meta || record?._meta;
-      if (!meta || typeof meta !== "object") continue;
-      const totalTokens = normalizeNonNegativeNumber(meta.totalTokens);
-      if (totalTokens <= 0) continue;
-      const timestamp = grokTimestampFromUpdate(meta, record, fallbackTimestamp);
-      events.push({
-        totalTokens,
-        timestamp,
-        eventId: grokEventId(meta.eventId ?? record?.eventId ?? record?.id, String(lineIndex)),
-      });
+      const turns = extractGrokTurnUsageEvents(
+        record,
+        fallbackTimestamp,
+        fallbackModel,
+        lineIndex,
+      );
+      if (turns.length > 0) {
+        turnEvents.push(...turns);
+        continue;
+      }
+      const contextEvent = extractGrokContextTokenEvent(record, fallbackTimestamp, lineIndex);
+      if (contextEvent) contextEvents.push(contextEvent);
     }
   } catch {
     // Stream error mid-read: keep the events we got, but do not advance the
-    // offset so the next sync retries the same range (watermark-safe).
-    return { events, offsetEntry: prevOffsetEntry || null };
+    // offset so the next sync retries the same range.
+    return { turnEvents, contextEvents, offsetEntry: prevOffsetEntry || null };
   }
 
   // When the file does not end on a newline, the final emitted line is a
   // partial tail still being written. Exclude its bytes so the committed offset
-  // stays on a complete-line boundary and the line is re-read once finished.
+  // stays on a complete-line boundary && the line is re-read once finished.
   const trailingPartialBytes = endsWithNewline ? 0 : Buffer.byteLength(lastLine, "utf8");
   const committedSize = Math.max(startOffset, stat.size - trailingPartialBytes);
-  return { events, offsetEntry: { size: committedSize, ...baseOffset } };
+  return {
+    turnEvents,
+    contextEvents,
+    offsetEntry: { size: committedSize, ...baseOffset },
+  };
 }
 
 function estimateGrokTokenDelta(totalTokens, conversationCount, options = {}) {
@@ -12706,6 +12824,70 @@ function estimateGrokTokenDelta(totalTokens, conversationCount, options = {}) {
   };
 }
 
+function clearGrokHourlyBuckets(hourlyState) {
+  if (!hourlyState || typeof hourlyState !== "object") return;
+  const buckets = hourlyState.buckets && typeof hourlyState.buckets === "object" ? hourlyState.buckets : null;
+  if (buckets) {
+    for (const key of Object.keys(buckets)) {
+      if (key.startsWith("grok|")) delete buckets[key];
+    }
+  }
+  const groupQueued =
+    hourlyState.groupQueued && typeof hourlyState.groupQueued === "object"
+      ? hourlyState.groupQueued
+      : null;
+  if (groupQueued) {
+    for (const key of Object.keys(groupQueued)) {
+      if (key.startsWith("grok|")) delete groupQueued[key];
+    }
+  }
+}
+
+async function retractStaleGrokQueueRows(queuePath, keepKeys) {
+  if (!queuePath) return 0;
+  let raw = "";
+  try {
+    raw = fssync.readFileSync(queuePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return 0;
+    throw error;
+  }
+
+  const latestGrok = new Map();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if ((row?.source || "") !== "grok") continue;
+    const model = normalizeModelInput(row.model) || DEFAULT_MODEL;
+    const hourStart = typeof row.hour_start === "string" ? row.hour_start : null;
+    if (!hourStart) continue;
+    latestGrok.set(bucketKey("grok", model, hourStart), { model, hour_start: hourStart, row });
+  }
+
+  const zero = initTotals();
+  const lines = [];
+  for (const [key, entry] of latestGrok.entries()) {
+    if (keepKeys.has(key)) continue;
+    if (totalsKey(entry.row) === totalsKey(zero)) continue;
+    lines.push(
+      JSON.stringify({
+        source: "grok",
+        model: entry.model,
+        hour_start: entry.hour_start,
+        ...zero,
+      }),
+    );
+  }
+  if (lines.length === 0) return 0;
+  await fs.appendFile(queuePath, `${lines.join("\n")}\n`, "utf8");
+  return lines.length;
+}
+
 async function parseGrokBuildIncremental({
   sessions,
   cursors = {},
@@ -12716,13 +12898,25 @@ async function parseGrokBuildIncremental({
   if (queuePath) await ensureDir(path.dirname(queuePath));
   const hourlyState = normalizeHourlyState(cursors?.hourly);
   const grokState = cursors.grok && typeof cursors.grok === "object" ? { ...cursors.grok } : {};
-  let sessionSnapshots = normalizeGrokSessionSnapshots(grokState);
+  const prevVersion = Number(grokState.version) || 0;
+  const needsTurnUsageMigration = prevVersion < GROK_CURSOR_VERSION;
+
+  // v3 && earlier treated context-window totalTokens as cumulative spend, which
+  // undercounts heavily (often 10-50x) && mis-splits input/output. Rebuild from
+  // turn_completed.usage when migrating to v4.
+  let sessionSnapshots = needsTurnUsageMigration ? {} : normalizeGrokSessionSnapshots(grokState);
   const prevUpdateOffsets =
-    grokState.updateOffsets && typeof grokState.updateOffsets === "object"
+    !needsTurnUsageMigration &&
+    grokState.updateOffsets &&
+    typeof grokState.updateOffsets === "object"
       ? grokState.updateOffsets
       : {};
+  if (needsTurnUsageMigration) {
+    clearGrokHourlyBuckets(hourlyState);
+  }
+
   // Rebuilt from the sessions seen this scan, so entries for deleted session
-  // dirs are pruned and the cursor stays bounded by the on-disk session count.
+  // dirs are pruned && the cursor stays bounded by the on-disk session count.
   const updateOffsets = {};
   const touchedBuckets = new Set();
 
@@ -12755,78 +12949,124 @@ async function parseGrokBuildIncremental({
     const model = grokModelFromSignals(safeSignals);
     const lastActive = grokLastActiveFromSignals(safeSignals, summary);
 
-    let highWatermark = previousTotal;
-    let observedTotal = previousTotal;
+    let cumulativeTotal = previousTotal;
     let tokenDeltaForSession = 0;
     let finalTouchedHourStart = null;
     let source = previous.source || null;
     let lastEventId = previous.lastEventId || null;
     let lastEventTimestamp = previous.lastEventTimestamp || null;
-    const pendingTokenDeltas = [];
-
-    const recordTokenDelta = (deltaTokens, timestamp, deltaSource) => {
-      const hourStartStr = toUtcHalfHourStart(timestamp) || toUtcHalfHourStart(Date.now());
-      if (!hourStartStr) return false;
-      pendingTokenDeltas.push({ deltaTokens, hourStartStr });
-      tokenDeltaForSession += deltaTokens;
-      finalTouchedHourStart = hourStartStr;
-      source = deltaSource;
-      lastEventTimestamp = timestamp || lastEventTimestamp;
-      return true;
-    };
+    let lastModel = previous.model || model;
+    let sawTurnUsage = source === "turn_usage" || previous.source === "turn_usage";
 
     const updatesPath = grokUpdatesPathForSession(sess);
     const updates = await readGrokUpdateTokenEvents(
       updatesPath,
       lastActive,
       updatesPath ? prevUpdateOffsets[updatesPath] : null,
+      { fallbackModel: model },
     );
     if (updatesPath && updates.offsetEntry) {
       updateOffsets[updatesPath] = updates.offsetEntry;
     }
-    for (const event of updates.events) {
-      observedTotal = Math.max(observedTotal, event.totalTokens);
+
+    // Preferred path: each turn_completed carries true cumulative API usage for
+    // that turn (input/output/cache/reasoning). Sum them.
+    for (const event of updates.turnEvents) {
+      sawTurnUsage = true;
+      const hourStartStr = toUtcHalfHourStart(event.timestamp) || toUtcHalfHourStart(lastActive) || toUtcHalfHourStart(Date.now());
+      if (!hourStartStr) continue;
+      const eventModel = event.model || model;
+      const delta = {
+        input_tokens: event.input_tokens,
+        cached_input_tokens: event.cached_input_tokens,
+        cache_creation_input_tokens: event.cache_creation_input_tokens,
+        output_tokens: event.output_tokens,
+        reasoning_output_tokens: event.reasoning_output_tokens,
+        total_tokens: event.total_tokens,
+        billable_total_tokens: event.billable_total_tokens,
+        conversation_count: event.conversation_count || 1,
+      };
+      const bucket = getHourlyBucket(hourlyState, "grok", eventModel, hourStartStr);
+      addTotals(bucket.totals, delta);
+      touchedBuckets.add(bucketKey("grok", eventModel, hourStartStr));
+      eventsAggregated++;
+      cumulativeTotal += event.total_tokens;
+      tokenDeltaForSession += event.total_tokens;
+      finalTouchedHourStart = hourStartStr;
+      source = "turn_usage";
       lastEventId = event.eventId || lastEventId;
       lastEventTimestamp = event.timestamp || lastEventTimestamp;
-      if (event.totalTokens <= highWatermark) continue;
-      const deltaTokens = event.totalTokens - highWatermark;
-      highWatermark = event.totalTokens;
-      recordTokenDelta(deltaTokens, event.timestamp || lastActive, "updates");
+      lastModel = eventModel;
     }
 
-    const effectiveSignalTotal = grokEffectiveTotalFromSignals(safeSignals);
-    observedTotal = Math.max(observedTotal, effectiveSignalTotal);
-    if (effectiveSignalTotal > highWatermark) {
-      const deltaTokens = effectiveSignalTotal - highWatermark;
-      highWatermark = effectiveSignalTotal;
-      recordTokenDelta(deltaTokens, lastActive, "signals");
-    }
-
-    const finalTotal = Math.max(previousTotal, highWatermark, observedTotal);
-    const legacyBaselineOnly = previous.legacySeen && previousTotal === 0 && finalTotal > 0;
-    if (!legacyBaselineOnly) {
-      for (const pending of pendingTokenDeltas) {
-        const delta = estimateGrokTokenDelta(pending.deltaTokens, 0, { allowZeroConversationCount: true });
-        const bucket = getHourlyBucket(hourlyState, "grok", model, pending.hourStartStr);
+    // Fallback only when this session never emitted turn_completed usage
+    // (older logs / partial sessions). Context watermark is a lower-bound
+    // estimate && must not run on top of turn usage.
+    if (!sawTurnUsage) {
+      let highWatermark = previousTotal;
+      for (const event of updates.contextEvents) {
+        lastEventId = event.eventId || lastEventId;
+        lastEventTimestamp = event.timestamp || lastEventTimestamp;
+        if (event.totalTokens <= highWatermark) continue;
+        const deltaTokens = event.totalTokens - highWatermark;
+        highWatermark = event.totalTokens;
+        const hourStartStr =
+          toUtcHalfHourStart(event.timestamp) ||
+          toUtcHalfHourStart(lastActive) ||
+          toUtcHalfHourStart(Date.now());
+        if (!hourStartStr) continue;
+        const delta = estimateGrokTokenDelta(deltaTokens, 0, { allowZeroConversationCount: true });
+        const bucket = getHourlyBucket(hourlyState, "grok", model, hourStartStr);
         addTotals(bucket.totals, delta);
-        touchedBuckets.add(bucketKey("grok", model, pending.hourStartStr));
+        touchedBuckets.add(bucketKey("grok", model, hourStartStr));
         eventsAggregated++;
+        tokenDeltaForSession += deltaTokens;
+        finalTouchedHourStart = hourStartStr;
+        source = "context_fallback";
       }
+
+      const effectiveSignalTotal = grokEffectiveTotalFromSignals(safeSignals);
+      if (effectiveSignalTotal > highWatermark) {
+        const deltaTokens = effectiveSignalTotal - highWatermark;
+        highWatermark = effectiveSignalTotal;
+        const hourStartStr = toUtcHalfHourStart(lastActive) || toUtcHalfHourStart(Date.now());
+        if (hourStartStr) {
+          const delta = estimateGrokTokenDelta(deltaTokens, 0, { allowZeroConversationCount: true });
+          const bucket = getHourlyBucket(hourlyState, "grok", model, hourStartStr);
+          addTotals(bucket.totals, delta);
+          touchedBuckets.add(bucketKey("grok", model, hourStartStr));
+          eventsAggregated++;
+          tokenDeltaForSession += deltaTokens;
+          finalTouchedHourStart = hourStartStr;
+          source = "signals_fallback";
+        }
+      }
+      cumulativeTotal = Math.max(previousTotal, highWatermark);
     }
 
-    if (!legacyBaselineOnly && tokenDeltaForSession > 0 && finalTouchedHourStart) {
+    const finalTotal = Math.max(previousTotal, cumulativeTotal);
+    const legacyBaselineOnly = previous.legacySeen && previousTotal === 0 && finalTotal > 0;
+
+    // Message/conversation count for fallback-only sessions (turn path already
+    // counts each turn_completed as one conversation).
+    if (
+      !legacyBaselineOnly &&
+      !sawTurnUsage &&
+      tokenDeltaForSession > 0 &&
+      finalTouchedHourStart
+    ) {
       const deltaMessageCount =
         messageCount > previousMessageCount ? messageCount - previousMessageCount : 1;
-      const bucket = getHourlyBucket(hourlyState, "grok", model, finalTouchedHourStart);
+      const bucket = getHourlyBucket(hourlyState, "grok", lastModel || model, finalTouchedHourStart);
       addTotals(bucket.totals, { conversation_count: deltaMessageCount });
-      touchedBuckets.add(bucketKey("grok", model, finalTouchedHourStart));
+      touchedBuckets.add(bucketKey("grok", lastModel || model, finalTouchedHourStart));
     }
 
     if (finalTotal > 0 && (tokenDeltaForSession > 0 || previousTotal > 0 || legacyBaselineOnly)) {
       sessionSnapshots[sessionId] = {
         totalTokens: finalTotal,
         messageCount: Math.max(previousMessageCount, messageCount),
-        model,
+        model: lastModel || model,
         source: source || previous.source || null,
         lastEventId,
         lastEventTimestamp,
@@ -12839,12 +13079,37 @@ async function parseGrokBuildIncremental({
     }
   }
 
-  const bucketsQueued = queuePath
+  let bucketsQueued = queuePath
     ? await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets })
     : 0;
+
+  // After a semantics migration, retract stale grok queue keys that the full
+  // rescan no longer produces so dashboard "latest per key" no longer keeps
+  // the old undercounted rows.
+  if (needsTurnUsageMigration && queuePath) {
+    const keepKeys = new Set();
+    for (const [key, bucket] of Object.entries(hourlyState.buckets || {})) {
+      if (!key.startsWith("grok|") || !bucket?.totals) continue;
+      keepKeys.add(key);
+    }
+    const retracted = await retractStaleGrokQueueRows(queuePath, keepKeys);
+    bucketsQueued += retracted;
+  }
+
   hourlyState.updatedAt = new Date().toISOString();
   cursors.hourly = hourlyState;
   sessionSnapshots = capGrokSessionSnapshots(sessionSnapshots);
+
+  const migrations = grokState.migrations && typeof grokState.migrations === "object"
+    ? { ...grokState.migrations }
+    : {};
+  if (needsTurnUsageMigration) {
+    migrations.turnUsageV4 = {
+      appliedAt: new Date().toISOString(),
+      fromVersion: prevVersion,
+      toVersion: GROK_CURSOR_VERSION,
+    };
+  }
 
   cursors.grok = {
     ...grokState,
@@ -12852,6 +13117,7 @@ async function parseGrokBuildIncremental({
     sessionSnapshots,
     seenSessions: Object.keys(sessionSnapshots),
     updateOffsets,
+    migrations,
     updatedAt: new Date().toISOString()
   };
 

--- a/test/grok-parser.test.js
+++ b/test/grok-parser.test.js
@@ -1,0 +1,359 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  parseGrokBuildIncremental,
+  resolveGrokBuildSessions,
+} = require("../src/lib/rollout");
+const { computeRowCost, ensurePricingLoaded, getModelPricing } = require("../src/lib/pricing");
+
+function makeSession({
+  sessionId = "019f0000-test-session",
+  model = "grok-4.5",
+  turns = [],
+  contextMetas = [],
+  signals = {},
+} = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-parser-"));
+  const encodedCwd = encodeURIComponent("/tmp/project");
+  const sessionDir = path.join(root, "sessions", encodedCwd, sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const lines = [];
+  let eventN = 1;
+  for (const totalTokens of contextMetas) {
+    lines.push(
+      JSON.stringify({
+        timestamp: 1784357000 + eventN,
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "..." },
+          },
+          _meta: {
+            totalTokens,
+            eventId: `${sessionId}-${eventN}`,
+            agentTimestampMs: 1784357000000 + eventN * 1000,
+            updateType: "AgentThoughtChunk",
+          },
+        },
+      }),
+    );
+    eventN += 1;
+  }
+  for (const turn of turns) {
+    lines.push(
+      JSON.stringify({
+        timestamp: 1784357000 + eventN,
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "turn_completed",
+            prompt_id: turn.promptId || `prompt-${eventN}`,
+            stop_reason: "end_turn",
+            usage: turn.usage,
+          },
+          _meta: {
+            totalTokens: turn.contextWindowTokens ?? 12_000,
+            eventId: `${sessionId}-${eventN}`,
+            agentTimestampMs: turn.timestampMs || 1784357100000 + eventN * 1000,
+          },
+        },
+      }),
+    );
+    eventN += 1;
+  }
+
+  fs.writeFileSync(path.join(sessionDir, "updates.jsonl"), `${lines.join("\n")}\n`);
+  fs.writeFileSync(
+    path.join(sessionDir, "signals.json"),
+    JSON.stringify({
+      primaryModelId: model,
+      modelsUsed: [model],
+      assistantMessageCount: turns.length || 1,
+      contextTokensUsed: signals.contextTokensUsed ?? 50_000,
+      totalTokensBeforeCompaction: signals.totalTokensBeforeCompaction ?? 0,
+      lastActiveAt: "2026-07-18T10:00:00.000Z",
+      ...signals,
+    }),
+  );
+  fs.writeFileSync(
+    path.join(sessionDir, "summary.json"),
+    JSON.stringify({ updated_at: "2026-07-18T10:00:00.000Z" }),
+  );
+
+  return {
+    root,
+    sessionDir,
+    sessionId,
+    env: { TOKENTRACKER_GROK_HOME: root, GROK_HOME: root },
+  };
+}
+
+function readQueue(queuePath) {
+  if (!fs.existsSync(queuePath)) return [];
+  return fs
+    .readFileSync(queuePath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function dedupeQueue(rows) {
+  const seen = new Map();
+  for (const row of rows) {
+    if (row.source !== "grok") continue;
+    seen.set(`${row.model}|${row.hour_start}`, row);
+  }
+  return [...seen.values()];
+}
+
+test("parseGrokBuildIncremental prefers turn_completed.usage over context-window totalTokens", async () => {
+  const fixture = makeSession({
+    contextMetas: [10_000, 40_000, 90_000],
+    turns: [
+      {
+        usage: {
+          inputTokens: 100_000,
+          outputTokens: 500,
+          totalTokens: 100_500,
+          cachedReadTokens: 20_000,
+          reasoningTokens: 100,
+          modelUsage: {
+            "grok-4.5-build": {
+              inputTokens: 100_000,
+              outputTokens: 500,
+              totalTokens: 100_500,
+              cachedReadTokens: 20_000,
+              reasoningTokens: 100,
+            },
+          },
+        },
+        timestampMs: Date.parse("2026-07-18T10:05:00.000Z"),
+      },
+      {
+        usage: {
+          inputTokens: 50_000,
+          outputTokens: 200,
+          totalTokens: 50_200,
+          cachedReadTokens: 10_000,
+          reasoningTokens: 40,
+          modelUsage: {
+            "grok-4.5-build": {
+              inputTokens: 50_000,
+              outputTokens: 200,
+              totalTokens: 50_200,
+              cachedReadTokens: 10_000,
+              reasoningTokens: 40,
+            },
+          },
+        },
+        timestampMs: Date.parse("2026-07-18T10:20:00.000Z"),
+      },
+    ],
+    signals: { contextTokensUsed: 90_000, totalTokensBeforeCompaction: 200_000 },
+  });
+
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 3 },
+  };
+  const result = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+
+  assert.equal(result.eventsAggregated, 2);
+  assert.equal(cursors.grok.version, 4);
+
+  const snap = cursors.grok.sessionSnapshots[fixture.sessionId];
+  assert.ok(snap);
+  assert.equal(snap.source, "turn_usage");
+  assert.equal(snap.totalTokens, 150_700);
+
+  const rows = dedupeQueue(readQueue(queuePath));
+  assert.equal(rows.length, 1);
+  const row = rows[0];
+  assert.equal(row.model, "grok-4.5-build");
+  assert.equal(row.total_tokens, 150_700);
+  assert.equal(row.input_tokens, 120_000);
+  assert.equal(row.cached_input_tokens, 30_000);
+  assert.equal(row.output_tokens, 700);
+  assert.equal(row.reasoning_output_tokens, 140);
+  assert.equal(row.conversation_count, 2);
+});
+
+test("parseGrokBuildIncremental canonicalizes free Build SKU so pricing stays $0", async () => {
+  await ensurePricingLoaded();
+  assert.equal(getModelPricing("grok-build-free", { source: "grok" }).input, 0);
+  assert.equal(getModelPricing("grok-4.5-build-free", { source: "grok" }).input, 0);
+  assert.equal(getModelPricing("grok-4.5-build", { source: "grok" }).input, 2);
+
+  const fixture = makeSession({
+    turns: [
+      {
+        usage: {
+          inputTokens: 21219,
+          outputTokens: 102,
+          totalTokens: 21321,
+          cachedReadTokens: 1280,
+          reasoningTokens: 54,
+          modelUsage: {
+            "grok-4.5-build-free": {
+              inputTokens: 21219,
+              outputTokens: 102,
+              totalTokens: 21321,
+              cachedReadTokens: 1280,
+              reasoningTokens: 54,
+            },
+          },
+        },
+        timestampMs: Date.parse("2026-07-18T11:00:00.000Z"),
+      },
+    ],
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+  await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+  const rows = dedupeQueue(readQueue(queuePath));
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].model, "grok-build-free");
+  assert.equal(computeRowCost(rows[0]), 0);
+});
+
+test("parseGrokBuildIncremental falls back to context watermark only without turn_completed", async () => {
+  const fixture = makeSession({
+    turns: [],
+    contextMetas: [5_000, 12_000, 8_000, 20_000],
+    signals: { contextTokensUsed: 18_000, totalTokensBeforeCompaction: 0 },
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+  await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+  const snap = cursors.grok.sessionSnapshots[fixture.sessionId];
+  assert.ok(snap);
+  assert.equal(snap.source, "context_fallback");
+  assert.equal(snap.totalTokens, 20_000);
+  const rows = dedupeQueue(readQueue(queuePath));
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].total_tokens, 20_000);
+  assert.equal(rows[0].input_tokens + rows[0].output_tokens, 20_000);
+});
+
+test("v3 -> v4 migration rebuilds from turn usage and does not keep old watermark totals", async () => {
+  const fixture = makeSession({
+    turns: [
+      {
+        usage: {
+          inputTokens: 80_000,
+          outputTokens: 1_000,
+          totalTokens: 81_000,
+          cachedReadTokens: 0,
+          modelUsage: {
+            "grok-4.5": {
+              inputTokens: 80_000,
+              outputTokens: 1_000,
+              totalTokens: 81_000,
+              cachedReadTokens: 0,
+            },
+          },
+        },
+        timestampMs: Date.parse("2026-07-18T12:00:00.000Z"),
+      },
+    ],
+    contextMetas: [9_000],
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const cursors = {
+    hourly: {
+      version: 3,
+      buckets: {
+        "grok|grok-4.5|2026-07-18T12:00:00.000Z": {
+          totals: {
+            input_tokens: 7200,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1800,
+            reasoning_output_tokens: 0,
+            total_tokens: 9000,
+            billable_total_tokens: 9000,
+            conversation_count: 1,
+          },
+          queuedKey: "x",
+        },
+      },
+      groupQueued: {},
+    },
+    grok: {
+      version: 3,
+      sessionSnapshots: {
+        [fixture.sessionId]: {
+          totalTokens: 9000,
+          messageCount: 1,
+          model: "grok-4.5",
+          source: "updates",
+          updatedAt: "2026-07-18T12:00:00.000Z",
+        },
+      },
+    },
+  };
+  fs.writeFileSync(
+    queuePath,
+    `${JSON.stringify({
+      source: "grok",
+      model: "grok-4.5",
+      hour_start: "2026-07-18T12:00:00.000Z",
+      input_tokens: 7200,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 1800,
+      reasoning_output_tokens: 0,
+      total_tokens: 9000,
+      billable_total_tokens: 9000,
+      conversation_count: 1,
+    })}\n`,
+  );
+
+  await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+
+  assert.equal(cursors.grok.version, 4);
+  assert.equal(cursors.grok.sessionSnapshots[fixture.sessionId].totalTokens, 81_000);
+  const rows = dedupeQueue(readQueue(queuePath));
+  const row = rows.find((r) => r.model === "grok-4.5");
+  assert.ok(row);
+  assert.equal(row.total_tokens, 81_000);
+  assert.equal(row.input_tokens, 80_000);
+  assert.equal(row.output_tokens, 1_000);
+});

--- a/test/grok-parser.test.js
+++ b/test/grok-parser.test.js
@@ -259,7 +259,7 @@ test("parseGrokBuildIncremental falls back to context watermark only without tur
   });
   const snap = cursors.grok.sessionSnapshots[fixture.sessionId];
   assert.ok(snap);
-  assert.equal(snap.source, "context_fallback");
+  assert.equal(snap.source, "updates");
   assert.equal(snap.totalTokens, 20_000);
   const rows = dedupeQueue(readQueue(queuePath));
   assert.equal(rows.length, 1);

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -9231,7 +9231,7 @@ test("parseGrokBuildIncremental reads Grok updates metadata by event timestamp",
     assert.equal(queued[1].input_tokens, 120);
     assert.equal(queued[1].output_tokens, 30);
     assert.equal(queued[1].conversation_count, 2);
-    assert.equal(cursors.grok.version, 3);
+    assert.equal(cursors.grok.version, 4);
     assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].totalTokens, 250);
     assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].source, "updates");
     assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].lastEventId, "evt-2");
@@ -9507,7 +9507,7 @@ test("parseGrokBuildIncremental preserves zero current context after compaction"
   }
 });
 
-test("parseGrokBuildIncremental upgrades v2 Grok cursor without replaying updates", async () => {
+test("parseGrokBuildIncremental upgrades pre-v4 Grok cursor by rebuilding from updates", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-v2-cursor-"));
   try {
     const queuePath = path.join(tmp, "queue.jsonl");
@@ -9516,6 +9516,9 @@ test("parseGrokBuildIncremental upgrades v2 Grok cursor without replaying update
       files: {},
       updatedAt: null,
       grok: {
+        // Pre-v4 cursors used context-window watermarks. Migrating to v4 must
+        // rebuild from disk (turn_completed when present; otherwise context
+        // fallback) rather than keep the old undercount forever.
         version: 2,
         sessionSnapshots: {
           "grok-session-v2": {
@@ -9549,15 +9552,30 @@ test("parseGrokBuildIncremental upgrades v2 Grok cursor without replaying update
       "utf8",
     );
 
-    const result = await parseGrokBuildIncremental({
-      sessions: [{ sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-v2" }],
+    const session = {
+      sessionDir,
+      updatesPath,
+      signalsPath,
+      summaryPath: path.join(sessionDir, "summary.json"),
+      sessionId: "grok-session-v2",
+    };
+    const firstRun = await parseGrokBuildIncremental({
+      sessions: [session],
       cursors,
       queuePath,
     });
-    assert.equal(result.eventsAggregated, 0);
-    assert.equal(result.bucketsQueued, 0);
-    assert.deepEqual(await readJsonLines(queuePath), []);
-    assert.equal(cursors.grok.version, 3);
+    assert.ok(firstRun.eventsAggregated >= 1);
+    assert.equal(cursors.grok.version, 4);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-v2"].totalTokens, 250);
+
+    // Second sync must not double-count the rebuilt totals.
+    const secondRun = await parseGrokBuildIncremental({
+      sessions: [session],
+      cursors,
+      queuePath,
+    });
+    assert.equal(secondRun.eventsAggregated, 0);
+    assert.equal(secondRun.bucketsQueued, 0);
     assert.equal(cursors.grok.sessionSnapshots["grok-session-v2"].totalTokens, 250);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes severe undercounting of **Grok Build** usage/cost.

This is an **upstream parser bug**, not a local config/hook problem. Grok's `params._meta.totalTokens` is a live **context-window** counter; true cumulative API usage lives on `sessionUpdate: \"turn_completed\"` → `usage` (with `modelUsage` per free/paid SKU).

Closes #362

## Root cause

In `parseGrokBuildIncremental` / `readGrokUpdateTokenEvents` (cursor v3):

1. Only high-watermark deltas of `params._meta.totalTokens` were counted
2. Optional top-up used `signals.totalTokensBeforeCompaction + contextTokensUsed`
3. Missing: `turn_completed.usage` input/output/cache/reasoning
4. Missing: free vs paid model ids from `usage.modelUsage`
5. Fallback 80/20 `estimateGrokTokenDelta` invented input/output and zeroed cache

### Real log vs old parser (one machine)

| Source | Tokens |
|---|---:|
| Sum of `turn_completed.usage.totalTokens` | ~899M |
| Old context watermark / signals path | ~17–21M |
| Ratio | ~**50× undercount** |

## Solution

1. **Prefer `turn_completed.usage`** (and per-model `modelUsage`) as the billable path
2. Split prompt correctly: `input_tokens = inputTokens - cachedReadTokens`, keep cache/reasoning fields
3. **Canonicalize free SKU** `grok-4.5-build-free` → `grok-build-free` so pricing cannot fuzzy-match paid `grok-4.5`
4. Keep context watermark / signals **only as fallback** when no turn usage exists
5. Bump `GROK_CURSOR_VERSION` **3 → 4** and rebuild Grok hourly buckets + retract stale queue keys on migration
6. Curated pricing entries for `grok-4.5-build`, `grok-build-free`, `grok-4.5-build-free`
7. Unit tests in `test/grok-parser.test.js`

## Test plan

- [x] `node --test test/grok-parser.test.js` (4/4 pass)
- [x] Local full rescan of real `~/.grok/sessions` after migration:
  - tokens jumped from ~20.8M → ~906M
  - free tier correctly priced at $0
  - paid `grok-4.5` / `grok-4.5-build` retain non-zero cost
- [ ] Reviewer: run `npm test` (or at least grok + pricing related tests)
- [ ] After merge/release: users on old data should auto-migrate on next sync (v4 cursor); no manual queue surgery required for local correctness (cloud may need re-upload/reset offset depending on product policy)

## Notes / follow-ups

- `src/lib/grok-hook.js` SessionEnd signal still writes context-ish totals for the hook signal file; sync's full scan path is authoritative after this fix. A follow-up can align the hook signal fields if desired.
- Free-tier $0 is intentional for `*build-free*` modelUsage labels. If product wants to show \"equivalent API cost\" for free usage, that should be a separate display mode, not silent mispricing.

## Files

- `src/lib/rollout.js`
- `src/lib/pricing/curated-overrides.json`
- `test/grok-parser.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated pricing for new Grok Build and free Build model variants.
  * Upgraded Grok Build usage tracking to use per-turn usage with improved model name canonicalization.
  * Added fallback accounting when per-turn usage is unavailable.

* **Bug Fixes**
  * Corrected cached vs non-cached token breakdown for accurate billing.
  * Improved v3→v4 migration to rebuild usage totals and prevent stale Grok queue buckets from persisting.

* **Tests**
  * Updated Grok incremental/cursor upgrade expectations and added coverage for v4 migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->