### PR TITLE
feat(grok): context breakdown + Sessions tab support

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -828,6 +828,10 @@ settings.appearance.language.traditional_chinese,ui,SettingsPage,SettingsPage,la
 settings.appearance.language.japanese,ui,SettingsPage,SettingsPage,language_japanese,Japanese,,active
 settings.appearance.language.korean,ui,SettingsPage,SettingsPage,language_korean,Korean,,active
 settings.appearance.language.german,ui,SettingsPage,SettingsPage,language_german,German,,active
+dashboard.context_breakdown.heading,dashboard,DashboardPage,UsageOverview,heading,"Context Breakdown",,active
+dashboard.context_breakdown.heading_claude,dashboard,DashboardPage,UsageOverview,heading_claude,"Claude Context Breakdown",,active
+dashboard.context_breakdown.heading_codex,dashboard,DashboardPage,UsageOverview,heading_codex,"Codex Context Breakdown",,active
+dashboard.context_breakdown.heading_grok,dashboard,DashboardPage,UsageOverview,heading_grok,"Grok Context Breakdown",,active
 dashboard.context_breakdown.empty,dashboard,DashboardPage,ContextBreakdownPanel,empty,"No Claude Code activity in the selected period.",,active
 dashboard.context_breakdown.empty_codex,dashboard,DashboardPage,ContextBreakdownPanel,empty_codex,"No Codex activity in the selected period.",,active
 dashboard.context_breakdown.error,dashboard,DashboardPage,ContextBreakdownPanel,error,"Couldn't read Claude Code logs for this view.",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -836,6 +836,9 @@ dashboard.context_breakdown.bar_aria,dashboard,DashboardPage,ContextBreakdownPan
 dashboard.context_breakdown.system_prefix_tooltip,dashboard,DashboardPage,ContextBreakdownPanel,tooltip,"System prompt, tools schema, skills, rules, and MCP descriptions are cached together as one prefix and can't be separated from the logs.",,active
 dashboard.context_breakdown.footnote,dashboard,DashboardPage,ContextBreakdownPanel,footnote,"Approximate: cache reads accumulate across turns, so conversation history dominates over time. Only Claude Code logs expose the per-message detail this view requires.",,active
 dashboard.context_breakdown.footnote_codex,dashboard,DashboardPage,ContextBreakdownPanel,footnote_codex,"Codex uses non-overlapping token buckets here. Tool and exec drill-downs are separate heuristic attributions over the same turns.",,active
+dashboard.context_breakdown.empty_grok,dashboard,DashboardPage,ContextBreakdownPanel,empty_grok,"No Grok Build activity in the selected period.",,active
+dashboard.context_breakdown.error_grok,dashboard,DashboardPage,ContextBreakdownPanel,error_grok,"Couldn't read Grok Build logs for this view.",,active
+dashboard.context_breakdown.footnote_grok,dashboard,DashboardPage,ContextBreakdownPanel,footnote_grok,"Grok uses non-overlapping token buckets here. Tool and exec drill-downs are separate heuristic attributions over the same turns, using turn_completed.usage as the authoritative total.",,active
 dashboard.context_breakdown.category.system_prompt,dashboard,DashboardPage,ContextBreakdownPanel,cat,"System prompt",,active
 dashboard.context_breakdown.category.messages,dashboard,DashboardPage,ContextBreakdownPanel,cat,"Messages",,active
 dashboard.context_breakdown.category.tool_calls,dashboard,DashboardPage,ContextBreakdownPanel,cat,"Tool calls",,active

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -452,5 +452,8 @@
   "achievements.signin.action": "Anmelden",
   "achievements.scope.local": "Lokal",
   "achievements.page.suggest": "Eine Idee für ein neues Abzeichen?",
-  "achievements.page.suggest_link": "Auf GitHub vorschlagen"
+  "achievements.page.suggest_link": "Auf GitHub vorschlagen",
+  "dashboard.context_breakdown.empty_grok": "Keine Grok-Build-Aktivität im ausgewählten Zeitraum.",
+  "dashboard.context_breakdown.error_grok": "Grok-Build-Logs für diese Ansicht konnten nicht gelesen werden.",
+  "dashboard.context_breakdown.footnote_grok": "Grok nutzt hier nicht-überlappende Token-Buckets. Tool- und Exec-Details sind separate heuristische Zuordnungen über dieselben Turns, mit turn_completed.usage als autoritativer Gesamtsumme."
 }

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -455,5 +455,9 @@
   "achievements.page.suggest_link": "Auf GitHub vorschlagen",
   "dashboard.context_breakdown.empty_grok": "Keine Grok-Build-Aktivität im ausgewählten Zeitraum.",
   "dashboard.context_breakdown.error_grok": "Grok-Build-Logs für diese Ansicht konnten nicht gelesen werden.",
-  "dashboard.context_breakdown.footnote_grok": "Grok nutzt hier nicht-überlappende Token-Buckets. Tool- und Exec-Details sind separate heuristische Zuordnungen über dieselben Turns, mit turn_completed.usage als autoritativer Gesamtsumme."
+  "dashboard.context_breakdown.footnote_grok": "Grok nutzt hier nicht-überlappende Token-Buckets. Tool- und Exec-Details sind separate heuristische Zuordnungen über dieselben Turns, mit turn_completed.usage als autoritativer Gesamtsumme.",
+  "dashboard.context_breakdown.heading": "Kontextaufschlüsselung",
+  "dashboard.context_breakdown.heading_claude": "Claude Kontextaufschlüsselung",
+  "dashboard.context_breakdown.heading_codex": "Codex Kontextaufschlüsselung",
+  "dashboard.context_breakdown.heading_grok": "Grok Kontextaufschlüsselung"
 }

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -444,5 +444,9 @@
   "achievements.page.suggest_link": "GitHub で提案する",
   "dashboard.context_breakdown.empty_grok": "選択した期間に Grok Build のアクティビティがありません。",
   "dashboard.context_breakdown.error_grok": "このビューに必要な Grok Build ログを読み取れませんでした。",
-  "dashboard.context_breakdown.footnote_grok": "Grok では重複しないトークン区分を使います。ツールと exec の詳細は同一ターンへのヒューリスティックな帰属で、turn_completed.usage を正とします。"
+  "dashboard.context_breakdown.footnote_grok": "Grok では重複しないトークン区分を使います。ツールと exec の詳細は同一ターンへのヒューリスティックな帰属で、turn_completed.usage を正とします。",
+  "dashboard.context_breakdown.heading": "コンテキスト内訳",
+  "dashboard.context_breakdown.heading_claude": "Claude コンテキスト内訳",
+  "dashboard.context_breakdown.heading_codex": "Codex コンテキスト内訳",
+  "dashboard.context_breakdown.heading_grok": "Grok コンテキスト内訳"
 }

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -441,5 +441,8 @@
   "achievements.signin.action": "サインイン",
   "achievements.scope.local": "ローカル",
   "achievements.page.suggest": "新しいバッジのアイデアがある?",
-  "achievements.page.suggest_link": "GitHub で提案する"
+  "achievements.page.suggest_link": "GitHub で提案する",
+  "dashboard.context_breakdown.empty_grok": "選択した期間に Grok Build のアクティビティがありません。",
+  "dashboard.context_breakdown.error_grok": "このビューに必要な Grok Build ログを読み取れませんでした。",
+  "dashboard.context_breakdown.footnote_grok": "Grok では重複しないトークン区分を使います。ツールと exec の詳細は同一ターンへのヒューリスティックな帰属で、turn_completed.usage を正とします。"
 }

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -441,5 +441,8 @@
   "achievements.signin.action": "로그인",
   "achievements.scope.local": "로컬",
   "achievements.page.suggest": "새 배지 아이디어가 있나요?",
-  "achievements.page.suggest_link": "GitHub에서 제안하기"
+  "achievements.page.suggest_link": "GitHub에서 제안하기",
+  "dashboard.context_breakdown.empty_grok": "선택한 기간에 Grok Build 활동이 없습니다.",
+  "dashboard.context_breakdown.error_grok": "이 보기에 필요한 Grok Build 로그를 읽을 수 없습니다.",
+  "dashboard.context_breakdown.footnote_grok": "Grok는 겹치지 않는 토큰 버킷을 사용합니다. 도구/실행 드릴다운은 동일 턴에 대한 휴리스틱 귀속이며 turn_completed.usage를 기준으로 합니다."
 }

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -444,5 +444,9 @@
   "achievements.page.suggest_link": "GitHub에서 제안하기",
   "dashboard.context_breakdown.empty_grok": "선택한 기간에 Grok Build 활동이 없습니다.",
   "dashboard.context_breakdown.error_grok": "이 보기에 필요한 Grok Build 로그를 읽을 수 없습니다.",
-  "dashboard.context_breakdown.footnote_grok": "Grok는 겹치지 않는 토큰 버킷을 사용합니다. 도구/실행 드릴다운은 동일 턴에 대한 휴리스틱 귀속이며 turn_completed.usage를 기준으로 합니다."
+  "dashboard.context_breakdown.footnote_grok": "Grok는 겹치지 않는 토큰 버킷을 사용합니다. 도구/실행 드릴다운은 동일 턴에 대한 휴리스틱 귀속이며 turn_completed.usage를 기준으로 합니다.",
+  "dashboard.context_breakdown.heading": "컨텍스트 분석",
+  "dashboard.context_breakdown.heading_claude": "Claude 컨텍스트 분석",
+  "dashboard.context_breakdown.heading_codex": "Codex 컨텍스트 분석",
+  "dashboard.context_breakdown.heading_grok": "Grok 컨텍스트 분석"
 }

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -595,5 +595,8 @@
   "wrapped.highlight.day": "最忙碌的一天是 {{day}}（{{tokens}} Token）。",
   "wrapped.highlight.hour": "你的高效時段集中在 UTC {{hour}}:00 左右。",
   "wrapped.highlight.streak": "最長連續活躍：連續 {{days}} 天使用 AI 編碼。",
-  "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉獵廣泛。"
+  "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉獵廣泛。",
+  "dashboard.context_breakdown.empty_grok": "所選時間範圍內沒有 Grok Build 活動。",
+  "dashboard.context_breakdown.error_grok": "無法讀取此檢視所需的 Grok Build 日誌。",
+  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重疊的 Token 分類。工具和命令執行下鑽資料，是對同一批對話輪次進行的獨立啟發式歸因，以 turn_completed.usage 為權威總量。"
 }

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -598,5 +598,9 @@
   "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉獵廣泛。",
   "dashboard.context_breakdown.empty_grok": "所選時間範圍內沒有 Grok Build 活動。",
   "dashboard.context_breakdown.error_grok": "無法讀取此檢視所需的 Grok Build 日誌。",
-  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重疊的 Token 分類。工具和命令執行下鑽資料，是對同一批對話輪次進行的獨立啟發式歸因，以 turn_completed.usage 為權威總量。"
+  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重疊的 Token 分類。工具和命令執行下鑽資料，是對同一批對話輪次進行的獨立啟發式歸因，以 turn_completed.usage 為權威總量。",
+  "dashboard.context_breakdown.heading": "上下文細分",
+  "dashboard.context_breakdown.heading_claude": "Claude 上下文細分",
+  "dashboard.context_breakdown.heading_codex": "Codex 上下文細分",
+  "dashboard.context_breakdown.heading_grok": "Grok 上下文細分"
 }

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -539,5 +539,9 @@
   "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉猎广泛。",
   "dashboard.context_breakdown.empty_grok": "所选时间段内没有 Grok Build 活动。",
   "dashboard.context_breakdown.error_grok": "无法读取此视图所需的 Grok Build 日志。",
