### PR TITLE
fix(grok): harden OIDC refresh follow-ups from #383 review

### DIFF
--- a/src/lib/grok-limits.js
+++ b/src/lib/grok-limits.js
@@ -186,6 +186,7 @@ function isGrokInstalled({ home, env } = {}) {
 function loadGrokAuthEntry({ home, env } = {}) {
   const authPath = path.join(resolveGrokHome({ home, env }), "auth.json");
   if (!fs.existsSync(authPath)) return null;
+  let fallback = null;
   try {
     const parsed = JSON.parse(fs.readFileSync(authPath, "utf8"));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
@@ -194,15 +195,20 @@ function loadGrokAuthEntry({ home, env } = {}) {
       const key = typeof value.key === "string" ? value.key.trim() : "";
       const refreshToken =
         typeof value.refresh_token === "string" ? value.refresh_token.trim() : "";
-      // Prefer entries that can still authenticate (access token and/or refresh token).
-      if (key || refreshToken) {
+      // Entries with an access token win outright. A refresh-token-only entry
+      // is only usable when a client id is resolvable, and must not shadow a
+      // later keyed entry — keep it as a fallback instead.
+      if (key) {
         return { entry: value, authPath, scopeKey, authFile: parsed };
+      }
+      if (refreshToken && !fallback && resolveGrokOidcClientId(value, scopeKey)) {
+        fallback = { entry: value, authPath, scopeKey, authFile: parsed };
       }
     }
   } catch (_error) {
     return null;
   }
-  return null;
+  return fallback;
 }
 
 function readGrokAccessToken({ home, env } = {}) {
@@ -266,6 +272,7 @@ async function refreshGrokTokens({
   clientId,
   tokenEndpoint = DEFAULT_TOKEN_ENDPOINT,
   fetchImpl = fetch,
+  timeoutMs = DEFAULT_BILLING_TIMEOUT_MS,
 } = {}) {
   if (typeof refreshToken !== "string" || !refreshToken.trim()) {
     const err = new Error("Grok refresh skipped: no refresh_token in auth.json");
@@ -284,68 +291,88 @@ async function refreshGrokTokens({
     client_id: clientId.trim(),
   });
 
-  const res = await fetchImpl(tokenEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    body: body.toString(),
-  });
+  // Same abort deadline discipline as fetchGrokBilling — a stalled token
+  // endpoint must not block fetchGrokLimits (and its poller) indefinitely.
+  // The timer stays armed through the body reads below, not just the headers.
+  const normalizedTimeoutMs =
+    Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_BILLING_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutError = new Error("Grok token refresh timed out.");
+  timeoutError.code = "GROK_REFRESH_TIMEOUT";
+  const timer = setTimeout(() => controller.abort(timeoutError), normalizedTimeoutMs);
 
-  if (res.status === 400 || res.status === 401) {
-    let oauthError = null;
-    try {
-      const payload = await res.json();
-      oauthError =
-        (typeof payload?.error === "string" && payload.error) ||
-        (payload?.error && typeof payload.error === "object" && payload.error.code) ||
-        null;
-    } catch (_error) {
-      // Status remains authoritative.
+  try {
+    const res = await fetchImpl(tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: body.toString(),
+      signal: controller.signal,
+    });
+
+    if (res.status === 400 || res.status === 401) {
+      let oauthError = null;
+      try {
+        const payload = await res.json();
+        oauthError =
+          (typeof payload?.error === "string" && payload.error) ||
+          (payload?.error && typeof payload.error === "object" && payload.error.code) ||
+          null;
+      } catch (_error) {
+        // Status remains authoritative.
+      }
+      const err = grokReauthError();
+      err.oauthError = oauthError;
+      err.status = res.status;
+      throw err;
     }
-    const err = grokReauthError();
-    err.oauthError = oauthError;
-    err.status = res.status;
-    throw err;
+
+    if (!res.ok) {
+      const err = new Error(`Grok token refresh failed: HTTP ${res.status}`);
+      err.code = "REFRESH_HTTP_ERROR";
+      err.status = res.status;
+      throw err;
+    }
+
+    const payload = await res.json();
+    const accessToken =
+      typeof payload?.access_token === "string" ? payload.access_token.trim() : "";
+    if (!accessToken) {
+      const err = new Error("Grok token refresh response missing access_token");
+      err.code = "REFRESH_INVALID_RESPONSE";
+      throw err;
+    }
+
+    const nextRefresh =
+      typeof payload?.refresh_token === "string" && payload.refresh_token.trim()
+        ? payload.refresh_token.trim()
+        : refreshToken.trim();
+
+    let expiresAt = null;
+    const expiresIn = Number(payload?.expires_in);
+    if (Number.isFinite(expiresIn) && expiresIn > 0) {
+      expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+    } else if (typeof payload?.expires_at === "string" && payload.expires_at.trim()) {
+      const parsed = Date.parse(payload.expires_at.trim());
+      if (Number.isFinite(parsed)) expiresAt = new Date(parsed).toISOString();
+    }
+
+    return {
+      access_token: accessToken,
+      refresh_token: nextRefresh,
+      expires_at: expiresAt,
+      token_type: typeof payload?.token_type === "string" ? payload.token_type : null,
+    };
+  } catch (error) {
+    if (controller.signal.aborted && controller.signal.reason === timeoutError) {
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
   }
-
-  if (!res.ok) {
-    const err = new Error(`Grok token refresh failed: HTTP ${res.status}`);
-    err.code = "REFRESH_HTTP_ERROR";
-    err.status = res.status;
-    throw err;
-  }
-
-  const payload = await res.json();
-  const accessToken =
-    typeof payload?.access_token === "string" ? payload.access_token.trim() : "";
-  if (!accessToken) {
-    const err = new Error("Grok token refresh response missing access_token");
-    err.code = "REFRESH_INVALID_RESPONSE";
-    throw err;
-  }
-
-  const nextRefresh =
-    typeof payload?.refresh_token === "string" && payload.refresh_token.trim()
-      ? payload.refresh_token.trim()
-      : refreshToken.trim();
-
-  let expiresAt = null;
-  const expiresIn = Number(payload?.expires_in);
-  if (Number.isFinite(expiresIn) && expiresIn > 0) {
-    expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
-  } else if (typeof payload?.expires_at === "string" && payload.expires_at.trim()) {
-    const parsed = Date.parse(payload.expires_at.trim());
-    if (Number.isFinite(parsed)) expiresAt = new Date(parsed).toISOString();
-  }
-
-  return {
-    access_token: accessToken,
-    refresh_token: nextRefresh,
-    expires_at: expiresAt,
-    token_type: typeof payload?.token_type === "string" ? payload.token_type : null,
-  };
 }
 
 async function persistGrokRefreshedAuth(authPath, authFile, scopeKey, entry, newTokens) {
@@ -359,14 +386,25 @@ async function persistGrokRefreshedAuth(authPath, authFile, scopeKey, entry, new
   };
   if (newTokens.expires_at) {
     nextEntry.expires_at = newTokens.expires_at;
+  } else {
+    // Unknown new lifetime: drop the stale timestamp, otherwise the next poll
+    // sees an already-expired expires_at next to a fresh key and refreshes
+    // again on every cycle (burning a rotation each time).
+    delete nextEntry.expires_at;
   }
   const merged = {
     ...authFile,
     [scopeKey]: nextEntry,
   };
   const tmp = `${authPath}.tmp.${process.pid}.${Date.now()}`;
-  await fs.promises.writeFile(tmp, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
-  await fs.promises.rename(tmp, authPath);
+  try {
+    await fs.promises.writeFile(tmp, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
+    await fs.promises.rename(tmp, authPath);
+  } catch (error) {
+    // Never leave a tmp file holding fresh tokens behind.
+    await fs.promises.rm(tmp, { force: true }).catch(() => {});
+    throw error;
+  }
   try {
     await fs.promises.chmod(authPath, 0o600);
   } catch (_error) {
@@ -495,6 +533,20 @@ function normalizeGrokBillingResponse(body) {
   if (usedPercent === null && Number.isFinite(monthlyLimit) && monthlyLimit > 0 && Number.isFinite(used)) {
     usedPercent = (used / monthlyLimit) * 100;
     if (!periodType) periodType = "monthly";
+  }
+
+  // Unified billing omits creditUsagePercent (and productUsage) entirely when
+  // nothing was used this period. A valid currentPeriod window with the usage
+  // fields absent means 0%, not an unparseable response. Present-but-malformed
+  // fields still fall through to the parse error below.
+  if (
+    usedPercent === null &&
+    currentPeriod &&
+    (periodStart || resetAt) &&
+    config.creditUsagePercent === undefined &&
+    config.productUsage === undefined
+  ) {
+    usedPercent = 0;
   }
 
   const onDemandCap = grokValNumber(config.onDemandCap);

--- a/test/grok-limits.test.js
+++ b/test/grok-limits.test.js
@@ -803,3 +803,190 @@ describe("resolveGrokAccessToken", () => {
     }
   });
 });
+
+describe("grok refresh hardening", () => {
+  it("treats a zero-usage unified period (creditUsagePercent omitted) as 0%", () => {
+    // Real payload shape from a zero-usage week: unified billing drops
+    // creditUsagePercent and productUsage entirely.
+    const result = normalizeGrokBillingResponse({
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-07-22T00:00:00+00:00",
+          end: "2026-07-29T00:00:00+00:00",
+        },
+        onDemandCap: { val: 0 },
+        onDemandUsed: { val: 0 },
+        isUnifiedBillingUser: true,
+        billingPeriodStart: "2026-07-22T00:00:00+00:00",
+        billingPeriodEnd: "2026-07-29T00:00:00+00:00",
+      },
+    });
+
+    assert.equal(result.period_type, "weekly");
+    assert.equal(result.credit_usage_percent, 0);
+    assert.deepEqual(result.primary_window, {
+      used_percent: 0,
+      reset_at: "2026-07-29T00:00:00.000Z",
+    });
+  });
+
+  it("still rejects a present-but-malformed creditUsagePercent", () => {
+    assert.throws(
+      () =>
+        normalizeGrokBillingResponse({
+          config: {
+            currentPeriod: {
+              type: "USAGE_PERIOD_TYPE_WEEKLY",
+              start: "2026-07-22T00:00:00+00:00",
+              end: "2026-07-29T00:00:00+00:00",
+            },
+            creditUsagePercent: "40%",
+          },
+        }),
+      /no quota windows/i,
+    );
+  });
+
+  it("aborts a stalled token endpoint with GROK_REFRESH_TIMEOUT", async () => {
+    await assert.rejects(
+      refreshGrokTokens({
+        refreshToken: "refresh-1",
+        clientId: "client-1",
+        timeoutMs: 30,
+        fetchImpl: (url, options) =>
+          new Promise((_, reject) => {
+            options.signal.addEventListener("abort", () => reject(options.signal.reason), {
+              once: true,
+            });
+          }),
+      }),
+      (err) => {
+        assert.equal(err.code, "GROK_REFRESH_TIMEOUT");
+        assert.match(err.message, /timed out/i);
+        return true;
+      },
+    );
+  });
+
+  it("keeps the timeout armed through the response body read", async () => {
+    await assert.rejects(
+      refreshGrokTokens({
+        refreshToken: "refresh-1",
+        clientId: "client-1",
+        timeoutMs: 30,
+        fetchImpl: async (url, options) => ({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_, reject) => {
+              options.signal.addEventListener("abort", () => reject(options.signal.reason), {
+                once: true,
+              });
+            }),
+        }),
+      }),
+      (err) => err.code === "GROK_REFRESH_TIMEOUT",
+    );
+  });
+
+  it("prefers a keyed auth entry over an earlier refresh-token-only entry", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-entry-order-"));
+    try {
+      const grokHome = path.join(tmp, ".grok");
+      fs.mkdirSync(grokHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(grokHome, "auth.json"),
+        JSON.stringify({
+          "https://auth.x.ai::refresh-only": {
+            refresh_token: "r1",
+            oidc_client_id: "refresh-only-client",
+          },
+          "https://auth.x.ai::keyed": { key: "usable-token" },
+        }),
+        "utf8",
+      );
+
+      const env = { GROK_HOME: grokHome };
+      const loaded = require("../src/lib/grok-limits").loadGrokAuthEntry({ home: tmp, env });
+      assert.equal(loaded.entry.key, "usable-token");
+      assert.equal(readGrokAccessToken({ home: tmp, env }), "usable-token");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores refresh-token-only entries with no resolvable client id", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-entry-noclient-"));
+    try {
+      const grokHome = path.join(tmp, ".grok");
+      fs.mkdirSync(grokHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(grokHome, "auth.json"),
+        // No oidc_client_id and no "::" suffix to recover it from.
+        JSON.stringify({ "plain-scope": { refresh_token: "r1" } }),
+        "utf8",
+      );
+
+      const loaded = require("../src/lib/grok-limits").loadGrokAuthEntry({
+        home: tmp,
+        env: { GROK_HOME: grokHome },
+      });
+      assert.equal(loaded, null);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("drops a stale expires_at when the refresh response has no lifetime", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-persist-stale-"));
+    try {
+      const authPath = path.join(tmp, "auth.json");
+      const scopeKey = "https://auth.x.ai::client-1";
+      const entry = {
+        key: "old-token",
+        refresh_token: "r1",
+        expires_at: "2026-07-19T20:44:02.792386Z",
+        oidc_client_id: "client-1",
+      };
+      const authFile = { [scopeKey]: entry };
+      fs.writeFileSync(authPath, JSON.stringify(authFile), { mode: 0o600 });
+
+      await persistGrokRefreshedAuth(authPath, authFile, scopeKey, entry, {
+        access_token: "new-token",
+        refresh_token: "r2",
+        expires_at: null,
+      });
+
+      const onDisk = JSON.parse(fs.readFileSync(authPath, "utf8"));
+      assert.equal(onDisk[scopeKey].key, "new-token");
+      // Keeping the old timestamp would force a refresh on every poll.
+      assert.equal("expires_at" in onDisk[scopeKey], false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up the tmp file when the atomic rename fails", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-persist-cleanup-"));
+    try {
+      // rename() onto a non-empty directory fails on POSIX.
+      const authPath = path.join(tmp, "auth.json");
+      fs.mkdirSync(path.join(authPath, "block"), { recursive: true });
+
+      const scopeKey = "https://auth.x.ai::client-1";
+      const entry = { key: "old", refresh_token: "r1" };
+      await assert.rejects(
+        persistGrokRefreshedAuth(authPath, { [scopeKey]: entry }, scopeKey, entry, {
+          access_token: "new-token",
+        }),
+      );
+
+      // No auth.json.tmp.* file with fresh tokens may remain.
+      const leftovers = fs.readdirSync(tmp).filter((name) => name.includes(".tmp."));
+      assert.deepEqual(leftovers, []);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #383 (thanks @duibaix!) picking up the review findings that didn't block the merge:

- **Zero-usage weeks parse as 0% instead of erroring** — the unified billing API omits `creditUsagePercent` / `productUsage` entirely when nothing was used this period, which made `normalizeGrokBillingResponse` throw `no quota windows` right after a successful token refresh (confirmed against the real API). Present-but-malformed fields still surface the parse error.
- **Abort deadline on the token refresh POST** (CodeRabbit's point on #383) — kept armed through the response body reads, so a stalled `auth.x.ai` can't block `fetchGrokLimits` and its poller.
- **Multi-entry auth.json selection** (Copilot's point on #383) — keyed entries win over earlier refresh-token-only entries; refresh-only entries with no resolvable client id are ignored instead of shadowing a usable key.
- **Stale `expires_at` no longer survives a refresh response without a lifetime** — previously the old (expired) timestamp stayed next to the fresh key, forcing a token-endpoint round trip and refresh-token rotation on every poll.
- **tmp-file cleanup when the atomic rename fails** — never leave `auth.json.tmp.*` holding fresh tokens on disk.

Refs #381.

## Test plan

- [x] `node --test test/grok-limits.test.js` (32/32, includes 8 new hardening tests)
- [x] Full suite `npm test` (1952 pass)
- [x] Zero-usage payload in the new test is the real API response shape captured live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection of Grok authentication credentials.
  * Added timeout handling for stalled token refresh requests.
  * Prevented stale expiration data from causing repeated refresh attempts.
  * Improved cleanup after failed credential updates.
  * Correctly handles billing responses showing zero usage while still reporting malformed data as an error.
* **Tests**
  * Added coverage for authentication selection, refresh timeouts, billing normalization, expiration handling, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->