### PR TITLE
fix: preserve Codex usage when token refresh fails

### DIFF
--- a/src/lib/codex-token-refresh.js
+++ b/src/lib/codex-token-refresh.js
@@ -6,11 +6,29 @@ const path = require("node:path");
 const REFRESH_ENDPOINT = "https://auth.openai.com/oauth/token";
 const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 
-// CodexBar refreshes when last_refresh > 8 days. We mirror that — actual TTL is shorter so
-// we always refresh before the access token can expire while users have the app running.
+// Match the official Codex CLI: when the access token exposes a JWT expiry, refresh only
+// shortly before it expires. Fall back to last_refresh > 8 days for opaque/legacy tokens.
 const REFRESH_THRESHOLD_MS = 8 * 24 * 60 * 60 * 1000;
+const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
 
-function isTokenStale(lastRefreshIso, nowMs = Date.now()) {
+function parseJwtExpirationMs(token) {
+  if (typeof token !== "string" || token.length === 0) return null;
+  const parts = token.split(".");
+  if (parts.length < 2 || !parts[1]) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    const exp = Number(payload?.exp);
+    return Number.isFinite(exp) ? exp * 1000 : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+function isTokenStale(lastRefreshIso, nowMs = Date.now(), accessToken = null) {
+  const expiresAtMs = parseJwtExpirationMs(accessToken);
+  if (expiresAtMs !== null) {
+    return expiresAtMs <= nowMs + ACCESS_TOKEN_REFRESH_WINDOW_MS;
+  }
   if (!lastRefreshIso) return true;
   const ts = Date.parse(lastRefreshIso);
   if (!Number.isFinite(ts)) return true;
@@ -34,7 +52,6 @@ async function refreshCodexTokens({ refreshToken, fetchImpl = fetch }) {
       client_id: CODEX_CLIENT_ID,
       grant_type: "refresh_token",
       refresh_token: refreshToken,
-      scope: "openid profile email",
     }),
   });
 
@@ -50,9 +67,18 @@ async function refreshCodexTokens({ refreshToken, fetchImpl = fetch }) {
     } catch (_e) {
       // Ignore parse failure — surface the generic reason.
     }
-    const err = new Error(
-      "Codex refresh token expired or revoked. Run `codex` to re-authenticate.",
-    );
+    const reason = String(openaiErrorCode || "").toLowerCase();
+    let message = "Codex refresh token was rejected. Run `codex login` to re-authenticate.";
+    if (reason === "refresh_token_expired") {
+      message = "Codex refresh token expired. Run `codex login` to re-authenticate.";
+    } else if (reason === "refresh_token_reused") {
+      message =
+        "Codex refresh token was already used, likely by another Codex process. " +
+        "Run `codex login` to re-authenticate.";
+    } else if (reason === "refresh_token_invalidated") {
+      message = "Codex refresh token was revoked. Run `codex login` to re-authenticate.";
+    }
+    const err = new Error(message);
     err.code = "REFRESH_TOKEN_EXPIRED";
     err.openaiErrorCode = openaiErrorCode;
     throw err;
