### PR TITLE
fix(ci): prevent recreating consumed releases

### DIFF
--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -72,6 +72,8 @@ jobs:
 
       # A failed release may be re-dispatched from the SAME commit and replace
       # draft assets. A published release is immutable and can never be reused.
+      # If the release is missing but its tag still exists, the version was
+      # already consumed (or partially created) and must not be reconstructed.
       - name: Create or reuse matching draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,17 +113,19 @@ jobs:
             fi
             echo "Reusing draft $tag from immutable commit $GITHUB_SHA."
           else
-            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-              git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
-              tag_sha=$(git rev-list -n 1 "$tag")
-              if [ "$tag_sha" != "$GITHUB_SHA" ]; then
-                echo "::error::Tag $tag points to $tag_sha, not workflow commit $GITHUB_SHA."
-                exit 1
-              fi
-            else
-              gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
-                -f ref="refs/tags/$tag" -f sha="$GITHUB_SHA" >/dev/null
+            # A tag without a release means this version has already been used.
+            # Refuse to recreate it even when the tag points to GITHUB_SHA:
+            # rebuilding the same source can still produce a different DMG
+            # checksum and leave package-manager metadata pinned to the old one.
+            if tag_ref=$(git ls-remote --exit-code --tags origin "refs/tags/$tag" 2>/dev/null); then
+              tag_sha=$(awk 'NR == 1 { print $1 }' <<<"$tag_ref")
+              echo "::error::Release $tag is missing, but its tag already exists at $tag_sha."
+              echo "::error::This version is already consumed; bump the version instead of recreating it."
+              exit 1
             fi
+
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$tag" -f sha="$GITHUB_SHA" >/dev/null
             gh release create "$tag" --verify-tag --draft --title "$tag" --generate-notes
           fi
 

--- a/test/release-dmg-workflow.test.js
+++ b/test/release-dmg-workflow.test.js
@@ -172,6 +172,9 @@ test("missing releases cannot be recreated from an existing version tag", () => 
   const createDraft = content.indexOf(
     'gh release create "$tag" --verify-tag --draft'
   );
+  // The fresh-create path's tag creation is the LAST git/refs POST; the first
+  // one belongs to the draft-reuse branch and legitimately precedes the guard.
+  const createTagRef = content.lastIndexOf("repos/$GITHUB_REPOSITORY/git/refs");
 
   assert.ok(
     missingReleaseGuard > 0,
@@ -182,6 +185,10 @@ test("missing releases cannot be recreated from an existing version tag", () => 
       "This version is already consumed; bump the version instead of recreating it."
     ),
     "the failure must require a new version"
+  );
+  assert.ok(
+    missingReleaseGuard < createTagRef,
+    "the existing-tag guard must run before creating a replacement tag ref"
   );
   assert.ok(
     missingReleaseGuard < createDraft,

--- a/test/release-dmg-workflow.test.js
+++ b/test/release-dmg-workflow.test.js
@@ -164,6 +164,31 @@ test("published releases are immutable and builds use the version tag", () => {
   );
 });
 
+test("missing releases cannot be recreated from an existing version tag", () => {
+  const content = loadWorkflow();
+  const missingReleaseGuard = content.indexOf(
+    "Release $tag is missing, but its tag already exists"
+  );
+  const createDraft = content.indexOf(
+    'gh release create "$tag" --verify-tag --draft'
+  );
+
+  assert.ok(
+    missingReleaseGuard > 0,
+    "a missing release with an existing tag must be rejected"
+  );
+  assert.ok(
+    content.includes(
+      "This version is already consumed; bump the version instead of recreating it."
+    ),
+    "the failure must require a new version"
+  );
+  assert.ok(
+    missingReleaseGuard < createDraft,
+    "the existing-tag guard must run before creating a replacement release"
+  );
+});
+
 test("homebrew tap is notified only after publish (not mid-build)", () => {
   const content = loadWorkflow();
   // The dispatch must come AFTER the un-draft, so the tap fetches a public,


### PR DESCRIPTION
## Summary

Prevent deleted GitHub releases from being recreated with an existing version tag, avoiding same-version assets with different Homebrew checksums.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config

## Checklist

- [ ] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no UI strings added)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

## Testing

- `node --test test/release-dmg-workflow.test.js` — 19/19 passed
- `npm test` — 1888 passed, 5 failed because the local environment is missing the existing `yauzl` dependency

## Behavior

- Existing draft release: may resume from the matching commit.
- Existing published release: rejected.
- Missing release with no tag: creates a new draft release.
- Missing release with an existing tag: rejected and requires a version bump.

## Out of scope

The Homebrew tap workflow lives in a separate repository and is not changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release automation now detects when a version tag already exists while its corresponding release is missing, and stops instead of attempting to recreate draft release assets.
  * Updated failure guidance to instruct bumping the version rather than reusing/reconstructing the existing tag.

* **Tests**
  * Added a workflow test to confirm the guard for the existing-tag/missing-release case appears before any tag or draft release creation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->