### PR TITLE
feat(grok): show Grok Build sessions in the Sessions tab

### DIFF
--- a/dashboard/src/pages/SessionsPage.jsx
+++ b/dashboard/src/pages/SessionsPage.jsx
@@ -31,6 +31,7 @@ const SOURCE_FILTERS = [
   { id: "all", label: () => copy("sessions.filter.source_all") },
   { id: "claude", label: () => "Claude Code" },
   { id: "codex", label: () => "Codex" },
+  { id: "grok", label: () => "Grok" },
 ];
 
 const DATE_RANGES = [
@@ -375,7 +376,7 @@ export function SessionsPage() {
 
   const truncated = Number(data?.session_count) > Number(data?.returned_count);
 
-  // Sessions read local Claude/Codex logs from the machine running the CLI;
+  // Sessions read local Claude/Codex/Grok logs from the machine running the CLI;
   // there is no cloud source. On the deployed web app, surface the local-only
   // notice instead of an empty list.
   if (!IS_LOCAL_HOST && !isMockEnabled()) {

--- a/dashboard/src/pages/SessionsPage.test.jsx
+++ b/dashboard/src/pages/SessionsPage.test.jsx
@@ -29,8 +29,8 @@ const response = {
   from: "",
   to: "",
   available: true,
-  session_count: 2,
-  returned_count: 2,
+  session_count: 3,
+  returned_count: 3,
   sessions: [
     {
       session_hash: "claude-row",
@@ -74,6 +74,27 @@ const response = {
       first_pass: false,
       resume_command: "codex resume aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
     },
+    {
+      session_hash: "grok-row",
+      session_id: "019f740c-e792-7fb1-a218-59ea1b340714",
+      title: "Debug local proxy",
+      source: "grok",
+      project_key: "alphafox-web",
+      project_ref: "/work/alphafox-web",
+      model: "grok-4.5-build-free",
+      started_at: "2026-07-22T08:00:00Z",
+      ended_at: "2026-07-22T08:15:00Z",
+      duration_ms: 900_000,
+      turns: 3,
+      edit_turns: 1,
+      retry_turns: 0,
+      subagent_calls: 0,
+      total_tokens: 21_000,
+      cost_usd: 0,
+      productive: true,
+      first_pass: true,
+      resume_command: "grok --resume 019f740c-e792-7fb1-a218-59ea1b340714",
+    },
   ],
 };
 
@@ -89,6 +110,7 @@ describe("SessionsPage", () => {
 
     expect(await screen.findByText("Fix authentication flow")).toBeInTheDocument();
     expect(screen.getByText("Review release")).toBeInTheDocument();
+    expect(screen.getByText("Debug local proxy")).toBeInTheDocument();
     // The whole list is fetched once; no row cap and no server-side window.
     expect(getSessions).toHaveBeenCalledWith({ refresh: false });
 
@@ -96,6 +118,11 @@ describe("SessionsPage", () => {
     fireEvent.click(sourceTabs.getByRole("tab", { name: "Codex" }));
     expect(screen.queryByText("Fix authentication flow")).not.toBeInTheDocument();
     expect(screen.getByText("Review release")).toBeInTheDocument();
+    expect(screen.queryByText("Debug local proxy")).not.toBeInTheDocument();
+
+    fireEvent.click(sourceTabs.getByRole("tab", { name: "Grok" }));
+    expect(screen.queryByText("Review release")).not.toBeInTheDocument();
+    expect(screen.getByText("Debug local proxy")).toBeInTheDocument();
 
     fireEvent.click(sourceTabs.getByRole("tab", { name: "All" }));
     fireEvent.change(screen.getByRole("searchbox", { name: "Search sessions" }), {
@@ -103,6 +130,7 @@ describe("SessionsPage", () => {
     });
     expect(screen.getByText("Fix authentication flow")).toBeInTheDocument();
     expect(screen.queryByText("Review release")).not.toBeInTheDocument();
+    expect(screen.queryByText("Debug local proxy")).not.toBeInTheDocument();
   });
 
   it("filters the date range client-side without re-querying", async () => {

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -48,12 +48,27 @@ const { computeRowCost } = require("./pricing");
 //   - session_id is only set when the log actually contained a sessionId
 //     record. It used to fall back to the file's basename, which produced
 //     resume commands for non-session files (`claude --resume journal`).
-const SIDECAR_VERSION = 9;
-const EDIT_TOOLS = new Set(["apply_patch", "edit", "write", "multiedit", "notebookedit"]);
+// v10 adds Grok Build sessions (~/.grok/sessions/**/updates.jsonl), scanned
+// from turn_completed.usage + tool_call metadata. Bump so Claude/Codex rows
+// stay valid while Grok entries appear on the next full rebuild.
+const SIDECAR_VERSION = 10;
+const EDIT_TOOLS = new Set([
+  "apply_patch",
+  "edit",
+  "write",
+  "multiedit",
+  "notebookedit",
+  // Grok Build write tools (ACP tool titles / x.ai/tool.name).
+  "search_replace",
+  "str_replace",
+  "create_file",
+  "write_file",
+]);
 const PLACEHOLDER_MODELS = new Set(["<synthetic>", "synthetic", "<unknown>", "unknown"]);
 const CLAUDE_MEM_OBSERVER_PROJECT_SUFFIX = "--claude-mem-observer-sessions";
 const CODEX_SUBAGENT_TOOLS = new Set(["spawn_agent", "multi_agent_v1__spawn_agent"]);
 const CODEX_SIGNAL_TOOLS = new Set([...EDIT_TOOLS, ...CODEX_SUBAGENT_TOOLS]);
+const GROK_SUBAGENT_TOOLS = new Set(["spawn_subagent", "spawn_agent"]);
 
 function normalizeSessionModel(value) {
   if (typeof value !== "string") return null;
@@ -457,11 +472,278 @@ async function scanCodexSession(filePath) {
   });
 }
 
+// Grok Build sessions live at:
+//   ~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/updates.jsonl
+// with sibling summary.json (id/cwd/title) and signals.json (aggregate
+// counters). Billable tokens come only from turn_completed.usage — the same
+// authority as the Grok usage parser — not from context-window totalTokens.
+function resolveGrokHome(home = os.homedir(), env = process.env) {
+  if (typeof env.TOKENTRACKER_GROK_HOME === "string" && env.TOKENTRACKER_GROK_HOME.trim()) {
+    return path.resolve(env.TOKENTRACKER_GROK_HOME.trim());
+  }
+  if (typeof env.GROK_HOME === "string" && env.GROK_HOME.trim()) {
+    return path.resolve(env.GROK_HOME.trim());
+  }
+  return path.join(home, ".grok");
+}
+
+function grokSummaryPathFor(updatesPath) {
+  return path.join(path.dirname(updatesPath), "summary.json");
+}
+
+function grokSignalsPathFor(updatesPath) {
+  return path.join(path.dirname(updatesPath), "signals.json");
+}
+
+function readJsonFileSync(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function grokTimestampIso(obj) {
+  const metaMs = Number(obj?.params?._meta?.agentTimestampMs);
+  if (Number.isFinite(metaMs) && metaMs > 0) return new Date(metaMs).toISOString();
+  const top = Number(obj?.timestamp);
+  if (!Number.isFinite(top) || top <= 0) return null;
+  // Grok writes unix seconds on the envelope; ms values are already > 1e12.
+  const ms = top > 1e12 ? top : top * 1000;
+  return new Date(ms).toISOString();
+}
+
+function grokUsageTotals(usage) {
+  if (!usage || typeof usage !== "object") return emptyTotals();
+  return tokenTotals({
+    input_tokens: usage.inputTokens ?? usage.input_tokens,
+    cache_read_input_tokens: usage.cachedReadTokens ?? usage.cache_read_input_tokens ?? usage.cached_input_tokens,
+    cache_creation_input_tokens: usage.cachedWriteTokens ?? usage.cache_creation_input_tokens,
+    output_tokens: usage.outputTokens ?? usage.output_tokens,
+    reasoning_output_tokens: usage.reasoningTokens ?? usage.reasoning_output_tokens,
+  });
+}
+
+function pickGrokModel(usage, fallback) {
+  const modelUsage = usage?.modelUsage;
+  if (modelUsage && typeof modelUsage === "object") {
+    let bestName = null;
+    let bestTokens = -1;
+    for (const [name, entry] of Object.entries(modelUsage)) {
+      const normalized = normalizeSessionModel(name);
+      if (!normalized) continue;
+      const tokens = finite(entry?.totalTokens ?? entry?.total_tokens)
+        + finite(entry?.inputTokens ?? entry?.input_tokens)
+        + finite(entry?.outputTokens ?? entry?.output_tokens);
+      if (tokens >= bestTokens) {
+        bestTokens = tokens;
+        bestName = normalized;
+      }
+    }
+    if (bestName) return bestName;
+  }
+  return normalizeSessionModel(fallback) || "unknown";
+}
+
+function extractGrokUserPrompt(update) {
+  if (!update || update.sessionUpdate !== "user_message_chunk") return null;
+  const content = update.content;
+  if (typeof content === "string") {
+    const text = content.trim();
+    return text || null;
+  }
+  if (content && typeof content === "object") {
+    if (typeof content.text === "string") {
+      const text = content.text.trim();
+      return text || null;
+    }
+  }
+  return null;
+}
+
+function extractGrokToolName(update) {
+  if (!update || update.sessionUpdate !== "tool_call") return "";
+  const metaName = update._meta?.["x.ai/tool"]?.name;
+  return canonicalToolName(metaName || update.title || "");
+}
+
+async function listGrokSessionFiles(sessionsRoot) {
+  if (!fs.existsSync(sessionsRoot)) return [];
+  const found = [];
+  async function walk(dir, depth) {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      const updatesPath = path.join(full, "updates.jsonl");
+      try {
+        const stat = await fsp.stat(updatesPath);
+        if (stat.isFile() && stat.size > 0) {
+          found.push(updatesPath);
+          continue;
+        }
+      } catch { /* not a session leaf */ }
+      await walk(full, depth + 1);
+    }
+  }
+  await walk(sessionsRoot, 0);
+  return found;
+}
+
+async function scanGrokSession(filePath) {
+  const summary = readJsonFileSync(grokSummaryPathFor(filePath)) || {};
+  const signals = readJsonFileSync(grokSignalsPathFor(filePath)) || {};
+  const tokens = emptyTotals();
+  const bounds = emptyBounds();
+  const dirName = path.basename(path.dirname(filePath));
+  let observedSessionId = typeof summary?.info?.id === "string" && summary.info.id
+    ? summary.info.id
+    : (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(dirName) ? dirName : null);
+  let cwd = typeof summary?.info?.cwd === "string" && summary.info.cwd
+    ? summary.info.cwd
+    : null;
+  // Prefer agent-authored generated_title over free-form session_summary when
+  // both exist; both are Grok metadata, never the raw user prompt body.
+  const title = cleanSessionTitle(summary.generated_title)
+    || cleanSessionTitle(summary.session_summary)
+    || null;
+  let model = pickGrokModel(null, signals.primaryModelId || summary.current_model_id);
+  let turns = 0;
+  let editTurns = 0;
+  let retryTurns = 0;
+  let currentHadEdit = false;
+  let subagentCalls = 0;
+  const subagentTypes = new Map();
+  let lastPromptFingerprint = null;
+  // Grok streams user_message_chunk pieces for one prompt. Accumulate until
+  // turn_completed, then fingerprint the full prompt for retry detection.
+  let openUserTurn = false;
+  let userChunkBuffer = "";
+
+  function closeTurn() {
+    if (currentHadEdit) editTurns += 1;
+    currentHadEdit = false;
+    if (userChunkBuffer) {
+      const fingerprint = promptFingerprint(userChunkBuffer);
+      if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+      lastPromptFingerprint = fingerprint;
+    }
+    openUserTurn = false;
+    userChunkBuffer = "";
+  }
+
+  const input = fs.createReadStream(filePath, { encoding: "utf8" });
+  const lines = readline.createInterface({ input, crlfDelay: Infinity });
+  for await (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    updateBounds(bounds, grokTimestampIso(obj));
+    const params = obj.params && typeof obj.params === "object" ? obj.params : {};
+    if (typeof params.sessionId === "string" && params.sessionId) {
+      observedSessionId = params.sessionId;
+    }
+    const update = params.update && typeof params.update === "object" ? params.update : null;
+    if (!update) continue;
+    const sessionUpdate = update.sessionUpdate;
+
+    if (sessionUpdate === "user_message_chunk") {
+      const piece = extractGrokUserPrompt(update);
+      if (!piece) continue;
+      // First non-empty chunk after a closed turn opens a new user turn;
+      // later chunks only extend the fingerprint buffer.
+      if (!openUserTurn) {
+        turns += 1;
+        openUserTurn = true;
+        userChunkBuffer = piece;
+      } else {
+        userChunkBuffer += piece;
+      }
+      continue;
+    }
+
+    if (sessionUpdate === "tool_call") {
+      // Tools belong to the current user turn. If Grok never emitted a user
+      // chunk (rare / resumed partial logs), open an anonymous turn so edit
+      // accounting still works.
+      if (!openUserTurn && turns === 0) {
+        turns += 1;
+        openUserTurn = true;
+      }
+      const name = extractGrokToolName(update);
+      if (EDIT_TOOLS.has(name)) currentHadEdit = true;
+      if (GROK_SUBAGENT_TOOLS.has(name)) {
+        subagentCalls += 1;
+        const display = name === "spawn_agent" ? "spawn_subagent" : name;
+        subagentTypes.set(display, (subagentTypes.get(display) || 0) + 1);
+      }
+      continue;
+    }
+
+    if (sessionUpdate === "turn_completed") {
+      closeTurn();
+      const usage = update.usage;
+      addTotals(tokens, grokUsageTotals(usage));
+      const candidate = pickGrokModel(usage, model);
+      if (candidate && candidate !== "unknown") model = candidate;
+      continue;
+    }
+  }
+  closeTurn();
+
+  // Prefer observed turn_completed totals. Fall back to signals only when the
+  // updates stream had no billable turns (empty/partial session).
+  if (tokens.total_tokens === 0 && finite(signals.contextTokensUsed) > 0) {
+    // Do NOT invent billable totals from context occupancy. Leave zeros so
+    // listSessionsForBrowser filters empty sessions out.
+  }
+  if (turns === 0 && finite(signals.turnCount) > 0) {
+    turns = finite(signals.turnCount);
+  }
+  if (!Number.isFinite(Date.parse(bounds.started_at || "")) && summary.created_at) {
+    updateBounds(bounds, summary.created_at);
+  }
+  if (!Number.isFinite(Date.parse(bounds.ended_at || "")) && (summary.last_active_at || summary.updated_at)) {
+    updateBounds(bounds, summary.last_active_at || summary.updated_at);
+  }
+  if ((!model || model === "unknown") && signals.primaryModelId) {
+    model = normalizeSessionModel(signals.primaryModelId) || model;
+  }
+
+  return finalizeRecord({
+    version: SIDECAR_VERSION,
+    session_hash: sessionHash("grok", observedSessionId || filePath),
+    session_id: observedSessionId || null,
+    // Local-only: stripped in summarizeSessions before any cloud/CSV export.
+    title,
+    source: "grok",
+    project_key: projectKey(cwd, filePath),
+    project_ref: cwd || null,
+    model: model || "unknown",
+    ...bounds,
+    turns,
+    edit_turns: editTurns,
+    retry_turns: retryTurns,
+    subagent_calls: subagentCalls,
+    subagent_types: Object.fromEntries([...subagentTypes.entries()].sort()),
+    tokens,
+    provenance: { source: "local-session-log", confidence: "observed", retry_confidence: "inferred", content_retained: false },
+  });
+}
+
 async function discoverSessionFiles(home) {
-  const [allClaude, codex, archived] = await Promise.all([
+  const grokHome = resolveGrokHome(home);
+  const [allClaude, codex, archived, grok] = await Promise.all([
     listClaudeProjectFiles(path.join(home, ".claude", "projects")),
     listRolloutFilesDeep(path.join(home, ".codex", "sessions")),
     listRolloutFilesDeep(path.join(home, ".codex", "archived_sessions")),
+    listGrokSessionFiles(path.join(grokHome, "sessions")),
   ]);
   // Claude Memory stores thousands of background observer transcripts beside
   // real Claude Code sessions. They contain <synthetic>/haiku bookkeeping and
@@ -479,7 +761,7 @@ async function discoverSessionFiles(home) {
     const previous = codexBySession.get(id);
     if (!previous || mtimeOf(filePath) > mtimeOf(previous)) codexBySession.set(id, filePath);
   }
-  return { claude, codex: [...codexBySession.values()] };
+  return { claude, codex: [...codexBySession.values()], grok };
 }
 
 function filesSignature(files) {
@@ -548,10 +830,18 @@ function loadCodexTitleIndex(filePath) {
 // A Codex row also depends on session_index.jsonl, not just its rollout file.
 // Include that dependency in the incremental cache key so renaming a thread is
 // visible after the next refresh instead of leaving a stale title indefinitely.
+// Grok titles live in sibling summary.json (and signals can change without
+// touching updates.jsonl on some partial flushes).
 function analyticsEntryStatKey(source, filePath) {
   const sessionStat = sessionFileStatKey(filePath);
-  if (!sessionStat || source !== "codex") return sessionStat;
-  return `${sessionStat}|title-index:${sessionFileStatKey(codexTitleIndexPathFor(filePath)) || "missing"}`;
+  if (!sessionStat) return sessionStat;
+  if (source === "codex") {
+    return `${sessionStat}|title-index:${sessionFileStatKey(codexTitleIndexPathFor(filePath)) || "missing"}`;
+  }
+  if (source === "grok") {
+    return `${sessionStat}|summary:${sessionFileStatKey(grokSummaryPathFor(filePath)) || "missing"}|signals:${sessionFileStatKey(grokSignalsPathFor(filePath)) || "missing"}`;
+  }
+  return sessionStat;
 }
 
 function readSidecar(sidecarPath) {
@@ -587,11 +877,15 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   const discovered = await discoverSessionFiles(home);
   // Codex thread titles are stored separately from rollout files. Include the
   // index in the overall signature so an index-only rename reaches the
-  // per-file dependency check below on the next refresh.
+  // per-file dependency check below on the next refresh. Grok titles/metadata
+  // live in sibling summary.json / signals.json next to updates.jsonl.
   const signature = filesSignature([
     ...discovered.claude,
     ...discovered.codex,
     ...discovered.codex.map(codexTitleIndexPathFor).filter(Boolean),
+    ...discovered.grok,
+    ...discovered.grok.map(grokSummaryPathFor),
+    ...discovered.grok.map(grokSignalsPathFor),
   ]);
   if (!force && previousMeta?.version === SIDECAR_VERSION && previousMeta.signature === signature) {
     await writeAtomic(metaPath, `${JSON.stringify({ ...previousMeta, checked_at: new Date().toISOString() })}\n`);
@@ -612,6 +906,7 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   const entries = [
     ...discovered.claude.map((filePath) => ({ source: "claude", filePath, scan: scanClaudeSession })),
     ...discovered.codex.map((filePath) => ({ source: "codex", filePath, scan: scanCodexSession })),
+    ...discovered.grok.map((filePath) => ({ source: "grok", filePath, scan: scanGrokSession })),
   ];
   // Files we could not turn into a row (permission denied, half-written line,
   // vanished mid-scan). Swallowing these silently made sessions disappear with
@@ -664,8 +959,8 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   return sessions;
 }
 
-// A cold scan walks every local Claude/Codex session file. Period switches can
-// issue overlapping requests while that scan is still running; share the
+// A cold scan walks every local Claude/Codex/Grok session file. Period switches
+// can issue overlapping requests while that scan is still running; share the
 // promise per home so those requests wait for one scan instead of multiplying
 // the disk work and racing the atomic sidecar write.
 const sessionAnalyticsBuilds = new Map();
@@ -808,6 +1103,9 @@ function resumeCommandFor(source, sessionId) {
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/.test(id)) return null;
   if (source === "claude") return `claude --resume ${id}`;
   if (source === "codex") return `codex resume ${id}`;
+  // Grok Build: `grok --resume <session-id>` (also accepts a title). The
+  // command must still be run from the session's project_ref cwd.
+  if (source === "grok") return `grok --resume ${id}`;
   return null;
 }
 
@@ -934,6 +1232,7 @@ module.exports = {
   sessionHash,
   scanClaudeSession,
   scanCodexSession,
+  scanGrokSession,
   buildSessionAnalytics,
   summarizeSessions,
   listSessionsForBrowser,

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -9,11 +9,57 @@ const {
   buildSessionAnalytics,
   scanClaudeSession,
   scanCodexSession,
+  scanGrokSession,
   summarizeSessions,
   listSessionsForBrowser,
   resumeCommandFor,
   sessionsToCsv,
 } = require("../src/lib/session-analytics");
+
+function writeGrokSessionFixture(home, {
+  sessionId = "019f740c-e792-7fb1-a218-59ea1b340714",
+  cwd = "/work/tokentracker",
+  title = "Wire up Grok sessions",
+  updates = [],
+  signals = null,
+} = {}) {
+  // Mirror Grok Build layout: ~/.grok/sessions/<url-encoded-cwd>/<uuid>/
+  const encodedCwd = encodeURIComponent(cwd);
+  const sessionDir = path.join(home, ".grok", "sessions", encodedCwd, sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const updatesPath = path.join(sessionDir, "updates.jsonl");
+  fs.writeFileSync(updatesPath, `${updates.map(JSON.stringify).join("\n")}\n`);
+  fs.writeFileSync(path.join(sessionDir, "summary.json"), `${JSON.stringify({
+    info: { id: sessionId, cwd },
+    generated_title: title,
+    session_summary: title,
+    created_at: "2026-07-18T06:00:00.000Z",
+    updated_at: "2026-07-18T06:10:00.000Z",
+    last_active_at: "2026-07-18T06:10:00.000Z",
+    current_model_id: "alphafox",
+  })}\n`);
+  fs.writeFileSync(path.join(sessionDir, "signals.json"), `${JSON.stringify(signals || {
+    turnCount: 1,
+    primaryModelId: "grok-4.5",
+    modelsUsed: ["grok-4.5"],
+    contextTokensUsed: 99999,
+  })}\n`);
+  return updatesPath;
+}
+
+function grokUpdate(sessionId, sessionUpdate, updateFields = {}, opts = {}) {
+  const ts = opts.timestamp ?? 1_784_358_461;
+  const agentTimestampMs = opts.agentTimestampMs ?? ts * 1000;
+  return {
+    timestamp: ts,
+    method: sessionUpdate === "turn_completed" ? "_x.ai/session/update" : "session/update",
+    params: {
+      sessionId,
+      update: { sessionUpdate, ...updateFields },
+      _meta: { agentTimestampMs },
+    },
+  };
+}
 
 test("Claude session analytics retains metadata but never content", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-"));
@@ -494,7 +540,176 @@ test("resume commands reject ids that could inject shell syntax", () => {
     resumeCommandFor("codex", "11111111-2222-3333-4444-555555555555"),
     "codex resume 11111111-2222-3333-4444-555555555555",
   );
+  assert.equal(
+    resumeCommandFor("grok", "019f740c-e792-7fb1-a218-59ea1b340714"),
+    "grok --resume 019f740c-e792-7fb1-a218-59ea1b340714",
+  );
   assert.equal(resumeCommandFor("claude", "--dangerous-flag"), null);
   assert.equal(resumeCommandFor("claude", "valid; touch /tmp/pwned"), null);
   assert.equal(resumeCommandFor("codex", "valid\nrm -rf workspace"), null);
+  assert.equal(resumeCommandFor("grok", "valid; rm -rf /"), null);
+});
+
+test("Grok session analytics bills from turn_completed.usage and keeps titles local-only", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-session-"));
+  const sessionId = "019f740c-e792-7fb1-a218-59ea1b340714";
+  const secret = "TOP-SECRET-GROK-PROMPT-CONTENT";
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    cwd: "/work/myproject",
+    title: "Refactor the auth module",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", {
+        content: { type: "text", text: secret },
+      }, { timestamp: 1_784_358_400, agentTimestampMs: 1_784_358_400_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        toolCallId: "call-1",
+        title: "search_replace",
+        _meta: { "x.ai/tool": { name: "search_replace", kind: "edit" } },
+      }, { timestamp: 1_784_358_410, agentTimestampMs: 1_784_358_410_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        toolCallId: "call-2",
+        title: "spawn_subagent",
+        _meta: { "x.ai/tool": { name: "spawn_subagent", kind: "other" } },
+      }, { timestamp: 1_784_358_415, agentTimestampMs: 1_784_358_415_000 }),
+      grokUpdate(sessionId, "turn_completed", {
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cachedReadTokens: 10,
+          reasoningTokens: 5,
+          modelUsage: {
+            "grok-4.5-build-free": {
+              inputTokens: 100,
+              outputTokens: 20,
+              totalTokens: 120,
+              cachedReadTokens: 10,
+              reasoningTokens: 5,
+            },
+          },
+        },
+      }, { timestamp: 1_784_358_430, agentTimestampMs: 1_784_358_430_000 }),
+    ],
+  });
+
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.source, "grok");
+  assert.equal(session.session_id, sessionId);
+  assert.equal(session.title, "Refactor the auth module");
+  assert.equal(session.project_key, "myproject");
+  assert.equal(session.project_ref, "/work/myproject");
+  assert.equal(session.turns, 1);
+  assert.equal(session.edit_turns, 1);
+  assert.equal(session.retry_turns, 0);
+  assert.equal(session.one_shot, true);
+  assert.equal(session.subagent_calls, 1);
+  assert.equal(session.subagent_types.spawn_subagent, 1);
+  // 100 input + 10 cached + 20 output = 130 (reasoning is tracked separately)
+  assert.equal(session.total_tokens, 130);
+  assert.equal(session.tokens.input_tokens, 100);
+  assert.equal(session.tokens.cached_input_tokens, 10);
+  assert.equal(session.tokens.output_tokens, 20);
+  assert.equal(session.tokens.reasoning_output_tokens, 5);
+  assert.equal(session.model, "grok-4.5-build-free");
+  // Prompt body never lands in the metadata row.
+  assert.equal(JSON.stringify(session).includes(secret), false);
+
+  const summary = summarizeSessions([session]);
+  assert.equal(Object.hasOwn(summary.sessions[0], "title"), false);
+  assert.equal(Object.hasOwn(summary.sessions[0], "project_ref"), false);
+  assert.equal(Object.hasOwn(summary.sessions[0], "session_id"), false);
+
+  const browser = listSessionsForBrowser([session]);
+  assert.equal(browser.sessions.length, 1);
+  assert.equal(browser.sessions[0].title, "Refactor the auth module");
+  assert.equal(browser.sessions[0].resume_command, `grok --resume ${sessionId}`);
+});
+
+test("Grok session analytics counts repeated prompts as retries across turns", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-retry-"));
+  const sessionId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  const prompt = "make the requested change";
+  const usage = {
+    inputTokens: 10,
+    outputTokens: 2,
+    totalTokens: 12,
+    cachedReadTokens: 0,
+    reasoningTokens: 0,
+    modelUsage: { "grok-4.5": { inputTokens: 10, outputTokens: 2, totalTokens: 12 } },
+  };
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    title: "Retry fixture",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: prompt } }, { timestamp: 100, agentTimestampMs: 100_000 }),
+      grokUpdate(sessionId, "tool_call", {
+        title: "search_replace",
+        _meta: { "x.ai/tool": { name: "search_replace" } },
+      }, { timestamp: 101, agentTimestampMs: 101_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 102, agentTimestampMs: 102_000 }),
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: prompt } }, { timestamp: 103, agentTimestampMs: 103_000 }),
+      grokUpdate(sessionId, "turn_completed", { usage }, { timestamp: 104, agentTimestampMs: 104_000 }),
+    ],
+  });
+
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.turns, 2);
+  assert.equal(session.edit_turns, 1);
+  assert.equal(session.retry_turns, 1);
+  assert.equal(session.one_shot, false);
+  assert.equal(session.total_tokens, 24);
+});
+
+test("Grok discovery builds sessions from ~/.grok/sessions layout", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-discover-"));
+  const sessionId = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+  writeGrokSessionFixture(home, {
+    sessionId,
+    cwd: "/repo/alpha",
+    title: "Discovered Grok session",
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: "hi" } }, { timestamp: 200, agentTimestampMs: 200_000 }),
+      grokUpdate(sessionId, "turn_completed", {
+        usage: {
+          inputTokens: 7,
+          outputTokens: 3,
+          totalTokens: 10,
+          cachedReadTokens: 0,
+          reasoningTokens: 0,
+          modelUsage: { "grok-4.5": { inputTokens: 7, outputTokens: 3, totalTokens: 10 } },
+        },
+      }, { timestamp: 210, agentTimestampMs: 210_000 }),
+    ],
+  });
+
+  const rows = await buildSessionAnalytics({ home, force: true });
+  const grokRows = rows.filter((row) => row.source === "grok");
+  assert.equal(grokRows.length, 1);
+  assert.equal(grokRows[0].session_id, sessionId);
+  assert.equal(grokRows[0].title, "Discovered Grok session");
+  assert.equal(grokRows[0].total_tokens, 10);
+
+  const browser = listSessionsForBrowser(rows);
+  const grokOnly = browser.sessions.filter((row) => row.source === "grok");
+  assert.equal(grokOnly.length, 1);
+  assert.equal(grokOnly[0].resume_command, `grok --resume ${sessionId}`);
+});
+
+test("Grok does not invent billable tokens from context window occupancy", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-nocontxt-"));
+  const sessionId = "cccccccc-dddd-4eee-8fff-000000000000";
+  // Only a user chunk — no turn_completed.usage. signals.contextTokensUsed is
+  // deliberately huge and must not become total_tokens.
+  const updatesPath = writeGrokSessionFixture(home, {
+    sessionId,
+    title: "Empty billable",
+    signals: { turnCount: 1, primaryModelId: "grok-4.5", contextTokensUsed: 500_000 },
+    updates: [
+      grokUpdate(sessionId, "user_message_chunk", { content: { type: "text", text: "hi" } }),
+    ],
+  });
+  const session = await scanGrokSession(updatesPath);
+  assert.equal(session.total_tokens, 0);
+  assert.equal(listSessionsForBrowser([session]).sessions.length, 0);
 });


