### PR TITLE
fix: prevent inflated Codex usage from interleaved counters

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -113,6 +113,11 @@ const {
 } = require("../lib/cursor-store");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const { resolveRuntimeConfig } = require("../lib/runtime-config");
+const { extractTokenCount } = require("../lib/codex-rollout-parser");
+const {
+  consumeUsageDelta,
+  createUsageDeltaState,
+} = require("../lib/codex-token-usage");
 
 const CURSOR_UNKNOWN_MIGRATION_KEY = "cursorUnknownPurge_2026_04";
 const ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY = "rolloutCumulativeDeltaReparse_2026_05";
@@ -189,6 +194,14 @@ const CODEX_RESCAN_DEDUP_REPAIR_KEY = "codexRescanDedupRepair_2026_06";
 // offset reset for the cloud overwrite). Pre-gated: installs with no forked
 // rollout on disk carry no fork phantom and mark done without the rebuild.
 const CODEX_FORK_REPLAY_REPAIR_KEY = "codexForkReplayRepair_2026_07";
+// One-time repair for Codex rollouts that contain token counters from multiple
+// interleaved SessionState instances. Older parsers subtracted each cumulative
+// total from the most recently observed total, even when it belonged to another
+// state, which could turn an ordinary turn into a multi-billion-token delta.
+const CODEX_USAGE_LINEAGE_REPAIR_KEY = "codexUsageLineageRepair_2026_07";
+// Keep the one escalated desktop refresh bounded; explicit full syncs can retry
+// the same migration without this ceiling when the history needs a deeper scan.
+const CODEX_BACKGROUND_LINEAGE_SCAN_MAX_BYTES = 1024 * 1024;
 const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
 const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const NOTIFY_LOCK_WAIT_MS = 130_000;
@@ -457,6 +470,28 @@ async function cmdSync(argv, context = {}) {
       if (autoSourceScope) return sources.includes(autoSourceScope);
       return true;
     };
+    // Desktop refreshes are deliberately lightweight, but that also means a
+    // migration wired only to full sync would never repair an existing native
+    // install. Escalate exactly the first eligible background run: fresh
+    // installs have no persisted Codex buckets to repair, while retryable
+    // failures remain reserved for an explicit full sync instead of turning
+    // every five-minute refresh into a deep historical scan.
+    const backgroundCodexUsageMigrationEligible = Boolean(
+      isBackgroundLightweightSync &&
+      sourceAllowed("codex") &&
+      !cursors.migrations?.[CODEX_USAGE_LINEAGE_REPAIR_KEY]
+    );
+    const hasPersistedCodexUsage = Object.keys(cursors.hourly?.buckets || {})
+      .some((key) => key.startsWith("codex|"));
+    const backgroundCodexUsageRepair =
+      backgroundCodexUsageMigrationEligible && hasPersistedCodexUsage;
+    if (backgroundCodexUsageMigrationEligible && !hasPersistedCodexUsage) {
+      // A fresh install has no old-parser buckets to repair. Mark it complete
+      // before the first bounded parse so the next refresh does not mistake
+      // newly parsed, already-correct data for legacy history.
+      (cursors.migrations ||= {})[CODEX_USAGE_LINEAGE_REPAIR_KEY] =
+        new Date().toISOString();
+    }
 
     const sources = [];
     if (sourceAllowed("codex")) {
@@ -467,13 +502,13 @@ async function cmdSync(argv, context = {}) {
       const codexPaths = resolveInstallPaths({ nativeValue: codexNativeValue, wslValue: wslCodexDir });
       if (codexPaths.native) {
         sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "sessions"), codexInventoryCache: true });
-        if (!isBackgroundLightweightSync) {
+        if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
           sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "archived_sessions"), deep: true });
         }
       }
       if (codexPaths.wsl) {
         sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "sessions"), codexInventoryCache: true });
-        if (!isBackgroundLightweightSync) {
+        if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
           sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "archived_sessions"), deep: true });
         }
       }
@@ -523,7 +558,7 @@ async function cmdSync(argv, context = {}) {
         projectQueueStatePath,
         rolloutFiles,
       });
-      await repairCodexForkReplayInflation({
+      const codexForkRepairRan = await repairCodexForkReplayInflation({
         cursors,
         queuePath,
         queueStatePath,
@@ -531,6 +566,15 @@ async function cmdSync(argv, context = {}) {
         projectQueueStatePath,
         rolloutFiles,
         legacyRepairRan: codexRescanRepairRan,
+      });
+      await repairCodexInterleavedUsageInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles,
+        legacyRepairRan: codexRescanRepairRan || codexForkRepairRan,
       });
       await repairDroidDuplicateSessionInflation({ cursors, queuePath, queueStatePath });
       await repairMimoClaudeMislabel({
@@ -540,6 +584,33 @@ async function cmdSync(argv, context = {}) {
         projectQueuePath,
         projectQueueStatePath,
       });
+    } else if (backgroundCodexUsageRepair) {
+      await cursorStore.materializeAllCodexState(cursors);
+      try {
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          projectQueuePath,
+          projectQueueStatePath,
+          rolloutFiles,
+          maxLineageScanBytes: CODEX_BACKGROUND_LINEAGE_SCAN_MAX_BYTES,
+        });
+      } catch (err) {
+        warnProviderParseFailure("Codex usage lineage repair", err, opts);
+      } finally {
+        // Rebuild failures intentionally leave the migration key unset so a
+        // future full sync can retry. Record a retryable sentinel here to keep
+        // routine native background refreshes bounded after that first attempt.
+        const migrations = (cursors.migrations ||= {});
+        if (!migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY]) {
+          migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY] = {
+            skipped: true,
+            reason: "background_repair_requires_full_sync",
+            at: new Date().toISOString(),
+          };
+        }
+      }
     }
 
     const codexColdSkipEnabled = opts.auto && sourceAllowed("codex");
