### PR TITLE
fix(macOS): disable WebView history gestures

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
@@ -82,7 +82,6 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
         let webView = WKWebView(frame: .zero, configuration: webConfig)
         webView.navigationDelegate = self
         webView.uiDelegate = self
-        webView.allowsBackForwardNavigationGestures = true
         webView.setValue(false, forKey: "drawsBackground")
         self.webView = webView
 


### PR DESCRIPTION
## Summary

Disable WKWebView back/forward navigation gestures in the macOS dashboard so horizontal trackpad swipes cannot accidentally navigate the embedded single-page app's history.

## Why

The dashboard uses React Router for in-app navigation, but `DashboardWindowController` also explicitly enabled WKWebView's native back/forward swipe gestures. On a trackpad, an ordinary horizontal swipe could therefore trigger WebKit history navigation and move the user away from the current dashboard route.

The app does not rely on WebKit's gesture-driven history navigation. Leaving `allowsBackForwardNavigationGestures` at its default `false` keeps routing under the dashboard's control while preserving normal vertical scrolling and page-level horizontal scrolling.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Validation

- Verified the behavior in a native macOS WKWebView test shell against the running local TokenTracker dashboard.
- Confirmed the test shell could coexist with the installed TokenTracker app without replacing its bundle or taking over its local server.
- Confirmed `git diff --check` passes.

## Checklist

- [ ] `npm test` passes (not run: the change is isolated to WKWebView configuration)
- [x] No new user-facing strings
- [x] Commit follows conventional style
- [x] PR description explains why the change is needed

## Known gaps

- A full Xcode build was not run locally because only Xcode Command Line Tools are installed. The upstream macOS CI build should provide the authoritative compilation check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed swipe-based back and forward navigation gestures from the dashboard window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->