### PR TITLE
fix(session-analytics): discover Claude/Codex sessions in WSL installs too

### DIFF
--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -31,6 +31,7 @@ const readline = require("node:readline");
 const { listClaudeProjectFiles, listRolloutFilesDeep, claudeMessageDedupKey } = require("./rollout");
 const { parseCodexRolloutFile } = require("./codex-rollout-parser");
 const { computeRowCost } = require("./pricing");
+const wsl = require("./wsl-probe");
 
 // Bump the sidecar when derived metrics change so cached rows are rebuilt
 // instead of leaving the dashboard on the previous (over-counted) heuristic.
@@ -761,14 +762,42 @@ async function scanGrokSession(filePath) {
   });
 }
 
-async function discoverSessionFiles(home) {
+// Multi-root discovery: on Windows a native install and a WSL one both count.
+// `sync` already walks both Claude homes (src/commands/sync.js), so without this
+// the WSL work lands in the token totals but is invisible in the session browser
+// and its project list. TOKENTRACKER_WSL_MODE gates which sides are probed;
+// duplicated files synced between environments collapse via the Codex session-id
+// pass below and claudeMessageDedupKey downstream.
+function providerRoots(home, providerDir, env) {
+  const roots = [];
+  if (process.platform !== "win32" || wsl.shouldProbeNative(env)) {
+    roots.push(path.join(home, providerDir));
+  }
+  // Only the real native home has a WSL sibling worth probing. discoverWslHome
+  // resolves \\wsl$ independently of `home`, so callers that inject their own
+  // home (tests, a custom HOME) would otherwise get the machine's live WSL
+  // sessions spliced into an isolated fixture.
+  const isRealHome = path.resolve(home) === path.resolve(os.homedir());
+  if (process.platform === "win32" && isRealHome && wsl.shouldProbeWsl(env)) {
+    const wslRoot = wsl.discoverWslHome(providerDir, { env });
+    if (wslRoot) roots.push(wslRoot);
+  }
+  return [...new Set(roots)];
+}
+
+async function discoverSessionFiles(home, env = process.env) {
   const grokHome = resolveGrokHome(home);
-  const [allClaude, codex, archived, grok] = await Promise.all([
-    listClaudeProjectFiles(path.join(home, ".claude", "projects")),
-    listRolloutFilesDeep(path.join(home, ".codex", "sessions")),
-    listRolloutFilesDeep(path.join(home, ".codex", "archived_sessions")),
+  const claudeRoots = providerRoots(home, ".claude", env);
+  const codexRoots = providerRoots(home, ".codex", env);
+  const [claudeGroups, codexGroups, archivedGroups, grok] = await Promise.all([
+    Promise.all(claudeRoots.map((r) => listClaudeProjectFiles(path.join(r, "projects")))),
+    Promise.all(codexRoots.map((r) => listRolloutFilesDeep(path.join(r, "sessions")))),
+    Promise.all(codexRoots.map((r) => listRolloutFilesDeep(path.join(r, "archived_sessions")))),
     listGrokSessionFiles(path.join(grokHome, "sessions")),
   ]);
+  const allClaude = [...new Set(claudeGroups.flat())];
+  const codex = [...new Set(codexGroups.flat())];
+  const archived = [...new Set(archivedGroups.flat())];
   // Claude Memory stores thousands of background observer transcripts beside
   // real Claude Code sessions. They contain <synthetic>/haiku bookkeeping and
   // no user coding outcome, so scanning them both slows the card dramatically

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -776,12 +776,19 @@ function providerRoots(home, providerDir, env, deps = {}) {
   if (platform !== "win32" || wsl.shouldProbeNative(env)) {
     roots.push(path.join(home, providerDir));
   }
-  // Only the real native home has a WSL sibling worth probing. discoverWslHome
-  // resolves \\wsl$ independently of `home`, so callers that inject their own
-  // home (tests, a custom HOME) would otherwise get the machine's live WSL
-  // sessions spliced into an isolated fixture.
-  const isRealHome = path.resolve(home) === path.resolve(homedir());
-  if (platform === "win32" && isRealHome && wsl.shouldProbeWsl(env)) {
+  // Only the machine's own home has a WSL sibling worth probing.
+  // discoverWslHome resolves \\wsl$ independently of `home`, so probing for an
+  // injected home (tests, a custom HOME) would splice the machine's live WSL
+  // sessions into what the caller expects to be an isolated tree.
+  //
+  // This defaults rather than hard-codes: the whole reason to thread a
+  // non-default home is to scan a tree that is not os.homedir(), and such a
+  // caller would otherwise lose WSL discovery silently, with nothing failing.
+  // `probeWsl` is the deliberate opt-in for that case.
+  const probeWsl = deps.probeWsl !== undefined
+    ? Boolean(deps.probeWsl)
+    : path.resolve(home) === path.resolve(homedir());
+  if (platform === "win32" && probeWsl && wsl.shouldProbeWsl(env)) {
     const wslRoot = discoverWslHome(providerDir, { env });
     if (wslRoot) roots.push(wslRoot);
   }

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -768,27 +768,30 @@ async function scanGrokSession(filePath) {
 // and its project list. TOKENTRACKER_WSL_MODE gates which sides are probed;
 // duplicated files synced between environments collapse via the Codex session-id
 // pass below and claudeMessageDedupKey downstream.
-function providerRoots(home, providerDir, env) {
+function providerRoots(home, providerDir, env, deps = {}) {
+  const platform = deps.platform || process.platform;
+  const homedir = deps.homedir || os.homedir;
+  const discoverWslHome = deps.discoverWslHome || wsl.discoverWslHome;
   const roots = [];
-  if (process.platform !== "win32" || wsl.shouldProbeNative(env)) {
+  if (platform !== "win32" || wsl.shouldProbeNative(env)) {
     roots.push(path.join(home, providerDir));
   }
   // Only the real native home has a WSL sibling worth probing. discoverWslHome
   // resolves \\wsl$ independently of `home`, so callers that inject their own
   // home (tests, a custom HOME) would otherwise get the machine's live WSL
   // sessions spliced into an isolated fixture.
-  const isRealHome = path.resolve(home) === path.resolve(os.homedir());
-  if (process.platform === "win32" && isRealHome && wsl.shouldProbeWsl(env)) {
-    const wslRoot = wsl.discoverWslHome(providerDir, { env });
+  const isRealHome = path.resolve(home) === path.resolve(homedir());
+  if (platform === "win32" && isRealHome && wsl.shouldProbeWsl(env)) {
+    const wslRoot = discoverWslHome(providerDir, { env });
     if (wslRoot) roots.push(wslRoot);
   }
   return [...new Set(roots)];
 }
 
-async function discoverSessionFiles(home, env = process.env) {
+async function discoverSessionFiles(home, env = process.env, deps = {}) {
   const grokHome = resolveGrokHome(home);
-  const claudeRoots = providerRoots(home, ".claude", env);
-  const codexRoots = providerRoots(home, ".codex", env);
+  const claudeRoots = providerRoots(home, ".claude", env, deps);
+  const codexRoots = providerRoots(home, ".codex", env, deps);
   const [claudeGroups, codexGroups, archivedGroups, grok] = await Promise.all([
     Promise.all(claudeRoots.map((r) => listClaudeProjectFiles(path.join(r, "projects")))),
     Promise.all(codexRoots.map((r) => listRolloutFilesDeep(path.join(r, "sessions")))),
@@ -1291,4 +1294,5 @@ module.exports = {
   listSessionsForBrowser,
   resumeCommandFor,
   sessionsToCsv,
+  providerRoots,
 };

--- a/test/session-analytics-wsl-roots.test.js
+++ b/test/session-analytics-wsl-roots.test.js
@@ -96,6 +96,33 @@ test("an injected home never inherits the machine's real WSL sessions", () => {
   assert.equal(probed, false, "WSL must not be probed for a home that is not os.homedir()");
 });
 
+// The default is a heuristic ("is this the machine's own home?"), so the
+// escape hatch has to be reachable and pinned: a caller that deliberately
+// scans a non-default tree must be able to keep WSL discovery, and one
+// scanning the real home must be able to turn it off. Without these, a future
+// refactor threading a custom home would lose WSL roots with nothing failing.
+test("probeWsl:true opts a non-default home back into WSL discovery", () => {
+  const roots = providerRoots("C:\\Temp\\other-profile", ".claude", { TOKENTRACKER_WSL_MODE: "both" }, {
+    platform: "win32",
+    homedir: () => REAL_HOME,
+    discoverWslHome: () => WSL_HOME,
+    probeWsl: true,
+  });
+  assert.deepEqual(roots, [path.join("C:\\Temp\\other-profile", ".claude"), WSL_HOME]);
+});
+
+test("probeWsl:false opts the real home out of WSL discovery", () => {
+  let probed = false;
+  const roots = providerRoots(REAL_HOME, ".claude", { TOKENTRACKER_WSL_MODE: "both" }, {
+    platform: "win32",
+    homedir: () => REAL_HOME,
+    discoverWslHome: () => { probed = true; return WSL_HOME; },
+    probeWsl: false,
+  });
+  assert.deepEqual(roots, [path.join(REAL_HOME, ".claude")]);
+  assert.equal(probed, false);
+});
+
 test("codex roots resolve independently of claude roots", () => {
   const deps = {
     platform: "win32",

--- a/test/session-analytics-wsl-roots.test.js
+++ b/test/session-analytics-wsl-roots.test.js
@@ -1,0 +1,107 @@
+/**
+ * Session-analytics WSL multi-root discovery.
+ *
+ * The sessions pipeline built its Claude/Codex roots from the native home
+ * only, so on a Windows host with a WSL install the session browser, its
+ * project list, and the `tracker sessions` export showed native sessions
+ * exclusively -- while sync (src/commands/sync.js) already walked both Claude
+ * homes, leaving the same work counted in token totals but absent here.
+ *
+ * Verifies:
+ *   - win32 + a discoverable WSL home yields both roots
+ *   - TOKENTRACKER_WSL_MODE gates each side (native-only / wsl-only / both)
+ *   - a WSL home that does not resolve degrades to native only
+ *   - non-win32 never probes WSL
+ *   - an injected home (tests, custom HOME) never picks up the machine's real
+ *     WSL sessions -- discoverWslHome resolves \\wsl$ independently of `home`,
+ *     so without this guard a fixture home silently inherits live WSL data
+ */
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { providerRoots } = require("../src/lib/session-analytics");
+
+const REAL_HOME = "C:\\Users\\dev";
+const WSL_HOME = "\\\\wsl$\\Ubuntu\\home\\dev\\.claude";
+
+// Stand-in for the real machine: `home` is the native home, and the WSL probe
+// resolves. deps keep the probe off the host running the suite.
+function win32Deps({ wslRoot = WSL_HOME, homedir = REAL_HOME } = {}) {
+  return {
+    platform: "win32",
+    homedir: () => homedir,
+    discoverWslHome: () => wslRoot,
+  };
+}
+
+test("win32 with a discoverable WSL home returns native + WSL roots", () => {
+  const roots = providerRoots(REAL_HOME, ".claude", { TOKENTRACKER_WSL_MODE: "both" }, win32Deps());
+  assert.deepEqual(roots, [path.join(REAL_HOME, ".claude"), WSL_HOME]);
+});
+
+test("default mode (wsl-first) still probes both sides", () => {
+  // wsl-first only changes precedence for single-install resolution; discovery
+  // is additive, so an unset mode must not drop the WSL root.
+  const roots = providerRoots(REAL_HOME, ".claude", {}, win32Deps());
+  assert.equal(roots.length, 2);
+  assert.ok(roots.includes(WSL_HOME));
+});
+
+test("native-only omits the WSL root", () => {
+  const roots = providerRoots(REAL_HOME, ".claude", { TOKENTRACKER_WSL_MODE: "native-only" }, win32Deps());
+  assert.deepEqual(roots, [path.join(REAL_HOME, ".claude")]);
+});
+
+test("wsl-only omits the native root", () => {
+  const roots = providerRoots(REAL_HOME, ".claude", { TOKENTRACKER_WSL_MODE: "wsl-only" }, win32Deps());
+  assert.deepEqual(roots, [WSL_HOME]);
+});
+
+test("an unresolvable WSL home degrades to native only", () => {
+  const roots = providerRoots(
+    REAL_HOME,
+    ".claude",
+    { TOKENTRACKER_WSL_MODE: "both" },
+    win32Deps({ wslRoot: null }),
+  );
+  assert.deepEqual(roots, [path.join(REAL_HOME, ".claude")]);
+});
+
+test("non-win32 never probes WSL", () => {
+  let probed = false;
+  const roots = providerRoots("/home/dev", ".claude", { TOKENTRACKER_WSL_MODE: "both" }, {
+    platform: "linux",
+    homedir: () => "/home/dev",
+    discoverWslHome: () => { probed = true; return "/should/not/be/used"; },
+  });
+  assert.deepEqual(roots, [path.join("/home/dev", ".claude")]);
+  assert.equal(probed, false);
+});
+
+test("an injected home never inherits the machine's real WSL sessions", () => {
+  // buildSessionAnalytics({ home }) is how the suite and a custom HOME reach
+  // this path. discoverWslHome ignores `home`, so probing on a fixture home
+  // would splice live WSL transcripts into an isolated temp dir.
+  let probed = false;
+  const fixtureHome = "C:\\Temp\\tt-fixture-home";
+  const roots = providerRoots(fixtureHome, ".claude", { TOKENTRACKER_WSL_MODE: "both" }, {
+    platform: "win32",
+    homedir: () => REAL_HOME,
+    discoverWslHome: () => { probed = true; return WSL_HOME; },
+  });
+  assert.deepEqual(roots, [path.join(fixtureHome, ".claude")]);
+  assert.equal(probed, false, "WSL must not be probed for a home that is not os.homedir()");
+});
+
+test("codex roots resolve independently of claude roots", () => {
+  const deps = {
+    platform: "win32",
+    homedir: () => REAL_HOME,
+    discoverWslHome: (providerDir) => `\\\\wsl$\\Ubuntu\\home\\dev\\${providerDir}`,
+  };
+  const roots = providerRoots(REAL_HOME, ".codex", { TOKENTRACKER_WSL_MODE: "both" }, deps);
+  assert.deepEqual(roots, [path.join(REAL_HOME, ".codex"), "\\\\wsl$\\Ubuntu\\home\\dev\\.codex"]);
+});


### PR DESCRIPTION
Follow-up to the last section of https://github.com/mm7894215/TokenTracker/issues/374#issuecomment-5088580132 — the sessions pipeline scanning only the native home. Separate from the attribution fix in v0.86.1; no shared code.

## Why

`discoverSessionFiles` built its Claude and Codex roots from `os.homedir()` alone. `sync` already walks both Claude homes (`src/commands/sync.js`), so on a Windows host with a WSL install the same work is **counted in the token totals but missing from the session browser, its project list, and the `tracker sessions` export**. `TOKENTRACKER_WSL_MODE` had no effect on any of them.

That split is the confusing part in practice: the numbers look right, so nothing signals that the session-level views are showing a subset.

## What

Build the roots through the existing `wsl-probe` helpers (`shouldProbeNative` / `shouldProbeWsl` / `discoverWslHome`), the same way `sync.js` does, so one env var gates both sides consistently. Discovery is additive; duplicates synced between environments collapse via the existing Codex session-id pass and `claudeMessageDedupKey` downstream, so no new dedup logic.

WSL is probed **only when `home === os.homedir()`**. `discoverWslHome` resolves `\wsl$` independently of whatever `home` it's called alongside, so probing on an injected home splices the machine's live WSL transcripts into what the caller expects to be an isolated fixture. I hit this on the first attempt — two suite tests started seeing 467 real sessions where they asserted 1.

## Verification

Windows 11 + WSL2 Ubuntu, against `main` @ 0.87.0:

| `TOKENTRACKER_WSL_MODE` | rows | projects |
|---|---|---|
| `native-only` | 635 | 7 |
| `both` | 1082 | 20 |

`native-only` is byte-identical to pre-change output — the native path is untouched.

Tests: `providerRoots` is made dependency-injectable (`platform`, `homedir`, `discoverWslHome`) and exported, so root selection is exercised without needing a WSL install on the runner — the new file passes on Linux CI. Eight cases cover mode gating, an unresolvable WSL home, non-win32, and the isolation guard. Removing the guard fails the isolation test and leaves the other seven green.

Ran `session-analytics` + `local-api` + `wsl` + `dual-install` suites in `both` / `native-only` / `wsl-first` against this branch and against unpatched `main`: failure counts identical (11 / 13 / 11), pass counts +8 (the new tests). Those pre-existing failures are unrelated and environment-coupled — several suites read the real `~/.claude`, `~/.codex` and `\wsl$` shares rather than fixtures, so they don't reproduce on the ubuntu CI runner. Happy to file that separately if useful.

## Notes

- No user-facing strings, no Swift, no parser changes — privacy rule unaffected (metadata only; this changes *which directories are listed*, nothing about what's read from them).
- Grok is left native-only: `resolveGrokHome` has its own override handling and I didn't want to change that behaviour blind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced session data discovery to scan both native Windows and WSL locations (multi-root).
  * Added/extended mode controls to support native-only, WSL-only, or combined discovery.
  * Improved multi-location discovery with de-duplicated results.

* **Bug Fixes**
  * Added robust fallback when WSL locations can’t be resolved, ensuring native results still load.
  * Prevented WSL probing on non-Windows platforms and ensured safe handling of mismatched home paths.

* **Tests**
  * Added coverage for WSL root discovery behavior, mode gating, and Codex vs. Claude path differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->