### PR DESCRIPTION
## Summary
- Discover Grok Build sessions under `~/.grok/sessions/**/updates.jsonl` (with sibling `summary.json` / `signals.json`)
- Scan billable usage only from `turn_completed.usage` (same authority as the Grok usage fix) — never invent totals from context-window `totalTokens`
- Add Sessions UI source filter **Grok**, plus `grok --resume <id>` for local browser rows
- Bump session sidecar to v10 so existing Claude/Codex caches rebuild cleanly when Grok rows appear

## Why
Usage and context breakdown already cover Grok; Sessions was still Claude/Codex-only. This closes the gap so the three local surfaces stay consistent.

## Privacy
Same metadata-only boundary as Claude/Codex:
- Titles come from Grok agent metadata (`generated_title` / `session_summary`), never the raw prompt body
- `title` / `session_id` / `project_ref` stay local-only (stripped by `summarizeSessions` for cloud/CSV)

## Test plan
- [x] `node --test test/session-analytics.test.js` (24/24)
- [x] `npx vitest run src/pages/SessionsPage.test.jsx` (6/6)
- [x] Smoke-scanned real `~/.grok/sessions` fixtures (turns / edit_turns / tokens / resume command)
- [ ] Local app: Sessions tab shows Grok filter + rows after restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and displaying local Grok Build sessions alongside Claude and Codex.
  * Added Grok session filtering in the Sessions dashboard.
  * Added Grok resume commands for supported sessions.

* **Bug Fixes**
  * Improved session analytics for Grok activity, usage, retries, edits, models, and subagent calls.
  * Prevented inaccurate token totals when usage data is unavailable.
  * Maintained protection against unsafe resume commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->