### PR TITLE
fix(grok): cache context breakdown like Codex/Claude

### DIFF
--- a/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
@@ -703,7 +703,9 @@ export function ContextBreakdownPanel({ from, to, source = "claude", referenceTo
     let cancelled = false;
     const cacheKey = `${from || ""}|${to || ""}|${source || "claude"}`;
     const cached = cacheRef.current[cacheKey];
-    if (cached) setData(cached);
+    // On a cache miss, reset data so the previous source's payload never
+    // renders under the new source's display branch while the fetch runs.
+    setData(cached || null);
     setLoading(true);
     onLoadingChange?.(true);
     setError(null);

--- a/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/ContextBreakdownPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { ChevronRight, Info } from "lucide-react";
 import { copy } from "../../../lib/copy";
@@ -690,6 +690,10 @@ export function ContextBreakdownPanel({ from, to, source = "claude", referenceTo
   const [error, setError] = useState(null);
   // Track which top-level disclosure rows are open
   const [openRows, setOpenRows] = useState({});
+  // Keep last successful payload per range+source so flipping provider tabs
+  // (Claude ↔ Codex ↔ Grok) does not flash the full "Scanning session logs…"
+  // skeleton when the server already has a warm cache.
+  const cacheRef = useRef({});
 
   function toggleRow(key) {
     setOpenRows((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -697,6 +701,9 @@ export function ContextBreakdownPanel({ from, to, source = "claude", referenceTo
 
   useEffect(() => {
     let cancelled = false;
+    const cacheKey = `${from || ""}|${to || ""}|${source || "claude"}`;
+    const cached = cacheRef.current[cacheKey];
+    if (cached) setData(cached);
     setLoading(true);
     onLoadingChange?.(true);
     setError(null);
@@ -708,7 +715,10 @@ export function ContextBreakdownPanel({ from, to, source = "claude", referenceTo
       tzOffsetMinutes: getBrowserTimeZoneOffsetMinutes(),
     })
       .then((res) => {
-        if (!cancelled) setData(res);
+        if (!cancelled) {
+          cacheRef.current[cacheKey] = res;
+          setData(res);
+        }
       })
       .catch((e) => {
         if (!cancelled) setError(e?.message || String(e));

--- a/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
@@ -644,4 +644,89 @@ describe("ContextBreakdownPanel", () => {
     expect(await screen.findByText("test")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+
+  it("does not flash loading skeleton when revisiting a cached source", async () => {
+    const codexPayload = {
+      source: "codex",
+      scope: "supported",
+      totals: {
+        input_tokens: 100,
+        cached_input_tokens: 900,
+        cache_creation_input_tokens: 0,
+        output_tokens: 20,
+        reasoning_output_tokens: 5,
+        total_tokens: 1020,
+      },
+      session_count: 1,
+      message_count: 2,
+      tool_calls_breakdown: {
+        total_calls: 1,
+        categories: [
+          {
+            name: "Execution",
+            calls: 1,
+            totals: {
+              input_tokens: 100,
+              cached_input_tokens: 900,
+              cache_creation_input_tokens: 0,
+              output_tokens: 20,
+              reasoning_output_tokens: 5,
+              total_tokens: 1020,
+            },
+            tools: [],
+          },
+        ],
+      },
+      exec_command_breakdown: { by_type: [], by_exit: [] },
+    };
+    const claudePayload = {
+      ...codexPayload,
+      source: "claude",
+      totals: { ...codexPayload.totals, total_tokens: 500 },
+    };
+
+    let resolveCodex;
+    const slowCodex = new Promise((resolve) => {
+      resolveCodex = resolve;
+    });
+
+    getUsageCategoryBreakdown
+      .mockResolvedValueOnce(codexPayload)
+      .mockResolvedValueOnce(claudePayload)
+      .mockReturnValueOnce(slowCodex);
+
+    const { rerender } = render(
+      <ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="codex" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(copy("dashboard.context_breakdown.category.tool_calls"))).toBeInTheDocument();
+    });
+
+    rerender(
+      <ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="claude" />,
+    );
+    await waitFor(() => {
+      expect(getUsageCategoryBreakdown).toHaveBeenCalledWith(
+        expect.objectContaining({ source: "claude" }),
+      );
+    });
+
+    // Revisit codex while the third fetch is intentionally pending: sticky cache
+    // should keep prior codex rows instead of the scanning skeleton.
+    rerender(
+      <ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="codex" />,
+    );
+
+    expect(screen.queryByText(copy("dashboard.context_breakdown.loading_hint"))).not.toBeInTheDocument();
+    expect(screen.getByText(copy("dashboard.context_breakdown.category.tool_calls"))).toBeInTheDocument();
+
+    // Background rescan may still be in flight; sticky cache is what matters for UX.
+    expect(getUsageCategoryBreakdown.mock.calls.some((call) => call[0]?.source === "codex")).toBe(true);
+    expect(getUsageCategoryBreakdown.mock.calls.some((call) => call[0]?.source === "claude")).toBe(true);
+
+    resolveCodex(codexPayload);
+  });
+
 });

--- a/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
@@ -729,4 +729,71 @@ describe("ContextBreakdownPanel", () => {
     resolveCodex(codexPayload);
   });
 
+  it("shows loading skeleton instead of stale data when visiting an uncached source", async () => {
+    const codexPayload = {
+      source: "codex",
+      scope: "supported",
+      totals: {
+        input_tokens: 100,
+        cached_input_tokens: 900,
+        cache_creation_input_tokens: 0,
+        output_tokens: 20,
+        reasoning_output_tokens: 5,
+        total_tokens: 1020,
+      },
+      session_count: 1,
+      message_count: 2,
+      tool_calls_breakdown: {
+        total_calls: 1,
+        categories: [
+          {
+            name: "Execution",
+            calls: 1,
+            totals: {
+              input_tokens: 100,
+              cached_input_tokens: 900,
+              cache_creation_input_tokens: 0,
+              output_tokens: 20,
+              reasoning_output_tokens: 5,
+              total_tokens: 1020,
+            },
+            tools: [],
+          },
+        ],
+      },
+      exec_command_breakdown: { by_type: [], by_exit: [] },
+    };
+
+    let resolveGrok;
+    const slowGrok = new Promise((resolve) => {
+      resolveGrok = resolve;
+    });
+
+    getUsageCategoryBreakdown
+      .mockResolvedValueOnce(codexPayload)
+      .mockReturnValueOnce(slowGrok);
+
+    const { rerender } = render(
+      <ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="codex" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(copy("dashboard.context_breakdown.category.tool_calls"))).toBeInTheDocument();
+    });
+
+    // First visit to grok (cache miss, fetch pending): must show the skeleton,
+    // never the previous codex payload under grok's display branch.
+    rerender(
+      <ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="grok" />,
+    );
+
+    expect(screen.getByText(copy("dashboard.context_breakdown.loading_hint"))).toBeInTheDocument();
+    expect(screen.queryByText(copy("dashboard.context_breakdown.category.tool_calls"))).not.toBeInTheDocument();
+
+    resolveGrok({ ...codexPayload, source: "grok" });
+    await waitFor(() => {
+      expect(screen.getByText(copy("dashboard.context_breakdown.category.tool_calls"))).toBeInTheDocument();
+    });
+  });
+
 });

--- a/src/lib/grok-context-breakdown.js
+++ b/src/lib/grok-context-breakdown.js
@@ -27,9 +27,16 @@ const {
   getExecutableName,
 } = require("./categorizer-utils");
 
-const CACHE_SCHEMA_VERSION = "grok-context-v1";
+const CACHE_SCHEMA_VERSION = "grok-context-v2";
 const CACHE = new Map();
-const CACHE_TTL_MS = 60_000;
+// Result-level TTL. Per-file parse cache is the main win when flipping tabs.
+const CACHE_TTL_MS = 5 * 60_000;
+// Deduplicate concurrent scans when the dashboard remounts the panel quickly.
+const IN_FLIGHT = new Map();
+// Per updates.jsonl parse cache — mirrors Codex PARSED_GROUP_CACHE so switching
+// back to Grok does not re-read every session log on each open.
+const FILE_PARSE_CACHE = new Map();
+const MAX_FILE_PARSE_CACHE_ENTRIES = 512;
 
 // ---------------------------------------------------------------------------
 // Time helpers
@@ -316,7 +323,45 @@ function finalizeExecRows(map) {
     .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
 }
 
+function fileParseCacheKey(updatesPath, { from, to, timeZoneContext } = {}, stat) {
+  return [
+    CACHE_SCHEMA_VERSION,
+    updatesPath,
+    from || "",
+    to || "",
+    timeZoneContext?.timeZone || "",
+    timeZoneContext?.offsetMinutes ?? "",
+    Number(stat?.size || 0),
+    Math.floor(Number(stat?.mtimeMs || 0)),
+  ].join("|");
+}
+
+function rememberFileParse(key, value) {
+  FILE_PARSE_CACHE.delete(key);
+  FILE_PARSE_CACHE.set(key, value);
+  while (FILE_PARSE_CACHE.size > MAX_FILE_PARSE_CACHE_ENTRIES) {
+    const oldest = FILE_PARSE_CACHE.keys().next().value;
+    if (oldest == null) break;
+    FILE_PARSE_CACHE.delete(oldest);
+  }
+}
+
 async function parseGrokUpdatesFile(updatesPath, { from, to, timeZoneContext } = {}) {
+  let stat = null;
+  try {
+    stat = fs.statSync(updatesPath);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile() || stat.size <= 0) return null;
+
+  const cacheKey = fileParseCacheKey(updatesPath, { from, to, timeZoneContext }, stat);
+  const hit = FILE_PARSE_CACHE.get(cacheKey);
+  if (hit) {
+    rememberFileParse(cacheKey, hit);
+    return hit;
+  }
+
   const byTool = new Map();
   const byExecKind = new Map();
   const byExecExit = new Map();
@@ -512,7 +557,7 @@ async function parseGrokUpdatesFile(updatesPath, { from, to, timeZoneContext } =
     input.destroy?.();
   }
 
-  return {
+  const parsedResult = {
     totals: roundTotals(totals),
     turnCount,
     toolBreakdown: { tool_rows: finalizeToolRows(byTool) },
@@ -525,6 +570,8 @@ async function parseGrokUpdatesFile(updatesPath, { from, to, timeZoneContext } =
       by_exit: finalizeExecRows(byExecExit),
     },
   };
+  rememberFileParse(cacheKey, parsedResult);
+  return parsedResult;
 }
 
 function emptySessionResult() {
@@ -580,37 +627,95 @@ function mergeExecRows(map, rows) {
   }
 }
 
-async function computeGrokContextBreakdown({
-  from = null,
-  to = null,
-  top = 50,
-  timeZoneContext = null,
-  env = process.env,
-} = {}) {
-  const limitedTop = Number.isFinite(top) && top > 0 ? Math.min(Math.floor(top), 200) : 50;
-  const sessions = discoverGrokSessionFiles(env);
-  const inventorySig = crypto
+function buildGrokInventorySignature(sessions) {
+  return crypto
     .createHash("sha256")
     .update(
-      sessions
+      (sessions || [])
         .map((s) => `${s.updatesPath}:${s.size}:${Math.floor(s.mtimeMs)}`)
         .join("|"),
     )
     .digest("hex");
-  const cacheKey = [
+}
+
+function buildGrokResultCacheKey({ from, to, top, timeZoneContext, inventorySig }) {
+  // Include inventorySig so a changed session file cannot serve a stale aggregate.
+  // Unchanged files still skip re-parse via FILE_PARSE_CACHE (Codex-style).
+  return [
     CACHE_SCHEMA_VERSION,
     from || "",
     to || "",
-    limitedTop,
+    top,
     timeZoneContext?.timeZone || "",
     timeZoneContext?.offsetMinutes ?? "",
-    inventorySig,
+    inventorySig || "",
   ].join("|");
+}
+
+async function computeGrokContextBreakdown(options = {}) {
+  const {
+    from = null,
+    to = null,
+    top = 50,
+    timeZoneContext = null,
+    env = process.env,
+  } = options;
+  const limitedTop = Number.isFinite(top) && top > 0 ? Math.min(Math.floor(top), 200) : 50;
+  const sessions = discoverGrokSessionFiles(env);
+  const inventorySig = buildGrokInventorySignature(sessions);
+  const cacheKey = buildGrokResultCacheKey({
+    from,
+    to,
+    top: limitedTop,
+    timeZoneContext,
+    inventorySig,
+  });
 
   const cached = CACHE.get(cacheKey);
   if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
     return cached.value;
   }
+
+  const existing = IN_FLIGHT.get(cacheKey);
+  if (existing) return existing;
+
+  const run = computeGrokContextBreakdownUncached({
+    from,
+    to,
+    top: limitedTop,
+    timeZoneContext,
+    env,
+    sessions,
+    cacheKey,
+  });
+  IN_FLIGHT.set(cacheKey, run);
+  try {
+    return await run;
+  } finally {
+    if (IN_FLIGHT.get(cacheKey) === run) IN_FLIGHT.delete(cacheKey);
+  }
+}
+
+async function computeGrokContextBreakdownUncached({
+  from = null,
+  to = null,
+  top = 50,
+  timeZoneContext = null,
+  env = process.env,
+  sessions = null,
+  cacheKey = null,
+} = {}) {
+  const limitedTop = Number.isFinite(top) && top > 0 ? Math.min(Math.floor(top), 200) : 50;
+  const sessionList = sessions || discoverGrokSessionFiles(env);
+  const resultCacheKey =
+    cacheKey ||
+    buildGrokResultCacheKey({
+      from,
+      to,
+      top: limitedTop,
+      timeZoneContext,
+      inventorySig: buildGrokInventorySignature(sessionList),
+    });
 
   const grand = emptyTotals();
   const byTool = new Map();
@@ -623,7 +728,7 @@ async function computeGrokContextBreakdown({
   let messageCount = 0;
   let sessionCount = 0;
 
-  for (const sess of sessions) {
+  for (const sess of sessionList) {
     const parsed = await parseGrokUpdatesFile(sess.updatesPath, {
       from,
       to,
@@ -776,7 +881,7 @@ async function computeGrokContextBreakdown({
     },
   };
 
-  CACHE.set(cacheKey, { at: Date.now(), value: result });
+  CACHE.set(resultCacheKey, { at: Date.now(), value: result });
   while (CACHE.size > 32) {
     const oldest = [...CACHE.entries()].sort((a, b) => a[1].at - b[1].at)[0];
     if (oldest) CACHE.delete(oldest[0]);

--- a/test/grok-context-breakdown.test.js
+++ b/test/grok-context-breakdown.test.js
@@ -162,3 +162,158 @@ test("computeGrokContextBreakdown returns empty supported payload without sessio
   assert.equal(result.totals.total_tokens, 0);
   assert.equal(result.session_count, 0);
 });
+
+
+test("computeGrokContextBreakdown reuses result cache on identical range", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-cache-"));
+  const sid = "019f-grok-cache-1";
+  const ts = Date.parse("2026-07-18T10:05:00.000Z");
+  writeSession(root, sid, [
+    JSON.stringify({
+      timestamp: 1784357110,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: "p1",
+          stop_reason: "end_turn",
+          usage: {
+            inputTokens: 500,
+            outputTokens: 50,
+            totalTokens: 550,
+            cachedReadTokens: 100,
+            reasoningTokens: 10,
+          },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts + 1000,
+          updateType: "TurnCompleted",
+        },
+      },
+    }),
+  ]);
+
+  const env = { GROK_HOME: root, HOME: root };
+  const a = await computeGrokContextBreakdown({
+    from: "2026-07-18",
+    to: "2026-07-18",
+    env,
+  });
+  const b = await computeGrokContextBreakdown({
+    from: "2026-07-18",
+    to: "2026-07-18",
+    env,
+  });
+  assert.equal(a.totals.total_tokens, 550);
+  assert.equal(b.totals.total_tokens, 550);
+  assert.equal(a.session_count, b.session_count);
+  // Same object from result cache (not a deep clone).
+  assert.equal(a, b);
+});
+
+test("computeGrokContextBreakdown coalesces concurrent in-flight scans", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-inflight-"));
+  const sid = "019f-grok-inflight-1";
+  const ts = Date.parse("2026-07-19T10:05:00.000Z");
+  writeSession(root, sid, [
+    JSON.stringify({
+      timestamp: 1784443510,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: "p1",
+          stop_reason: "end_turn",
+          usage: {
+            inputTokens: 200,
+            outputTokens: 20,
+            totalTokens: 220,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts + 500,
+          updateType: "TurnCompleted",
+        },
+      },
+    }),
+  ]);
+
+  const env = { GROK_HOME: root, HOME: root };
+  const opts = { from: "2026-07-19", to: "2026-07-19", env };
+  const [a, b] = await Promise.all([
+    computeGrokContextBreakdown(opts),
+    computeGrokContextBreakdown(opts),
+  ]);
+  assert.equal(a.totals.total_tokens, 220);
+  assert.equal(b.totals.total_tokens, 220);
+  assert.equal(a, b);
+});
+
+test("file parse cache invalidates when updates.jsonl size/mtime change", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-filecache-"));
+  const sid = "019f-grok-filecache-1";
+  const ts = Date.parse("2026-07-20T10:05:00.000Z");
+  const line = (total) =>
+    JSON.stringify({
+      timestamp: 1784529910,
+      method: "session/update",
+      params: {
+        sessionId: sid,
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: "p1",
+          stop_reason: "end_turn",
+          usage: {
+            inputTokens: total,
+            outputTokens: 0,
+            totalTokens: total,
+            cachedReadTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+        _meta: {
+          promptId: "p1",
+          turnStartMs: ts,
+          agentTimestampMs: ts + 500,
+          updateType: "TurnCompleted",
+        },
+      },
+    });
+
+  writeSession(root, sid, [line(100)]);
+  const env = { GROK_HOME: root, HOME: root };
+  const first = await computeGrokContextBreakdown({
+    from: "2026-07-20",
+    to: "2026-07-20",
+    env,
+  });
+  assert.equal(first.totals.total_tokens, 100);
+
+  // Append a second turn so size+mtime change → file cache miss, new totals.
+  const updatesPath = path.join(
+    root,
+    "sessions",
+    encodeURIComponent("/tmp/project"),
+    sid,
+    "updates.jsonl",
+  );
+  fs.appendFileSync(updatesPath, `${line(50)}\n`);
+  // Ensure mtime advances on coarse FS clocks.
+  const st = fs.statSync(updatesPath);
+  fs.utimesSync(updatesPath, st.atime, new Date(st.mtimeMs + 2000));
+
+  const second = await computeGrokContextBreakdown({
+    from: "2026-07-20",
+    to: "2026-07-20",
+    env,
+  });
+  assert.equal(second.totals.total_tokens, 150);
+});


### PR DESCRIPTION
## Summary
- Grok **Context Breakdown** was re-scanning every `updates.jsonl` whenever the dashboard switched provider tabs (Claude ↔ Codex ↔ Grok), so users with large Grok histories saw repeated “Scanning session logs…”.
- Align Grok with the Codex/Claude approach:
  - **Per-file parse cache** (`FILE_PARSE_CACHE`, size+mtime keyed) — same idea as Codex `PARSED_GROUP_CACHE`
  - **In-flight request coalescing** so concurrent panel mounts share one scan
  - **Result cache** still keyed with inventory signature for correctness when files change
  - **UI sticky cache** in `ContextBreakdownPanel` so revisiting a source keeps the last payload instead of flashing the skeleton (`loading && !data`)

## API surface
No API change. Still `GET /functions/tokentracker-usage-category-breakdown?source=grok|codex|claude` with the same response shape.

## Test plan
- [x] `node --test test/grok-context-breakdown.test.js` (includes result cache, in-flight, file invalidation)
- [x] `dashboard` vitest `ContextBreakdownPanel.test.jsx` (sticky source revisit)
- [ ] Manual: open Usage Overview → expand Grok → wait for first scan → switch to Claude/Codex → switch back to Grok (should not re-show long scan)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the context breakdown panel from flashing back to the loading state when revisiting a previously viewed source.
  * Avoided stale breakdown content by showing a loading hint when switching to an uncached source until fresh data is ready.
* **Performance**
  * Improved repeated Grok context breakdown requests with stronger caching and automatic coalescing of duplicate in-flight computations.
  * Ensured breakdown totals update when underlying session/update data changes.
* **Tests**
  * Added coverage for cached vs. uncached behavior and concurrency/deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->