@@ -106,6 +132,8 @@ module.exports = {
   REFRESH_ENDPOINT,
   CODEX_CLIENT_ID,
   REFRESH_THRESHOLD_MS,
+  ACCESS_TOKEN_REFRESH_WINDOW_MS,
+  parseJwtExpirationMs,
   isTokenStale,
   refreshCodexTokens,
   persistRefreshedAuth,

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -523,15 +523,16 @@ async function fetchCodexUsageLimits(
       // 401/403/404 from wham means "no usage data available for this auth state" — render
       // a neutral empty state instead of a red "Fetch failed" error.
       if (res.status === 401 || res.status === 403 || res.status === 404) {
-        return { body: null };
+        return { body: null, status: res.status };
       }
       if (res.status !== 200) {
         throw new Error(`Codex API returned ${res.status}`);
       }
-      return { body: await res.json() };
+      return { body: await res.json(), status: res.status };
     }), "Codex", providerTimeoutMs);
   if (!usage.body) {
     return {
+      upstream_status: usage.status,
       primary_window: null,
       secondary_window: null,
       credit_window: null,
@@ -558,6 +559,7 @@ async function fetchCodexUsageLimits(
     }
   }
   return {
+    upstream_status: usage.status,
     ...normalizeCodexRateWindows(body.rate_limit || {}),
     credit_window: normalizeCodexCreditWindow(body.spend_control?.individual_limit),
     ...normalizeCodexSparkRateWindows(body.additional_rate_limits),
@@ -3051,14 +3053,14 @@ async function fetchUsageLimitsUncached({
   ]);
   const claudePlanType = claudeSubscription?.planType || null;
 
-  // Proactively refresh Codex tokens that are >8 days stale, mirroring CodexBar's
-  // CodexTokenRefresher.swift. Without this, users who logged in once and didn't run
-  // `codex` for >a week get wham 401 → "Fetch failed" (issue #52). Best-effort: any
-  // refresh failure falls through to using the existing (possibly stale) token, then the
-  // 4xx graceful path in fetchCodexUsageLimits surfaces a neutral state instead of red.
+  // Match the official Codex CLI: prefer the access token's JWT expiry and refresh only
+  // within five minutes of it; fall back to last_refresh >8 days for opaque/legacy tokens.
+  // Best-effort: a refresh failure still falls through to the existing access token.
   let refreshError = null;
   let codexAuthRefreshed = codexAuth;
-  if (codexAuth && isTokenStale(codexAuth.lastRefresh) && codexAuth.refreshToken) {
+  if (codexAuth
+    && isTokenStale(codexAuth.lastRefresh, nowMs, codexAuth.accessToken)
+    && codexAuth.refreshToken) {
     try {
       const newTokens = await refreshCodexTokens({
         refreshToken: codexAuth.refreshToken,
@@ -3225,12 +3227,39 @@ async function fetchUsageLimitsUncached({
     claude.service_status = claudeServiceStatus;
   }
 
+  const codexRefreshRequiresReauth = refreshError?.code === "REFRESH_TOKEN_EXPIRED";
+  const codexLiveUsageSucceeded = codexResult?.status === "fulfilled"
+    && codexResult.value.upstream_status === 200;
   let codex;
   if (!codexToken) {
     codex = { configured: false };
-  } else if (refreshError && refreshError.code === "REFRESH_TOKEN_EXPIRED") {
+  } else if (codexResult?.status === "fulfilled"
+    && (!codexRefreshRequiresReauth || codexLiveUsageSucceeded)) {
+    // A proactive refresh can fail while the existing access token is still valid.
+    // Prefer a confirmed 200 live usage read over the refresh error so usable quota
+    // data is not discarded before the access token actually expires. A neutral
+    // 401/403/404 no-data response must not mask a failed refresh.
+    codex = {
+      configured: true,
+      error: null,
+      plan_type: codexPlanType || null,
+      primary_window: codexResult.value.primary_window,
+      secondary_window: codexResult.value.secondary_window,
+      credit_window: codexResult.value.credit_window,
+      spark_primary_window: codexResult.value.spark_primary_window,
+      spark_secondary_window: codexResult.value.spark_secondary_window,
+      reset_credits: codexResult.value.reset_credits,
+      // Live read is current as of now; the stale fallback path below serves the
+      // disk cache with `stale: true`. Always emitting both lets the client show a
+      // data-age label uniformly (see the Claude live-success block).
+      stale: false,
+      cached_at: new Date(nowMs).toISOString(),
+    };
+    writeCodexLimitsCache(codex, { home, nowMs });
+  } else if (codexRefreshRequiresReauth) {
     // Refresh token is dead — the user must re-run `codex` to log in again. Surface a
-    // specific, actionable message rather than the generic "Fetch failed".
+    // specific, actionable message rather than the generic "Fetch failed", but only
+    // after the existing access token also failed to fetch live usage above.
     codex = {
       configured: true,
       error: refreshError.message,
@@ -3246,24 +3275,6 @@ async function fetchUsageLimitsUncached({
     } else {
       codex = { configured: true, error: codexResult?.reason?.message || "Unknown error" };
     }
-  } else {
-    codex = {
-      configured: true,
-      error: null,
-      plan_type: codexPlanType || null,
-      primary_window: codexResult.value.primary_window,
-      secondary_window: codexResult.value.secondary_window,
-      credit_window: codexResult.value.credit_window,
-      spark_primary_window: codexResult.value.spark_primary_window,
-      spark_secondary_window: codexResult.value.spark_secondary_window,
-      reset_credits: codexResult.value.reset_credits,
-      // Live read is current as of now; the stale fallback path above serves the
-      // disk cache with `stale: true`. Always emitting both lets the client show a
-      // data-age label uniformly (see the Claude live-success block).
-      stale: false,
-      cached_at: new Date(nowMs).toISOString(),
-    };
-    writeCodexLimitsCache(codex, { home, nowMs });
   }
 
   const data = {

--- a/test/codex-token-refresh.test.js
+++ b/test/codex-token-refresh.test.js
@@ -9,10 +9,16 @@ const {
   refreshCodexTokens,
   persistRefreshedAuth,
   REFRESH_THRESHOLD_MS,
+  ACCESS_TOKEN_REFRESH_WINDOW_MS,
   REFRESH_ENDPOINT,
 } = require("../src/lib/codex-token-refresh");
 
 describe("isTokenStale", () => {
+  function jwtWithExpiration(exp) {
+    const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+    return `header.${payload}.signature`;
+  }
+
   it("treats missing last_refresh as stale", () => {
     assert.equal(isTokenStale(null), true);
     assert.equal(isTokenStale(""), true);
@@ -37,6 +43,28 @@ describe("isTokenStale", () => {
 
   it("uses an 8-day threshold (not 7, not 30)", () => {
     assert.equal(REFRESH_THRESHOLD_MS, 8 * 24 * 60 * 60 * 1000);
+  });
+
+  it("prefers JWT expiry over an old last_refresh timestamp", () => {
+    const now = Date.parse("2026-05-05T00:00:00Z");
+    const expiresInTwoDays = Math.floor((now + 2 * 24 * 60 * 60 * 1000) / 1000);
+    assert.equal(
+      isTokenStale("2026-01-01T00:00:00Z", now, jwtWithExpiration(expiresInTwoDays)),
+      false,
+    );
+  });
+
+  it("refreshes JWT access tokens within the official five-minute window", () => {
+    const now = Date.parse("2026-05-05T00:00:00Z");
+    assert.equal(ACCESS_TOKEN_REFRESH_WINDOW_MS, 5 * 60 * 1000);
+    assert.equal(
+      isTokenStale(null, now, jwtWithExpiration(Math.floor((now + 6 * 60 * 1000) / 1000))),
+      false,
+    );
+    assert.equal(
+      isTokenStale(null, now, jwtWithExpiration(Math.floor((now + 5 * 60 * 1000) / 1000))),
+      true,
+    );
   });
 });
 
@@ -65,6 +93,7 @@ describe("refreshCodexTokens", () => {
     assert.equal(observedBody.client_id, "app_EMoamEEZ73f0CkXaXp7hrann");
     assert.equal(observedBody.grant_type, "refresh_token");
     assert.equal(observedBody.refresh_token, "rt-abc");
+    assert.equal(observedBody.scope, undefined);
     assert.deepEqual(result, {
       access_token: "new-access",
       refresh_token: "new-refresh",
@@ -102,7 +131,26 @@ describe("refreshCodexTokens", () => {
     assert.ok(thrown);
     assert.equal(thrown.code, "REFRESH_TOKEN_EXPIRED");
     assert.equal(thrown.openaiErrorCode, "refresh_token_expired");
-    assert.match(thrown.message, /Run `codex` to re-authenticate/);
+    assert.match(thrown.message, /Run `codex login` to re-authenticate/);
+  });
+
+  it("explains a refresh_token_reused 401 separately", async () => {
+    await assert.rejects(
+      refreshCodexTokens({
+        refreshToken: "rt-abc",
+        fetchImpl: async () => ({
+          ok: false,
+          status: 401,
+          json: async () => ({ error: { code: "refresh_token_reused" } }),
+        }),
+      }),
+      (err) => {
+        assert.equal(err.code, "REFRESH_TOKEN_EXPIRED");
+        assert.equal(err.openaiErrorCode, "refresh_token_reused");
+        assert.match(err.message, /already used/);
+        return true;
+      },
+    );
   });
 
   it("throws NO_REFRESH_TOKEN when no refresh_token is available", async () => {

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -1502,13 +1502,92 @@ describe("getUsageLimits", () => {
               json: async () => ({ error: { code: "refresh_token_expired" } }),
             });
           }
+          if (url === CODEX_WHAM_USAGE_URL) {
+            return Promise.resolve({
+              ok: false,
+              status: 401,
+              json: async () => ({}),
+            });
+          }
           return pendingUnlessCodexReset(url);
         },
       });
 
       assert.equal(result.codex.configured, true);
       assert.equal(result.codex.auth_action_required, "reauth");
-      assert.match(result.codex.error, /Run `codex` to re-authenticate/);
+      assert.match(result.codex.error, /Run `codex login` to re-authenticate/);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("uses live Codex usage when refresh fails but the access token remains valid", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-codex-valid-access-"));
+    try {
+      const codexHome = path.join(tmp, ".codex");
+      const accessToken = makeFakeCodexJwt("plus");
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(codexHome, "auth.json"),
+        JSON.stringify({
+          tokens: {
+            access_token: accessToken,
+            id_token: accessToken,
+            refresh_token: "rt-dead-valid-access",
+            account_id: "acc-valid-access",
+          },
+          last_refresh: "2026-01-01T00:00:00Z",
+        }),
+      );
+
+      let whamAuthHeader = null;
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 2000,
+        securityRunner: inactiveRunner,
+        commandRunner: inactiveRunner,
+        fetchImpl(url, options) {
+          if (url === "https://auth.openai.com/oauth/token") {
+            return Promise.resolve({
+              ok: false,
+              status: 401,
+              json: async () => ({ error: { code: "refresh_token_expired" } }),
+            });
+          }
+          if (url === CODEX_WHAM_USAGE_URL) {
+            whamAuthHeader = options?.headers?.Authorization || null;
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({
+                rate_limit: {
+                  primary_window: {
+                    used_percent: 12,
+                    limit_window_seconds: 604800,
+                    reset_at: 1_900_000_000,
+                  },
+                  secondary_window: null,
+                },
+              }),
+            });
+          }
+          return pendingUnlessCodexReset(url);
+        },
+      });
+
+      assert.equal(whamAuthHeader, `Bearer ${accessToken}`);
+      assert.equal(result.codex.configured, true);
+      assert.equal(result.codex.error, null);
+      assert.equal(result.codex.auth_action_required, undefined);
+      assert.equal(result.codex.primary_window, null);
+      assert.deepEqual(result.codex.secondary_window, {
+        used_percent: 12,
+        limit_window_seconds: 604800,
+        reset_at: 1_900_000_000,
+      });
     } finally {
       resetUsageLimitsCache();
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- align proactive Codex token refresh with the official CLI by using JWT expiry and a five-minute refresh window, with the existing eight-day fallback for opaque tokens
- preserve confirmed live Codex quota data when refresh-token renewal returns 401 but the current access token is still valid
- remove the legacy refresh scope and provide clearer messages for expired, reused, or invalidated refresh tokens
- add regression coverage for refresh timing and the refresh-401/live-usage-200 path

## Testing

- `node --test test/codex-token-refresh.test.js test/usage-limits.test.js` — 117 passed
- `npm run validate:guardrails`
- macOS Release App and DMG built and signature/checksum verified
- installed App returned live Codex Pro weekly quota with HTTP 200 and no token-file mutation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Codex access tokens now refresh shortly before JWT expiration, with legacy-token fallback support.
  * Usage data remains available when an existing access token is still valid, even if token refresh fails.
  * Upstream authorization statuses are preserved for unavailable usage data.
  * Successful live usage responses now include consistent cache and freshness information.

* **Bug Fixes**
  * Added clearer re-authentication messages for expired, reused, or invalidated refresh tokens.
  * Improved handling of cached usage data when live requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->