### PR TITLE
fix(codex): repair indeterminate lineage history

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -9,6 +9,7 @@ const { resolveInstallPaths, ensureFlatCursor } = require("../lib/install-resolv
 const { multiInstallParse, mergeBothFileSources } = require("../lib/multi-install-parser");
 const wsl = require("../lib/wsl-probe");
 const { ensureDir, readJson, writeJson, openLock } = require("../lib/fs");
+const { physicalJsonlRecords } = require("../lib/jsonl-lines");
 const {
   listRolloutFiles,
   listRolloutFilesDeep,
@@ -4265,7 +4266,6 @@ async function scanForInterleavedCodexUsage(
 
 async function scanCodexUsageLineages(filePath, maxBytes = Infinity) {
   let stream = null;
-  let rl = null;
   try {
     const before = await readCodexFileSnapshot(filePath);
     const state = createUsageDeltaState();
@@ -4276,9 +4276,9 @@ async function scanCodexUsageLineages(filePath, maxBytes = Infinity) {
       encoding: "utf8",
       highWaterMark: 32 * 1024,
     });
-    rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    for await (const line of rl) {
-      bytesRead += Buffer.byteLength(line, "utf8") + 1;
+    for await (const record of physicalJsonlRecords(stream)) {
+      const { line } = record;
+      bytesRead += record.physicalBytes;
       if (bytesRead > byteLimit) return { affected: false, indeterminate: true };
       if (!line.trim()) continue;
       let obj;
@@ -4308,7 +4308,6 @@ async function scanCodexUsageLineages(filePath, maxBytes = Infinity) {
   } catch (_e) {
     return { affected: false, indeterminate: true };
   } finally {
-    if (rl) rl.close();
     if (stream) stream.destroy();
   }
 }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -3819,6 +3819,7 @@ async function repairCodexRescanInflation({
       cursors: tmpCursors,
       queuePath: tmpQueue,
       projectQueuePath: tmpProjectQueue,
+      invalidRecordPolicy: "throw",
     });
     let tmpRaw = "";
     try {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -4272,11 +4272,10 @@ async function scanCodexUsageLineages(filePath, maxBytes = Infinity) {
     const byteLimit = Number.isFinite(maxBytes) ? Math.max(0, maxBytes) : Infinity;
     let bytesRead = 0;
     let affected = false;
-    stream = fssync.createReadStream(filePath, {
-      encoding: "utf8",
-      highWaterMark: 32 * 1024,
-    });
-    for await (const record of physicalJsonlRecords(stream)) {
+    stream = fssync.createReadStream(filePath, { highWaterMark: 32 * 1024 });
+    for await (const record of physicalJsonlRecords(stream, {
+      maxPhysicalBytes: byteLimit,
+    })) {
       const { line } = record;
       bytesRead += record.physicalBytes;
       if (bytesRead > byteLimit) return { affected: false, indeterminate: true };

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -920,6 +920,8 @@ async function parseCodexRolloutFile(filePath, {
   return result;
 }
 
+const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
 function parseCodexLine(lineBuffer, diagnostics) {
   let content = lineBuffer;
   if (content.length > 0 && content[content.length - 1] === 0x0d) {
@@ -928,7 +930,7 @@ function parseCodexLine(lineBuffer, diagnostics) {
   if (content.length === 0) return null;
   try {
     if (diagnostics) diagnostics.json_parse_calls += 1;
-    return JSON.parse(content.toString("utf8"));
+    return JSON.parse(fatalUtf8Decoder.decode(content));
   } catch {
     return null;
   }

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -8,7 +8,6 @@
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
-const readline = require("node:readline");
 
 const { listRolloutFiles } = require("./rollout");
 const {
@@ -1045,57 +1044,12 @@ async function* readCodexObjectsFull(filePath, diagnostics, fileIndex, {
   readProgress = null,
   contentHasher = null,
 } = {}) {
-  const start = Math.max(0, Number(startOffset) || 0);
-  const requestedEnd = Number(endOffset);
-  const hasBoundedEnd = endOffset !== null && endOffset !== undefined &&
-    Number.isFinite(requestedEnd) && requestedEnd >= 0;
-  if (hasBoundedEnd && requestedEnd <= start) {
-    if (readProgress) readProgress.endOffset = start;
-    return;
-  }
-
-  if (diagnostics) diagnostics.opened_files += 1;
-  const stream = fs.createReadStream(filePath, {
-    ...(contentHasher ? {} : { encoding: "utf8" }),
-    start,
-    ...(hasBoundedEnd ? { end: requestedEnd - 1 } : {}),
+  yield* readCodexObjectsIncremental(filePath, diagnostics, fileIndex, {
+    startOffset,
+    endOffset,
+    readProgress,
+    contentHasher,
   });
-  const trackChunk = contentHasher
-    ? (value) => {
-        const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
-        contentHasher.update(chunk);
-        if (readProgress && chunk.length > 0) {
-          readProgress.lastByte = chunk[chunk.length - 1];
-        }
-      }
-    : null;
-  if (trackChunk) stream.on("data", trackChunk);
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-  let lineIndex = 0;
-  try {
-    for await (const line of rl) {
-      if (!line) continue;
-      let obj;
-      try {
-        if (diagnostics) diagnostics.json_parse_calls += 1;
-        obj = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      yield { obj, fileIndex, lineIndex };
-      lineIndex += 1;
-    }
-  } finally {
-    const bytesRead = Number(stream.bytesRead || 0);
-    if (readProgress) readProgress.endOffset = start + bytesRead;
-    if (diagnostics) {
-      diagnostics.bytes_read = Number(diagnostics.bytes_read || 0) + bytesRead;
-      diagnostics.parsed_files += 1;
-    }
-    if (trackChunk) stream.off("data", trackChunk);
-    rl.close();
-    stream.close?.();
-  }
 }
 
 async function* readCodexObjects(filePath, diagnostics, fileIndex, options = {}) {

--- a/src/lib/jsonl-lines.js
+++ b/src/lib/jsonl-lines.js
@@ -23,7 +23,13 @@ function decodePhysicalLine(buffer, { stripCr = false } = {}) {
   return fatalUtf8Decoder.decode(content);
 }
 
-async function* physicalJsonlRecords(input, { maxPhysicalBytes = Infinity } = {}) {
+async function* physicalJsonlRecords(input, {
+  invalidUtf8 = "throw",
+  maxPhysicalBytes = Infinity,
+} = {}) {
+  if (invalidUtf8 !== "throw" && invalidUtf8 !== "record") {
+    throw new TypeError(`unsupported invalidUtf8 policy: ${invalidUtf8}`);
+  }
   const byteLimit = Number.isFinite(maxPhysicalBytes)
     ? Math.max(0, Number(maxPhysicalBytes))
     : Infinity;
@@ -53,13 +59,17 @@ async function* physicalJsonlRecords(input, { maxPhysicalBytes = Infinity } = {}
       fragments.length = 0;
       fragmentsBytes = 0;
       physicalBytesRead += physicalBytes;
-      yield {
-        line: decodePhysicalLine(lineBuffer, { stripCr: true }),
-        physicalBytes,
-        terminated: true,
-      };
       start = newline + 1;
       newline = chunk.indexOf(0x0a, start);
+      let line;
+      try {
+        line = decodePhysicalLine(lineBuffer, { stripCr: true });
+      } catch (error) {
+        if (invalidUtf8 === "throw") throw error;
+        yield { line: null, utf8Valid: false, physicalBytes, terminated: true };
+        continue;
+      }
+      yield { line, utf8Valid: true, physicalBytes, terminated: true };
     }
 
     if (start < chunk.length) {
@@ -76,16 +86,35 @@ async function* physicalJsonlRecords(input, { maxPhysicalBytes = Infinity } = {}
     const lineBuffer = fragments.length === 1
       ? fragments[0]
       : Buffer.concat(fragments, fragmentsBytes);
-    yield {
-      line: decodePhysicalLine(lineBuffer),
-      physicalBytes: fragmentsBytes,
-      terminated: false,
-    };
+    try {
+      yield {
+        line: decodePhysicalLine(lineBuffer),
+        utf8Valid: true,
+        physicalBytes: fragmentsBytes,
+        terminated: false,
+      };
+    } catch (error) {
+      if (invalidUtf8 === "throw") throw error;
+      yield {
+        line: null,
+        utf8Valid: false,
+        physicalBytes: fragmentsBytes,
+        terminated: false,
+      };
+    }
   }
 }
 
-async function* physicalJsonlLines(input) {
-  for await (const record of physicalJsonlRecords(input)) {
+async function* physicalJsonlLines(input, { invalidUtf8 = "throw", ...options } = {}) {
+  if (invalidUtf8 !== "throw" && invalidUtf8 !== "skip") {
+    throw new TypeError(`unsupported invalidUtf8 policy: ${invalidUtf8}`);
+  }
+  const recordPolicy = invalidUtf8 === "skip" ? "record" : "throw";
+  for await (const record of physicalJsonlRecords(input, {
+    ...options,
+    invalidUtf8: recordPolicy,
+  })) {
+    if (!record.utf8Valid) continue;
     yield record.line;
   }
 }

--- a/src/lib/jsonl-lines.js
+++ b/src/lib/jsonl-lines.js
@@ -3,48 +3,82 @@
 /**
  * Yield physical JSONL records. Unlike node:readline, this intentionally treats
  * only LF as a record separator so valid U+2028/U+2029 characters inside JSON
- * strings remain part of the record.
- *
- * The input must emit decoded strings (for example, a read stream created with
- * encoding: "utf8") so the stream owns UTF-8 chunk-boundary handling.
+ * strings remain part of the record. Reading raw bytes keeps byte budgets exact
+ * and lets malformed UTF-8 fail closed.
  */
-async function* physicalJsonlRecords(input) {
-  let fragments = [];
+class PhysicalJsonlLimitError extends Error {
+  constructor(maxPhysicalBytes) {
+    super(`physical JSONL byte limit exceeded: ${maxPhysicalBytes}`);
+    this.name = "PhysicalJsonlLimitError";
+    this.code = "PHYSICAL_JSONL_LIMIT_EXCEEDED";
+  }
+}
 
-  for await (const chunk of input) {
-    if (typeof chunk !== "string") {
-      throw new TypeError("physicalJsonlLines input must emit strings");
+const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodePhysicalLine(buffer, { stripCr = false } = {}) {
+  const content = stripCr && buffer.length > 0 && buffer[buffer.length - 1] === 0x0d
+    ? buffer.subarray(0, buffer.length - 1)
+    : buffer;
+  return fatalUtf8Decoder.decode(content);
+}
+
+async function* physicalJsonlRecords(input, { maxPhysicalBytes = Infinity } = {}) {
+  const byteLimit = Number.isFinite(maxPhysicalBytes)
+    ? Math.max(0, Number(maxPhysicalBytes))
+    : Infinity;
+  const fragments = [];
+  let fragmentsBytes = 0;
+  let physicalBytesRead = 0;
+
+  for await (const value of input) {
+    if (!Buffer.isBuffer(value) && !(value instanceof Uint8Array)) {
+      throw new TypeError("physicalJsonlLines input must emit bytes");
     }
+    const chunk = Buffer.isBuffer(value)
+      ? value
+      : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
 
     let start = 0;
-    let newline = chunk.indexOf("\n");
+    let newline = chunk.indexOf(0x0a);
     while (newline !== -1) {
-      const fragment = chunk.slice(start, newline);
-      let line;
-      if (fragments.length === 0) {
-        line = fragment;
-      } else {
-        fragments.push(fragment);
-        line = fragments.join("");
-        fragments = [];
+      const fragment = chunk.subarray(start, newline);
+      const physicalBytes = fragmentsBytes + fragment.length + 1;
+      if (physicalBytesRead + physicalBytes > byteLimit) {
+        throw new PhysicalJsonlLimitError(byteLimit);
       }
-      const physicalBytes = Buffer.byteLength(line, "utf8") + 1;
-      if (line.endsWith("\r")) line = line.slice(0, -1);
-      yield { line, physicalBytes, terminated: true };
+      const lineBuffer = fragments.length === 0
+        ? fragment
+        : Buffer.concat([...fragments, fragment], fragmentsBytes + fragment.length);
+      fragments.length = 0;
+      fragmentsBytes = 0;
+      physicalBytesRead += physicalBytes;
+      yield {
+        line: decodePhysicalLine(lineBuffer, { stripCr: true }),
+        physicalBytes,
+        terminated: true,
+      };
       start = newline + 1;
-      newline = chunk.indexOf("\n", start);
+      newline = chunk.indexOf(0x0a, start);
     }
 
     if (start < chunk.length) {
-      fragments.push(chunk.slice(start));
+      const fragment = chunk.subarray(start);
+      if (physicalBytesRead + fragmentsBytes + fragment.length > byteLimit) {
+        throw new PhysicalJsonlLimitError(byteLimit);
+      }
+      fragments.push(Buffer.from(fragment));
+      fragmentsBytes += fragment.length;
     }
   }
 
-  if (fragments.length > 0) {
-    const line = fragments.join("");
+  if (fragmentsBytes > 0) {
+    const lineBuffer = fragments.length === 1
+      ? fragments[0]
+      : Buffer.concat(fragments, fragmentsBytes);
     yield {
-      line,
-      physicalBytes: Buffer.byteLength(line, "utf8"),
+      line: decodePhysicalLine(lineBuffer),
+      physicalBytes: fragmentsBytes,
       terminated: false,
     };
   }
@@ -56,4 +90,8 @@ async function* physicalJsonlLines(input) {
   }
 }
 
-module.exports = { physicalJsonlLines, physicalJsonlRecords };
+module.exports = {
+  PhysicalJsonlLimitError,
+  physicalJsonlLines,
+  physicalJsonlRecords,
+};

--- a/src/lib/jsonl-lines.js
+++ b/src/lib/jsonl-lines.js
@@ -86,22 +86,15 @@ async function* physicalJsonlRecords(input, {
     const lineBuffer = fragments.length === 1
       ? fragments[0]
       : Buffer.concat(fragments, fragmentsBytes);
+    let line = null;
+    let utf8Valid = true;
     try {
-      yield {
-        line: decodePhysicalLine(lineBuffer),
-        utf8Valid: true,
-        physicalBytes: fragmentsBytes,
-        terminated: false,
-      };
+      line = decodePhysicalLine(lineBuffer);
     } catch (error) {
       if (invalidUtf8 === "throw") throw error;
-      yield {
-        line: null,
-        utf8Valid: false,
-        physicalBytes: fragmentsBytes,
-        terminated: false,
-      };
+      utf8Valid = false;
     }
+    yield { line, utf8Valid, physicalBytes: fragmentsBytes, terminated: false };
   }
 }
 

--- a/src/lib/jsonl-lines.js
+++ b/src/lib/jsonl-lines.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/**
+ * Yield physical JSONL records. Unlike node:readline, this intentionally treats
+ * only LF as a record separator so valid U+2028/U+2029 characters inside JSON
+ * strings remain part of the record.
+ *
+ * The input must emit decoded strings (for example, a read stream created with
+ * encoding: "utf8") so the stream owns UTF-8 chunk-boundary handling.
+ */
+async function* physicalJsonlRecords(input) {
+  let fragments = [];
+
+  for await (const chunk of input) {
+    if (typeof chunk !== "string") {
+      throw new TypeError("physicalJsonlLines input must emit strings");
+    }
+
+    let start = 0;
+    let newline = chunk.indexOf("\n");
+    while (newline !== -1) {
+      const fragment = chunk.slice(start, newline);
+      let line;
+      if (fragments.length === 0) {
+        line = fragment;
+      } else {
+        fragments.push(fragment);
+        line = fragments.join("");
+        fragments = [];
+      }
+      const physicalBytes = Buffer.byteLength(line, "utf8") + 1;
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      yield { line, physicalBytes, terminated: true };
+      start = newline + 1;
+      newline = chunk.indexOf("\n", start);
+    }
+
+    if (start < chunk.length) {
+      fragments.push(chunk.slice(start));
+    }
+  }
+
+  if (fragments.length > 0) {
+    const line = fragments.join("");
+    yield {
+      line,
+      physicalBytes: Buffer.byteLength(line, "utf8"),
+      terminated: false,
+    };
+  }
+}
+
+async function* physicalJsonlLines(input) {
+  for await (const record of physicalJsonlRecords(input)) {
+    yield record.line;
+  }
+}
+
+module.exports = { physicalJsonlLines, physicalJsonlRecords };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6,7 +6,7 @@ const readline = require("node:readline");
 
 const crypto = require("node:crypto");
 const { ensureDir, writeJson, chmod600IfPossible } = require("./fs");
-const { physicalJsonlLines } = require("./jsonl-lines");
+const { physicalJsonlLines, physicalJsonlRecords } = require("./jsonl-lines");
 const { readSqliteJsonRows, readSqliteJsonRowsAsync } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
 const { resolveInstallPaths } = require("./install-resolver");
@@ -1962,7 +1962,10 @@ async function parseRolloutFile({
     };
   }
 
-  const stream = fssync.createReadStream(filePath, { start: startOffset });
+  const stream = fssync.createReadStream(filePath, {
+    start: startOffset,
+    end: endOffset - 1,
+  });
 
   let model = typeof lastModel === "string" ? lastModel : null;
   const usageDeltaState = createUsageDeltaState({
@@ -1987,9 +1990,22 @@ async function parseRolloutFile({
   let currentProjectRef = projectRef || null;
   let currentProjectKey = projectKey || null;
   let eventsAggregated = 0;
+  let scannedEndOffset = startOffset;
+  let committedEndOffset = startOffset;
 
-  for await (const line of physicalJsonlLines(stream)) {
-    if (!line) continue;
+  for await (const record of physicalJsonlRecords(stream, { invalidUtf8: "record" })) {
+    scannedEndOffset += record.physicalBytes;
+    if (record.terminated) committedEndOffset = scannedEndOffset;
+    if (!record.utf8Valid) {
+      if (!record.terminated) break;
+      continue;
+    }
+
+    const { line } = record;
+    if (!line) {
+      if (!record.terminated) committedEndOffset = scannedEndOffset;
+      continue;
+    }
     const maybeTokenCount = line.includes('"token_count"');
     const maybeTurnContext =
       !maybeTokenCount &&
@@ -1998,14 +2014,26 @@ async function parseRolloutFile({
         line.includes('"cwd"') ||
         line.includes('"current_date"') ||
         line.includes('"forked_from_id"'));
-    if (!maybeTokenCount && !maybeTurnContext) continue;
+    if (!maybeTokenCount && !maybeTurnContext) {
+      if (!record.terminated) {
+        try {
+          JSON.parse(line);
+          committedEndOffset = scannedEndOffset;
+        } catch (_e) {
+          break;
+        }
+      }
+      continue;
+    }
 
     let obj;
     try {
       obj = JSON.parse(line);
     } catch (_e) {
+      if (!record.terminated) break;
       continue;
     }
+    if (!record.terminated) committedEndOffset = scannedEndOffset;
 
     if (
       (obj?.type === "turn_context" || obj?.type === "session_meta") &&
@@ -2149,7 +2177,7 @@ async function parseRolloutFile({
   }
 
   return {
-    endOffset,
+    endOffset: committedEndOffset,
     lastTotal: latestTotal,
     tokenUsageBaselines: snapshotUsageBaselines(usageDeltaState),
     lastModel: model,
@@ -2185,11 +2213,20 @@ async function scanRolloutProjectFileContexts({
     };
   }
 
-  const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: 0 });
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  const stream = fssync.createReadStream(filePath, { start: 0, end: endOffset - 1 });
   let currentCwd = null;
+  let scannedEndOffset = 0;
+  let committedEndOffset = 0;
 
-  for await (const line of rl) {
+  for await (const record of physicalJsonlRecords(stream, { invalidUtf8: "record" })) {
+    scannedEndOffset += record.physicalBytes;
+    if (record.terminated) committedEndOffset = scannedEndOffset;
+    if (!record.utf8Valid) {
+      if (!record.terminated) break;
+      continue;
+    }
+
+    const { line } = record;
     if (
       !line ||
       !(
@@ -2198,6 +2235,14 @@ async function scanRolloutProjectFileContexts({
       ) ||
       !line.includes('"cwd"')
     ) {
+      if (!record.terminated && line) {
+        try {
+          JSON.parse(line);
+          committedEndOffset = scannedEndOffset;
+        } catch (_e) {
+          break;
+        }
+      }
       continue;
     }
 
@@ -2205,8 +2250,10 @@ async function scanRolloutProjectFileContexts({
     try {
       obj = JSON.parse(line);
     } catch (_e) {
+      if (!record.terminated) break;
       continue;
     }
+    if (!record.terminated) committedEndOffset = scannedEndOffset;
     if (
       (obj?.type !== "turn_context" && obj?.type !== "session_meta") ||
       !obj?.payload ||
@@ -2230,7 +2277,7 @@ async function scanRolloutProjectFileContexts({
   }
 
   return {
-    endOffset,
+    endOffset: committedEndOffset,
     lastTotal,
     tokenUsageBaselines,
     lastModel,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6,6 +6,7 @@ const readline = require("node:readline");
 
 const crypto = require("node:crypto");
 const { ensureDir, writeJson, chmod600IfPossible } = require("./fs");
+const { physicalJsonlLines } = require("./jsonl-lines");
 const { readSqliteJsonRows, readSqliteJsonRowsAsync } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
 const { resolveInstallPaths } = require("./install-resolver");
@@ -1962,7 +1963,6 @@ async function parseRolloutFile({
   }
 
   const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
   let model = typeof lastModel === "string" ? lastModel : null;
   const usageDeltaState = createUsageDeltaState({
@@ -1988,7 +1988,7 @@ async function parseRolloutFile({
   let currentProjectKey = projectKey || null;
   let eventsAggregated = 0;
 
-  for await (const line of rl) {
+  for await (const line of physicalJsonlLines(stream)) {
     if (!line) continue;
     const maybeTokenCount = line.includes('"token_count"');
     const maybeTurnContext =

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -181,7 +181,11 @@ async function parseRolloutIncremental({
   source,
   publicRepoResolver,
   diagnostics,
+  invalidRecordPolicy = "skip",
 }) {
+  if (invalidRecordPolicy !== "skip" && invalidRecordPolicy !== "throw") {
+    throw new TypeError(`unsupported invalidRecordPolicy: ${invalidRecordPolicy}`);
+  }
   await ensureDir(path.dirname(queuePath));
   let filesProcessed = 0;
   let eventsAggregated = 0;
@@ -447,6 +451,7 @@ async function parseRolloutIncremental({
           publicRepoCache,
           publicRepoResolver,
           projectContext,
+          invalidRecordPolicy,
         })
       : await parseRolloutFile({
           filePath,
@@ -468,6 +473,7 @@ async function parseRolloutIncremental({
           projectContext,
           seenCodexEvents: codexEventTracker,
           sessionId: codexSessionIdFromPath(filePath),
+          invalidRecordPolicy,
         });
 
     const nextCursor = {
@@ -1946,6 +1952,7 @@ async function parseRolloutFile({
   projectContext,
   seenCodexEvents,
   sessionId,
+  invalidRecordPolicy,
 }) {
   const st = fileStat || (await fs.stat(filePath));
   const endOffset = st.size;
@@ -1993,7 +2000,8 @@ async function parseRolloutFile({
   let scannedEndOffset = startOffset;
   let committedEndOffset = startOffset;
 
-  for await (const record of physicalJsonlRecords(stream, { invalidUtf8: "record" })) {
+  const invalidUtf8 = invalidRecordPolicy === "throw" ? "throw" : "record";
+  for await (const record of physicalJsonlRecords(stream, { invalidUtf8 })) {
     scannedEndOffset += record.physicalBytes;
     if (record.terminated) committedEndOffset = scannedEndOffset;
     if (!record.utf8Valid) {
@@ -2015,11 +2023,12 @@ async function parseRolloutFile({
         line.includes('"current_date"') ||
         line.includes('"forked_from_id"'));
     if (!maybeTokenCount && !maybeTurnContext) {
-      if (!record.terminated) {
+      if (invalidRecordPolicy === "throw" || !record.terminated) {
         try {
           JSON.parse(line);
           committedEndOffset = scannedEndOffset;
-        } catch (_e) {
+        } catch (error) {
+          if (invalidRecordPolicy === "throw") throw error;
           break;
         }
       }
@@ -2029,7 +2038,8 @@ async function parseRolloutFile({
     let obj;
     try {
       obj = JSON.parse(line);
-    } catch (_e) {
+    } catch (error) {
+      if (invalidRecordPolicy === "throw") throw error;
       if (!record.terminated) break;
       continue;
     }
@@ -2197,6 +2207,7 @@ async function scanRolloutProjectFileContexts({
   publicRepoCache,
   publicRepoResolver,
   projectContext,
+  invalidRecordPolicy,
 }) {
   const st = fileStat || (await fs.stat(filePath));
   const endOffset = st.size;
@@ -2218,7 +2229,8 @@ async function scanRolloutProjectFileContexts({
   let scannedEndOffset = 0;
   let committedEndOffset = 0;
 
-  for await (const record of physicalJsonlRecords(stream, { invalidUtf8: "record" })) {
+  const invalidUtf8 = invalidRecordPolicy === "throw" ? "throw" : "record";
+  for await (const record of physicalJsonlRecords(stream, { invalidUtf8 })) {
     scannedEndOffset += record.physicalBytes;
     if (record.terminated) committedEndOffset = scannedEndOffset;
     if (!record.utf8Valid) {
@@ -2235,11 +2247,12 @@ async function scanRolloutProjectFileContexts({
       ) ||
       !line.includes('"cwd"')
     ) {
-      if (!record.terminated && line) {
+      if (line && (invalidRecordPolicy === "throw" || !record.terminated)) {
         try {
           JSON.parse(line);
           committedEndOffset = scannedEndOffset;
-        } catch (_e) {
+        } catch (error) {
+          if (invalidRecordPolicy === "throw") throw error;
           break;
         }
       }
@@ -2249,7 +2262,8 @@ async function scanRolloutProjectFileContexts({
     let obj;
     try {
       obj = JSON.parse(line);
-    } catch (_e) {
+    } catch (error) {
+      if (invalidRecordPolicy === "throw") throw error;
       if (!record.terminated) break;
       continue;
     }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -1962,7 +1962,7 @@ async function parseRolloutFile({
     };
   }
 
-  const stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
+  const stream = fssync.createReadStream(filePath, { start: startOffset });
 
   let model = typeof lastModel === "string" ? lastModel : null;
   const usageDeltaState = createUsageDeltaState({

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6,7 +6,7 @@ const readline = require("node:readline");
 
 const crypto = require("node:crypto");
 const { ensureDir, writeJson, chmod600IfPossible } = require("./fs");
-const { physicalJsonlLines, physicalJsonlRecords } = require("./jsonl-lines");
+const { physicalJsonlRecords } = require("./jsonl-lines");
 const { readSqliteJsonRows, readSqliteJsonRowsAsync } = require("./sqlite-reader");
 const wsl = require("./wsl-probe");
 const { resolveInstallPaths } = require("./install-resolver");
@@ -2010,10 +2010,7 @@ async function parseRolloutFile({
     }
 
     const { line } = record;
-    if (!line) {
-      if (!record.terminated) committedEndOffset = scannedEndOffset;
-      continue;
-    }
+    if (!line) continue;
     const maybeTokenCount = line.includes('"token_count"');
     const maybeTurnContext =
       !maybeTokenCount &&

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -905,6 +905,7 @@ test("Context incrementally parses append-only sessions with pending tools and d
 test("Context resume state preserves interleaved cumulative usage lineages", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-lineage-"));
   const freshRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-context-lineage-fresh-"));
+  let rolloutHandle;
   try {
     const day = "2030-06-02";
     const fileName =
@@ -949,6 +950,7 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
       event(`${day}T04:46:10.000Z`, usage(30), usage(130)),
     ];
     const filePath = await writeRollout(root, day, fileName, initialEvents);
+    rolloutHandle = await fs.open(filePath, "a+");
     const args = {
       from: day,
       to: day,
@@ -958,12 +960,12 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
 
     const primed = await computeCodexContextBreakdown(args);
     assert.equal(primed.totals.total_tokens, 300);
-    assert.equal(primed.diagnostics.bytes_read, (await fs.stat(filePath)).size);
+    assert.equal(primed.diagnostics.bytes_read, (await rolloutHandle.stat()).size);
     assert.equal(primed.diagnostics.parsed_files, 1);
     const appendedContent = rolloutContents(appendedEvents);
-    await fs.appendFile(filePath, appendedContent, "utf8");
+    await rolloutHandle.appendFile(appendedContent, "utf8");
     const active = new Date(`${day}T12:01:00.000Z`);
-    await fs.utimes(filePath, active, active);
+    await rolloutHandle.utimes(active, active);
 
     const resumed = await computeCodexContextBreakdown(args);
     const freshPath = await writeRollout(freshRoot, day, fileName, []);
@@ -979,6 +981,7 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
     assert.equal(resumed.diagnostics.bytes_read, Buffer.byteLength(appendedContent));
     assert.equal(resumed.diagnostics.parsed_files, 1);
   } finally {
+    await rolloutHandle?.close();
     await fs.rm(root, { recursive: true, force: true });
     await fs.rm(freshRoot, { recursive: true, force: true });
   }

--- a/test/codex-context-hot-path.test.js
+++ b/test/codex-context-hot-path.test.js
@@ -917,11 +917,12 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
       reasoning_output_tokens: 0,
       total_tokens: totalTokens,
     });
-    const event = (timestamp, last, total) => ({
+    const event = (timestamp, last, total, annotation = null) => ({
       timestamp,
       type: "event_msg",
       payload: {
         type: "token_count",
+        ...(annotation == null ? {} : { annotation }),
         info: {
           last_token_usage: last,
           total_token_usage: total,
@@ -939,11 +940,11 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
           model_provider: "openai",
         },
       },
-      event(`${day}T04:45:39.000Z`, usage(100), usage(100)),
+      event(`${day}T04:45:39.000Z`, usage(100), usage(100), "before\u2028after"),
       event(`${day}T04:45:45.000Z`, usage(200), usage(200)),
     ];
     const appendedEvents = [
-      event(`${day}T04:46:02.000Z`, usage(100), usage(100)),
+      event(`${day}T04:46:02.000Z`, usage(100), usage(100), "before\u2029after"),
       event(`${day}T04:46:05.000Z`, usage(50), usage(250)),
       event(`${day}T04:46:10.000Z`, usage(30), usage(130)),
     ];
@@ -957,7 +958,10 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
 
     const primed = await computeCodexContextBreakdown(args);
     assert.equal(primed.totals.total_tokens, 300);
-    await fs.appendFile(filePath, rolloutContents(appendedEvents), "utf8");
+    assert.equal(primed.diagnostics.bytes_read, (await fs.stat(filePath)).size);
+    assert.equal(primed.diagnostics.parsed_files, 1);
+    const appendedContent = rolloutContents(appendedEvents);
+    await fs.appendFile(filePath, appendedContent, "utf8");
     const active = new Date(`${day}T12:01:00.000Z`);
     await fs.utimes(filePath, active, active);
 
@@ -972,6 +976,8 @@ test("Context resume state preserves interleaved cumulative usage lineages", asy
     assert.deepEqual(resumed.totals, fresh.totals);
     assert.equal(resumed.diagnostics.incremental_parse_hits, 1);
     assert.equal(resumed.diagnostics.incremental_parse_fallbacks, 0);
+    assert.equal(resumed.diagnostics.bytes_read, Buffer.byteLength(appendedContent));
+    assert.equal(resumed.diagnostics.parsed_files, 1);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
     await fs.rm(freshRoot, { recursive: true, force: true });

--- a/test/jsonl-lines.test.js
+++ b/test/jsonl-lines.test.js
@@ -7,7 +7,7 @@ const { physicalJsonlLines, physicalJsonlRecords } = require("../src/lib/jsonl-l
 
 async function collectLines(chunks) {
   const lines = [];
-  for await (const line of physicalJsonlLines(chunks)) {
+  for await (const line of physicalJsonlLines(chunks.map((chunk) => Buffer.from(chunk)))) {
     lines.push(line);
   }
   return lines;
@@ -41,7 +41,7 @@ test("physicalJsonlLines preserves bare carriage returns", async () => {
 
 test("physicalJsonlRecords reports exact CRLF and unterminated byte spans", async () => {
   const records = [];
-  for await (const record of physicalJsonlRecords(["first\r\nlast"])) {
+  for await (const record of physicalJsonlRecords([Buffer.from("first\r\nlast")])) {
     records.push(record);
   }
 
@@ -57,7 +57,7 @@ test("physicalJsonlLines closes its input when the consumer stops early", async 
     [Symbol.asyncIterator]() {
       return {
         async next() {
-          return { value: "first\nsecond\n", done: false };
+          return { value: Buffer.from("first\nsecond\n"), done: false };
         },
         async return() {
           returned = true;
@@ -69,6 +69,38 @@ test("physicalJsonlLines closes its input when the consumer stops early", async 
 
   for await (const _line of physicalJsonlLines(input)) break;
 
+  assert.equal(returned, true);
+});
+
+test("physicalJsonlRecords closes an unterminated input as soon as its byte limit is exceeded", async () => {
+  let pulled = 0;
+  let returned = false;
+  const chunks = ["1234", "5678", "9abcdef"].map((chunk) => Buffer.from(chunk));
+  const input = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          const value = chunks[pulled];
+          pulled += 1;
+          return value === undefined ? { done: true } : { value, done: false };
+        },
+        async return() {
+          returned = true;
+          return { done: true };
+        },
+      };
+    },
+  };
+
+  await assert.rejects(
+    async () => {
+      for await (const _record of physicalJsonlRecords(input, { maxPhysicalBytes: 8 })) {
+        assert.fail("an unterminated over-budget record must not be yielded");
+      }
+    },
+    (error) => error?.code === "PHYSICAL_JSONL_LIMIT_EXCEEDED",
+  );
+  assert.equal(pulled, 3);
   assert.equal(returned, true);
 });
 
@@ -102,4 +134,40 @@ test("physicalJsonlLines handles a large record split across many chunks", async
 
   assert.equal(chunks.length > 10_000, true);
   assert.deepEqual(lines, [record]);
+});
+
+test("physicalJsonlRecords counts multibyte UTF-8 exactly", async () => {
+  const content = Buffer.from('{"text":"中\u2028文"}\r\n');
+  const records = [];
+  for await (const record of physicalJsonlRecords([content], {
+    maxPhysicalBytes: content.length,
+  })) {
+    records.push(record);
+  }
+
+  assert.deepEqual(records, [{
+    line: '{"text":"中\u2028文"}',
+    physicalBytes: content.length,
+    terminated: true,
+  }]);
+  await assert.rejects(
+    async () => {
+      for await (const _record of physicalJsonlRecords([content], {
+        maxPhysicalBytes: content.length - 1,
+      })) {
+        assert.fail("an over-budget multibyte record must not be yielded");
+      }
+    },
+    (error) => error?.code === "PHYSICAL_JSONL_LIMIT_EXCEEDED",
+  );
+});
+
+test("physicalJsonlRecords rejects invalid UTF-8", async () => {
+  const invalid = Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d, 0x0a]);
+
+  await assert.rejects(async () => {
+    for await (const _record of physicalJsonlRecords([invalid])) {
+      assert.fail("invalid UTF-8 must not be yielded");
+    }
+  }, TypeError);
 });

--- a/test/jsonl-lines.test.js
+++ b/test/jsonl-lines.test.js
@@ -199,3 +199,21 @@ test("physicalJsonlRecords rejects invalid UTF-8 by default", async () => {
     }
   }, TypeError);
 });
+
+test("physicalJsonlRecords propagates errors thrown into a final record yield", async () => {
+  const iterator = physicalJsonlRecords([Buffer.from("last")], { invalidUtf8: "record" });
+  assert.deepEqual(await iterator.next(), {
+    done: false,
+    value: { line: "last", utf8Valid: true, physicalBytes: 4, terminated: false },
+  });
+  await assert.rejects(iterator.throw(new Error("consumer failed")), /consumer failed/);
+});
+
+test("physical JSONL iterators reject unsupported UTF-8 policies", async () => {
+  await assert.rejects(async () => {
+    for await (const _line of physicalJsonlLines([], { invalidUtf8: "record" })) {}
+  }, TypeError);
+  await assert.rejects(async () => {
+    for await (const _record of physicalJsonlRecords([], { invalidUtf8: "skip" })) {}
+  }, TypeError);
+});

--- a/test/jsonl-lines.test.js
+++ b/test/jsonl-lines.test.js
@@ -1,0 +1,105 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { physicalJsonlLines, physicalJsonlRecords } = require("../src/lib/jsonl-lines");
+
+async function collectLines(chunks) {
+  const lines = [];
+  for await (const line of physicalJsonlLines(chunks)) {
+    lines.push(line);
+  }
+  return lines;
+}
+
+test("physicalJsonlLines splits LF records", async () => {
+  const lines = await collectLines(["first\nsecond\nthird\n"]);
+
+  assert.deepEqual(lines, ["first", "second", "third"]);
+});
+
+test("physicalJsonlLines strips CR from CRLF records, including split CRLF chunks", async () => {
+  const lines = await collectLines(["first\r", "\nsecond\r", "\nthird\r\n"]);
+
+  assert.deepEqual(lines, ["first", "second", "third"]);
+});
+
+test("physicalJsonlLines preserves legal U+2028 and U+2029 characters", async () => {
+  const first = '{"text":"before\u2028after"}';
+  const second = '{"text":"before\u2029after"}';
+  const lines = await collectLines([`${first}\n${second}\n`]);
+
+  assert.deepEqual(lines, [first, second]);
+});
+
+test("physicalJsonlLines preserves bare carriage returns", async () => {
+  const lines = await collectLines(["first\rsecond\nfinal\r"]);
+
+  assert.deepEqual(lines, ["first\rsecond", "final\r"]);
+});
+
+test("physicalJsonlRecords reports exact CRLF and unterminated byte spans", async () => {
+  const records = [];
+  for await (const record of physicalJsonlRecords(["first\r\nlast"])) {
+    records.push(record);
+  }
+
+  assert.deepEqual(records, [
+    { line: "first", physicalBytes: 7, terminated: true },
+    { line: "last", physicalBytes: 4, terminated: false },
+  ]);
+});
+
+test("physicalJsonlLines closes its input when the consumer stops early", async () => {
+  let returned = false;
+  const input = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          return { value: "first\nsecond\n", done: false };
+        },
+        async return() {
+          returned = true;
+          return { done: true };
+        },
+      };
+    },
+  };
+
+  for await (const _line of physicalJsonlLines(input)) break;
+
+  assert.equal(returned, true);
+});
+
+test("physicalJsonlLines reassembles records split across chunks", async () => {
+  const lines = await collectLines(['{"id":', "1}", '\n{"id"', ":2}\n"]);
+
+  assert.deepEqual(lines, ['{"id":1}', '{"id":2}']);
+});
+
+test("physicalJsonlLines yields a final unterminated record", async () => {
+  const lines = await collectLines(["complete\nunter", "minated"]);
+
+  assert.deepEqual(lines, ["complete", "unterminated"]);
+});
+
+test("physicalJsonlLines preserves empty physical records", async () => {
+  const lines = await collectLines(["\n", "\nvalue\n\n"]);
+
+  assert.deepEqual(lines, ["", "", "value", ""]);
+});
+
+test("physicalJsonlLines handles a large record split across many chunks", async () => {
+  const record = `{"payload":"${"x".repeat(2 * 1024 * 1024)}"}`;
+  const chunks = [];
+  for (let offset = 0; offset < record.length; offset += 127) {
+    chunks.push(record.slice(offset, offset + 127));
+  }
+  chunks.push("\n");
+
+  const lines = await collectLines(chunks);
+
+  assert.equal(chunks.length > 10_000, true);
+  assert.deepEqual(lines, [record]);
+});

--- a/test/jsonl-lines.test.js
+++ b/test/jsonl-lines.test.js
@@ -46,8 +46,8 @@ test("physicalJsonlRecords reports exact CRLF and unterminated byte spans", asyn
   }
 
   assert.deepEqual(records, [
-    { line: "first", physicalBytes: 7, terminated: true },
-    { line: "last", physicalBytes: 4, terminated: false },
+    { line: "first", utf8Valid: true, physicalBytes: 7, terminated: true },
+    { line: "last", utf8Valid: true, physicalBytes: 4, terminated: false },
   ]);
 });
 
@@ -147,6 +147,7 @@ test("physicalJsonlRecords counts multibyte UTF-8 exactly", async () => {
 
   assert.deepEqual(records, [{
     line: '{"text":"中\u2028文"}',
+    utf8Valid: true,
     physicalBytes: content.length,
     terminated: true,
   }]);
@@ -162,7 +163,34 @@ test("physicalJsonlRecords counts multibyte UTF-8 exactly", async () => {
   );
 });
 
-test("physicalJsonlRecords rejects invalid UTF-8", async () => {
+test("physicalJsonlRecords preserves invalid UTF-8 record spans in record mode", async () => {
+  const invalid = Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]);
+  const input = Buffer.concat([Buffer.from("first\n"), invalid, Buffer.from("\nlast\n")]);
+  const records = [];
+
+  for await (const record of physicalJsonlRecords([input], { invalidUtf8: "record" })) {
+    records.push(record);
+  }
+
+  assert.deepEqual(records, [
+    { line: "first", utf8Valid: true, physicalBytes: 6, terminated: true },
+    { line: null, utf8Valid: false, physicalBytes: invalid.length + 1, terminated: true },
+    { line: "last", utf8Valid: true, physicalBytes: 5, terminated: true },
+  ]);
+  assert.equal(records.reduce((sum, record) => sum + record.physicalBytes, 0), input.length);
+});
+
+test("physicalJsonlLines skips invalid UTF-8 only when explicitly requested", async () => {
+  const invalid = Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]);
+  const input = Buffer.concat([Buffer.from("first\n"), invalid, Buffer.from("\nlast\n")]);
+  const lines = [];
+
+  for await (const line of physicalJsonlLines([input], { invalidUtf8: "skip" })) lines.push(line);
+
+  assert.deepEqual(lines, ["first", "last"]);
+});
+
+test("physicalJsonlRecords rejects invalid UTF-8 by default", async () => {
   const invalid = Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d, 0x0a]);
 
   await assert.rejects(async () => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -199,6 +199,187 @@ test("parseRolloutIncremental preserves Unicode line separators inside physical 
   }
 });
 
+test("parseRolloutIncremental skips an invalid UTF-8 record and keeps surrounding usage", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-invalid-utf8-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const usage = (totalTokens) => ({
+      input_tokens: totalTokens,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    });
+    const first = buildTokenCountLine({
+      ts: "2025-12-17T00:00:00.000Z",
+      last: usage(100),
+      total: usage(100),
+    });
+    const second = buildTokenCountLine({
+      ts: "2025-12-17T00:00:01.000Z",
+      last: usage(50),
+      total: usage(150),
+    });
+    const invalidLine = buildTokenCountLine({
+      ts: "2025-12-17T00:00:00.500Z",
+      last: usage(9_900),
+      total: usage(10_000),
+      annotation: "BROKEN",
+    });
+    const invalid = Buffer.from(invalidLine);
+    invalid[invalid.indexOf(Buffer.from("BROKEN"))] = 0xff;
+    const content = Buffer.concat([
+      Buffer.from(`${first}\n`),
+      invalid,
+      Buffer.from(`\n${second}\n`),
+    ]);
+    await fs.writeFile(rolloutPath, content);
+
+    const result = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+
+    assert.equal(result.eventsAggregated, 2);
+    assert.equal(cursors.files[rolloutPath].offset, content.length);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.reduce((sum, row) => sum + Number(row.total_tokens || 0), 0), 150);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental retries incomplete trailing JSONL records", async (t) => {
+  const cases = [
+    {
+      name: "ASCII JSON truncation",
+      splitOffset(line) {
+        return line.indexOf(Buffer.from('"total_token_usage"')) + 8;
+      },
+    },
+    {
+      name: "UTF-8 character truncation",
+      splitOffset(line) {
+        return line.indexOf(Buffer.from("中")) + 1;
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-partial-jsonl-"));
+      try {
+        const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+        const queuePath = path.join(tmp, "queue.jsonl");
+        const cursors = { version: 1, files: {}, updatedAt: null };
+        const usage = (totalTokens) => ({
+          input_tokens: totalTokens,
+          cached_input_tokens: 0,
+          output_tokens: 0,
+          reasoning_output_tokens: 0,
+          total_tokens: totalTokens,
+        });
+        const firstLine = Buffer.from(`${buildTokenCountLine({
+          ts: "2025-12-17T00:00:00.000Z",
+          last: usage(100),
+          total: usage(100),
+        })}\n`);
+        const secondLine = Buffer.from(buildTokenCountLine({
+          ts: "2025-12-17T00:00:01.000Z",
+          last: usage(50),
+          total: usage(150),
+          annotation: "中",
+        }));
+        const splitOffset = testCase.splitOffset(secondLine);
+        assert.ok(splitOffset > 0 && splitOffset < secondLine.length);
+        await fs.writeFile(
+          rolloutPath,
+          Buffer.concat([firstLine, secondLine.subarray(0, splitOffset)]),
+        );
+
+        const first = await parseRolloutIncremental({
+          rolloutFiles: [rolloutPath],
+          cursors,
+          queuePath,
+        });
+        assert.equal(first.eventsAggregated, 1);
+        assert.equal(cursors.files[rolloutPath].offset, firstLine.length);
+
+        await fs.appendFile(
+          rolloutPath,
+          Buffer.concat([secondLine.subarray(splitOffset), Buffer.from("\n")]),
+        );
+        const second = await parseRolloutIncremental({
+          rolloutFiles: [rolloutPath],
+          cursors,
+          queuePath,
+        });
+        assert.equal(second.eventsAggregated, 1);
+        const finalSize = (await fs.stat(rolloutPath)).size;
+        assert.equal(cursors.files[rolloutPath].offset, finalSize);
+        const queued = await readJsonLines(queuePath);
+        assert.equal(queued.length, 2);
+        assert.equal(Number(queued.at(-1)?.total_tokens || 0), 150);
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("parseRolloutIncremental recovers from a legacy cursor inside a UTF-8 character", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-legacy-utf8-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const usage = (totalTokens) => ({
+      input_tokens: totalTokens,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    });
+    const first = buildTokenCountLine({
+      ts: "2025-12-17T00:00:00.000Z",
+      last: usage(100),
+      total: usage(100),
+      annotation: "中",
+    });
+    const second = buildTokenCountLine({
+      ts: "2025-12-17T00:00:01.000Z",
+      last: usage(50),
+      total: usage(150),
+    });
+    const content = Buffer.from(`${first}\n${second}\n`);
+    await fs.writeFile(rolloutPath, content);
+    const stat = await fs.stat(rolloutPath);
+    const markerStart = content.indexOf(Buffer.from("中"));
+    const legacyOffset = markerStart + 1;
+    assert.ok(markerStart > 0);
+    assert.equal(content[legacyOffset] & 0xc0, 0x80);
+    const cursors = {
+      version: 1,
+      files: {
+        [rolloutPath]: {
+          inode: stat.ino,
+          offset: legacyOffset,
+          lastTotal: usage(100),
+          lastModel: "unknown",
+        },
+      },
+      updatedAt: null,
+    };
+
+    const result = await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal(cursors.files[rolloutPath].offset, content.length);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.reduce((sum, row) => sum + Number(row.total_tokens || 0), 0), 50);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseRolloutIncremental separates interleaved cumulative usage lineages", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {
@@ -742,7 +923,7 @@ test("parseRolloutIncremental recovers legacy Codex EOF cursor project freshness
     await fs.writeFile(
       rolloutPath,
       [
-        buildTurnContextLine({ model: "gpt-4", cwd: repoRoot }),
+        buildTurnContextLine({ model: "gpt-4", cwd: repoRoot, annotation: "left\u2028right" }),
         buildTokenCountLine({ ts: "2026-01-26T00:10:00.000Z", last: usage, total: usage }),
       ].join("\n") + "\n",
       "utf8",
@@ -778,6 +959,90 @@ test("parseRolloutIncremental recovers legacy Codex EOF cursor project freshness
     assert.equal(third.filesProcessed, 0);
     assert.equal(third.eventsAggregated, 0);
     assert.equal(third.projectBucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental retries a partial legacy project-context-only tail", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-project-partial-"));
+  try {
+    const repoRoot = path.join(tmp, "repo");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      `[remote "origin"]\n\turl = https://github.com/acme/alpha.git\n`,
+      "utf8",
+    );
+    const sessionsDir = path.join(tmp, ".codex", "sessions", "2026", "01", "26");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const rolloutPath = path.join(
+      sessionsDir,
+      "rollout-2026-01-26T00-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
+    );
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const usage = {
+      input_tokens: 2,
+      cached_input_tokens: 0,
+      output_tokens: 3,
+      reasoning_output_tokens: 0,
+      total_tokens: 5,
+    };
+    const completePrefix = Buffer.from(`${buildTokenCountLine({
+      ts: "2026-01-26T00:10:00.000Z",
+      last: usage,
+      total: usage,
+    })}\n`);
+    const contextLine = Buffer.from(buildTurnContextLine({
+      model: "gpt-4",
+      cwd: repoRoot,
+      annotation: "left\u2028right",
+    }));
+    const splitOffset = contextLine.indexOf(Buffer.from(repoRoot)) + 3;
+    assert.ok(splitOffset > 0 && splitOffset < contextLine.length);
+    const initialContent = Buffer.concat([completePrefix, contextLine.subarray(0, splitOffset)]);
+    await fs.writeFile(rolloutPath, initialContent);
+    const stat = await fs.stat(rolloutPath);
+    const cursors = {
+      version: 1,
+      files: {
+        [rolloutPath]: {
+          inode: stat.ino,
+          offset: initialContent.length,
+          lastTotal: usage,
+          lastModel: "gpt-4",
+        },
+      },
+      updatedAt: null,
+    };
+
+    const first = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(first.filesProcessed, 1);
+    assert.equal(first.eventsAggregated, 0);
+    assert.equal(cursors.files[rolloutPath].offset, completePrefix.length);
+    assert.equal(cursors.files[rolloutPath].projectOffset, completePrefix.length);
+    assert.equal(Boolean(cursors.files[rolloutPath].projectFileContext?.configPath), false);
+
+    await fs.appendFile(
+      rolloutPath,
+      Buffer.concat([contextLine.subarray(splitOffset), Buffer.from("\n")]),
+    );
+    const second = await parseRolloutIncremental({
+      rolloutFiles: [rolloutPath],
+      cursors,
+      queuePath,
+      projectQueuePath,
+    });
+    assert.equal(second.filesProcessed, 1);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(cursors.files[rolloutPath].offset, (await fs.stat(rolloutPath)).size);
+    assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -4587,13 +4852,16 @@ test("parseClaudeIncremental defaults missing model to unknown", async () => {
   }
 });
 
-function buildTurnContextLine({ model, cwd, currentDate }) {
+function buildTurnContextLine({ model, cwd, currentDate, annotation }) {
   const payload = { model };
   if (typeof cwd === "string" && cwd.length > 0) {
     payload.cwd = cwd;
   }
   if (typeof currentDate === "string" && currentDate.length > 0) {
     payload.current_date = currentDate;
+  }
+  if (typeof annotation === "string") {
+    payload.annotation = annotation;
   }
   return JSON.stringify({
     type: "turn_context",
@@ -4615,7 +4883,7 @@ function buildSessionMetaLine({ model, cwd, forkedFromId }) {
   });
 }
 
-function buildTokenCountLine({ ts, last, total, contextWindow }) {
+function buildTokenCountLine({ ts, last, total, contextWindow, annotation }) {
   const info = {
     last_token_usage: last,
     total_token_usage: total,
@@ -4627,6 +4895,7 @@ function buildTokenCountLine({ ts, last, total, contextWindow }) {
     payload: {
       type: "token_count",
       info,
+      ...(typeof annotation === "string" ? { annotation } : {}),
     },
   });
 }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -966,6 +966,7 @@ test("parseRolloutIncremental recovers legacy Codex EOF cursor project freshness
 
 test("parseRolloutIncremental retries a partial legacy project-context-only tail", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-project-partial-"));
+  let rolloutHandle;
   try {
     const repoRoot = path.join(tmp, "repo");
     await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
@@ -1003,7 +1004,8 @@ test("parseRolloutIncremental retries a partial legacy project-context-only tail
     assert.ok(splitOffset > 0 && splitOffset < contextLine.length);
     const initialContent = Buffer.concat([completePrefix, contextLine.subarray(0, splitOffset)]);
     await fs.writeFile(rolloutPath, initialContent);
-    const stat = await fs.stat(rolloutPath);
+    rolloutHandle = await fs.open(rolloutPath, "a+");
+    const stat = await rolloutHandle.stat();
     const cursors = {
       version: 1,
       files: {
@@ -1029,8 +1031,7 @@ test("parseRolloutIncremental retries a partial legacy project-context-only tail
     assert.equal(cursors.files[rolloutPath].projectOffset, completePrefix.length);
     assert.equal(Boolean(cursors.files[rolloutPath].projectFileContext?.configPath), false);
 
-    await fs.appendFile(
-      rolloutPath,
+    await rolloutHandle.appendFile(
       Buffer.concat([contextLine.subarray(splitOffset), Buffer.from("\n")]),
     );
     const second = await parseRolloutIncremental({
@@ -1041,9 +1042,10 @@ test("parseRolloutIncremental retries a partial legacy project-context-only tail
     });
     assert.equal(second.filesProcessed, 1);
     assert.equal(second.eventsAggregated, 0);
-    assert.equal(cursors.files[rolloutPath].offset, (await fs.stat(rolloutPath)).size);
+    assert.equal(cursors.files[rolloutPath].offset, (await rolloutHandle.stat()).size);
     assert.equal(cursors.files[rolloutPath].projectFileContext.configPath.endsWith("config"), true);
   } finally {
+    await rolloutHandle?.close();
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -229,7 +229,9 @@ test("parseRolloutIncremental skips an invalid UTF-8 record and keeps surroundin
       annotation: "BROKEN",
     });
     const invalid = Buffer.from(invalidLine);
-    invalid[invalid.indexOf(Buffer.from("BROKEN"))] = 0xff;
+    const invalidMarker = invalid.indexOf(Buffer.from("BROKEN"));
+    assert.ok(invalidMarker >= 0);
+    invalid[invalidMarker] = 0xff;
     const content = Buffer.concat([
       Buffer.from(`${first}\n`),
       invalid,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -150,6 +150,55 @@ test("parseRolloutIncremental ignores repeated token_count records with unchange
   }
 });
 
+test("parseRolloutIncremental preserves Unicode line separators inside physical JSONL records", async () => {
+  for (const separator of ["\u2028", "\u2029"]) {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-unicode-line-"));
+    try {
+      const rolloutPath = path.join(tmp, "rollout-test.jsonl");
+      const queuePath = path.join(tmp, "queue.jsonl");
+      const cursors = { version: 1, files: {}, updatedAt: null };
+      const usage = (totalTokens) => ({
+        input_tokens: totalTokens,
+        cached_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: totalTokens,
+      });
+      const records = [
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2025-12-17T00:00:00.000Z",
+          payload: {
+            type: "token_count",
+            annotation: `before${separator}after`,
+            info: { last_token_usage: usage(100), total_token_usage: usage(100) },
+          },
+        }),
+        buildTokenCountLine({
+          ts: "2025-12-17T00:00:01.000Z",
+          last: usage(50),
+          total: usage(150),
+        }),
+      ];
+      assert.ok(records[0].includes(separator));
+      assert.doesNotThrow(() => JSON.parse(records[0]));
+      await fs.writeFile(rolloutPath, records.join("\n") + "\n", "utf8");
+
+      const result = await parseRolloutIncremental({
+        rolloutFiles: [rolloutPath],
+        cursors,
+        queuePath,
+      });
+
+      assert.equal(result.eventsAggregated, 2);
+      const queued = await readJsonLines(queuePath);
+      assert.equal(queued.reduce((sum, event) => sum + event.total_tokens, 0), 150);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  }
+});
+
 test("parseRolloutIncremental separates interleaved cumulative usage lineages", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   try {

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -14,11 +14,15 @@ async function makeTempHome() {
   return await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codexrepair-"));
 }
 
-function tokenCountLine({ ts, last, total }) {
+function tokenCountLine({ ts, last, total, annotation }) {
   return JSON.stringify({
     type: "event_msg",
     timestamp: ts,
-    payload: { type: "token_count", info: { last_token_usage: last, total_token_usage: total } },
+    payload: {
+      type: "token_count",
+      info: { last_token_usage: last, total_token_usage: total },
+      ...(annotation == null ? {} : { annotation }),
+    },
   });
 }
 
@@ -1248,6 +1252,7 @@ async function writeLineageCodexFile(home, {
   multiAgentVersion = "v2",
   resumedMultiAgent = false,
   tailPaddingLines = 0,
+  tokenAnnotation = null,
   uuid = "dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb",
 } = {}) {
   const dir = archived
@@ -1284,6 +1289,7 @@ async function writeLineageCodexFile(home, {
       ts: "2025-12-18T00:00:00.000Z",
       last: lineageUsage(100),
       total: lineageUsage(100),
+      annotation: tokenAnnotation,
     }));
     if (resumedMultiAgent) {
       // Old sessions can be resumed after upgrading Codex. The active marker
@@ -1377,6 +1383,104 @@ describe("repairCodexInterleavedUsageInflation — cumulative lineage repair", (
       );
       assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
       assert.equal((await queueRowsBySource(queuePath)).codex.total, LINEAGE_TRUE_TOTAL);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  for (const [name, separator] of [
+    ["line separator", "\u2028"],
+    ["paragraph separator", "\u2029"],
+  ]) {
+    it(`repairs valid physical JSONL records containing a Unicode ${name}`, async () => {
+      const home = await makeTempHome();
+      try {
+        const codexFile = await writeLineageCodexFile(home, {
+          tokenAnnotation: `before${separator}after`,
+        });
+        const physicalRecords = (await fs.readFile(codexFile, "utf8")).split("\n");
+        assert.ok(physicalRecords[2].includes(separator));
+        assert.doesNotThrow(() => JSON.parse(physicalRecords[2]));
+
+        const { queuePath, queueStatePath } = await seedInflatedLineageInstall(home, codexFile);
+        const cursors = JSON.parse(
+          await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
+        );
+
+        assert.equal(
+          await repairCodexInterleavedUsageInflation({
+            cursors,
+            queuePath,
+            queueStatePath,
+            rolloutFiles: [{ path: codexFile, source: "codex" }],
+          }),
+          true,
+        );
+        assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
+        assert.equal((await queueRowsBySource(queuePath)).codex.total, LINEAGE_TRUE_TOTAL);
+        assert.equal(typeof cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY], "string");
+      } finally {
+        await fs.rm(home, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("counts CRLF bytes exactly when enforcing the lineage scan budget", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeLineageCodexFile(home);
+      const content = await fs.readFile(codexFile, "utf8");
+      await fs.writeFile(codexFile, content.replaceAll("\n", "\r\n"), "utf8");
+      const stat = await fs.stat(codexFile);
+      const { queuePath, queueStatePath } = await seedInflatedLineageInstall(home, codexFile);
+      const originalQueue = await fs.readFile(queuePath, "utf8");
+      const cursors = JSON.parse(
+        await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
+      );
+
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+          maxLineageScanBytes: stat.size - 1,
+        }),
+        false,
+      );
+      assert.equal(
+        cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
+        "usage_lineage_scan_indeterminate",
+      );
+      assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an unterminated final record when the byte budget equals the file size", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeLineageCodexFile(home);
+      const content = await fs.readFile(codexFile, "utf8");
+      await fs.writeFile(codexFile, content.slice(0, -1), "utf8");
+      const stat = await fs.stat(codexFile);
+      const { queuePath, queueStatePath } = await seedInflatedLineageInstall(home, codexFile);
+      const cursors = JSON.parse(
+        await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
+      );
+
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+          maxLineageScanBytes: stat.size,
+        }),
+        true,
+      );
+      assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -248,6 +248,73 @@ describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
     }
   });
 
+  it("fails closed without mutation when historical rebuild input contains invalid UTF-8", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeCodexFile(home);
+      const raw = await fs.readFile(codexFile);
+      const firstNewline = raw.indexOf(0x0a);
+      const secondLine = Buffer.from(raw.subarray(firstNewline + 1, raw.length - 1));
+      const marker = secondLine.indexOf(Buffer.from('"event_msg"'));
+      assert.ok(marker >= 0);
+      secondLine[marker + 1] = 0xff;
+      await fs.writeFile(
+        codexFile,
+        Buffer.concat([raw.subarray(0, firstNewline + 1), secondLine, Buffer.from("\n")]),
+      );
+
+      const queuePath = path.join(home, "queue.jsonl");
+      const queueStatePath = path.join(home, "queue.state.json");
+      const originalQueue = [
+        JSON.stringify({
+          source: "codex",
+          model: "unknown",
+          hour_start: "2025-12-17T00:00:00.000Z",
+          total_tokens: TRUE_CODEX_TOTAL,
+        }),
+        JSON.stringify({
+          source: "claude",
+          model: "opus",
+          hour_start: "2025-12-17T00:00:00.000Z",
+          total_tokens: 5000,
+        }),
+      ].join("\n") + "\n";
+      await fs.writeFile(queuePath, originalQueue, "utf8");
+      await fs.writeFile(queueStatePath, JSON.stringify({ offset: 123 }), "utf8");
+      const cursors = {
+        hourly: {
+          buckets: {
+            "codex|unknown|2025-12-17T00:00:00.000Z": {
+              totals: { total_tokens: TRUE_CODEX_TOTAL },
+            },
+            "claude|opus|2025-12-17T00:00:00.000Z": {
+              totals: { total_tokens: 5000 },
+            },
+          },
+          groupQueued: {},
+        },
+        files: { [codexFile]: { inode: 1, offset: 5, lastTotal: T2 } },
+        codexHashes: ["existing:key"],
+        migrations: {},
+      };
+      const originalCursors = structuredClone(cursors);
+
+      const ran = await repairCodexRescanInflation({
+        cursors,
+        queuePath,
+        queueStatePath,
+        rolloutFiles: [{ path: codexFile, source: "codex" }],
+      });
+
+      assert.equal(ran, false);
+      assert.deepEqual(cursors, originalCursors);
+      assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+      assert.deepEqual(JSON.parse(await fs.readFile(queueStatePath, "utf8")), { offset: 123 });
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("rebuilds Codex project usage during rescan repair", async () => {
     const home = await makeTempHome();
     try {

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -1453,6 +1453,18 @@ describe("repairCodexInterleavedUsageInflation — cumulative lineage repair", (
         "usage_lineage_scan_indeterminate",
       );
       assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+          maxLineageScanBytes: stat.size,
+        }),
+        true,
+      );
+      assert.equal(codexBucketTotal(cursors), LINEAGE_TRUE_TOTAL);
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }
@@ -1528,17 +1540,32 @@ describe("repairCodexInterleavedUsageInflation — cumulative lineage repair", (
       );
       await fs.writeFile(malformedFile, '{"type":"turn_context","payload":\n', "utf8");
       const { queuePath, queueStatePath } = await seedInflatedLineageInstall(home, codexFile);
+      const projectQueuePath = path.join(home, "project.queue.jsonl");
+      const projectQueueStatePath = path.join(home, "project.queue.state.json");
+      await fs.writeFile(projectQueuePath, '{"source":"codex","total_tokens":17}\n', "utf8");
+      await fs.writeFile(projectQueueStatePath, '{"offset":321}', "utf8");
       const cursors = JSON.parse(
         await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
       );
       cursors.files[malformedFile] = { inode: 2, offset: 5 };
       const originalQueue = await fs.readFile(queuePath, "utf8");
+      const originalQueueState = await fs.readFile(queueStatePath, "utf8");
+      const originalProjectQueue = await fs.readFile(projectQueuePath, "utf8");
+      const originalProjectQueueState = await fs.readFile(projectQueueStatePath, "utf8");
+      const originalCursorState = structuredClone({
+        files: cursors.files,
+        hourly: cursors.hourly,
+        projectHourly: cursors.projectHourly,
+        codexHashes: cursors.codexHashes,
+      });
 
       assert.equal(
         await repairCodexInterleavedUsageInflation({
           cursors,
           queuePath,
           queueStatePath,
+          projectQueuePath,
+          projectQueueStatePath,
           rolloutFiles: [
             { path: codexFile, source: "codex" },
             { path: malformedFile, source: "codex" },
@@ -1548,6 +1575,62 @@ describe("repairCodexInterleavedUsageInflation — cumulative lineage repair", (
       );
       assert.equal(codexBucketTotal(cursors), 4_700_000_000);
       assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+      assert.equal(await fs.readFile(queueStatePath, "utf8"), originalQueueState);
+      assert.equal(await fs.readFile(projectQueuePath, "utf8"), originalProjectQueue);
+      assert.equal(await fs.readFile(projectQueueStatePath, "utf8"), originalProjectQueueState);
+      assert.deepEqual(
+        {
+          files: cursors.files,
+          hourly: cursors.hourly,
+          projectHourly: cursors.projectHourly,
+          codexHashes: cursors.codexHashes,
+        },
+        originalCursorState,
+      );
+      assert.equal(
+        cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
+        "usage_lineage_scan_indeterminate",
+      );
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("defers atomically when a contributing rollout contains invalid UTF-8", async () => {
+    const home = await makeTempHome();
+    try {
+      const codexFile = await writeLineageCodexFile(home);
+      await fs.appendFile(
+        codexFile,
+        Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d, 0x0a]),
+      );
+      const { queuePath, queueStatePath } = await seedInflatedLineageInstall(home, codexFile);
+      const cursors = JSON.parse(
+        await fs.readFile(path.join(home, ".tokentracker", "tracker", "cursors.json"), "utf8"),
+      );
+      const originalQueue = await fs.readFile(queuePath, "utf8");
+      const originalQueueState = await fs.readFile(queueStatePath, "utf8");
+      const originalCursorState = structuredClone({
+        files: cursors.files,
+        hourly: cursors.hourly,
+        codexHashes: cursors.codexHashes,
+      });
+
+      assert.equal(
+        await repairCodexInterleavedUsageInflation({
+          cursors,
+          queuePath,
+          queueStatePath,
+          rolloutFiles: [{ path: codexFile, source: "codex" }],
+        }),
+        false,
+      );
+      assert.equal(await fs.readFile(queuePath, "utf8"), originalQueue);
+      assert.equal(await fs.readFile(queueStatePath, "utf8"), originalQueueState);
+      assert.deepEqual(
+        { files: cursors.files, hourly: cursors.hourly, codexHashes: cursors.codexHashes },
+        originalCursorState,
+      );
       assert.equal(
         cursors.migrations[CODEX_USAGE_LINEAGE_REPAIR_KEY].reason,
         "usage_lineage_scan_indeterminate",


### PR DESCRIPTION
## Summary

- parse Codex JSONL by physical LF records instead of `node:readline`, preserving legal raw `U+2028` and `U+2029` inside JSON strings
- reuse the byte-level reader for full Codex context parsing and the historical lineage repair
- enforce exact byte budgets, bounded record memory, fatal UTF-8 decoding, and atomic fail-closed repair behavior

## Root cause

Codex permits raw `U+2028` and `U+2029` characters inside JSON strings. Node's `readline` treats those characters as line separators, so a valid physical JSONL record was split and failed `JSON.parse`. The one-time lineage repair then remained retryable forever with `usage_lineage_scan_indeterminate`, leaving previously inflated Codex totals unchanged.

## Safety

- physical records are framed from raw bytes using literal LF only
- CRLF and unterminated EOF byte spans are exact
- malformed JSON and invalid UTF-8 keep the repair indeterminate
- scan byte limits are enforced while chunks accumulate, so oversized unterminated records cannot exceed the memory/I/O budget
- guarded rebuilds leave main/project queues, upload offsets, file cursors, hashes, and usage buckets unchanged on failure

## Verification

- focused regression suite: 303 passed, 0 failed
- full `npm run ci:local`: passed, including 1,908 Node tests, copy/locale/UI/architecture guardrails, and dashboard production build
- independent code and test-coverage reviews: no remaining blocking findings
- read-only real-data scan: 31,038 candidate files, 42,681,543,098 bytes, 10,068,097 records, 135 affected files, 0 parse failures
- formerly blocked rollout: 68 physical records, 288,400 bytes, 0 parse failures, stable snapshot

No manual TokenTracker sync was run and no `~/.tokentracker` data or settings were modified during validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex session and rollout JSONL parsing with strict byte-level record splitting, correct CRLF/LF handling across chunk boundaries, and accurate physical byte accounting (including unterminated tails).
  - Strengthened invalid UTF-8 handling with configurable behavior (throw, preserve corrupted records, or skip invalid lines), improving incremental resume and aggregation correctness.
  - Enhanced lineage scanning and max-bytes enforcement to prevent over-budget/truncated input from producing incorrect results.

- **Reliability**
  - Improved rescan/repair safeguards so repairs are deferred without mutating queue files, queue state, or cursor state when historical data is malformed or contains invalid UTF-8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->