-  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重叠的 Token 分类。工具和命令执行下钻数据，是对同一批对话轮次进行的独立启发式归因，以 turn_completed.usage 为权威总量。"
+  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重叠的 Token 分类。工具和命令执行下钻数据，是对同一批对话轮次进行的独立启发式归因，以 turn_completed.usage 为权威总量。",
+  "dashboard.context_breakdown.heading": "上下文细分",
+  "dashboard.context_breakdown.heading_claude": "Claude 上下文细分",
+  "dashboard.context_breakdown.heading_codex": "Codex 上下文细分",
+  "dashboard.context_breakdown.heading_grok": "Grok 上下文细分"
 }

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -536,5 +536,8 @@
   "wrapped.highlight.day": "最忙碌的一天是 {{day}}（{{tokens}} Token）。",
   "wrapped.highlight.hour": "你的高效时段集中在 UTC {{hour}}:00 左右。",
   "wrapped.highlight.streak": "最长连续活跃：连续 {{days}} 天使用 AI 编程。",
-  "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉猎广泛。"
+  "wrapped.highlight.tools": "你使用了 {{count}} 款不同的 AI 工具，涉猎广泛。",
+  "dashboard.context_breakdown.empty_grok": "所选时间段内没有 Grok Build 活动。",
+  "dashboard.context_breakdown.error_grok": "无法读取此视图所需的 Grok Build 日志。",
+  "dashboard.context_breakdown.footnote_grok": "Grok 在此使用互不重叠的 Token 分类。工具和命令执行下钻数据，是对同一批对话轮次进行的独立启发式归因，以 turn_completed.usage 为权威总量。"
 }

--- a/dashboard/src/lib/sessions-api.ts
+++ b/dashboard/src/lib/sessions-api.ts
@@ -5,7 +5,7 @@ import { copy } from "./copy";
 
 const SLUG = "tokentracker-sessions";
 