@@ -2339,6 +2410,7 @@ module.exports = {
   migrateRolloutCumulativeDeltaBuckets,
   repairCodexRescanInflation,
   repairCodexForkReplayInflation,
+  repairCodexInterleavedUsageInflation,
   repairDroidDuplicateSessionInflation,
   repairMimoClaudeMislabel,
   reincludeClaudeMemObserverFiles,
@@ -2352,6 +2424,7 @@ module.exports = {
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
   CODEX_RESCAN_DEDUP_REPAIR_KEY,
   CODEX_FORK_REPLAY_REPAIR_KEY,
+  CODEX_USAGE_LINEAGE_REPAIR_KEY,
   DROID_DUP_SESSION_REPAIR_KEY,
   CLAUDE_MEM_OBSERVER_REINCLUDE_KEY,
   GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY,
@@ -3826,6 +3899,260 @@ async function repairCodexForkReplayInflation({
     migrationKey: CODEX_FORK_REPLAY_REPAIR_KEY,
     uploadNote: "reset_after_codex_fork_replay_2026_07",
   });
+}
+
+// Rebuild historical Codex usage only when a rollout proves that the old
+// single-baseline parser crossed cumulative SessionState lineages. The cheap
+// head gate keeps the one-time migration from fully reading installations that
+// predate Codex multi-agent support; the rebuild itself retains the existing
+// missing-history, project-queue, atomic-swap, and upload-reset guards.
+async function repairCodexInterleavedUsageInflation({
+  cursors,
+  queuePath,
+  queueStatePath,
+  projectQueuePath,
+  projectQueueStatePath,
+  rolloutFiles,
+  // Either older guarded repair rebuilt every Codex file with the current
+  // parser earlier in this sync, so a second full rebuild is unnecessary.
+  legacyRepairRan = false,
+  maxLineageScanBytes = Infinity,
+}) {
+  if (!cursors || typeof cursors !== "object") return false;
+  const migrations = (cursors.migrations ||= {});
+  const prior = migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY];
+  if (prior && !(typeof prior === "object" && prior.skipped)) return false;
+
+  if (legacyRepairRan) {
+    migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY] = new Date().toISOString();
+    return false;
+  }
+
+  const scan = await scanForInterleavedCodexUsage(rolloutFiles, {
+    maxLineageScanBytes,
+  });
+  if (scan.indeterminate) {
+    migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY] = {
+      skipped: true,
+      reason: "usage_lineage_scan_indeterminate",
+      at: new Date().toISOString(),
+    };
+    return false;
+  }
+
+  if (!scan.affected) {
+    if (!isCodexHistoryCovered(cursors, rolloutFiles)) {
+      migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY] = {
+        skipped: true,
+        reason: "codex_history_not_covered",
+        at: new Date().toISOString(),
+      };
+      return false;
+    }
+    migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY] = new Date().toISOString();
+    return false;
+  }
+
+  return repairCodexRescanInflation({
+    cursors,
+    queuePath,
+    queueStatePath,
+    projectQueuePath,
+    projectQueueStatePath,
+    rolloutFiles,
+    migrationKey: CODEX_USAGE_LINEAGE_REPAIR_KEY,
+    uploadNote: "reset_after_codex_usage_lineage_2026_07",
+  });
+}
+
+async function scanForInterleavedCodexUsage(
+  rolloutFiles,
+  { maxLineageScanBytes = Infinity } = {},
+) {
+  for (const entry of Array.isArray(rolloutFiles) ? rolloutFiles : []) {
+    const fp = typeof entry === "string" ? entry : entry?.path;
+    const src = typeof entry === "string" ? "codex" : String(entry?.source || "codex");
+    if (!fp || src !== "codex") continue;
+
+    const head = await scanCodexMultiAgentHead(fp);
+    if (head.indeterminate) return { affected: false, indeterminate: true };
+    if (!head.candidate) continue;
+
+    const lineage = await scanCodexUsageLineages(fp, maxLineageScanBytes);
+    if (lineage.indeterminate) return { affected: false, indeterminate: true };
+    if (lineage.affected) return { affected: true, indeterminate: false };
+  }
+  return { affected: false, indeterminate: false };
+}
+
+// New rollouts emit multi_agent_version in the initial turn_context. A session
+// created by an older Codex build can later be resumed under a multi-agent
+// build, though, so an inactive initial context also checks the final context
+// from a bounded tail read. The 1 MiB ceilings protect this one-time migration
+// from malformed metadata; an inconclusive bound is retryable, never a final
+// "not affected" verdict.
+async function scanCodexMultiAgentHead(filePath) {
+  const MAX_BYTES = 1024 * 1024;
+  let stream = null;
+  let rl = null;
+  let needsTail = false;
+  try {
+    stream = fssync.createReadStream(filePath, {
+      encoding: "utf8",
+      highWaterMark: 32 * 1024,
+    });
+    rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let bytesRead = 0;
+    for await (const line of rl) {
+      bytesRead += Buffer.byteLength(line, "utf8") + 1;
+      if (line.includes('"turn_context"')) {
+        let obj;
+        try {
+          obj = JSON.parse(line);
+        } catch (_e) {
+          return { candidate: false, indeterminate: true };
+        }
+        if (obj?.type === "turn_context") {
+          if (isActiveMultiAgentVersion(obj?.payload?.multi_agent_version)) {
+            return { candidate: true, indeterminate: false };
+          }
+          needsTail = true;
+        }
+      }
+      if (line.includes('"token_count"')) {
+        needsTail = true;
+        break;
+      }
+      if (bytesRead >= MAX_BYTES) return { candidate: false, indeterminate: true };
+    }
+  } catch (_e) {
+    return { candidate: false, indeterminate: true };
+  } finally {
+    if (rl) rl.close();
+    if (stream) stream.destroy();
+  }
+  if (needsTail) return scanCodexMultiAgentTail(filePath);
+  return { candidate: false, indeterminate: false };
+}
+
+async function scanCodexMultiAgentTail(filePath) {
+  const MAX_BYTES = 1024 * 1024;
+  let handle = null;
+  try {
+    handle = await fs.open(filePath, "r");
+    const stat = await handle.stat();
+    const size = Number(stat.size || 0);
+    const start = Math.max(0, size - MAX_BYTES);
+    const length = Math.max(0, size - start);
+    const buffer = Buffer.alloc(length);
+    let bytesRead = 0;
+    while (bytesRead < length) {
+      const result = await handle.read(
+        buffer,
+        bytesRead,
+        length - bytesRead,
+        start + bytesRead,
+      );
+      if (result.bytesRead <= 0) break;
+      bytesRead += result.bytesRead;
+    }
+    if (bytesRead !== length) return { candidate: false, indeterminate: true };
+    const lines = buffer.toString("utf8").split("\n");
+    if (start > 0) lines.shift(); // discard a line truncated by the tail boundary
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index];
+      if (!line.includes('"turn_context"')) continue;
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch (_e) {
+        return { candidate: false, indeterminate: true };
+      }
+      if (obj?.type !== "turn_context") continue;
+      return {
+        candidate: isActiveMultiAgentVersion(obj?.payload?.multi_agent_version),
+        indeterminate: false,
+      };
+    }
+    return { candidate: false, indeterminate: start > 0 };
+  } catch (_e) {
+    return { candidate: false, indeterminate: true };
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+function isActiveMultiAgentVersion(value) {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return Boolean(
+    normalized &&
+      normalized !== "off" &&
+      normalized !== "none" &&
+      normalized !== "disabled",
+  );
+}
+
+async function scanCodexUsageLineages(filePath, maxBytes = Infinity) {
+  let stream = null;
+  let rl = null;
+  try {
+    const state = createUsageDeltaState();
+    const byteLimit = Number.isFinite(maxBytes) ? Math.max(0, maxBytes) : Infinity;
+    let bytesRead = 0;
+    stream = fssync.createReadStream(filePath, {
+      encoding: "utf8",
+      highWaterMark: 32 * 1024,
+    });
+    rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    for await (const line of rl) {
+      bytesRead += Buffer.byteLength(line, "utf8") + 1;
+      if (bytesRead > byteLimit) return { affected: false, indeterminate: true };
+      if (!line.includes('"token_count"')) continue;
+      let obj;
+      try {
+        obj = JSON.parse(line);
+      } catch (_e) {
+        continue;
+      }
+      const token = extractTokenCount(obj);
+      const info = token?.info;
+      if (!info || typeof info !== "object") continue;
+      consumeUsageDelta(state, info.last_token_usage, info.total_token_usage);
+      if (state.sawInterleaved || state.sawDivergentCumulative) {
+        return { affected: true, indeterminate: false };
+      }
+    }
+    return { affected: false, indeterminate: false };
+  } catch (_e) {
+    return { affected: false, indeterminate: true };
+  } finally {
+    if (rl) rl.close();
+    if (stream) stream.destroy();
+  }
+}
+
+function isCodexHistoryCovered(cursors, rolloutFiles) {
+  const scannedPaths = new Set();
+  const scannedSessionIds = new Set();
+  for (const entry of Array.isArray(rolloutFiles) ? rolloutFiles : []) {
+    const fp = typeof entry === "string" ? entry : entry?.path;
+    const src = typeof entry === "string" ? "codex" : String(entry?.source || "codex");
+    if (!fp || src !== "codex") continue;
+    scannedPaths.add(fp);
+    const id = codexSessionIdFromPath(fp);
+    if (id) scannedSessionIds.add(id);
+  }
+  if (!cursors.files || typeof cursors.files !== "object") return true;
+  for (const fp of Object.keys(cursors.files)) {
+    if (!isCodexSessionCursorPath(fp)) continue;
+    if (scannedPaths.has(fp)) continue;
+    const id = codexSessionIdFromPath(fp);
+    if (id && scannedSessionIds.has(id)) continue;
+    return false;
+  }
+  return true;
 }
 
 // Scans codex rollout heads for the fork marker. The child session_meta (with

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -12,6 +12,12 @@ const readline = require("node:readline");
 
 const { listRolloutFiles } = require("./rollout");
 const {
+  consumeUsageDelta,
+  createUsageDeltaState,
+  snapshotUsageBaselines,
+  totalsReset,
+} = require("./codex-token-usage");
+const {
   emptyTotals,
   addInto,
   inferExecCommandKind,
@@ -434,42 +440,10 @@ function normalizeUsage(u) {
   return out;
 }
 
-function totalsReset(curr, prev) {
-  const a = Number(curr?.total_tokens);
-  const b = Number(prev?.total_tokens);
-  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
-  return a < b;
-}
-
 function pickDelta(lastUsage, totalUsage, prevTotals) {
-  const hasLast = lastUsage && typeof lastUsage === "object";
-  const hasTotal = totalUsage && typeof totalUsage === "object";
-  const hasPrev = prevTotals && typeof prevTotals === "object";
-
-  if (hasTotal && hasPrev) {
-    if (totalsReset(totalUsage, prevTotals)) {
-      const resetUsage = hasLast ? lastUsage : totalUsage;
-      return normalizeUsage(resetUsage);
-    }
-    const delta = {};
-    for (const k of [
-      "input_tokens",
-      "cached_input_tokens",
-      "cache_creation_input_tokens",
-      "output_tokens",
-      "reasoning_output_tokens",
-      "total_tokens",
-    ]) {
-      const a = Number(totalUsage[k]);
-      const b = Number(prevTotals[k]);
-      if (Number.isFinite(a) && Number.isFinite(b)) delta[k] = Math.max(0, a - b);
-    }
-    return normalizeUsage(delta);
-  }
-
-  if (hasLast) return normalizeUsage(lastUsage);
-  if (hasTotal) return normalizeUsage(totalUsage);
-  return null;
+  const state = createUsageDeltaState({ lastTotal: prevTotals });
+  const delta = consumeUsageDelta(state, lastUsage, totalUsage);
+  return delta ? normalizeUsage(delta) : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -596,7 +570,10 @@ async function parseCodexRolloutFile(filePath, {
   let provider = isResuming ? resumeState.provider || null : null;
   let cliVersion = isResuming ? resumeState.cliVersion || null : null;
 
-  let prevTotals = isResuming ? resumeState.prevTotals || null : null;
+  const usageDeltaState = createUsageDeltaState({
+    lastTotal: isResuming ? resumeState.prevTotals || null : null,
+    baselines: isResuming ? resumeState.tokenUsageBaselines || null : null,
+  });
   let pendingToolNames = isResuming
     ? Array.from(resumeState.pendingToolNames || [])
     : [];
@@ -875,8 +852,8 @@ async function parseCodexRolloutFile(filePath, {
       const info = tokenCount.info;
       const lastUsage = info?.last_token_usage;
       const totalUsage = info?.total_token_usage;
-      const delta = pickDelta(lastUsage, totalUsage, prevTotals);
-      if (totalUsage && typeof totalUsage === "object") prevTotals = totalUsage;
+      const rawDelta = consumeUsageDelta(usageDeltaState, lastUsage, totalUsage);
+      const delta = rawDelta ? normalizeUsage(rawDelta) : null;
       const isNewResumeEvent = noteTokenEvent(ts, lastUsage, totalUsage);
       if (inRequestedRange) {
         const eventSessionId = sessionId || rolloutSessionIdFromPath(primaryFilePath) || primaryFilePath;
@@ -927,7 +904,8 @@ async function parseCodexRolloutFile(filePath, {
       model,
       provider,
       cliVersion,
-      prevTotals,
+      prevTotals: usageDeltaState.lastTotal,
+      tokenUsageBaselines: snapshotUsageBaselines(usageDeltaState),
       pendingToolNames,
       pendingSkills,
       pendingExecDetails,

--- a/src/lib/codex-token-usage.js
+++ b/src/lib/codex-token-usage.js
@@ -1,0 +1,195 @@
+"use strict";
+
+// A rollout can contain TokenCount events from more than one Codex SessionState
+// (for example, a parent agent and an embedded reviewer). Each SessionState has
+// its own cumulative total, but the event does not carry a stable stream id.
+// Recover the stream from Codex's invariant: total - last = that stream's prior
+// total. Keeping a small LRU of stream heads also makes repeated rate-limit
+// snapshots idempotent when the streams are interleaved.
+
+const USAGE_FIELDS = [
+  "input_tokens",
+  "cached_input_tokens",
+  "cache_creation_input_tokens",
+  "output_tokens",
+  "reasoning_output_tokens",
+  "total_tokens",
+];
+const MAX_USAGE_BASELINES = 32;
+
+function canonicalUsage(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const out = {};
+  let sawNumber = false;
+  for (const field of USAGE_FIELDS) {
+    const raw = field === "cache_creation_input_tokens"
+      ? value.cache_creation_input_tokens ?? value.cache_write_input_tokens
+      : value[field];
+    const number = Number(raw);
+    if (Number.isFinite(number) && number >= 0) {
+      out[field] = Math.floor(number);
+      sawNumber = true;
+    } else {
+      out[field] = 0;
+    }
+  }
+  return sawNumber ? out : null;
+}
+
+function usageSignature(value) {
+  const usage = canonicalUsage(value);
+  return usage ? USAGE_FIELDS.map((field) => usage[field]).join(":") : null;
+}
+
+function sameUsage(left, right) {
+  const leftSignature = usageSignature(left);
+  return leftSignature !== null && leftSignature === usageSignature(right);
+}
+
+function subtractUsage(totalUsage, lastUsage) {
+  const total = canonicalUsage(totalUsage);
+  const last = canonicalUsage(lastUsage);
+  if (!total || !last) return null;
+  const previous = {};
+  for (const field of USAGE_FIELDS) {
+    if (total[field] < last[field]) return null;
+    previous[field] = total[field] - last[field];
+  }
+  return previous;
+}
+
+function diffUsage(totalUsage, previousUsage) {
+  const total = canonicalUsage(totalUsage);
+  const previous = canonicalUsage(previousUsage);
+  if (!total || !previous) return null;
+  const delta = {};
+  for (const field of USAGE_FIELDS) {
+    delta[field] = Math.max(0, total[field] - previous[field]);
+  }
+  return delta;
+}
+
+function totalsReset(totalUsage, previousUsage) {
+  const total = canonicalUsage(totalUsage);
+  const previous = canonicalUsage(previousUsage);
+  return Boolean(total && previous && total.total_tokens < previous.total_tokens);
+}
+
+function createUsageDeltaState({ lastTotal = null, baselines = null } = {}) {
+  const state = {
+    lastTotal: null,
+    baselines: [],
+    sawDivergentCumulative: false,
+    sawInterleaved: false,
+  };
+  for (const baseline of Array.isArray(baselines) ? baselines : []) {
+    touchBaseline(state, baseline);
+  }
+  if (canonicalUsage(lastTotal)) touchBaseline(state, lastTotal);
+  return state;
+}
+
+function snapshotUsageBaselines(state) {
+  return Array.isArray(state?.baselines)
+    ? state.baselines.map((usage) => ({ ...usage }))
+    : [];
+}
+
+function consumeUsageDelta(state, lastUsage, totalUsage) {
+  if (!state || typeof state !== "object") {
+    throw new TypeError("usage delta state is required");
+  }
+  if (!Array.isArray(state.baselines)) state.baselines = [];
+
+  const last = canonicalUsage(lastUsage);
+  const total = canonicalUsage(totalUsage);
+  if (!total) return last;
+
+  const activeSignature = usageSignature(state.lastTotal);
+  const duplicateIndex = findBaselineIndex(state, total);
+  if (duplicateIndex >= 0) {
+    if (
+      activeSignature !== null &&
+      usageSignature(state.baselines[duplicateIndex]) !== activeSignature
+    ) {
+      state.sawInterleaved = true;
+    }
+    touchBaselineAt(state, duplicateIndex, total);
+    return null;
+  }
+
+  if (last) {
+    const expectedPrevious = subtractUsage(total, last);
+    const lineageIndex = findBaselineIndex(state, expectedPrevious);
+    if (lineageIndex >= 0) {
+      if (
+        activeSignature !== null &&
+        usageSignature(state.baselines[lineageIndex]) !== activeSignature
+      ) {
+        state.sawInterleaved = true;
+      }
+      touchBaselineAt(state, lineageIndex, total);
+      return last;
+    }
+    if (expectedPrevious) {
+      if (canonicalUsage(state.lastTotal)) state.sawDivergentCumulative = true;
+      touchBaseline(state, total);
+      return last;
+    }
+  }
+
+  const active = canonicalUsage(state.lastTotal);
+  if (active && !totalsReset(total, active)) {
+    const delta = diffUsage(total, active);
+    if (!last || Number(delta?.total_tokens || 0) <= Number(last.total_tokens || 0)) {
+      const activeIndex = findBaselineIndex(state, active);
+      touchBaselineAt(state, activeIndex, total);
+      return delta;
+    }
+
+    // A cumulative jump larger than last usage cannot come from the normal
+    // append_last_usage path. Treat it as a new stream instead of charging the
+    // unrelated cumulative gap; a later event will establish its lineage.
+    state.sawDivergentCumulative = true;
+  }
+
+  touchBaseline(state, total);
+  return last || total;
+}
+
+function findBaselineIndex(state, usage) {
+  const signature = usageSignature(usage);
+  if (signature === null) return -1;
+  return state.baselines.findIndex((baseline) => usageSignature(baseline) === signature);
+}
+
+function touchBaselineAt(state, index, usage) {
+  const canonical = canonicalUsage(usage);
+  if (!canonical) return;
+  if (Number.isInteger(index) && index >= 0 && index < state.baselines.length) {
+    state.baselines.splice(index, 1);
+  } else {
+    const duplicateIndex = findBaselineIndex(state, canonical);
+    if (duplicateIndex >= 0) state.baselines.splice(duplicateIndex, 1);
+  }
+  state.baselines.push(canonical);
+  while (state.baselines.length > MAX_USAGE_BASELINES) state.baselines.shift();
+  state.lastTotal = canonical;
+}
+
+function touchBaseline(state, usage) {
+  touchBaselineAt(state, findBaselineIndex(state, usage), usage);
+}
+
+module.exports = {
+  MAX_USAGE_BASELINES,
+  canonicalUsage,
+  consumeUsageDelta,
+  createUsageDeltaState,
+  diffUsage,
+  sameUsage,
+  snapshotUsageBaselines,
+  subtractUsage,
+  totalsReset,
+  usageSignature,
+};

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -8,6 +8,11 @@ const { ensureDir } = require("./fs");
 const { readSqliteJsonRows, readSqliteJsonRowsAsync } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
 const { resolveInstallPaths } = require("./install-resolver");
+const {
+  consumeUsageDelta,
+  createUsageDeltaState,
+  snapshotUsageBaselines,
+} = require("./codex-token-usage");
 
 const DEFAULT_SOURCE = "codex";
 const DEFAULT_MODEL = "unknown";
@@ -360,6 +365,9 @@ async function parseRolloutIncremental({
     const lastTotal = sameInode && !truncated && !rebuildingCodexBaseline
       ? prev.lastTotal || null
       : null;
+    const tokenUsageBaselines = sameInode && !truncated && !rebuildingCodexBaseline
+      ? prev.tokenUsageBaselines || null
+      : null;
     const lastModel = sameInode && !truncated ? prev.lastModel || null : null;
 
     const codexProjectFastPath = projectEnabled && fileSource === DEFAULT_SOURCE;
@@ -430,6 +438,7 @@ async function parseRolloutIncremental({
           filePath,
           fileStat: st,
           lastTotal,
+          tokenUsageBaselines,
           lastModel,
           projectState,
           projectMetaCache,
@@ -442,6 +451,7 @@ async function parseRolloutIncremental({
           fileStat: st,
           startOffset,
           lastTotal,
+          tokenUsageBaselines,
           lastModel,
           hourlyState,
           touchedBuckets,
@@ -462,6 +472,7 @@ async function parseRolloutIncremental({
       inode,
       offset: result.endOffset,
       lastTotal: result.lastTotal,
+      tokenUsageBaselines: result.tokenUsageBaselines,
       lastModel: result.lastModel,
       updatedAt: new Date().toISOString(),
     };
@@ -1731,6 +1742,7 @@ async function parseRolloutFile({
   fileStat,
   startOffset,
   lastTotal,
+  tokenUsageBaselines,
   lastModel,
   hourlyState,
   touchedBuckets,
@@ -1751,14 +1763,25 @@ async function parseRolloutFile({
   const projectFileContexts = [];
   addProjectFileContext(projectFileContexts, projectContext);
   if (startOffset >= endOffset) {
-    return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
+    return {
+      endOffset,
+      lastTotal,
+      tokenUsageBaselines,
+      lastModel,
+      eventsAggregated: 0,
+      projectFileContexts,
+    };
   }
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
   let model = typeof lastModel === "string" ? lastModel : null;
-  let totals = lastTotal && typeof lastTotal === "object" ? lastTotal : null;
+  const usageDeltaState = createUsageDeltaState({
+    lastTotal,
+    baselines: tokenUsageBaselines,
+  });
+  let latestTotal = lastTotal && typeof lastTotal === "object" ? lastTotal : null;
   let currentCwd = null;
   let currentDate = null;
   let isForkedRollout = false;
@@ -1840,14 +1863,12 @@ async function parseRolloutFile({
 
     const lastUsage = info.last_token_usage;
     const totalUsage = info.total_token_usage;
+    if (totalUsage && typeof totalUsage === "object") latestTotal = totalUsage;
 
-    const delta = pickDelta(lastUsage, totalUsage, totals);
-    if (!delta) continue;
+    const rawDelta = consumeUsageDelta(usageDeltaState, lastUsage, totalUsage);
+    const delta = rawDelta ? normalizeUsage(rawDelta) : null;
+    if (!delta || isAllZeroUsage(delta)) continue;
     delta.conversation_count = 1;
-
-    if (totalUsage && typeof totalUsage === "object") {
-      totals = totalUsage;
-    }
 
     // Forked Codex rollouts replay the parent session's entire token history
     // into the child file the moment the fork is created. The date guard below
@@ -1863,8 +1884,8 @@ async function parseRolloutFile({
     // flush spacing and well below genuine turn cadence (≥~4.6s observed). The
     // first replayed row cannot be identified without lookahead, so it is still
     // counted (a bounded, <1% residual over-count); dropping real usage is the
-    // worse failure, so we bias against it. `totals` is already advanced above,
-    // keeping the cumulative-delta baseline correct for the live turns we keep.
+    // worse failure, so we bias against it. `usageDeltaState` is already advanced above,
+    // keeping the cumulative lineage correct for the live turns we keep.
     // Scoped to forked codex rollouts. (issue #169 follow-up.)
     let forkedReplaySkip = false;
     if (isForkedRollout && source === DEFAULT_SOURCE && replayPrefixActive) {
@@ -1903,8 +1924,8 @@ async function parseRolloutFile({
     // buckets. External tools rewrite session files without changing the token
     // data — Codex-Manager atomically rewrites them (new inode) to patch the
     // provider on every account/channel switch — so without dedup each switch
-    // double-counts the rewritten sessions. `totals` is already advanced above,
-    // so skipping an already-seen event keeps the cumulative-delta chain intact
+    // double-counts the rewritten sessions. `usageDeltaState` is already advanced above,
+    // so skipping an already-seen event keeps the cumulative lineage intact
     // while preventing the re-add; genuinely new turns carry new timestamps and
     // are still counted. Key = sessionUUID:eventTimestamp (both stable across the
     // rewrite and across a sessions/ -> archived_sessions/ move).
@@ -1939,13 +1960,21 @@ async function parseRolloutFile({
     eventsAggregated += 1;
   }
 
-  return { endOffset, lastTotal: totals, lastModel: model, eventsAggregated, projectFileContexts };
+  return {
+    endOffset,
+    lastTotal: latestTotal,
+    tokenUsageBaselines: snapshotUsageBaselines(usageDeltaState),
+    lastModel: model,
+    eventsAggregated,
+    projectFileContexts,
+  };
 }
 
 async function scanRolloutProjectFileContexts({
   filePath,
   fileStat,
   lastTotal,
+  tokenUsageBaselines,
   lastModel,
   projectState,
   projectMetaCache,
@@ -1958,7 +1987,14 @@ async function scanRolloutProjectFileContexts({
   const projectFileContexts = [];
   addProjectFileContext(projectFileContexts, projectContext);
   if (!projectState || endOffset <= 0) {
-    return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
+    return {
+      endOffset,
+      lastTotal,
+      tokenUsageBaselines,
+      lastModel,
+      eventsAggregated: 0,
+      projectFileContexts,
+    };
   }
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: 0 });
@@ -2005,7 +2041,14 @@ async function scanRolloutProjectFileContexts({
     addProjectFileContext(projectFileContexts, context);
   }
 
-  return { endOffset, lastTotal, lastModel, eventsAggregated: 0, projectFileContexts };
+  return {
+    endOffset,
+    lastTotal,
+    tokenUsageBaselines,
+    lastModel,
+    eventsAggregated: 0,
+    projectFileContexts,
+  };
 }
 
 async function parseClaudeFile({
@@ -3570,48 +3613,6 @@ function extractTokenCount(obj) {
   return null;
 }
 
-function pickDelta(lastUsage, totalUsage, prevTotals) {
-  const hasLast = isNonEmptyObject(lastUsage);
-  const hasTotal = isNonEmptyObject(totalUsage);
-  const hasPrevTotals = isNonEmptyObject(prevTotals);
-
-  if (hasTotal && hasPrevTotals) {
-    if (totalsReset(totalUsage, prevTotals)) {
-      const resetUsage = hasLast ? lastUsage : totalUsage;
-      const normalized = normalizeUsage(resetUsage);
-      return isAllZeroUsage(normalized) ? null : normalized;
-    }
-
-    const delta = {};
-    for (const k of [
-      "input_tokens",
-      "cached_input_tokens",
-      "cache_creation_input_tokens",
-      "output_tokens",
-      "reasoning_output_tokens",
-      "total_tokens",
-    ]) {
-      const a = Number(totalUsage[k]);
-      const b = Number(prevTotals[k]);
-      if (Number.isFinite(a) && Number.isFinite(b)) delta[k] = Math.max(0, a - b);
-    }
-    const normalized = normalizeUsage(delta);
-    return isAllZeroUsage(normalized) ? null : normalized;
-  }
-
-  if (hasLast) {
-    const normalized = normalizeUsage(lastUsage);
-    return isAllZeroUsage(normalized) ? null : normalized;
-  }
-
-  if (hasTotal) {
-    const normalized = normalizeUsage(totalUsage);
-    return isAllZeroUsage(normalized) ? null : normalized;
-  }
-
-  return null;
-}
-
 function normalizeUsage(u) {
   const out = {};
   for (const k of [
@@ -3692,13 +3693,6 @@ function isAllZeroUsage(u) {
     if (Number(u[k] || 0) !== 0) return false;
   }
   return true;
-}
-
-function totalsReset(curr, prev) {
-  const currTotal = curr?.total_tokens;
-  const prevTotal = prev?.total_tokens;
-  if (!isFiniteNumber(currTotal) || !isFiniteNumber(prevTotal)) return false;
-  return currTotal < prevTotal;
 }
 
 function isFiniteNumber(v) {

--- a/test/codex-context-breakdown.test.js
+++ b/test/codex-context-breakdown.test.js
@@ -182,6 +182,63 @@ test("computeCodexContextBreakdown returns non-overlapping totals plus exec dril
   }
 });
 
+test("computeCodexContextBreakdown does not inflate interleaved SessionState counters", async () => {
+  const dir = await makeTmpDir("tt-codex-interleaved");
+  try {
+    const day = "2026-07-24";
+    const usage = (totalTokens) => ({
+      input_tokens: totalTokens,
+      cached_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    });
+    const tokenCount = (timestamp, last, total) => ({
+      timestamp,
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: last,
+          total_token_usage: total,
+          model_context_window: 258400,
+        },
+      },
+    });
+    await writeRollout(dir, day, "rollout-interleaved.jsonl", [
+      {
+        timestamp: `${day}T04:45:00.000Z`,
+        type: "session_meta",
+        payload: { id: "interleaved", cwd: "/tmp/project", model_provider: "openai" },
+      },
+      {
+        timestamp: `${day}T04:45:01.000Z`,
+        type: "turn_context",
+        payload: { cwd: "/tmp/project", model: "gpt-5.6-sol" },
+      },
+      tokenCount(`${day}T04:45:39.000Z`, usage(100), usage(100)),
+      tokenCount(`${day}T04:45:45.000Z`, usage(200), usage(200)),
+      tokenCount(`${day}T04:46:02.000Z`, usage(100), usage(100)),
+      tokenCount(`${day}T04:46:05.000Z`, usage(50), usage(250)),
+      tokenCount(`${day}T04:46:10.000Z`, usage(30), usage(130)),
+    ]);
+
+    const result = await computeCodexContextBreakdown({
+      from: day,
+      to: day,
+      codexDir: dir,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    });
+
+    assert.equal(result.totals.total_tokens, 100 + 200 + 50 + 30);
+    assert.equal(result.totals.input_tokens, result.totals.total_tokens);
+    assert.equal(result.message_count, 4);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("computeCodexContextBreakdown preserves exec stats on a zero-token turn", async () => {
   const dir = await makeTmpDir("tt-codex-breakdown-zero-token-exec");
   try {

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -902,6 +902,82 @@ test("Context incrementally parses append-only sessions with pending tools and d
   }
 });
 
+test("Context resume state preserves interleaved cumulative usage lineages", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-lineage-"));
+  const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-lineage-fresh-"));
+  try {
+    const day = "2030-06-02";
+    const fileName =
+      "rollout-2030-06-02T04-45-00-44444444-4444-4444-8444-444444444444.jsonl";
+    const usage = (totalTokens) => ({
+      input_tokens: totalTokens,
+      cached_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    });
+    const event = (timestamp, last, total) => ({
+      timestamp,
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: last,
+          total_token_usage: total,
+          model_context_window: 258400,
+        },
+      },
+    });
+    const initialEvents = [
+      {
+        timestamp: `${day}T04:45:00.000Z`,
+        type: "session_meta",
+        payload: {
+          id: "44444444-4444-4444-8444-444444444444",
+          cwd: "/tmp/project",
+          model_provider: "openai",
+        },
+      },
+      event(`${day}T04:45:39.000Z`, usage(100), usage(100)),
+      event(`${day}T04:45:45.000Z`, usage(200), usage(200)),
+    ];
+    const appendedEvents = [
+      event(`${day}T04:46:02.000Z`, usage(100), usage(100)),
+      event(`${day}T04:46:05.000Z`, usage(50), usage(250)),
+      event(`${day}T04:46:10.000Z`, usage(30), usage(130)),
+    ];
+    const filePath = await writeRollout(root, day, fileName, initialEvents);
+    const args = {
+      from: day,
+      to: day,
+      codexDir: root,
+      timeZoneContext: { timeZone: "UTC", offsetMinutes: 0 },
+    };
+
+    const primed = await computeCodexContextBreakdown(args);
+    assert.equal(primed.totals.total_tokens, 300);
+    await fs.appendFile(filePath, rolloutContents(appendedEvents), "utf8");
+    const active = new Date(`${day}T12:01:00.000Z`);
+    await fs.utimes(filePath, active, active);
+
+    const resumed = await computeCodexContextBreakdown(args);
+    const freshPath = await writeRollout(freshRoot, day, fileName, []);
+    await fs.copyFile(filePath, freshPath);
+    await fs.utimes(freshPath, active, active);
+    const fresh = await computeCodexContextBreakdown({ ...args, codexDir: freshRoot });
+
+    assert.equal(resumed.totals.total_tokens, 100 + 200 + 50 + 30);
+    assert.equal(resumed.message_count, 4);
+    assert.deepEqual(resumed.totals, fresh.totals);
+    assert.equal(resumed.diagnostics.incremental_parse_hits, 1);
+    assert.equal(resumed.diagnostics.incremental_parse_fallbacks, 0);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.rm(freshRoot, { recursive: true, force: true });
+  }
+});
+
 test("Context preserves appended JSONL records larger than the stable read buffer", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-large-record-"));
   const freshRoot = await fs.mkdtemp(

--- a/test/codex-token-usage.test.js
+++ b/test/codex-token-usage.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  MAX_USAGE_BASELINES,
+  consumeUsageDelta,
+  createUsageDeltaState,
+  snapshotUsageBaselines,
+} = require("../src/lib/codex-token-usage");
+
+function usage(totalTokens) {
+  return {
+    input_tokens: totalTokens,
+    cached_input_tokens: 0,
+    cache_write_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+  };
+}
+
+test("usage delta state follows alternating cumulative lineages and skips repeated snapshots", () => {
+  const state = createUsageDeltaState();
+  const deltas = [
+    consumeUsageDelta(state, usage(100), usage(100)),
+    consumeUsageDelta(state, usage(200), usage(200)),
+    consumeUsageDelta(state, usage(100), usage(100)),
+    consumeUsageDelta(state, usage(50), usage(250)),
+    consumeUsageDelta(state, usage(30), usage(130)),
+  ];
+
+  assert.deepEqual(deltas.map((delta) => delta?.total_tokens ?? null), [100, 200, null, 50, 30]);
+  assert.equal(state.sawInterleaved, true);
+  assert.equal(state.sawDivergentCumulative, true);
+  assert.equal(snapshotUsageBaselines(state).length, 2);
+});
+
+test("usage delta state keeps one lineage across ordinary cumulative growth", () => {
+  const state = createUsageDeltaState();
+  assert.equal(consumeUsageDelta(state, usage(100), usage(100)).total_tokens, 100);
+  assert.equal(consumeUsageDelta(state, usage(50), usage(150)).total_tokens, 50);
+  assert.equal(consumeUsageDelta(state, usage(25), usage(175)).total_tokens, 25);
+  assert.equal(state.sawInterleaved, false);
+  assert.equal(state.sawDivergentCumulative, false);
+  assert.equal(snapshotUsageBaselines(state).length, 1);
+});
+
+test("usage delta state retains the smaller cumulative delta when last usage is inconsistent", () => {
+  const state = createUsageDeltaState();
+  consumeUsageDelta(state, usage(15), usage(15));
+
+  const delta = consumeUsageDelta(state, usage(150), usage(22));
+  assert.equal(delta.total_tokens, 7);
+  assert.equal(snapshotUsageBaselines(state).length, 1);
+});
+
+test("usage delta state bounds persisted stream heads", () => {
+  const state = createUsageDeltaState();
+  for (let index = 1; index <= MAX_USAGE_BASELINES + 5; index += 1) {
+    const total = index * 1000;
+    consumeUsageDelta(state, usage(total), usage(total));
+  }
+
+  assert.equal(snapshotUsageBaselines(state).length, MAX_USAGE_BASELINES);
+});

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -150,6 +150,60 @@ test("parseRolloutIncremental ignores repeated token_count records with unchange
   }
 });
 
+test("parseRolloutIncremental separates interleaved cumulative usage lineages", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-interleaved.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = (totalTokens) => ({
+      input_tokens: totalTokens,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    });
+
+    // A and B are independent Codex SessionState counters emitted into one
+    // rollout. They intentionally share a context window to prove that the
+    // parser follows cumulative lineage rather than treating that field as an
+    // identity. The repeated A snapshot after B must remain a no-op.
+    const initialLines = [
+      buildTokenCountLine({ ts: "2026-07-24T04:45:39.000Z", last: usage(100), total: usage(100), contextWindow: 258400 }),
+      buildTokenCountLine({ ts: "2026-07-24T04:45:45.000Z", last: usage(200), total: usage(200), contextWindow: 258400 }),
+    ];
+    const appendedLines = [
+      buildTokenCountLine({ ts: "2026-07-24T04:46:02.000Z", last: usage(100), total: usage(100), contextWindow: 258400 }),
+      buildTokenCountLine({ ts: "2026-07-24T04:46:05.000Z", last: usage(50), total: usage(250), contextWindow: 258400 }),
+      buildTokenCountLine({ ts: "2026-07-24T04:46:10.000Z", last: usage(30), total: usage(130), contextWindow: 258400 }),
+    ];
+    await fs.writeFile(rolloutPath, initialLines.join("\n") + "\n", "utf8");
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(first.eventsAggregated, 2);
+    assert.equal(cursors.files[rolloutPath].tokenUsageBaselines.length, 2);
+
+    await fs.appendFile(rolloutPath, appendedLines.join("\n") + "\n", "utf8");
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+    });
+
+    assert.equal(second.eventsAggregated, 2);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 2);
+    assert.equal(queued.at(-1).total_tokens, 100 + 200 + 50 + 30);
+    assert.equal(cursors.files[rolloutPath].tokenUsageBaselines.length, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental does not re-count a session file rewritten with a new inode (issue #187)", async () => {
   // Codex-Manager atomically rewrites session rollout files (new inode, same
   // token data) when switching account/channel. The parser keys incremental
@@ -4512,16 +4566,18 @@ function buildSessionMetaLine({ model, cwd, forkedFromId }) {
   });
 }
 
-function buildTokenCountLine({ ts, last, total }) {
+function buildTokenCountLine({ ts, last, total, contextWindow }) {
+  const info = {
+    last_token_usage: last,
+    total_token_usage: total,
+  };
+  if (Number.isFinite(contextWindow)) info.model_context_window = contextWindow;
   return JSON.stringify({
     type: "event_msg",
     timestamp: ts,
     payload: {
       type: "token_count",
-      info: {
-        last_token_usage: last,
-        total_token_usage: total,
-      },
+      info,
     },
   });
 }

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -1218,3 +1218,489 @@ describe("repairCodexForkReplayInflation (#169 follow-up) — fork replay histor
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Interleaved SessionState historical repair. Multi-agent Codex can emit two
+// independent cumulative counters into one rollout; older TokenTracker builds
+// treated them as one counter and persisted the cross-stream gaps.
+// ---------------------------------------------------------------------------
+
+const {
+  repairCodexInterleavedUsageInflation,
+  CODEX_USAGE_LINEAGE_REPAIR_KEY,
+} = require("../src/commands/sync");
+
+const lineageUsage = (totalTokens) => ({
+  input_tokens: totalTokens,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  reasoning_output_tokens: 0,
+  total_tokens: totalTokens,
+});
+const LINEAGE_TRUE_TOTAL = 380;
+
+async function writeLineageCodexFile(home, {
+  archived = false,
+  cwd = null,
+  interleaved = true,
+  lineagePaddingLines = 0,
+  resumedMultiAgent = false,
+  uuid = "dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb",
+} = {}) {
+  const dir = archived
+    ? path.join(home, ".codex", "archived_sessions", "nested")
+    : path.join(home, ".codex", "sessions", "2025", "12", "18");
+  await fs.mkdir(dir, { recursive: true });
+  const fp = path.join(dir, `rollout-2025-12-18T00-00-00-${uuid}.jsonl`);
+  const lines = [
+    // The real affected rollout's marker begins after byte 95,915. Keep this
+    // fixture above the old 64 KiB fork-head window to lock in the wider gate.
+    JSON.stringify({
+      type: "session_meta",
+      payload: { id: uuid, base_instructions: { text: "x".repeat(96 * 1024) } },
+    }),
+    JSON.stringify({
+      type: "turn_context",
+      payload: {
+        cwd,
+        model: "gpt-5.6",
+        multi_agent_version: resumedMultiAgent ? "none" : "v2",
+      },
+    }),
+  ];
+  for (let index = 0; index < lineagePaddingLines; index += 1) {
+    lines.push(JSON.stringify({
+      type: "event_msg",
+      payload: { type: "note", text: "x".repeat(32 * 1024) },
+    }));
+  }
+  if (interleaved) {
+    lines.push(tokenCountLine({
+      ts: "2025-12-18T00:00:00.000Z",
+      last: lineageUsage(100),
+      total: lineageUsage(100),
+    }));
+    if (resumedMultiAgent) {
+      // Old sessions can be resumed after upgrading Codex. The active marker
+      // then appears after an earlier token_count, so the migration must use
+      // its bounded tail gate instead of finalizing from the first turn.
+      lines.push(JSON.stringify({
+        type: "turn_context",
+        payload: { cwd, model: "gpt-5.6", multi_agent_version: "v2" },
+      }));
+    }
+    lines.push(
+      tokenCountLine({ ts: "2025-12-18T00:00:01.000Z", last: lineageUsage(200), total: lineageUsage(200) }),
+      tokenCountLine({ ts: "2025-12-18T00:00:02.000Z", last: lineageUsage(100), total: lineageUsage(100) }),
+      tokenCountLine({ ts: "2025-12-18T00:00:03.000Z", last: lineageUsage(50), total: lineageUsage(250) }),
+      tokenCountLine({ ts: "2025-12-18T00:00:04.000Z", last: lineageUsage(30), total: lineageUsage(130) }),
+    );
+  } else {
+    lines.push(
+      tokenCountLine({ ts: "2025-12-18T00:00:00.000Z", last: lineageUsage(100), total: lineageUsage(100) }),
+      tokenCountLine({ ts: "2025-12-18T00:00:01.000Z", last: lineageUsage(150), total: lineageUsage(250) }),
+    );
+  }
+  await fs.writeFile(fp, lines.join("\n") + "\n", "utf8");
+  return fp;
+}
+
+async function seedInflatedLineageInstall(home, codexFile) {
+  const trackerDir = path.join(home, ".tokentracker", "tracker");
+  const cursorsPath = path.join(trackerDir, "cursors.json");
+  const queuePath = path.join(trackerDir, "queue.jsonl");
+  const queueStatePath = path.join(trackerDir, "queue.state.json");
+  const hour = "2025-12-18T00:00:00.000Z";
+  const inflated = 4_700_000_000;
+  await fs.mkdir(trackerDir, { recursive: true });
+  await fs.writeFile(
+    cursorsPath,
+    JSON.stringify({
+      version: 1,
+      files: { [codexFile]: { inode: 1, offset: 5, lastTotal: lineageUsage(inflated) } },
+      hourly: {
+        buckets: {
+          [`codex|gpt-5.6|${hour}`]: { totals: { total_tokens: inflated } },
+        },
+        groupQueued: {},
+      },
+      codexHashes: ["stale:background-lineage"],
+      migrations: {},
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    queuePath,
+    JSON.stringify({
+      source: "codex",
+      model: "gpt-5.6",
+      hour_start: hour,
+      total_tokens: inflated,
+    }) + "\n",
+    "utf8",
+  );
+  await fs.writeFile(queueStatePath, JSON.stringify({ offset: 777 }), "utf8");
+  return { cursorsPath, queuePath, queueStatePath };
+}
+
+describe("repairCodexInterleavedUsageInflation — cumulative lineage repair", () => {
+  it("rebuilds affected main and project history, preserves other sources, resets uploads, and is idempotent", async () => {
+    const home = await makeTempHome();
+    try {
+      const repoRoot = path.join(home, "work", "lineage");
+      await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+      await fs.writeFile(
+        path.join(repoRoot, ".git", "config"),
+        `[remote "origin"]\n\turl = https://github.com/acme/lineage.git\n`,
+        "utf8",
+      );
+      const codexFile = await writeLineageCodexFile(home, {
+        cwd: repoRoot,
+        resumedMultiAgent: true,
+      });
+      const hour = "2025-12-18T00:00:00.000Z";
+      const projectKey = "acme/lineage";
+      const projectRef = "https://github.com/acme/lineage";
+      const inflated = 4_700_000_000;
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+      await fs.writeFile(
+        queuePath,
+        [
+          JSON.stringify({ source: "codex", model: "gpt-5.6", hour_start: hour, total_tokens: inflated }),
+          JSON.stringify({ source: "claude", model: "opus", hour_start: hour, total_tokens: 5000 }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        projectQueuePath,
+        [
+          JSON.stringify({ project_ref: projectRef, project_key: projectKey, source: "codex", hour_start: hour, total_tokens: inflated }),
+          JSON.stringify({ project_ref: projectRef, project_key: projectKey, source: "claude", hour_start: hour, total_tokens: 5000 }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 999 }), "utf8");
+      await fs.writeFile(projectQueueStatePath, JSON.stringify({ offset: 888 }), "utf8");
+
+      const cursors = {
+        hourly: {
+          buckets: {
+            [`codex|gpt-5.6|${hour}`]: { totals: { total_tokens: inflated } },
+            [`claude|opus|${hour}`]: { totals: { total_tokens: 5000 } },
+          },
+          groupQueued: {},
+        },
+        projectHourly: {
+          version: 2,
+          buckets: {
+            [`${projectKey}|codex|${hour}`]: {
+              project_ref: projectRef,
+              project_key: projectKey,
+              source: "codex",
+              hour_start: hour,
+              totals: { total_tokens: inflated },
+            },
+            [`${projectKey}|claude|${hour}`]: {
+              project_ref: projectRef,
+              project_key: projectKey,
+              source: "claude",
+              hour_start: hour,
+              totals: { total_tokens: 5000 },
+            },
+          },
+          projects: { [projectKey]: { projectRef, projectKey, status: "public_verified" } },
+        },
+        files: { [codexFile]: { inode: 1, offset: 5, lastTotal: lineageUsage(inflated) } },
+        codexHashes: ["stale:lineage"],
+        migrations: {},
+      };
+
+      const args = {
+        cursors,
+        queuePath,
+        queueStatePath,
+        projectQueuePath,
+        projectQueueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      };
+      assert.equal(await repairCodexInterleavedUsageInflation(args), true);
+      assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
+      assert.equal(projectBucketTotal(cursors, "codex"), LINEAGE_TRUE_TOTAL);
+      assert.equal(cursors.hourly.buckets[`claude|opus|${hour}`].totals.total_tokens, 5000);
+      assert.equal(projectBucketTotal(cursors, "claude"), 5000);
+
+      const queue = await queueRowsBySource(queuePath);
+      const projectQueue = await queueRowsBySource(projectQueuePath);
+      assert.equal(queue.codex.total, LINEAGE_TRUE_TOTAL);
+      assert.equal(queue.claude.total, 5000);
+      assert.equal(projectQueue.codex.total, LINEAGE_TRUE_TOTAL);
+      assert.equal(projectQueue.claude.total, 5000);
+
+      const uploadState = JSON.parse(await fs.readFile(queueStatePath, "utf8"));
+      const projectUploadState = JSON.parse(await fs.readFile(projectQueueStatePath, "utf8"));
+      assert.equal(uploadState.offset, 0);
+      assert.equal(projectUploadState.offset, 0);
+      assert.equal(uploadState.note, "reset_after_codex_usage_lineage_2026_07");
+      assert.equal(projectUploadState.note, "reset_after_codex_usage_lineage_2026_07");
+      assert.equal(cursors.files[codexFile].tokenUsageBaselines.length, 2);
+      assert.equal(typeof cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY], "string");
+
+      const queueAfterRepair = await fs.readFile(queuePath, "utf8");
+      const projectQueueAfterRepair = await fs.readFile(projectQueuePath, "utf8");
+      assert.equal(await repairCodexInterleavedUsageInflation(args), false);
+      assert.equal(await fs.readFile(queuePath, "utf8"), queueAfterRepair);
+      assert.equal(await fs.readFile(projectQueuePath, "utf8"), projectQueueAfterRepair);
+      assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("defers without mutation when affected history includes an unreproducible session", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeLineageCodexFile(home);
+      const deletedPath = path.join(
+        home,
+        ".codex",
+        "sessions",
+        "2025",
+        "12",
+        "10",
+        "rollout-2025-12-10T00-00-00-99999999-9999-9999-9999-999999999999.jsonl",
+      );
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const originalQueue = JSON.stringify({
+        source: "codex",
+        model: "gpt-5.6",
+        hour_start: "2025-12-18T00:00:00.000Z",
+        total_tokens: 4_700_000_000,
+      }) + "\n";
+      const originalUploadState = JSON.stringify({ offset: 444 });
+      await fs.writeFile(queuePath, originalQueue, "utf8");
+      await fs.writeFile(queueStatePath, originalUploadState, "utf8");
+      const cursors = {
+        hourly: {
+          buckets: {
+            "codex|gpt-5.6|2025-12-18T00:00:00.000Z": {
+              totals: { total_tokens: 4_700_000_000 },
+            },
+          },
+          groupQueued: {},
+        },
+        files: {
+          [codexFile]: { inode: 1, offset: 5 },
+          [deletedPath]: { inode: 2, offset: 5 },
+        },
+        codexHashes: ["keep:lineage"],
+        migrations: {},
+      };
+
+      const ran = await repairCodexInterleavedUsageInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+      assert.equal(ran, false);
+      assert.equal(codexBucketTotal(cursors), 4_700_000_000);
+      assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+      assert.equal(await fs.readFile(queueStatePath, "utf8"), originalUploadState);
+      assert.deepEqual(cursors.codexHashes, ["keep:lineage"]);
+      assert.equal(cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].skipped, true);
+      assert.equal(
+        cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
+        "codex_session_unreproducible",
+      );
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("marks a covered, single-lineage multi-agent history complete without queue mutation", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeLineageCodexFile(home, { interleaved: false });
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const originalQueue = JSON.stringify({
+        source: "codex",
+        model: "gpt-5.6",
+        hour_start: "2025-12-18T00:00:00.000Z",
+        total_tokens: 250,
+      }) + "\n";
+      const originalUploadState = JSON.stringify({ offset: 321 });
+      await fs.writeFile(queuePath, originalQueue, "utf8");
+      await fs.writeFile(queueStatePath, originalUploadState, "utf8");
+      const cursors = {
+        hourly: {
+          buckets: {
+            "codex|gpt-5.6|2025-12-18T00:00:00.000Z": { totals: { total_tokens: 250 } },
+          },
+          groupQueued: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 5 } },
+        codexHashes: ["keep:single"],
+        migrations: {},
+      };
+
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+        }),
+        false,
+      );
+      assert.equal(typeof cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY], "string");
+      assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+      assert.equal(await fs.readFile(queueStatePath, "utf8"), originalUploadState);
+      assert.deepEqual(cursors.codexHashes, ["keep:single"]);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("marks complete without scanning when an earlier guarded repair rebuilt this sync", async () => {
+    const cursors = { migrations: {} };
+    assert.equal(
+      await repairCodexInterleavedUsageInflation({
+        cursors,
+        rolloutFiles: [],
+        legacyRepairRan: true,
+      }),
+      false,
+    );
+    assert.equal(typeof cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY], "string");
+  });
+
+  it("bounds the background lineage scan and leaves an explicit full repair retryable", async () => {
+    await withTempSyncEnv(async (home) => {
+      const codexFile = await writeLineageCodexFile(home, {
+        archived: true,
+        lineagePaddingLines: 40,
+      });
+      const { cursorsPath, queuePath, queueStatePath } =
+        await seedInflatedLineageInstall(home, codexFile);
+
+      await cmdSync(["--auto", "--background", "--all-local-sources"]);
+
+      const bounded = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+      assert.equal(
+        bounded.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
+        "usage_lineage_scan_indeterminate",
+      );
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors: bounded,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+        }),
+        true,
+      );
+      assert.equal(codexBucketTotal(bounded), LINEAGE_TRUE_TOTAL);
+      assert.equal((await queueRowsBySource(queuePath)).codex.total, LINEAGE_TRUE_TOTAL);
+      assert.equal(typeof bounded.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY], "string");
+    });
+  });
+
+  it("keeps background refreshes alive when the one-time repair commit throws", async () => {
+    await withTempSyncEnv(async (home) => {
+      const codexFile = await writeLineageCodexFile(home, {
+        archived: true,
+        resumedMultiAgent: true,
+      });
+      const { cursorsPath, queuePath } = await seedInflatedLineageInstall(home, codexFile);
+      const realRename = fs.rename;
+      let injectedFailure = false;
+      fs.rename = async function failRepairQueueRename(from, to, ...args) {
+        if (
+          !injectedFailure &&
+          String(to) === queuePath &&
+          String(from).startsWith(`${queuePath}.tmp.`)
+        ) {
+          injectedFailure = true;
+          throw new Error("injected repair queue rename failure");
+        }
+        return realRename.call(this, from, to, ...args);
+      };
+      try {
+        await cmdSync(["--auto", "--background", "--all-local-sources"]);
+      } finally {
+        fs.rename = realRename;
+      }
+
+      assert.equal(injectedFailure, true);
+      const persisted = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+      assert.equal(
+        persisted.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
+        "background_repair_requires_full_sync",
+      );
+
+      const archiveRoot = path.join(home, ".codex", "archived_sessions");
+      const realReaddir = fs.readdir;
+      let archiveReads = 0;
+      fs.readdir = async function countedReaddir(target, ...args) {
+        const value = String(target);
+        if (value === archiveRoot || value.startsWith(`${archiveRoot}${path.sep}`)) {
+          archiveReads += 1;
+        }
+        return realReaddir.call(this, target, ...args);
+      };
+      try {
+        await cmdSync(["--auto", "--background", "--all-local-sources"]);
+      } finally {
+        fs.readdir = realReaddir;
+      }
+      assert.equal(archiveReads, 0);
+    });
+  });
+
+  it("repairs an existing native install on its first background sync, then restores lightweight archive scanning", async () => {
+    await withTempSyncEnv(async (home) => {
+      const codexFile = await writeLineageCodexFile(home, {
+        archived: true,
+        resumedMultiAgent: true,
+      });
+      const { cursorsPath, queuePath, queueStatePath } =
+        await seedInflatedLineageInstall(home, codexFile);
+
+      await cmdSync(["--auto", "--background", "--all-local-sources"]);
+
+      const repaired = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+      assert.equal(codexBucketTotal(repaired), LINEAGE_TRUE_TOTAL);
+      assert.equal(
+        typeof repaired.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY],
+        "string",
+      );
+      assert.equal((await queueRowsBySource(queuePath)).codex.total, LINEAGE_TRUE_TOTAL);
+      assert.equal(
+        JSON.parse(await fs.readFile(queueStatePath, "utf8")).note,
+        "reset_after_codex_usage_lineage_2026_07",
+      );
+
+      const archiveRoot = path.join(home, ".codex", "archived_sessions");
+      const realReaddir = fs.readdir;
+      let archiveReads = 0;
+      fs.readdir = async function countedReaddir(target, ...args) {
+        const value = String(target);
+        if (value === archiveRoot || value.startsWith(`${archiveRoot}${path.sep}`)) {
+          archiveReads += 1;
+        }
+        return realReaddir.call(this, target, ...args);
+      };
+      try {
+        await cmdSync(["--auto", "--background", "--all-local-sources"]);
+      } finally {
+        fs.readdir = realReaddir;
+      }
+      assert.equal(archiveReads, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Prevent interleaved Codex `SessionState` cumulative counters from being subtracted across unrelated lineages, and safely rebuild historical Codex usage that was inflated by the old accounting.

## Root cause

Codex rollouts can interleave multiple cumulative counter streams. The parser previously kept one effective baseline, so a snapshot from one lineage could be compared with another lineage's prior total. The resulting near-full snapshot was treated as a delta and repeatedly inflated main usage, project usage, and upload queues.

A read-only replay of an affected local history produced `3,746,522,785` tokens with the legacy accounting and `306,434,755` with lineage-aware accounting.

## What changed

- Track cumulative baselines per lineage and persist at most 32 stream heads for bounded incremental resumes.
- Preserve ordinary single-lineage growth, reset handling, rewrite detection, fork replay handling, and Context breakdown behavior.
- Run a guarded one-time repair on the first desktop background sync after upgrade.
- Cap background lineage inspection at 1 MiB per candidate while leaving explicit full sync unbounded for retry.
- Keep the background refresh running and persist a retry sentinel if the repair commit fails.
- Atomically rebuild only reproducible Codex main/project rows, queues, and cursor state.
- Preserve non-Codex providers and unreproducible history.
- Fail closed without mutation when files are missing, malformed, partially rebuilt, or project coverage is incomplete.
- Reset upload offsets only after a successful rebuild so corrected rows are retried in full.
- Use the existing legacy/v2 cursor-store abstractions.

The steady-state parser only carries a bounded 32-entry lineage map. The heavier repair is one-time; subsequent background syncs return to the existing lightweight scan path.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Verification

| Check | Result |
| --- | --- |
| Codex + Grok parser/repair regression suite | 294/294 passed |
| Full `npm run ci:local` | Passed, including Node suite, copy/locale/UI/guardrail validators, architecture checks, and Dashboard production build |
| Lock waiter regression | 30/30 isolated repetitions passed; also passed in the latest full suite |
| macOS XCTest | 107/107 passed |
| Release build | Official `xcodegen` + icon patch + dual-architecture Release `clean build` passed |
| Release artifacts | App and Embedded Node are both `x86_64 + arm64`; packaged Node is v22.22.2 |
| Package integrity | Source, generated EmbeddedServer, and packaged App SHA-256 match for all four changed runtime modules |
| Dependencies | Root install reports 0 vulnerabilities; no dependency versions changed in this PR |

## Checklist

- [x] `npm test` passes
- [x] No user-facing strings were added
- [x] Commits follow conventional style (`fix:`)
- [x] PR description explains why, not just what

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

- Cumulative deltas are compared only within the same lineage.
- Historical mutation is allowed only when every affected Codex row is reproducible.
- Non-Codex data is preserved byte-for-byte by the repair.
- Any ambiguous or incomplete rebuild fails closed.

### Boundary matrix

| Boundary | Covered behavior |
| --- | --- |
| Interleaved vs single lineage | Separate baselines without changing ordinary cumulative growth |
| Incremental resume vs full replay | Persist bounded stream heads and reproduce the same totals |
| Legacy vs v2 cursor store | Read/write through the existing store abstraction |
| Complete vs missing/malformed history | Atomic rebuild on complete input; zero mutation otherwise |
| Main vs project queues | Rebuild both consistently or skip the repair |

</details>

<details>
<summary><strong>Codex review context</strong></summary>

- **Delta since last Codex review:** Two coherent commits: lineage-aware accounting, then guarded historical repair.
- **Intended behavior / invariants:** Accurate per-lineage deltas; one-time, atomic, reproducibility-gated repair; bounded steady-state state.
- **Edge cases covered:** Interleaving, resets, rewrites, truncation, fork replay, missing files, malformed queue rows, partial project coverage, legacy/v2 stores, idempotency.
- **Tests run (command + result):** Direct parser/repair suite 294/294; full `ci:local` passed; macOS XCTest 107/107; universal Release clean build passed.
- **Known gaps / out of scope:** Deleted/unreproducible Codex history is intentionally not rewritten; the repair remains retryable if evidence later becomes reproducible.

### Most likely regression surface

Codex incremental token deltas and the one-time main/project queue rebuild.

### Verification method

Synthetic lineage fixtures, guarded rebuild integration tests, read-only affected-history replay, full repository CI, macOS tests, and release-package integrity checks.

### Uncovered scope

No cloud backend, auth, Dashboard UI, or Windows UI behavior changes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inflated Codex usage totals caused by interleaved multi-agent session history.
  * Improved token-usage reconciliation for incremental and resumed syncs to keep totals/message counts consistent and avoid re-counting duplicate/regressed snapshots.
  * Added a one-time Codex “usage lineage” repair flow that safely handles incomplete/indeterminate history and supports later retries.

* **Tests**
  * Added coverage for interleaved usage accounting, incremental resume correctness, and repair idempotency/retry behavior in both full and background sync scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->