-export type SessionSource = "claude" | "codex";
+export type SessionSource = "claude" | "codex" | "grok";
 
 export interface SessionRow {
   session_hash: string;

--- a/dashboard/src/pages/SessionsPage.jsx
+++ b/dashboard/src/pages/SessionsPage.jsx
@@ -31,6 +31,7 @@ const SOURCE_FILTERS = [
   { id: "all", label: () => copy("sessions.filter.source_all") },
   { id: "claude", label: () => "Claude Code" },
   { id: "codex", label: () => "Codex" },
+  { id: "grok", label: () => "Grok" },
 ];
 
 const DATE_RANGES = [
@@ -375,7 +376,7 @@ export function SessionsPage() {
 
   const truncated = Number(data?.session_count) > Number(data?.returned_count);
 
-  // Sessions read local Claude/Codex logs from the machine running the CLI;
+  // Sessions read local Claude/Codex/Grok logs from the machine running the CLI;
   // there is no cloud source. On the deployed web app, surface the local-only
   // notice instead of an empty list.
   if (!IS_LOCAL_HOST && !isMockEnabled()) {

--- a/dashboard/src/pages/SessionsPage.test.jsx
+++ b/dashboard/src/pages/SessionsPage.test.jsx
@@ -29,8 +29,8 @@ const response = {
   from: "",
   to: "",
   available: true,
-  session_count: 2,
-  returned_count: 2,
+  session_count: 3,
+  returned_count: 3,
   sessions: [
     {
       session_hash: "claude-row",
@@ -74,6 +74,27 @@ const response = {
       first_pass: false,
       resume_command: "codex resume aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
     },
+    {
+      session_hash: "grok-row",
+      session_id: "019f740c-e792-7fb1-a218-59ea1b340714",
+      title: "Debug local proxy",
+      source: "grok",
+      project_key: "alphafox-web",
+      project_ref: "/work/alphafox-web",
+      model: "grok-4.5-build-free",
+      started_at: "2026-07-22T08:00:00Z",
+      ended_at: "2026-07-22T08:15:00Z",
+      duration_ms: 900_000,
+      turns: 3,
+      edit_turns: 1,
+      retry_turns: 0,
+      subagent_calls: 0,
+      total_tokens: 21_000,
+      cost_usd: 0,
+      productive: true,
+      first_pass: true,
+      resume_command: "grok --resume 019f740c-e792-7fb1-a218-59ea1b340714",
+    },
   ],
 };
 
@@ -89,6 +110,7 @@ describe("SessionsPage", () => {
 
     expect(await screen.findByText("Fix authentication flow")).toBeInTheDocument();
     expect(screen.getByText("Review release")).toBeInTheDocument();
+    expect(screen.getByText("Debug local proxy")).toBeInTheDocument();
     // The whole list is fetched once; no row cap and no server-side window.
     expect(getSessions).toHaveBeenCalledWith({ refresh: false });
 
@@ -96,6 +118,11 @@ describe("SessionsPage", () => {
     fireEvent.click(sourceTabs.getByRole("tab", { name: "Codex" }));
     expect(screen.queryByText("Fix authentication flow")).not.toBeInTheDocument();
     expect(screen.getByText("Review release")).toBeInTheDocument();
+    expect(screen.queryByText("Debug local proxy")).not.toBeInTheDocument();
+
+    fireEvent.click(sourceTabs.getByRole("tab", { name: "Grok" }));
+    expect(screen.queryByText("Review release")).not.toBeInTheDocument();
+    expect(screen.getByText("Debug local proxy")).toBeInTheDocument();
 
     fireEvent.click(sourceTabs.getByRole("tab", { name: "All" }));
     fireEvent.change(screen.getByRole("searchbox", { name: "Search sessions" }), {
@@ -103,6 +130,7 @@ describe("SessionsPage", () => {
     });
     expect(screen.getByText("Fix authentication flow")).toBeInTheDocument();
     expect(screen.queryByText("Review release")).not.toBeInTheDocument();
+    expect(screen.queryByText("Debug local proxy")).not.toBeInTheDocument();
   });
 
   it("filters the date range client-side without re-querying", async () => {

--- a/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
@@ -22,6 +22,7 @@ import { oklchColor } from "../../../lib/oklch-fallback";
 const SOURCE_HUE = {
   claude: 35, // orange (was 290 violet)
   codex: 250, // blue (was 165 emerald)
+  grok: 200, // cyan/teal for xAI Grok
 };
 
 // OKLCH ramp per bucket key. We vary chroma + lightness within the hue so
@@ -371,15 +372,21 @@ function isExecToolName(name) {
 }
 
 function sourceEmptyCopyKey(source) {
-  return source === "codex" ? "dashboard.context_breakdown.empty_codex" : "dashboard.context_breakdown.empty";
+  if (source === "codex") return "dashboard.context_breakdown.empty_codex";
+  if (source === "grok") return "dashboard.context_breakdown.empty_grok";
+  return "dashboard.context_breakdown.empty";
 }
 
 function sourceErrorCopyKey(source) {
-  return source === "codex" ? "dashboard.context_breakdown.error_codex" : "dashboard.context_breakdown.error";
+  if (source === "codex") return "dashboard.context_breakdown.error_codex";
+  if (source === "grok") return "dashboard.context_breakdown.error_grok";
+  return "dashboard.context_breakdown.error";
 }
 
 function sourceFootnoteCopyKey(source) {
-  return source === "codex" ? "dashboard.context_breakdown.footnote_codex" : "dashboard.context_breakdown.footnote";
+  if (source === "codex") return "dashboard.context_breakdown.footnote_codex";
+  if (source === "grok") return "dashboard.context_breakdown.footnote_grok";
+  return "dashboard.context_breakdown.footnote";
 }
 
 // Row — unified grid-aligned row primitive used at every level of the panel.
@@ -510,7 +517,7 @@ function ExecDrillDown({ execDetails, source = "claude" }) {
   const { formatTokens } = useTokenFormat();
   const [activeTab, setActiveTab] = useState("by_type");
   const rows = normalizeExecRows(selectedExecRows(execDetails, activeTab));
-  const showRuntime = source === "codex";
+  const showRuntime = source === "codex" || source === "grok";
   const gridCols = showRuntime
     ? "grid-cols-[minmax(0,1fr)_48px_48px_72px_72px_60px_60px]"
     : "grid-cols-[minmax(0,1fr)_56px_60px]";
@@ -761,7 +768,7 @@ export function ContextBreakdownPanel({ from, to, source = "claude", referenceTo
   const categories =
     source === "claude"
       ? buildDisplayCategories(data.categories || [], referenceTotalTokens)
-      : buildCodexDisplayCategories(data, referenceTotalTokens);
+      : buildCodexDisplayCategories(data, referenceTotalTokens); // codex + grok
   const toolDetails = data.tool_calls_breakdown || null;
   const skillsDetails = data.skills_breakdown || null;
   const messageDetails = data.message_breakdown || null;

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -101,10 +101,10 @@ function resolveContextBreakdownSource(provider) {
 }
 
 function contextBreakdownHeading(source) {
-  if (source === "claude") return "Claude Context Breakdown";
-  if (source === "codex") return "Codex Context Breakdown";
-  if (source === "grok") return "Grok Context Breakdown";
-  return "Context Breakdown";
+  if (source === "claude") return copy("dashboard.context_breakdown.heading_claude");
+  if (source === "codex") return copy("dashboard.context_breakdown.heading_codex");
+  if (source === "grok") return copy("dashboard.context_breakdown.heading_grok");
+  return copy("dashboard.context_breakdown.heading");
 }
 
 function hasProviderModels(provider) {
@@ -614,9 +614,9 @@ export function UsageOverview({
                   .map((provider) => {
                     const color = getProviderColor(provider.label, 0);
                     const contextSource = resolveContextBreakdownSource(provider);
-                    const sortedModels = [...provider.models].sort(
-                      (a, b) => (b.share || 0) - (a.share || 0)
-                    );
+                    const sortedModels = [...provider.models].sort((a, b) => {
+                      return (b.share || 0) - (a.share || 0);
+                    });
 
                     const providerHeading = contextSource
                       ? contextBreakdownHeading(contextSource)

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -96,7 +96,15 @@ function resolveContextBreakdownSource(provider) {
   const label = String(provider?.label || "").trim().toLowerCase();
   if (source === "claude" || label === "claude") return "claude";
   if (source === "codex" || label === "codex") return "codex";
+  if (source === "grok" || label === "grok" || label.includes("grok")) return "grok";
   return null;
+}
+
+function contextBreakdownHeading(source) {
+  if (source === "claude") return "Claude Context Breakdown";
+  if (source === "codex") return "Codex Context Breakdown";
+  if (source === "grok") return "Grok Context Breakdown";
+  return "Context Breakdown";
 }
 
 function hasProviderModels(provider) {
@@ -611,7 +619,7 @@ export function UsageOverview({
                     );
 
                     const providerHeading = contextSource
-                      ? `${contextSource === "claude" ? "Claude" : "Codex"} Context Breakdown`
+                      ? contextBreakdownHeading(contextSource)
                       : formatProviderDisplayName(provider.label);
                     return (
                       <ProviderExpandedSection

--- a/src/lib/grok-context-breakdown.js
+++ b/src/lib/grok-context-breakdown.js
@@ -588,7 +588,7 @@ async function computeGrokContextBreakdown({
   const limitedTop = Number.isFinite(top) && top > 0 ? Math.min(Math.floor(top), 200) : 50;
   const sessions = discoverGrokSessionFiles(env);
   const inventorySig = crypto
-    .createHash("sha1")
+    .createHash("sha256")
     .update(
       sessions
         .map((s) => `${s.updatesPath}:${s.size}:${Math.floor(s.mtimeMs)}`)

--- a/src/lib/grok-context-breakdown.js
+++ b/src/lib/grok-context-breakdown.js
@@ -1,0 +1,792 @@
+// Grok Build "Context Breakdown" — Codex-style tool-oriented view.
+//
+// Privacy: tokens + timestamps + tool names only. Never return prompt text,
+// assistant text, tool arguments, or file contents.
+//
+// Data source: ~/.grok/sessions/**/updates.jsonl
+// Authoritative billable totals come from turn_completed.usage. Tool/exec
+// attribution is heuristic: the turn's non-reasoning tokens are split evenly
+// across tools observed in that turn (same approach as Codex).
+
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const {
+  emptyTotals,
+  addInto,
+  roundTotals,
+  buildExecStatsEntry,
+  categorizeTool,
+  inferExecCommandKind,
+  sanitizeCommandSignature,
+  getExecutableName,
+} = require("./categorizer-utils");
+
+const CACHE_SCHEMA_VERSION = "grok-context-v1";
+const CACHE = new Map();
+const CACHE_TTL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+function dayKeyToIsoBounds(from, to) {
+  if (!from && !to) return { fromIso: null, toIso: null };
+  const fromDate = from ? new Date(`${from}T00:00:00Z`) : null;
+  const toDate = to ? new Date(`${to}T23:59:59Z`) : null;
+  if (fromDate && Number.isFinite(fromDate.getTime())) {
+    fromDate.setUTCHours(fromDate.getUTCHours() - 14);
+  }
+  if (toDate && Number.isFinite(toDate.getTime())) {
+    toDate.setUTCHours(toDate.getUTCHours() + 14);
+  }
+  return {
+    fromIso: fromDate ? fromDate.toISOString() : null,
+    toIso: toDate ? toDate.toISOString() : null,
+  };
+}
+
+function timestampToIso(value) {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) return null;
+    const millis = value < 10_000_000_000 ? value * 1000 : value;
+    const dt = new Date(millis);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^[0-9]+(?:\.[0-9]+)?$/.test(trimmed)) return timestampToIso(Number(trimmed));
+    const dt = new Date(trimmed);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  return null;
+}
+
+function dayKeyFromIso(iso, timeZoneContext) {
+  if (!iso) return "";
+  const { timeZone, offsetMinutes } = timeZoneContext || {};
+  const dt = new Date(iso);
+  if (!Number.isFinite(dt.getTime())) return iso.slice(0, 10);
+
+  if (timeZone && typeof Intl !== "undefined" && Intl.DateTimeFormat) {
+    try {
+      const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hourCycle: "h23",
+      }).formatToParts(dt);
+      const values = {};
+      for (const part of parts) {
+        if (part.type !== "literal") values[part.type] = part.value;
+      }
+      if (values.year && values.month && values.day) {
+        return `${values.year}-${values.month}-${values.day}`;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (Number.isFinite(offsetMinutes)) {
+    const shifted = new Date(dt.getTime() - Number(offsetMinutes) * 60_000);
+    return `${String(shifted.getUTCFullYear()).padStart(4, "0")}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}-${String(shifted.getUTCDate()).padStart(2, "0")}`;
+  }
+  return iso.slice(0, 10);
+}
+
+function isIsoInRange(iso, { from, to, timeZoneContext } = {}) {
+  if (!from && !to) return true;
+  const day = dayKeyFromIso(iso, timeZoneContext);
+  if (!day) return false;
+  if (from && day < from) return false;
+  if (to && day > to) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Grok path discovery
+// ---------------------------------------------------------------------------
+
+function resolveGrokHome(env = process.env) {
+  if (env.TOKENTRACKER_GROK_HOME) return env.TOKENTRACKER_GROK_HOME;
+  if (env.GROK_HOME) return env.GROK_HOME;
+  return path.join(os.homedir(), ".grok");
+}
+
+function discoverGrokSessionFiles(env = process.env) {
+  const home = resolveGrokHome(env);
+  const sessionsRoot = path.join(home, "sessions");
+  if (!fs.existsSync(sessionsRoot)) return [];
+
+  const out = [];
+  let cwdDirs = [];
+  try {
+    cwdDirs = fs.readdirSync(sessionsRoot);
+  } catch {
+    return [];
+  }
+
+  for (const cwdDir of cwdDirs) {
+    const cwdPath = path.join(sessionsRoot, cwdDir);
+    let st;
+    try {
+      st = fs.statSync(cwdPath);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+
+    let sessionIds = [];
+    try {
+      sessionIds = fs.readdirSync(cwdPath);
+    } catch {
+      continue;
+    }
+
+    for (const sid of sessionIds) {
+      const sessionDir = path.join(cwdPath, sid);
+      const updatesPath = path.join(sessionDir, "updates.jsonl");
+      let ust;
+      try {
+        ust = fs.statSync(updatesPath);
+      } catch {
+        continue;
+      }
+      if (!ust.isFile() || ust.size <= 0) continue;
+      out.push({
+        sessionId: sid,
+        sessionDir,
+        updatesPath,
+        mtimeMs: ust.mtimeMs,
+        size: ust.size,
+      });
+    }
+  }
+  out.sort((a, b) => a.updatesPath.localeCompare(b.updatesPath));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tool / exec naming
+// ---------------------------------------------------------------------------
+
+function mapGrokToolName(rawName) {
+  const name = String(rawName || "").trim();
+  if (!name) return "unknown";
+  const lower = name.toLowerCase();
+  if (lower === "read_file" || lower === "read") return "Read";
+  if (lower === "write" || lower === "write_file") return "Write";
+  if (lower === "search_replace" || lower === "str_replace" || lower === "edit") return "Edit";
+  if (lower === "grep") return "Grep";
+  if (lower === "list_dir" || lower === "glob" || lower === "find") return "Glob";
+  if (lower === "run_terminal_command" || lower === "bash" || lower === "shell") return "Bash";
+  if (lower === "todo_write" || lower === "todowrite") return "TodoWrite";
+  if (lower === "web_search" || lower === "websearch") return "WebSearch";
+  if (lower === "web_fetch" || lower === "webfetch") return "WebFetch";
+  if (lower.startsWith("mcp_") || lower.startsWith("mcp-")) {
+    return name.replace(/^mcp[_-]/i, "mcp__").replace(/-/g, "_");
+  }
+  return name;
+}
+
+function extractToolName(update, meta) {
+  const fromMetaTool =
+    update?._meta?.["x.ai/tool"]?.name ||
+    update?._meta?.["x.ai/tool"]?.label ||
+    null;
+  const fromUpdateParams = meta?.updateParams?.title || meta?.updateParams?.name || null;
+  const fromUpdate = update?.title || update?.name || null;
+  return mapGrokToolName(fromMetaTool || fromUpdateParams || fromUpdate || "unknown");
+}
+
+function extractExecCommand(update) {
+  const raw = update?.rawInput;
+  if (!raw || typeof raw !== "object") return null;
+  const command =
+    typeof raw.command === "string"
+      ? raw.command
+      : typeof raw.cmd === "string"
+        ? raw.cmd
+        : null;
+  if (!command || !command.trim()) return null;
+  return command.trim();
+}
+
+function durationBucket(ms) {
+  const n = Number(ms || 0);
+  if (n < 100) return "<100ms";
+  if (n < 500) return "100-500ms";
+  if (n < 2000) return "0.5-2s";
+  if (n < 10000) return "2-10s";
+  if (n < 60000) return "10-60s";
+  return ">=60s";
+}
+
+function outputSizeBucket(lines, chars) {
+  if (lines >= 500 || chars >= 50_000) return "huge";
+  if (lines >= 100 || chars >= 10_000) return "large";
+  if (lines >= 20 || chars >= 2_000) return "medium";
+  if (lines > 0 || chars > 0) return "small";
+  return "empty";
+}
+
+function readUsageTotals(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const inputRaw = Math.max(0, Number(usage.inputTokens ?? usage.input_tokens ?? 0) || 0);
+  const cached = Math.max(
+    0,
+    Number(usage.cachedReadTokens ?? usage.cache_read_input_tokens ?? usage.cached_input_tokens ?? 0) || 0,
+  );
+  const output = Math.max(0, Number(usage.outputTokens ?? usage.output_tokens ?? 0) || 0);
+  const reasoning = Math.max(
+    0,
+    Number(usage.reasoningTokens ?? usage.reasoning_output_tokens ?? 0) || 0,
+  );
+  const nonCachedInput = Math.max(0, inputRaw - cached);
+  let total = Math.max(0, Number(usage.totalTokens ?? usage.total_tokens ?? 0) || 0);
+  if (total <= 0) total = nonCachedInput + cached + output;
+  if (total <= 0) return null;
+  return {
+    input_tokens: nonCachedInput,
+    cached_input_tokens: cached,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: reasoning,
+    total_tokens: total,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-session parse
+// ---------------------------------------------------------------------------
+
+function ensureTool(map, name) {
+  if (!map.has(name)) map.set(name, { name, raw_name: name, calls: 0, totals: emptyTotals() });
+  return map.get(name);
+}
+
+function ensureExec(map, key) {
+  if (!map.has(key)) map.set(key, { name: key, ...buildExecStatsEntry() });
+  return map.get(key);
+}
+
+function absorbExecStats(map, key, details) {
+  const row = ensureExec(map, key);
+  row.calls += 1;
+  row.duration_ms += details.dur;
+  row.max_duration_ms = Math.max(row.max_duration_ms, details.dur);
+  row.output_chars += details.outputChars;
+  row.output_lines += details.outputLines;
+  if (details.failed) row.failures += 1;
+}
+
+function finalizeToolRows(map) {
+  return Array.from(map.values())
+    .map((row) => ({
+      name: row.name,
+      raw_name: row.raw_name || row.name,
+      calls: row.calls,
+      totals: roundTotals(row.totals),
+    }))
+    .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
+}
+
+function finalizeExecRows(map) {
+  return Array.from(map.values())
+    .map((row) => ({
+      name: row.name,
+      calls: row.calls,
+      failures: row.failures,
+      duration_ms: row.duration_ms,
+      max_duration_ms: row.max_duration_ms,
+      output_chars: row.output_chars,
+      output_lines: row.output_lines,
+      totals: roundTotals(row.totals),
+    }))
+    .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
+}
+
+async function parseGrokUpdatesFile(updatesPath, { from, to, timeZoneContext } = {}) {
+  const byTool = new Map();
+  const byExecKind = new Map();
+  const byExecExit = new Map();
+  const byExecExecutable = new Map();
+  const byExecCommand = new Map();
+  const byExecDuration = new Map();
+  const byExecOutput = new Map();
+  const totals = emptyTotals();
+  let turnCount = 0;
+
+  // promptId -> { tools: string[], execs: details[], sawThought: bool }
+  const turns = new Map();
+
+  function getTurn(key) {
+    if (!turns.has(key)) {
+      turns.set(key, { tools: [], execs: [], sawThought: false, sawMessage: false });
+    }
+    return turns.get(key);
+  }
+
+  function buildExecDetails(command, status) {
+    const kind = inferExecCommandKind(command);
+    const failed = String(status || "").toLowerCase() === "failed" || String(status || "").toLowerCase() === "error";
+    return {
+      kind,
+      exitKey: failed ? "failed:unknown" : "completed:0",
+      executable: getExecutableName(command),
+      command: sanitizeCommandSignature(command),
+      duration: durationBucket(0),
+      output: outputSizeBucket(0, 0),
+      dur: 0,
+      outputChars: 0,
+      outputLines: 0,
+      failed,
+    };
+  }
+
+  function attributeTurn(delta, turnState) {
+    if (!delta || delta.total_tokens <= 0) return;
+    turnCount += 1;
+
+    const uniqueTools = [...new Set((turnState?.tools || []).filter(Boolean))];
+    const tools = uniqueTools.length > 0 ? uniqueTools : ["text_response"];
+    const share = 1 / tools.length;
+
+    for (const name of tools) {
+      const row = ensureTool(byTool, name);
+      row.calls += share;
+      addInto(row.totals, {
+        input_tokens: delta.input_tokens * share,
+        cached_input_tokens: delta.cached_input_tokens * share,
+        cache_creation_input_tokens: delta.cache_creation_input_tokens * share,
+        output_tokens: delta.output_tokens * share,
+        reasoning_output_tokens: delta.reasoning_output_tokens * share,
+        total_tokens: delta.total_tokens * share,
+      });
+    }
+
+    // Prefer Bash bucket share when present (Codex attaches exec tokens only to
+    // the shell tool's fraction of the turn).
+    const bashShare = tools.includes("Bash") ? share : 0;
+    const execDelta =
+      bashShare > 0
+        ? {
+            input_tokens: delta.input_tokens * bashShare,
+            cached_input_tokens: delta.cached_input_tokens * bashShare,
+            cache_creation_input_tokens: delta.cache_creation_input_tokens * bashShare,
+            output_tokens: delta.output_tokens * bashShare,
+            reasoning_output_tokens: delta.reasoning_output_tokens * bashShare,
+            total_tokens: delta.total_tokens * bashShare,
+          }
+        : null;
+
+    const pendingExecDetails = turnState?.execs || [];
+    if (execDelta && pendingExecDetails.length > 0) {
+      const per = 1 / pendingExecDetails.length;
+      for (const details of pendingExecDetails) {
+        const attributed = {
+          input_tokens: execDelta.input_tokens * per,
+          cached_input_tokens: execDelta.cached_input_tokens * per,
+          cache_creation_input_tokens: execDelta.cache_creation_input_tokens * per,
+          output_tokens: execDelta.output_tokens * per,
+          reasoning_output_tokens: execDelta.reasoning_output_tokens * per,
+          total_tokens: execDelta.total_tokens * per,
+        };
+        addInto(ensureExec(byExecKind, details.kind).totals, attributed);
+        addInto(ensureExec(byExecExit, details.exitKey).totals, attributed);
+        addInto(ensureExec(byExecExecutable, details.executable).totals, attributed);
+        addInto(ensureExec(byExecCommand, details.command).totals, attributed);
+        addInto(ensureExec(byExecDuration, details.duration).totals, attributed);
+        addInto(ensureExec(byExecOutput, details.output).totals, attributed);
+        absorbExecStats(byExecKind, details.kind, details);
+        absorbExecStats(byExecExit, details.exitKey, details);
+        absorbExecStats(byExecExecutable, details.executable, details);
+        absorbExecStats(byExecCommand, details.command, details);
+        absorbExecStats(byExecDuration, details.duration, details);
+        absorbExecStats(byExecOutput, details.output, details);
+      }
+    } else {
+      for (const details of pendingExecDetails) {
+        absorbExecStats(byExecKind, details.kind, details);
+        absorbExecStats(byExecExit, details.exitKey, details);
+        absorbExecStats(byExecExecutable, details.executable, details);
+        absorbExecStats(byExecCommand, details.command, details);
+        absorbExecStats(byExecDuration, details.duration, details);
+        absorbExecStats(byExecOutput, details.output, details);
+      }
+    }
+
+    addInto(totals, delta);
+  }
+
+  if (!fs.existsSync(updatesPath)) {
+    return emptySessionResult();
+  }
+
+  const input = fs.createReadStream(updatesPath, { encoding: "utf8" });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line || !line.trim()) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const params = record?.params || {};
+      const meta = params._meta || record?._meta || {};
+      const update = params.update;
+      if (!update || typeof update !== "object") continue;
+
+      const sessionUpdate = update.sessionUpdate || meta.updateType || "";
+      const promptId =
+        meta.promptId ||
+        update.prompt_id ||
+        (meta.turnStartMs != null ? `turn-${meta.turnStartMs}` : null) ||
+        "unknown";
+      const ts =
+        timestampToIso(meta.agentTimestampMs) ||
+        timestampToIso(meta.timestampMs) ||
+        timestampToIso(record.timestamp) ||
+        null;
+
+      if (sessionUpdate === "tool_call" || meta.updateType === "ToolCall") {
+        const turn = getTurn(promptId);
+        const toolName = extractToolName(update, meta);
+        turn.tools.push(toolName);
+        if (toolName === "Bash") {
+          const cmd = extractExecCommand(update);
+          if (cmd) {
+            const status = update.status || meta.updateParams?.status || "completed";
+            turn.execs.push(buildExecDetails(cmd, status));
+          }
+        }
+        continue;
+      }
+
+      if (sessionUpdate === "agent_thought_chunk" || meta.updateType === "AgentThoughtChunk") {
+        getTurn(promptId).sawThought = true;
+        continue;
+      }
+
+      if (
+        sessionUpdate === "agent_message_chunk" ||
+        sessionUpdate === "user_message_chunk" ||
+        meta.updateType === "AgentMessageChunk"
+      ) {
+        getTurn(promptId).sawMessage = true;
+        continue;
+      }
+
+      if (sessionUpdate !== "turn_completed") continue;
+      if (ts && !isIsoInRange(ts, { from, to, timeZoneContext })) {
+        turns.delete(promptId);
+        continue;
+      }
+
+      const usage = readUsageTotals(update.usage);
+      if (!usage) {
+        turns.delete(promptId);
+        continue;
+      }
+
+      // Prefer per-model split when present (sum models into one turn total —
+      // already aggregated in usage.totalTokens).
+      const turnState = turns.get(promptId) || { tools: [], execs: [], sawThought: false, sawMessage: false };
+      attributeTurn(usage, turnState);
+      turns.delete(promptId);
+    }
+  } finally {
+    rl.close();
+    input.destroy?.();
+  }
+
+  return {
+    totals: roundTotals(totals),
+    turnCount,
+    toolBreakdown: { tool_rows: finalizeToolRows(byTool) },
+    execCommandBreakdown: {
+      by_type: finalizeExecRows(byExecKind),
+      by_executable: finalizeExecRows(byExecExecutable),
+      by_command: finalizeExecRows(byExecCommand),
+      by_duration: finalizeExecRows(byExecDuration),
+      by_output: finalizeExecRows(byExecOutput),
+      by_exit: finalizeExecRows(byExecExit),
+    },
+  };
+}
+
+function emptySessionResult() {
+  return {
+    totals: emptyTotals(),
+    turnCount: 0,
+    toolBreakdown: { tool_rows: [] },
+    execCommandBreakdown: {
+      by_type: [],
+      by_executable: [],
+      by_command: [],
+      by_duration: [],
+      by_output: [],
+      by_exit: [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge + display assembly (mirrors codex-context-breakdown)
+// ---------------------------------------------------------------------------
+
+function mergeRows(map, rows) {
+  for (const row of rows || []) {
+    const name = row?.name ? String(row.name) : "";
+    const rawName = row?.raw_name ? String(row.raw_name) : name;
+    const key = rawName || name;
+    if (!key) continue;
+    if (!map.has(key)) {
+      map.set(key, { name, raw_name: rawName, calls: 0, totals: emptyTotals() });
+    }
+    const cur = map.get(key);
+    cur.name = name;
+    cur.raw_name = rawName;
+    cur.calls += Number(row.calls || 0);
+    addInto(cur.totals, row.totals || {});
+  }
+}
+
+function mergeExecRows(map, rows) {
+  for (const row of rows || []) {
+    const name = row?.name ? String(row.name) : "";
+    if (!name) continue;
+    if (!map.has(name)) map.set(name, { name, ...buildExecStatsEntry() });
+    const cur = map.get(name);
+    cur.calls += Number(row.calls || 0);
+    cur.failures += Number(row.failures || 0);
+    cur.duration_ms += Number(row.duration_ms || 0);
+    cur.max_duration_ms = Math.max(cur.max_duration_ms, Number(row.max_duration_ms || 0));
+    cur.output_chars += Number(row.output_chars || 0);
+    cur.output_lines += Number(row.output_lines || 0);
+    addInto(cur.totals, row.totals || {});
+  }
+}
+
+async function computeGrokContextBreakdown({
+  from = null,
+  to = null,
+  top = 50,
+  timeZoneContext = null,
+  env = process.env,
+} = {}) {
+  const limitedTop = Number.isFinite(top) && top > 0 ? Math.min(Math.floor(top), 200) : 50;
+  const sessions = discoverGrokSessionFiles(env);
+  const inventorySig = crypto
+    .createHash("sha1")
+    .update(
+      sessions
+        .map((s) => `${s.updatesPath}:${s.size}:${Math.floor(s.mtimeMs)}`)
+        .join("|"),
+    )
+    .digest("hex");
+  const cacheKey = [
+    CACHE_SCHEMA_VERSION,
+    from || "",
+    to || "",
+    limitedTop,
+    timeZoneContext?.timeZone || "",
+    timeZoneContext?.offsetMinutes ?? "",
+    inventorySig,
+  ].join("|");
+
+  const cached = CACHE.get(cacheKey);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.value;
+  }
+
+  const grand = emptyTotals();
+  const byTool = new Map();
+  const byExecKind = new Map();
+  const byExecExit = new Map();
+  const byExecExecutable = new Map();
+  const byExecCommand = new Map();
+  const byExecDuration = new Map();
+  const byExecOutput = new Map();
+  let messageCount = 0;
+  let sessionCount = 0;
+
+  for (const sess of sessions) {
+    const parsed = await parseGrokUpdatesFile(sess.updatesPath, {
+      from,
+      to,
+      timeZoneContext,
+    });
+    if (!parsed?.totals?.total_tokens) continue;
+    sessionCount += 1;
+    messageCount += Number(parsed.turnCount || 0);
+    addInto(grand, parsed.totals);
+    mergeRows(byTool, parsed.toolBreakdown?.tool_rows);
+    mergeExecRows(byExecKind, parsed.execCommandBreakdown?.by_type);
+    mergeExecRows(byExecExecutable, parsed.execCommandBreakdown?.by_executable);
+    mergeExecRows(byExecCommand, parsed.execCommandBreakdown?.by_command);
+    mergeExecRows(byExecDuration, parsed.execCommandBreakdown?.by_duration);
+    mergeExecRows(byExecOutput, parsed.execCommandBreakdown?.by_output);
+    mergeExecRows(byExecExit, parsed.execCommandBreakdown?.by_exit);
+  }
+
+  const toolRows = finalizeToolRows(byTool);
+  const toolRowsLimited = toolRows.slice(0, limitedTop);
+
+  // Category rows from tool names (File Ops / Search / Execution / ...)
+  const byCategory = new Map();
+  for (const row of toolRows) {
+    if (row.name === "text_response") continue;
+    const cat = categorizeTool(row.raw_name || row.name);
+    if (!byCategory.has(cat)) {
+      byCategory.set(cat, { name: cat, calls: 0, totals: emptyTotals(), tools: [] });
+    }
+    const target = byCategory.get(cat);
+    target.calls += Number(row.calls || 0);
+    addInto(target.totals, row.totals || {});
+    target.tools.push({
+      name: row.name,
+      calls: row.calls,
+      totals: roundTotals(row.totals),
+    });
+  }
+  const categoryRows = Array.from(byCategory.values())
+    .map((c) => ({
+      name: c.name,
+      calls: Math.round(c.calls || 0),
+      totals: roundTotals(c.totals),
+      tools: (c.tools || [])
+        .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0))
+        .slice(0, limitedTop),
+    }))
+    .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
+
+  // Message breakdown: residual "text_response" tools + reasoning/output split
+  const textResponse = toolRows.find((r) => r.name === "text_response");
+  const textTotals = textResponse?.totals || emptyTotals();
+  const reasoning = Number(grand.reasoning_output_tokens || 0);
+  const assistantOut = Math.max(0, Number(grand.output_tokens || 0) - Math.min(reasoning, Number(grand.output_tokens || 0)));
+  // For Grok, cached reads dominate conversation history; non-cached input is
+  // closer to "current user/context injection". Heuristic only — matches Codex
+  // message_breakdown intent without reading message bodies.
+  const historyTokens = Number(grand.cached_input_tokens || 0);
+  const userish = Number(grand.input_tokens || 0);
+  const messageBreakdown = [
+    {
+      key: "user_input",
+      name: "User input",
+      totals: roundTotals({
+        input_tokens: userish,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: userish,
+      }),
+    },
+    {
+      key: "conversation_history",
+      name: "Conversation history",
+      totals: roundTotals({
+        input_tokens: 0,
+        cached_input_tokens: historyTokens,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: historyTokens,
+      }),
+    },
+    {
+      key: "assistant_response",
+      name: "Assistant response",
+      totals: roundTotals({
+        input_tokens: 0,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: assistantOut,
+        reasoning_output_tokens: 0,
+        total_tokens: assistantOut,
+      }),
+    },
+  ].sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
+
+  const serializeExecRows = (rows) =>
+    (rows || []).slice(0, limitedTop).map((r) => ({
+      name: r.name,
+      calls: r.calls,
+      failures: r.failures,
+      duration_ms: r.duration_ms,
+      max_duration_ms: r.max_duration_ms,
+      output_chars: r.output_chars,
+      output_lines: r.output_lines,
+      totals: roundTotals(r.totals),
+    }));
+
+  const result = {
+    source: "grok",
+    scope: "supported",
+    breakdown_status: "ok",
+    totals: roundTotals(grand),
+    session_count: sessionCount,
+    message_count: messageCount,
+    message_breakdown: {
+      categories: messageBreakdown,
+      privacy: {
+        includes_content: false,
+        note: "Aggregated message token categories only; prompt and assistant text are never returned.",
+      },
+    },
+    tool_calls_breakdown: {
+      total_calls: Math.round(toolRows.reduce((a, r) => a + Number(r.calls || 0), 0)),
+      tools: toolRowsLimited,
+      categories: categoryRows.slice(0, limitedTop),
+      tools_total: toolRows.reduce((a, r) => a + Math.round(r.totals?.total_tokens || 0), 0),
+      privacy: {
+        includes_inputs: false,
+        note: "Aggregated tool names only; no tool arguments or outputs are included.",
+      },
+    },
+    skills_breakdown: {
+      total_calls: 0,
+      skills: [],
+      privacy: {
+        includes_inputs: false,
+        note: "Grok Build does not currently expose a dedicated skill usage channel in turn logs.",
+      },
+    },
+    exec_command_breakdown: {
+      by_type: serializeExecRows(finalizeExecRows(byExecKind)),
+      by_executable: serializeExecRows(finalizeExecRows(byExecExecutable)),
+      by_command: serializeExecRows(finalizeExecRows(byExecCommand)),
+      by_duration: serializeExecRows(finalizeExecRows(byExecDuration)),
+      by_output: serializeExecRows(finalizeExecRows(byExecOutput)),
+      by_exit: serializeExecRows(finalizeExecRows(byExecExit)),
+    },
+  };
+
+  CACHE.set(cacheKey, { at: Date.now(), value: result });
+  while (CACHE.size > 32) {
+    const oldest = [...CACHE.entries()].sort((a, b) => a[1].at - b[1].at)[0];
+    if (oldest) CACHE.delete(oldest[0]);
+  }
+  return result;
+}
+
+module.exports = {
+  computeGrokContextBreakdown,
+  // test helpers
+  mapGrokToolName,
+  readUsageTotals,
+  discoverGrokSessionFiles,
+  parseGrokUpdatesFile,
+};

--- a/src/lib/grok-context-breakdown.js
+++ b/src/lib/grok-context-breakdown.js
@@ -251,8 +251,10 @@ function readUsageTotals(usage) {
     Number(usage.reasoningTokens ?? usage.reasoning_output_tokens ?? 0) || 0,
   );
   const nonCachedInput = Math.max(0, inputRaw - cached);
+  // Prefer the reported totalTokens (authoritative billable total). Fallback
+  // includes reasoning so a missing total still matches usage-parser shape.
   let total = Math.max(0, Number(usage.totalTokens ?? usage.total_tokens ?? 0) || 0);
-  if (total <= 0) total = nonCachedInput + cached + output;
+  if (total <= 0) total = nonCachedInput + cached + output + reasoning;
   if (total <= 0) return null;
   return {
     input_tokens: nonCachedInput,

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -57,6 +57,7 @@ const {
 } = require("./claude-categorizer");
 
 const { computeCodexContextBreakdown } = require("./codex-context-breakdown");
+const { computeGrokContextBreakdown } = require("./grok-context-breakdown");
 
 const {
   deriveProjectKeyFromRef,
@@ -2308,11 +2309,11 @@ function createLocalApiHandler({ queuePath }) {
       return true;
     }
 
-    // --- usage-category-breakdown (Claude + Codex) ---
+    // --- usage-category-breakdown (Claude + Codex + Grok) ---
     // Claude: splits historical Claude usage into seven semantic categories
     // mirroring Claude Code's /context view (approx).
-    // Codex: provides a tool-oriented breakdown, attributing per-turn token
-    // deltas to observed tool calls (heuristic).
+    // Codex/Grok: tool-oriented breakdown, attributing per-turn token
+    // totals to observed tool calls (heuristic).
     if (p === "/functions/tokentracker-usage-category-breakdown") {
       const from = url.searchParams.get("from") || "";
       const to = url.searchParams.get("to") || "";
@@ -2350,6 +2351,23 @@ function createLocalApiHandler({ queuePath }) {
         } catch (e) {
           console.error("[LocalAPI] usage-category-breakdown(codex):", e?.message || e);
           json(res, { from, to, ...unsupportedCategoryPayload("codex"), error: "compute_failed" }, 500);
+        }
+        return true;
+      }
+
+      if (requestedSource === "grok") {
+        try {
+          const timeZoneContext = getTimeZoneContext(url);
+          const result = await computeGrokContextBreakdown({
+            from,
+            to,
+            top: 50,
+            timeZoneContext,
+          });
+          json(res, { from, to, ...result });
+        } catch (e) {
+          console.error("[LocalAPI] usage-category-breakdown(grok):", e?.message || e);
+          json(res, { from, to, ...unsupportedCategoryPayload("grok"), error: "compute_failed" }, 500);
         }
         return true;
       }

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -48,12 +48,27 @@ const { computeRowCost } = require("./pricing");
 //   - session_id is only set when the log actually contained a sessionId
 //     record. It used to fall back to the file's basename, which produced
 //     resume commands for non-session files (`claude --resume journal`).
-const SIDECAR_VERSION = 9;
-const EDIT_TOOLS = new Set(["apply_patch", "edit", "write", "multiedit", "notebookedit"]);
+// v10 adds Grok Build sessions (~/.grok/sessions/**/updates.jsonl), scanned
+// from turn_completed.usage + tool_call metadata. Bump so Claude/Codex rows
+// stay valid while Grok entries appear on the next full rebuild.
+const SIDECAR_VERSION = 10;
+const EDIT_TOOLS = new Set([
+  "apply_patch",
+  "edit",
+  "write",
+  "multiedit",
+  "notebookedit",
+  // Grok Build write tools (ACP tool titles / x.ai/tool.name).
+  "search_replace",
+  "str_replace",
+  "create_file",
+  "write_file",
+]);
 const PLACEHOLDER_MODELS = new Set(["<synthetic>", "synthetic", "<unknown>", "unknown"]);
 const CLAUDE_MEM_OBSERVER_PROJECT_SUFFIX = "--claude-mem-observer-sessions";
 const CODEX_SUBAGENT_TOOLS = new Set(["spawn_agent", "multi_agent_v1__spawn_agent"]);
 const CODEX_SIGNAL_TOOLS = new Set([...EDIT_TOOLS, ...CODEX_SUBAGENT_TOOLS]);
+const GROK_SUBAGENT_TOOLS = new Set(["spawn_subagent", "spawn_agent"]);
 
 function normalizeSessionModel(value) {
   if (typeof value !== "string") return null;
@@ -457,11 +472,278 @@ async function scanCodexSession(filePath) {
   });
 }
 
+// Grok Build sessions live at:
+//   ~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/updates.jsonl
+// with sibling summary.json (id/cwd/title) and signals.json (aggregate
+// counters). Billable tokens come only from turn_completed.usage — the same
+// authority as the Grok usage parser — not from context-window totalTokens.
+function resolveGrokHome(home = os.homedir(), env = process.env) {
+  if (typeof env.TOKENTRACKER_GROK_HOME === "string" && env.TOKENTRACKER_GROK_HOME.trim()) {
+    return path.resolve(env.TOKENTRACKER_GROK_HOME.trim());
+  }
+  if (typeof env.GROK_HOME === "string" && env.GROK_HOME.trim()) {
+    return path.resolve(env.GROK_HOME.trim());
+  }
+  return path.join(home, ".grok");
+}
+
+function grokSummaryPathFor(updatesPath) {
+  return path.join(path.dirname(updatesPath), "summary.json");
+}
+
+function grokSignalsPathFor(updatesPath) {
+  return path.join(path.dirname(updatesPath), "signals.json");
+}
+
+function readJsonFileSync(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function grokTimestampIso(obj) {
+  const metaMs = Number(obj?.params?._meta?.agentTimestampMs);
+  if (Number.isFinite(metaMs) && metaMs > 0) return new Date(metaMs).toISOString();
+  const top = Number(obj?.timestamp);
+  if (!Number.isFinite(top) || top <= 0) return null;
+  // Grok writes unix seconds on the envelope; ms values are already > 1e12.
+  const ms = top > 1e12 ? top : top * 1000;
+  return new Date(ms).toISOString();
+}
+
+function grokUsageTotals(usage) {
+  if (!usage || typeof usage !== "object") return emptyTotals();
+  return tokenTotals({
+    input_tokens: usage.inputTokens ?? usage.input_tokens,
+    cache_read_input_tokens: usage.cachedReadTokens ?? usage.cache_read_input_tokens ?? usage.cached_input_tokens,
+    cache_creation_input_tokens: usage.cachedWriteTokens ?? usage.cache_creation_input_tokens,
+    output_tokens: usage.outputTokens ?? usage.output_tokens,
+    reasoning_output_tokens: usage.reasoningTokens ?? usage.reasoning_output_tokens,
+  });
+}
+
+function pickGrokModel(usage, fallback) {
+  const modelUsage = usage?.modelUsage;
+  if (modelUsage && typeof modelUsage === "object") {
+    let bestName = null;
+    let bestTokens = -1;
+    for (const [name, entry] of Object.entries(modelUsage)) {
+      const normalized = normalizeSessionModel(name);
+      if (!normalized) continue;
+      const tokens = finite(entry?.totalTokens ?? entry?.total_tokens)
+        + finite(entry?.inputTokens ?? entry?.input_tokens)
+        + finite(entry?.outputTokens ?? entry?.output_tokens);
+      if (tokens >= bestTokens) {
+        bestTokens = tokens;
+        bestName = normalized;
+      }
+    }
+    if (bestName) return bestName;
+  }
+  return normalizeSessionModel(fallback) || "unknown";
+}
+
+function extractGrokUserPrompt(update) {
+  if (!update || update.sessionUpdate !== "user_message_chunk") return null;
+  const content = update.content;
+  if (typeof content === "string") {
+    const text = content.trim();
+    return text || null;
+  }
+  if (content && typeof content === "object") {
+    if (typeof content.text === "string") {
+      const text = content.text.trim();
+      return text || null;
+    }
+  }
+  return null;
+}
+
+function extractGrokToolName(update) {
+  if (!update || update.sessionUpdate !== "tool_call") return "";
+  const metaName = update._meta?.["x.ai/tool"]?.name;
+  return canonicalToolName(metaName || update.title || "");
+}
+
+async function listGrokSessionFiles(sessionsRoot) {
+  if (!fs.existsSync(sessionsRoot)) return [];
+  const found = [];
+  async function walk(dir, depth) {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      const updatesPath = path.join(full, "updates.jsonl");
+      try {
+        const stat = await fsp.stat(updatesPath);
+        if (stat.isFile() && stat.size > 0) {
+          found.push(updatesPath);
+          continue;
+        }
+      } catch { /* not a session leaf */ }
+      await walk(full, depth + 1);
+    }
+  }
+  await walk(sessionsRoot, 0);
+  return found;
+}
+
+async function scanGrokSession(filePath) {
+  const summary = readJsonFileSync(grokSummaryPathFor(filePath)) || {};
+  const signals = readJsonFileSync(grokSignalsPathFor(filePath)) || {};
+  const tokens = emptyTotals();
+  const bounds = emptyBounds();
+  const dirName = path.basename(path.dirname(filePath));
+  let observedSessionId = typeof summary?.info?.id === "string" && summary.info.id
+    ? summary.info.id
+    : (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(dirName) ? dirName : null);
+  let cwd = typeof summary?.info?.cwd === "string" && summary.info.cwd
+    ? summary.info.cwd
+    : null;
+  // Prefer agent-authored generated_title over free-form session_summary when
+  // both exist; both are Grok metadata, never the raw user prompt body.
+  const title = cleanSessionTitle(summary.generated_title)
+    || cleanSessionTitle(summary.session_summary)
+    || null;
+  let model = pickGrokModel(null, signals.primaryModelId || summary.current_model_id);
+  let turns = 0;
+  let editTurns = 0;
+  let retryTurns = 0;
+  let currentHadEdit = false;
+  let subagentCalls = 0;
+  const subagentTypes = new Map();
+  let lastPromptFingerprint = null;
+  // Grok streams user_message_chunk pieces for one prompt. Accumulate until
+  // turn_completed, then fingerprint the full prompt for retry detection.
+  let openUserTurn = false;
+  let userChunkBuffer = "";
+
+  function closeTurn() {
+    if (currentHadEdit) editTurns += 1;
+    currentHadEdit = false;
+    if (userChunkBuffer) {
+      const fingerprint = promptFingerprint(userChunkBuffer);
+      if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+      lastPromptFingerprint = fingerprint;
+    }
+    openUserTurn = false;
+    userChunkBuffer = "";
+  }
+
+  const input = fs.createReadStream(filePath, { encoding: "utf8" });
+  const lines = readline.createInterface({ input, crlfDelay: Infinity });
+  for await (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    updateBounds(bounds, grokTimestampIso(obj));
+    const params = obj.params && typeof obj.params === "object" ? obj.params : {};
+    if (typeof params.sessionId === "string" && params.sessionId) {
+      observedSessionId = params.sessionId;
+    }
+    const update = params.update && typeof params.update === "object" ? params.update : null;
+    if (!update) continue;
+    const sessionUpdate = update.sessionUpdate;
+
+    if (sessionUpdate === "user_message_chunk") {
+      const piece = extractGrokUserPrompt(update);
+      if (!piece) continue;
+      // First non-empty chunk after a closed turn opens a new user turn;
+      // later chunks only extend the fingerprint buffer.
+      if (!openUserTurn) {
+        turns += 1;
+        openUserTurn = true;
+        userChunkBuffer = piece;
+      } else {
+        userChunkBuffer += piece;
+      }
+      continue;
+    }
+
+    if (sessionUpdate === "tool_call") {
+      // Tools belong to the current user turn. If Grok never emitted a user
+      // chunk (rare / resumed partial logs), open an anonymous turn so edit
+      // accounting still works.
+      if (!openUserTurn && turns === 0) {
+        turns += 1;
+        openUserTurn = true;
+      }
+      const name = extractGrokToolName(update);
+      if (EDIT_TOOLS.has(name)) currentHadEdit = true;
+      if (GROK_SUBAGENT_TOOLS.has(name)) {
+        subagentCalls += 1;
+        const display = name === "spawn_agent" ? "spawn_subagent" : name;
+        subagentTypes.set(display, (subagentTypes.get(display) || 0) + 1);
+      }
+      continue;
+    }
+
+    if (sessionUpdate === "turn_completed") {
+      closeTurn();
+      const usage = update.usage;
+      addTotals(tokens, grokUsageTotals(usage));
+      const candidate = pickGrokModel(usage, model);
+      if (candidate && candidate !== "unknown") model = candidate;
+      continue;
+    }
+  }
+  closeTurn();
+
+  // Prefer observed turn_completed totals. Fall back to signals only when the
+  // updates stream had no billable turns (empty/partial session).
+  if (tokens.total_tokens === 0 && finite(signals.contextTokensUsed) > 0) {
+    // Do NOT invent billable totals from context occupancy. Leave zeros so
+    // listSessionsForBrowser filters empty sessions out.
+  }
+  if (turns === 0 && finite(signals.turnCount) > 0) {
+    turns = finite(signals.turnCount);
+  }
+  if (!Number.isFinite(Date.parse(bounds.started_at || "")) && summary.created_at) {
+    updateBounds(bounds, summary.created_at);
+  }
+  if (!Number.isFinite(Date.parse(bounds.ended_at || "")) && (summary.last_active_at || summary.updated_at)) {
+    updateBounds(bounds, summary.last_active_at || summary.updated_at);
+  }
+  if ((!model || model === "unknown") && signals.primaryModelId) {
+    model = normalizeSessionModel(signals.primaryModelId) || model;
+  }
+
+  return finalizeRecord({
+    version: SIDECAR_VERSION,
+    session_hash: sessionHash("grok", observedSessionId || filePath),
+    session_id: observedSessionId || null,
+    // Local-only: stripped in summarizeSessions before any cloud/CSV export.
+    title,
+    source: "grok",
+    project_key: projectKey(cwd, filePath),
+    project_ref: cwd || null,
+    model: model || "unknown",
+    ...bounds,
+    turns,
+    edit_turns: editTurns,
+    retry_turns: retryTurns,
+    subagent_calls: subagentCalls,
+    subagent_types: Object.fromEntries([...subagentTypes.entries()].sort()),
+    tokens,
+    provenance: { source: "local-session-log", confidence: "observed", retry_confidence: "inferred", content_retained: false },
+  });
+}
+
 async function discoverSessionFiles(home) {
-  const [allClaude, codex, archived] = await Promise.all([
+  const grokHome = resolveGrokHome(home);
+  const [allClaude, codex, archived, grok] = await Promise.all([
     listClaudeProjectFiles(path.join(home, ".claude", "projects")),
     listRolloutFilesDeep(path.join(home, ".codex", "sessions")),
     listRolloutFilesDeep(path.join(home, ".codex", "archived_sessions")),
+    listGrokSessionFiles(path.join(grokHome, "sessions")),
   ]);
   // Claude Memory stores thousands of background observer transcripts beside
   // real Claude Code sessions. They contain <synthetic>/haiku bookkeeping and
@@ -479,7 +761,7 @@ async function discoverSessionFiles(home) {
     const previous = codexBySession.get(id);
     if (!previous || mtimeOf(filePath) > mtimeOf(previous)) codexBySession.set(id, filePath);
   }
-  return { claude, codex: [...codexBySession.values()] };
+  return { claude, codex: [...codexBySession.values()], grok };
 }
 
 function filesSignature(files) {
@@ -548,10 +830,18 @@ function loadCodexTitleIndex(filePath) {
 // A Codex row also depends on session_index.jsonl, not just its rollout file.
 // Include that dependency in the incremental cache key so renaming a thread is
 // visible after the next refresh instead of leaving a stale title indefinitely.
+// Grok titles live in sibling summary.json (and signals can change without
+// touching updates.jsonl on some partial flushes).
 function analyticsEntryStatKey(source, filePath) {
   const sessionStat = sessionFileStatKey(filePath);
-  if (!sessionStat || source !== "codex") return sessionStat;
-  return `${sessionStat}|title-index:${sessionFileStatKey(codexTitleIndexPathFor(filePath)) || "missing"}`;
+  if (!sessionStat) return sessionStat;
+  if (source === "codex") {
+    return `${sessionStat}|title-index:${sessionFileStatKey(codexTitleIndexPathFor(filePath)) || "missing"}`;
+  }
+  if (source === "grok") {
+    return `${sessionStat}|summary:${sessionFileStatKey(grokSummaryPathFor(filePath)) || "missing"}|signals:${sessionFileStatKey(grokSignalsPathFor(filePath)) || "missing"}`;
+  }
+  return sessionStat;
 }
 
 function readSidecar(sidecarPath) {
@@ -587,11 +877,15 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   const discovered = await discoverSessionFiles(home);
   // Codex thread titles are stored separately from rollout files. Include the
   // index in the overall signature so an index-only rename reaches the
-  // per-file dependency check below on the next refresh.
+  // per-file dependency check below on the next refresh. Grok titles/metadata
+  // live in sibling summary.json / signals.json next to updates.jsonl.
   const signature = filesSignature([
     ...discovered.claude,
     ...discovered.codex,
     ...discovered.codex.map(codexTitleIndexPathFor).filter(Boolean),
+    ...discovered.grok,
+    ...discovered.grok.map(grokSummaryPathFor),
+    ...discovered.grok.map(grokSignalsPathFor),
   ]);
   if (!force && previousMeta?.version === SIDECAR_VERSION && previousMeta.signature === signature) {
     await writeAtomic(metaPath, `${JSON.stringify({ ...previousMeta, checked_at: new Date().toISOString() })}\n`);
@@ -612,6 +906,7 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   const entries = [
     ...discovered.claude.map((filePath) => ({ source: "claude", filePath, scan: scanClaudeSession })),
     ...discovered.codex.map((filePath) => ({ source: "codex", filePath, scan: scanCodexSession })),
+    ...discovered.grok.map((filePath) => ({ source: "grok", filePath, scan: scanGrokSession })),
   ];
   // Files we could not turn into a row (permission denied, half-written line,
   // vanished mid-scan). Swallowing these silently made sessions disappear with
@@ -664,8 +959,8 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   return sessions;
 }
 
-// A cold scan walks every local Claude/Codex session file. Period switches can
-// issue overlapping requests while that scan is still running; share the
+// A cold scan walks every local Claude/Codex/Grok session file. Period switches
+// can issue overlapping requests while that scan is still running; share the
 // promise per home so those requests wait for one scan instead of multiplying
 // the disk work and racing the atomic sidecar write.
 const sessionAnalyticsBuilds = new Map();
@@ -808,6 +1103,9 @@ function resumeCommandFor(source, sessionId) {
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/.test(id)) return null;
   if (source === "claude") return `claude --resume ${id}`;
   if (source === "codex") return `codex resume ${id}`;
+  // Grok Build: `grok --resume <session-id>` (also accepts a title). The
+  // command must still be run from the session's project_ref cwd.
+  if (source === "grok") return `grok --resume ${id}`;
   return null;
 }
 
@@ -934,6 +1232,7 @@ module.exports = {
   sessionHash,
   scanClaudeSession,
   scanCodexSession,
+  scanGrokSession,
   buildSessionAnalytics,
   summarizeSessions,
   listSessionsForBrowser,

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -513,15 +513,40 @@ function grokTimestampIso(obj) {
   return new Date(ms).toISOString();
 }
 
+// Grok reports inputTokens as the full prompt (including cache hits). Split so
+// pricing can apply cache_read rates correctly — same authority as the usage
+// parser and grok-context-breakdown.readUsageTotals. Prefer the reported
+// totalTokens; do not re-sum input+cached (that double-counts cache hits).
 function grokUsageTotals(usage) {
   if (!usage || typeof usage !== "object") return emptyTotals();
-  return tokenTotals({
-    input_tokens: usage.inputTokens ?? usage.input_tokens,
-    cache_read_input_tokens: usage.cachedReadTokens ?? usage.cache_read_input_tokens ?? usage.cached_input_tokens,
-    cache_creation_input_tokens: usage.cachedWriteTokens ?? usage.cache_creation_input_tokens,
-    output_tokens: usage.outputTokens ?? usage.output_tokens,
-    reasoning_output_tokens: usage.reasoningTokens ?? usage.reasoning_output_tokens,
-  });
+  const inputRaw = finite(usage.inputTokens ?? usage.input_tokens);
+  const cached_input_tokens = finite(
+    usage.cachedReadTokens ?? usage.cache_read_input_tokens ?? usage.cached_input_tokens,
+  );
+  const cache_creation_input_tokens = finite(
+    usage.cachedWriteTokens ?? usage.cache_creation_input_tokens,
+  );
+  const output_tokens = finite(usage.outputTokens ?? usage.output_tokens);
+  const reasoning_output_tokens = finite(
+    usage.reasoningTokens ?? usage.reasoning_output_tokens,
+  );
+  const input_tokens = Math.max(0, inputRaw - cached_input_tokens);
+  let total_tokens = finite(usage.totalTokens ?? usage.total_tokens);
+  if (total_tokens <= 0) {
+    total_tokens = input_tokens
+      + cached_input_tokens
+      + cache_creation_input_tokens
+      + output_tokens
+      + reasoning_output_tokens;
+  }
+  return {
+    input_tokens,
+    cached_input_tokens,
+    cache_creation_input_tokens,
+    output_tokens,
+    reasoning_output_tokens,
+    total_tokens,
+  };
 }
 
 function pickGrokModel(usage, fallback) {
@@ -594,6 +619,8 @@ async function listGrokSessionFiles(sessionsRoot) {
     }
   }
   await walk(sessionsRoot, 0);
+  // Deterministic order so filesSignature is stable across readdir() shuffles.
+  found.sort((a, b) => a.localeCompare(b));
   return found;
 }
 
@@ -669,10 +696,10 @@ async function scanGrokSession(filePath) {
     }
 
     if (sessionUpdate === "tool_call") {
-      // Tools belong to the current user turn. If Grok never emitted a user
-      // chunk (rare / resumed partial logs), open an anonymous turn so edit
-      // accounting still works.
-      if (!openUserTurn && turns === 0) {
+      // Tools belong to the current user turn. After turn_completed closes a
+      // turn, a tool-only follow-up must open a new anonymous turn — otherwise
+      // edit_turns can exceed turns.
+      if (!openUserTurn) {
         turns += 1;
         openUserTurn = true;
       }
@@ -697,12 +724,9 @@ async function scanGrokSession(filePath) {
   }
   closeTurn();
 
-  // Prefer observed turn_completed totals. Fall back to signals only when the
-  // updates stream had no billable turns (empty/partial session).
-  if (tokens.total_tokens === 0 && finite(signals.contextTokensUsed) > 0) {
-    // Do NOT invent billable totals from context occupancy. Leave zeros so
-    // listSessionsForBrowser filters empty sessions out.
-  }
+  // Prefer observed turn_completed totals. Never invent billable totals from
+  // signals.contextTokensUsed (context-window occupancy is not API usage);
+  // leave zeros so listSessionsForBrowser filters empty sessions out.
   if (turns === 0 && finite(signals.turnCount) > 0) {
     turns = finite(signals.turnCount);
   }

--- a/test/grok-context-breakdown.test.js
+++ b/test/grok-context-breakdown.test.js
@@ -1,0 +1,164 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  computeGrokContextBreakdown,
+  mapGrokToolName,
+  readUsageTotals,
+} = require("../src/lib/grok-context-breakdown");
+
+test("mapGrokToolName normalizes Grok Build tool ids to Claude-like names", () => {
+  assert.equal(mapGrokToolName("read_file"), "Read");
+  assert.equal(mapGrokToolName("search_replace"), "Edit");
+  assert.equal(mapGrokToolName("run_terminal_command"), "Bash");
+  assert.equal(mapGrokToolName("grep"), "Grep");
+});
+
+test("readUsageTotals splits cache-inclusive inputTokens", () => {
+  const totals = readUsageTotals({
+    inputTokens: 1000,
+    outputTokens: 50,
+    totalTokens: 1050,
+    cachedReadTokens: 400,
+    reasoningTokens: 20,
+  });
+  assert.equal(totals.input_tokens, 600);
+  assert.equal(totals.cached_input_tokens, 400);
+  assert.equal(totals.output_tokens, 50);
+  assert.equal(totals.reasoning_output_tokens, 20);
+  assert.equal(totals.total_tokens, 1050);
+});
+
+function writeSession(root, sessionId, lines) {
+  const encoded = encodeURIComponent("/tmp/project");
+  const dir = path.join(root, "sessions", encoded, sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "updates.jsonl"), `${lines.join("\n")}\n`);
+  return dir;
+}
+
+test("computeGrokContextBreakdown attributes turn usage to tools like Codex", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-ctx-"));
+  const sid = "019f-grok-ctx-1";
+  const ts = Date.parse("2026-07-18T10:05:00.000Z");
+  const lines = [
+    JSON.stringify({
+      timestamp: 1784357100,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "c1",
+          title: "read_file",
+          rawInput: { target_file: "a.ts" },
+          _meta: { "x.ai/tool": { name: "read_file", kind: "read" } },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts,
+          updateType: "ToolCall",
+        },
+      },
+    }),
+    JSON.stringify({
+      timestamp: 1784357101,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "c2",
+          title: "run_terminal_command",
+          rawInput: { command: "npm test" },
+          _meta: { "x.ai/tool": { name: "run_terminal_command", kind: "execute" } },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts + 1000,
+          updateType: "ToolCall",
+        },
+      },
+    }),
+    JSON.stringify({
+      timestamp: 1784357110,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: "p1",
+          stop_reason: "end_turn",
+          usage: {
+            inputTokens: 1000,
+            outputTokens: 100,
+            totalTokens: 1100,
+            cachedReadTokens: 200,
+            reasoningTokens: 40,
+            modelUsage: {
+              "grok-4.5-build": {
+                inputTokens: 1000,
+                outputTokens: 100,
+                totalTokens: 1100,
+                cachedReadTokens: 200,
+                reasoningTokens: 40,
+              },
+            },
+          },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts + 10_000,
+          totalTokens: 12_000,
+        },
+      },
+    }),
+  ];
+  writeSession(root, sid, lines);
+
+  const result = await computeGrokContextBreakdown({
+    from: "2026-07-18",
+    to: "2026-07-18",
+    env: { GROK_HOME: root, TOKENTRACKER_GROK_HOME: root },
+  });
+
+  assert.equal(result.source, "grok");
+  assert.equal(result.scope, "supported");
+  assert.equal(result.totals.total_tokens, 1100);
+  assert.equal(result.totals.input_tokens, 800);
+  assert.equal(result.totals.cached_input_tokens, 200);
+  assert.equal(result.totals.output_tokens, 100);
+  assert.equal(result.totals.reasoning_output_tokens, 40);
+  assert.equal(result.session_count, 1);
+  assert.equal(result.message_count, 1);
+
+  const tools = result.tool_calls_breakdown.tools;
+  const names = tools.map((t) => t.name).sort();
+  assert.deepEqual(names, ["Bash", "Read"]);
+  for (const t of tools) {
+    assert.equal(Math.round(t.totals.total_tokens), 550);
+  }
+
+  assert.ok(result.tool_calls_breakdown.categories.length > 0);
+  assert.ok(Array.isArray(result.exec_command_breakdown.by_type));
+  assert.ok(result.message_breakdown.categories.length >= 2);
+});
+
+test("computeGrokContextBreakdown returns empty supported payload without sessions", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-ctx-empty-"));
+  fs.mkdirSync(path.join(root, "sessions"), { recursive: true });
+  const result = await computeGrokContextBreakdown({
+    env: { GROK_HOME: root, TOKENTRACKER_GROK_HOME: root },
+  });
+  assert.equal(result.scope, "supported");
+  assert.equal(result.totals.total_tokens, 0);
+  assert.equal(result.session_count, 0);
+});

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -9,11 +9,57 @@ const {
   buildSessionAnalytics,
   scanClaudeSession,
   scanCodexSession,
+  scanGrokSession,
   summarizeSessions,
   listSessionsForBrowser,
   resumeCommandFor,
   sessionsToCsv,
 } = require("../src/lib/session-analytics");
+
+function writeGrokSessionFixture(home, {
+  sessionId = "019f740c-e792-7fb1-a218-59ea1b340714",
+  cwd = "/work/tokentracker",
+  title = "Wire up Grok sessions",
+  updates = [],
+  signals = null,
+} = {}) {
+  // Mirror Grok Build layout: ~/.grok/sessions/<url-encoded-cwd>/<uuid>/
+  const encodedCwd = encodeURIComponent(cwd);
+  const sessionDir = path.join(home, ".grok", "sessions", encodedCwd, sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const updatesPath = path.join(sessionDir, "updates.jsonl");
+  fs.writeFileSync(updatesPath, `${updates.map(JSON.stringify).join("\n")}\n`);
+  fs.writeFileSync(path.join(sessionDir, "summary.json"), `${JSON.stringify({
+    info: { id: sessionId, cwd },
+    generated_title: title,
+    session_summary: title,
+    created_at: "2026-07-18T06:00:00.000Z",
+    updated_at: "2026-07-18T06:10:00.000Z",
+    last_active_at: "2026-07-18T06:10:00.000Z",
+    current_model_id: "alphafox",
+  })}\n`);
+  fs.writeFileSync(path.join(sessionDir, "signals.json"), `${JSON.stringify(signals || {
+    turnCount: 1,
+    primaryModelId: "grok-4.5",
+    modelsUsed: ["grok-4.5"],
+    contextTokensUsed: 99999,
+  })}\n`);
+  return updatesPath;
+}
+
+function grokUpdate(sessionId, sessionUpdate, updateFields = {}, opts = {}) {
+  const ts = opts.timestamp ?? 1_784_358_461;
+  const agentTimestampMs = opts.agentTimestampMs ?? ts * 1000;
+  return {
+    timestamp: ts,
+    method: sessionUpdate === "turn_completed" ? "_x.ai/session/update" : "session/update",
+    params: {
+      sessionId,
+      update: { sessionUpdate, ...updateFields },
+      _meta: { agentTimestampMs },
+    },
+  };
+}
 
 test("Claude session analytics retains metadata but never content", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-"));
@@ -494,7 +540,176 @@ test("resume commands reject ids that could inject shell syntax", () => {
     resumeCommandFor("codex", "11111111-2222-3333-4444-555555555555"),
     "codex resume 11111111-2222-3333-4444-555555555555",
   );
+  assert.equal(
+    resumeCommandFor("grok", "019f740c-e792-7fb1-a218-59ea1b340714"),
+    "grok --resume 019f740c-e792-7fb1-a218-59ea1b340714",
+  );
   assert.equal(resumeCommandFor("claude", "--dangerous-flag"), null);
   assert.equal(resumeCommandFor("claude", "valid; touch /tmp/pwned"), null);
   assert.equal(resumeCommandFor("codex", "valid\nrm -rf workspace"), null);
+  assert.equal(resumeCommandFor("grok", "valid; rm -rf /"), null);
+});
+
+test("Grok session analytics bills from turn_completed.usage and keeps titles local-only", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-session-"));
+  const sessionId = "019f740c-e792-7fb1-a218-59ea1b340714";
+  const secret = "TOP-SECRET-GROK-PROMPT-CONTENT";
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    cwd: "/work/myproject",
+    title: "Refactor the auth module",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", {
+        content: { type: "text", text: secret },
+      }, { timestamp: 1_784_358_400, agentTimestampMs: 1_784_358_400_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        toolCallId: "call-1",
+        title: "search_replace",
+        _meta: { "x.ai/tool": { name: "search_replace", kind: "edit" } },
+      }, { timestamp: 1_784_358_410, agentTimestampMs: 1_784_358_410_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        toolCallId: "call-2",
+        title: "spawn_subagent",
+        _meta: { "x.ai/tool": { name: "spawn_subagent", kind: "other" } },
+      }, { timestamp: 1_784_358_415, agentTimestampMs: 1_784_358_415_000 }),
+      grokUpdate(sessionId, "turn_completed", {
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cachedReadTokens: 10,
+          reasoningTokens: 5,
+          modelUsage: {
+            "grok-4.5-build-free": {
+              inputTokens: 100,
+              outputTokens: 20,
+              totalTokens: 120,
+              cachedReadTokens: 10,
+              reasoningTokens: 5,
+            },
+          },
+        },
+      }, { timestamp: 1_784_358_430, agentTimestampMs: 1_784_358_430_000 }),
+    ],
+  });
+
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.source, "grok");
+  assert.equal(session.session_id, sessionId);
+  assert.equal(session.title, "Refactor the auth module");
+  assert.equal(session.project_key, "myproject");
+  assert.equal(session.project_ref, "/work/myproject");
+  assert.equal(session.turns, 1);
+  assert.equal(session.edit_turns, 1);
+  assert.equal(session.retry_turns, 0);
+  assert.equal(session.one_shot, true);
+  assert.equal(session.subagent_calls, 1);
+  assert.equal(session.subagent_types.spawn_subagent, 1);
+  // 100 input + 10 cached + 20 output = 130 (reasoning is tracked separately)
+  assert.equal(session.total_tokens, 130);
+  assert.equal(session.tokens.input_tokens, 100);
+  assert.equal(session.tokens.cached_input_tokens, 10);
+  assert.equal(session.tokens.output_tokens, 20);
+  assert.equal(session.tokens.reasoning_output_tokens, 5);
+  assert.equal(session.model, "grok-4.5-build-free");
+  // Prompt body never lands in the metadata row.
+  assert.equal(JSON.stringify(session).includes(secret), false);
+
+  const summary = summarizeSessions([session]);
+  assert.equal(Object.hasOwn(summary.sessions[0], "title"), false);
+  assert.equal(Object.hasOwn(summary.sessions[0], "project_ref"), false);
+  assert.equal(Object.hasOwn(summary.sessions[0], "session_id"), false);
+
+  const browser = listSessionsForBrowser([session]);
+  assert.equal(browser.sessions.length, 1);
+  assert.equal(browser.sessions[0].title, "Refactor the auth module");
+  assert.equal(browser.sessions[0].resume_command, `grok --resume ${sessionId}`);
+});
+
+test("Grok session analytics counts repeated prompts as retries across turns", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-retry-"));
+  const sessionId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  const prompt = "make the requested change";
+  const usage = {
+    inputTokens: 10,
+    outputTokens: 2,
+    totalTokens: 12,
+    cachedReadTokens: 0,
+    reasoningTokens: 0,
+    modelUsage: { "grok-4.5": { inputTokens: 10, outputTokens: 2, totalTokens: 12 } },
+  };
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    title: "Retry fixture",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: prompt } }, { timestamp: 100, agentTimestampMs: 100_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        title: "search_replace",
+        _meta: { "x.ai/tool": { name: "search_replace" } },
+      }, { timestamp: 101, agentTimestampMs: 101_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 102, agentTimestampMs: 102_000 }),
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: prompt } }, { timestamp: 103, agentTimestampMs: 103_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 104, agentTimestampMs: 104_000 }),
+    ],
+  });
+
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.turns, 2);
+  assert.equal(session.edit_turns, 1);
+  assert.equal(session.retry_turns, 1);
+  assert.equal(session.one_shot, false);
+  assert.equal(session.total_tokens, 24);
+});
+
+test("Grok discovery builds sessions from ~/.grok/sessions layout", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-discover-"));
+  const sessionId = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+  writeGrokSessionFixture(home, {
+    sessionId,
+    cwd: "/repo/alpha",
+    title: "Discovered Grok session",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: "hi" } }, { timestamp: 200, agentTimestampMs: 200_000 }),
+      grokUpdate(sessionId, "turn_completed", {
+        usage: {
+          inputTokens: 7,
+          outputTokens: 3,
+          totalTokens: 10,
+          cachedReadTokens: 0,
+          reasoningTokens: 0,
+          modelUsage: { "grok-4.5": { inputTokens: 7, outputTokens: 3, totalTokens: 10 } },
+        },
+      }, { timestamp: 210, agentTimestampMs: 210_000 }),
+    ],
+  });
+
+  const rows = await buildSessionAnalytics({ home, force: true });
+  const grokRows = rows.filter((row) => row.source === "grok");
+  assert.equal(grokRows.length, 1);
+  assert.equal(grokRows[0].session_id, sessionId);
+  assert.equal(grokRows[0].title, "Discovered Grok session");
+  assert.equal(grokRows[0].total_tokens, 10);
+
+  const browser = listSessionsForBrowser(rows);
+  const grokOnly = browser.sessions.filter((row) => row.source === "grok");
+  assert.equal(grokOnly.length, 1);
+  assert.equal(grokOnly[0].resume_command, `grok --resume ${sessionId}`);
+});
+
+test("Grok does not invent billable tokens from context window occupancy", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-nocontxt-"));
+  const sessionId = "cccccccc-dddd-4eee-8fff-000000000000";
+  // Only a user chunk — no turn_completed.usage. signals.contextTokensUsed is
+  // deliberately huge and must not become total_tokens.
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    title: "Empty billable",
+    signals: { turnCount: 1, primaryModelId: "grok-4.5", contextTokensUsed: 500_000 },
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: "hi" } }),
+    ],
+  });
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.total_tokens, 0);
+  assert.equal(listSessionsForBrowser([session]).sessions.length, 0);
 });

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -605,9 +605,10 @@ test("Grok session analytics bills from turn_completed.usage and keeps titles lo
   assert.equal(session.one_shot, true);
   assert.equal(session.subagent_calls, 1);
   assert.equal(session.subagent_types.spawn_subagent, 1);
-  // 100 input + 10 cached + 20 output = 130 (reasoning is tracked separately)
-  assert.equal(session.total_tokens, 130);
-  assert.equal(session.tokens.input_tokens, 100);
+  // Grok inputTokens is cache-inclusive: non-cached input = 100 - 10 = 90.
+  // Prefer reported totalTokens (120), never input+cached+output (would be 130).
+  assert.equal(session.total_tokens, 120);
+  assert.equal(session.tokens.input_tokens, 90);
   assert.equal(session.tokens.cached_input_tokens, 10);
   assert.equal(session.tokens.output_tokens, 20);
   assert.equal(session.tokens.reasoning_output_tokens, 5);
@@ -683,17 +684,63 @@ test("Grok discovery builds sessions from ~/.grok/sessions layout", async () => 
     ],
   });
 
-  const rows = await buildSessionAnalytics({ home, force: true });
-  const grokRows = rows.filter((row) => row.source === "grok");
-  assert.equal(grokRows.length, 1);
-  assert.equal(grokRows[0].session_id, sessionId);
-  assert.equal(grokRows[0].title, "Discovered Grok session");
-  assert.equal(grokRows[0].total_tokens, 10);
+  // Pin Grok home to the fixture tree so a developer-exported GROK_HOME /
+  // TOKENTRACKER_GROK_HOME cannot pull real sessions into this unit test.
+  const prevGrokHome = process.env.GROK_HOME;
+  const prevTtGrokHome = process.env.TOKENTRACKER_GROK_HOME;
+  delete process.env.GROK_HOME;
+  delete process.env.TOKENTRACKER_GROK_HOME;
+  try {
+    const rows = await buildSessionAnalytics({ home, force: true });
+    const grokRows = rows.filter((row) => row.source === "grok");
+    assert.equal(grokRows.length, 1);
+    assert.equal(grokRows[0].session_id, sessionId);
+    assert.equal(grokRows[0].title, "Discovered Grok session");
+    assert.equal(grokRows[0].total_tokens, 10);
 
-  const browser = listSessionsForBrowser(rows);
-  const grokOnly = browser.sessions.filter((row) => row.source === "grok");
-  assert.equal(grokOnly.length, 1);
-  assert.equal(grokOnly[0].resume_command, `grok --resume ${sessionId}`);
+    const browser = listSessionsForBrowser(rows);
+    const grokOnly = browser.sessions.filter((row) => row.source === "grok");
+    assert.equal(grokOnly.length, 1);
+    assert.equal(grokOnly[0].resume_command, `grok --resume ${sessionId}`);
+  } finally {
+    if (prevGrokHome === undefined) delete process.env.GROK_HOME;
+    else process.env.GROK_HOME = prevGrokHome;
+    if (prevTtGrokHome === undefined) delete process.env.TOKENTRACKER_GROK_HOME;
+    else process.env.TOKENTRACKER_GROK_HOME = prevTtGrokHome;
+  }
+});
+
+test("Grok tool-only turn after turn_completed still increments turns", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-tool-only-"));
+  const sessionId = "dddddddd-eeee-4fff-8000-111111111111";
+  const usage = {
+    inputTokens: 20,
+    outputTokens: 5,
+    totalTokens: 25,
+    cachedReadTokens: 0,
+    reasoningTokens: 0,
+    modelUsage: { "grok-4.5": { inputTokens: 20, outputTokens: 5, totalTokens: 25 } },
+  };
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    title: "Tool-only follow-up",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: "first" } }, { timestamp: 100, agentTimestampMs: 100_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 101, agentTimestampMs: 101_000 }),
+      // No new user_message_chunk — only a tool after the previous turn closed.
+      grokUpdate(sessionId, "tool_call", {
+        title: "search_replace",
+        _meta: { "x.ai/tool": { name: "search_replace" } },
+      }, { timestamp: 102, agentTimestampMs: 102_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 103, agentTimestampMs: 103_000 }),
+    ],
+  });
+
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.turns, 2);
+  assert.equal(session.edit_turns, 1);
+  assert.ok(session.edit_turns <= session.turns);
+  assert.equal(session.total_tokens, 50);
 });
 
 test("Grok does not invent billable tokens from context window occupancy", async () => {


### PR DESCRIPTION
## Summary
Unify the remaining Grok Build local surfaces that were still Claude/Codex-only:

1. **Context breakdown** — Codex-style category split from `turn_completed.usage` + tools observed in the same turn (`source=grok` on the category-breakdown API + dashboard panel/i18n).
2. **Sessions tab** — discover `~/.grok/sessions/**/updates.jsonl`, bill from `turn_completed.usage` only (never context-window `totalTokens`), add a **Grok** source filter, and emit `grok --resume <id>`.

This supersedes the separate Sessions PR (#368); both features ship together for review.

## Details

### Context breakdown
- New `src/lib/grok-context-breakdown.js` (heuristic tool/exec attribution, same pattern as Codex)
- Wire `source=grok` in local-api + UsageOverview / ContextBreakdownPanel
- i18n empty/error/footnote/heading copy; sha256 inventory cache key (CodeQL)

### Sessions
- `scanGrokSession` + discovery under `~/.grok/sessions`
- Sidecar v10 so Claude/Codex caches rebuild cleanly when Grok rows appear
- Titles from agent metadata (`generated_title` / `session_summary`) only — never raw prompts
- `title` / `session_id` / `project_ref` remain local-only (stripped by `summarizeSessions`)

## Privacy
Same metadata-only boundary as Claude/Codex for both features.

## Test plan
- [x] `node --test test/grok-context-breakdown.test.js`
- [x] `node --test test/session-analytics.test.js` (includes Grok cases)
- [x] `npx vitest run src/pages/SessionsPage.test.jsx`
- [x] Local smoke: Sessions API returns Grok rows; context breakdown accepts `source=grok`
- [ ] Reviewer: dashboard Context Breakdown source selector + Sessions filter show Grok

## Related
- Closes the gap after the Grok usage fix (#363)
- Supersedes #368 (Sessions-only PR — closing as duplicate of this combined PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grok Build “Context Breakdown” to the dashboard, including token totals, tool activity, and execution drill-down alongside existing providers.
  * Extended usage-category local API with `source=grok`.
  * Added Grok as a selectable source filter on the Sessions page.
  * Added Grok-specific localization strings (DE/JA/KO/ZH-TW/ZH) for empty/error states, attribution notes, and headings.
* **Bug Fixes**
  * Improved resilience when Grok sessions/logs are missing or can’t be processed, including clearer compute-failure responses.
  * Extended Grok resume-command safety checks to block shell-injection patterns.
* **Tests**
  * Added/updated coverage for Grok context breakdown, Grok session analytics, and Grok-related dashboard/session-page filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->