### PR TITLE
fix(codex): scan both Windows and WSL installs, fix WSL shadow dropping Windows usage

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -589,17 +589,31 @@ async function cmdSync(argv, context = {}) {
       const wslCodexDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".codex")
         : null;
+      // resolveInstallPaths in wsl-first/native-first modes returns a SINGLE
+      // path (the preferred install) with wsl=null, which silently drops the
+      // other install's usage. For codex a user may have it installed in BOTH
+      // Windows and WSL, and each install has its own sessions/ tree — we must
+      // scan both or usage goes missing. So instead of trusting the single-path
+      // resolution, collect every install whose sessions/ actually exists and
+      // push each as its own source. The codexHashes event-dedup (keyed by
+      // sessionUUID:eventTimestamp) makes overlapping scans idempotent even if
+      // the same file is somehow reachable from both paths. (issue #codex-wsl-shadow)
+      const codexSessionsExists = (p) => {
+        if (!p) return false;
+        try { return fssync.existsSync(path.join(p, "sessions")); } catch { return false; }
+      };
+      const codexInstalls = new Set();
+      if (codexSessionsExists(codexNativeValue)) codexInstalls.add(codexNativeValue);
+      if (codexSessionsExists(wslCodexDir)) codexInstalls.add(wslCodexDir);
+      // Also honor resolveInstallPaths' pick (it may include env-overridden
+      // paths or future resolution logic we don't want to bypass entirely).
       const codexPaths = resolveInstallPaths({ nativeValue: codexNativeValue, wslValue: wslCodexDir });
-      if (codexPaths.native) {
-        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "sessions"), codexInventoryCache: true });
+      if (codexPaths.native && codexSessionsExists(codexPaths.native)) codexInstalls.add(codexPaths.native);
+      if (codexPaths.wsl && codexSessionsExists(codexPaths.wsl)) codexInstalls.add(codexPaths.wsl);
+      for (const install of codexInstalls) {
+        sources.push({ source: "codex", sessionsDir: path.join(install, "sessions"), codexInventoryCache: true });
         if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
-          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "archived_sessions"), deep: true });
-        }
-      }
-      if (codexPaths.wsl) {
-        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "sessions"), codexInventoryCache: true });
-        if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
-          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "archived_sessions"), deep: true });
+          sources.push({ source: "codex", sessionsDir: path.join(install, "archived_sessions"), deep: true });
         }
       }
     }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -589,31 +589,26 @@ async function cmdSync(argv, context = {}) {
       const wslCodexDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".codex")
         : null;
-      // resolveInstallPaths in wsl-first/native-first modes returns a SINGLE
-      // path (the preferred install) with wsl=null, which silently drops the
-      // other install's usage. For codex a user may have it installed in BOTH
-      // Windows and WSL, and each install has its own sessions/ tree — we must
-      // scan both or usage goes missing. So instead of trusting the single-path
-      // resolution, collect every install whose sessions/ actually exists and
-      // push each as its own source. The codexHashes event-dedup (keyed by
-      // sessionUUID:eventTimestamp) makes overlapping scans idempotent even if
-      // the same file is somehow reachable from both paths. (issue #codex-wsl-shadow)
-      const codexSessionsExists = (p) => {
-        if (!p) return false;
-        try { return fssync.existsSync(path.join(p, "sessions")); } catch { return false; }
-      };
-      const codexInstalls = new Set();
-      if (codexSessionsExists(codexNativeValue)) codexInstalls.add(codexNativeValue);
-      if (codexSessionsExists(wslCodexDir)) codexInstalls.add(wslCodexDir);
-      // Also honor resolveInstallPaths' pick (it may include env-overridden
-      // paths or future resolution logic we don't want to bypass entirely).
-      const codexPaths = resolveInstallPaths({ nativeValue: codexNativeValue, wslValue: wslCodexDir });
-      if (codexPaths.native && codexSessionsExists(codexPaths.native)) codexInstalls.add(codexPaths.native);
-      if (codexPaths.wsl && codexSessionsExists(codexPaths.wsl)) codexInstalls.add(codexPaths.wsl);
-      for (const install of codexInstalls) {
-        sources.push({ source: "codex", sessionsDir: path.join(install, "sessions"), codexInventoryCache: true });
+      // resolveInstallPaths stays the single authority for wsl-first /
+      // native-first / wsl-only / native-only / both selection; requireAnyChild
+      // makes it validate that a candidate actually holds sessions/ or
+      // archived_sessions/ so an empty WSL ~/.codex shell cannot shadow the
+      // native install (issue #codex-wsl-shadow).
+      const codexPaths = resolveInstallPaths({
+        nativeValue: codexNativeValue,
+        wslValue: wslCodexDir,
+        requireAnyChild: ["sessions", "archived_sessions"],
+      });
+      if (codexPaths.native) {
+        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "sessions"), codexInventoryCache: true });
         if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
-          sources.push({ source: "codex", sessionsDir: path.join(install, "archived_sessions"), deep: true });
+          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.native, "archived_sessions"), deep: true });
+        }
+      }
+      if (codexPaths.wsl) {
+        sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "sessions"), codexInventoryCache: true });
+        if (!isBackgroundLightweightSync || backgroundCodexUsageRepair) {
+          sources.push({ source: "codex", sessionsDir: path.join(codexPaths.wsl, "archived_sessions"), deep: true });
         }
       }
     }

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -1,23 +1,39 @@
 const fssync = require("node:fs");
+const path = require("node:path");
 const wsl = require("./wsl-probe");
 
-function resolveInstallPaths({ nativeValue, wslDir, wslValue } = {}, env = process.env, deps = {}) {
-  if (process.platform !== "win32") {
+function resolveInstallPaths({ nativeValue, wslDir, wslValue, requireAnyChild } = {}, env = process.env, deps = {}) {
+  const platform = deps.platform || process.platform;
+  if (platform !== "win32") {
     return { native: nativeValue ?? null, wsl: null };
   }
 
+  // requireAnyChild (opt-in): a candidate install must hold at least one of
+  // the named children (e.g. "sessions"/"archived_sessions") to qualify — an
+  // empty shell dir must not shadow a populated install. For wslDir discovery
+  // the check is folded into the existsSync probe so discoverWslHome skips an
+  // empty-shell distro and continues to the next one.
+  const populated = (p) => !requireAnyChild || hasAnyChild(p, requireAnyChild, deps.existsSync);
+  const wslExists = requireAnyChild
+    ? (p) => Boolean(pathExists(p, deps.existsSync)) && hasAnyChild(p, requireAnyChild, deps.existsSync)
+    : deps.existsSync;
   const wslCandidate = wslValue !== undefined
-    ? (wsl.shouldProbeWsl(env) && pathExists(wslValue, deps.existsSync) ? wslValue : null)
-    : (wslDir && wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslDir, { ...deps, env }) : null);
-  const nativeCandidate = wsl.shouldProbeNative(env) && nativeValue
+    ? (wsl.shouldProbeWsl(env) && pathExists(wslValue, deps.existsSync) && populated(wslValue) ? wslValue : null)
+    : (wslDir && wsl.shouldProbeWsl(env) ? wsl.discoverWslHome(wslDir, { ...deps, env, existsSync: wslExists }) : null);
+  const nativeCandidate = wsl.shouldProbeNative(env) && nativeValue && populated(nativeValue)
     ? pathExists(nativeValue, deps.existsSync) : null;
 
-  return wsl.resolveAllWin32Paths({ nativeValue: nativeCandidate, wslValue: wslCandidate, env, platform: "win32" });
+  return wsl.resolveAllWin32Paths({ nativeValue: nativeCandidate, wslValue: wslCandidate, env, platform });
 }
 
 function pathExists(p, existsSync) {
   if (typeof p !== "string" || !p) return null;
   try { return (existsSync || fssync.existsSync)(p) ? p : null; } catch (_e) { return null; }
+}
+
+function hasAnyChild(p, children, existsSync) {
+  const ex = existsSync || fssync.existsSync;
+  return children.some((c) => { try { return ex(path.join(p, c)); } catch (_e) { return false; } });
 }
 
 // Migrate a flat (single-install) cursor to { native, wsl } namespaces.

--- a/test/codex-wsl-shadow.test.js
+++ b/test/codex-wsl-shadow.test.js
@@ -5,36 +5,96 @@ const fs = require("node:fs/promises");
 const { test } = require("node:test");
 
 const { cmdSync } = require("../src/commands/sync");
+const wsl = require("../src/lib/wsl-probe");
+const { mockPlatform, mockMethod } = require("./helpers/mock");
 
-// Reproduces the WSL-shadowing bug: resolveInstallPaths in wsl-first mode
-// picks a WSL ~/.codex path that exists but has NO sessions/ subdir (codex is
-// installed on Windows, not in WSL). Before the fix, listRolloutFiles scanned
-// the non-existent WSL sessions/ dir, silently returned 0 files, and all
-// Windows codex usage went missing. After the fix, sync.js verifies sessions/
-// exists before trusting a path, so the Windows install is still scanned.
+// Hermetic Windows-mode matrix for the codex WSL-shadowing scenario.
+//
+// The bug: resolveInstallPaths in wsl-first mode picked a WSL ~/.codex path
+// that exists but has NO sessions/ subdir (codex is installed on Windows, not
+// in WSL), silently scanning 0 files while the real Windows install went
+// missing. The first fix attempt then regressed into scanning BOTH installs
+// (union) regardless of mode, double-counting and leaking native usage into
+// wsl-only mode.
+//
+// Hermeticity design (passes identically on any host OS, with any real home):
+// - process.platform is mocked to "win32" so the win32 resolver branches run
+//   everywhere (Object.defineProperty, restored in teardown).
+// - wsl.discoverWslHome is mocked on the shared wsl-probe module object (the
+//   seam sync.js calls through), so no real wsl.exe exec and no real
+//   \\wsl$\... filesystem probes. Only ".codex" may resolve to the fake WSL
+//   fixture; every other provider dir must get null. No src injection point
+//   is needed — mockMethod intercepts the late-bound property call.
+// - HOME/USERPROFILE plus every host-touching env knob (APPDATA,
+//   LOCALAPPDATA, provider *_HOME overrides) point at a fresh temp dir, so
+//   the mocked-win32 provider branches cannot read host data.
+// - Env restore DELETES originally-absent vars instead of assigning
+//   undefined (which would materialize the string "undefined").
 
-async function withTempHome(fn) {
+// Upload endpoints and provider overrides that would otherwise leak host
+// installs into the mocked-win32 branches are deleted outright.
+const DELETE_KEYS = [
+  "TOKENTRACKER_DEVICE_TOKEN",
+  "TOKENTRACKER_INSFORGE_BASE_URL",
+  "TOKENTRACKER_INSFORGE_ANON_KEY",
+  "TOKENTRACKER_OPENCLAW_AGENT_ID",
+  "TOKENTRACKER_OPENCLAW_PREV_SESSION_ID",
+  "TOKENTRACKER_OPENCLAW_SESSION_KEY",
+  "KILO_HOME",
+  "MIMO_HOME",
+  "ZCODE_HOME",
+  "KIRO_CLI_DB_PATH",
+  "KIRO_HOME",
+  "TOKENTRACKER_HERMES_HOME",
+  "TOKENTRACKER_COPILOT_SESSION_STORE_DB",
+];
+
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "CODEX_HOME",
+  "CODE_HOME",
+  "GEMINI_HOME",
+  "OPENCODE_HOME",
+  "XDG_DATA_HOME",
+  "TOKENTRACKER_OPENCLAW_HOME",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "TOKENTRACKER_WSL_MODE",
+  ...DELETE_KEYS,
+];
+
+async function withIsolatedEnv(fn) {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-wsl-shadow-"));
-  const saved = {
-    HOME: process.env.HOME,
-    USERPROFILE: process.env.USERPROFILE,
-    CODEX_HOME: process.env.CODEX_HOME,
-    TOKENTRACKER_WSL_MODE: process.env.TOKENTRACKER_WSL_MODE,
-  };
+  const saved = {};
+  for (const key of ENV_KEYS) saved[key] = process.env[key];
   try {
     process.env.HOME = home;
     process.env.USERPROFILE = home;
+    process.env.CODEX_HOME = path.join(home, ".codex");
+    process.env.CODE_HOME = path.join(home, ".code");
+    process.env.GEMINI_HOME = path.join(home, ".gemini");
+    process.env.OPENCODE_HOME = path.join(home, ".opencode");
+    process.env.XDG_DATA_HOME = path.join(home, ".local", "share");
+    process.env.TOKENTRACKER_OPENCLAW_HOME = path.join(home, ".openclaw");
+    process.env.APPDATA = path.join(home, "AppData", "Roaming");
+    process.env.LOCALAPPDATA = path.join(home, "AppData", "Local");
+    for (const key of DELETE_KEYS) delete process.env[key];
+    // TOKENTRACKER_WSL_MODE is set or deleted per matrix case.
     return await fn(home);
   } finally {
-    process.env.HOME = saved.HOME;
-    process.env.USERPROFILE = saved.USERPROFILE;
-    process.env.CODEX_HOME = saved.CODEX_HOME;
-    process.env.TOKENTRACKER_WSL_MODE = saved.TOKENTRACKER_WSL_MODE;
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
     await fs.rm(home, { recursive: true, force: true }).catch(() => {});
   }
 }
 
-async function writeCodexRollout(codexHome, date, uuid, totalTokens = 120) {
+const NATIVE_TOKENS = 120;
+const WSL_TOKENS = 240;
+
+async function writeCodexRollout(codexHome, date, uuid, totalTokens) {
   const [year, month, day] = date.split("-");
   const dir = path.join(codexHome, "sessions", year, month, day);
   await fs.mkdir(dir, { recursive: true });
@@ -61,32 +121,89 @@ async function writeCodexRollout(codexHome, date, uuid, totalTokens = 120) {
   return filePath;
 }
 
-test("codex WSL shadow: Windows install is scanned when WSL ~/.codex shell exists without sessions/", async () => {
-  await withTempHome(async (home) => {
-    // Windows-style codex install under the mocked HOME, WITH sessions/.
-    const winCodex = path.join(home, ".codex");
-    await writeCodexRollout(winCodex, "2026-07-31", "test-uuid-1", 120);
-
-    // Force wsl-first mode (the default that triggered the bug).
-    process.env.TOKENTRACKER_WSL_MODE = "wsl-first";
-
-    await cmdSync([], {});
-
-    const queuePath = path.join(home, ".tokentracker", "tracker", "queue.jsonl");
-    const queueContent = await fs.readFile(queuePath, "utf8").catch(() => "");
-    const lines = queueContent.trim() ? queueContent.trim().split("\n") : [];
-    const codexRecords = lines
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((r) => r && r.source === "codex");
-
-    assert.ok(
-      codexRecords.length > 0,
-      "Windows codex usage must be queued even when a WSL ~/.codex shell exists without sessions/",
-    );
-    const totalTokens = codexRecords.reduce((s, r) => s + (r.total_tokens || 0), 0);
-    assert.ok(
-      totalTokens > 0,
-      `codex token count must be > 0, got ${totalTokens}`,
-    );
+async function readQueue(queuePath) {
+  const raw = await fs.readFile(queuePath, "utf8").catch((err) => {
+    if (err && err.code === "ENOENT") return "";
+    throw err;
   });
-});
+  const records = raw.trim() ? raw.trim().split("\n").map((l) => JSON.parse(l)) : [];
+  const codex = records.filter((r) => r && r.source === "codex");
+  return {
+    raw,
+    codexCount: codex.length,
+    codexTokens: codex.reduce((sum, r) => sum + (r.total_tokens || 0), 0),
+  };
+}
+
+// Distinct native (120) vs WSL (240) totals make "which install was scanned"
+// directly assertable from the queue sum: a union scan yields 360, a native
+// leak into wsl-only yields 120 where 0 is expected.
+const CASES = [
+  { name: "wsl-first falls back to the native install when no WSL home exists", mode: "wsl-first", wsl: "missing", expected: NATIVE_TOKENS },
+  { name: "wsl-first falls back past an empty WSL ~/.codex shell (the reported bug)", mode: "wsl-first", wsl: "empty", expected: NATIVE_TOKENS, runTwice: true },
+  { name: "wsl-first prefers a populated WSL install without union-scanning native", mode: "wsl-first", wsl: "populated", expected: WSL_TOKENS },
+  { name: "auto (unset) falls back past an empty WSL ~/.codex shell", mode: null, wsl: "empty", expected: NATIVE_TOKENS },
+  { name: "auto (unset) prefers a populated WSL install without union-scanning native", mode: null, wsl: "populated", expected: WSL_TOKENS },
+  { name: "wsl-only scans nothing when no WSL home exists (no native leak)", mode: "wsl-only", wsl: "missing", expected: 0 },
+  { name: "wsl-only scans nothing when the WSL ~/.codex shell is empty (no native leak)", mode: "wsl-only", wsl: "empty", expected: 0 },
+  { name: "wsl-only scans only the populated WSL install", mode: "wsl-only", wsl: "populated", expected: WSL_TOKENS, runTwice: true },
+  { name: "both scans native and WSL installs", mode: "both", wsl: "populated", expected: NATIVE_TOKENS + WSL_TOKENS },
+];
+
+for (const kase of CASES) {
+  test(`codex WSL shadow matrix: ${kase.name}`, async (t) => {
+    wsl.resetWslProbeCache();
+    t.after(() => wsl.resetWslProbeCache());
+    mockPlatform(t, "win32");
+
+    await withIsolatedEnv(async (home) => {
+      if (kase.mode == null) delete process.env.TOKENTRACKER_WSL_MODE;
+      else process.env.TOKENTRACKER_WSL_MODE = kase.mode;
+
+      // Native (Windows) codex install, always populated.
+      const nativeCodex = path.join(home, ".codex");
+      await writeCodexRollout(nativeCodex, "2026-07-31", "test-uuid-native", NATIVE_TOKENS);
+
+      // Fake WSL distro home in one of three states: missing (no dir, mock
+      // returns null), empty shell (dir exists, no sessions/), or populated.
+      const wslCodex = path.join(home, "wsl-home", ".codex");
+      if (kase.wsl === "empty") {
+        await fs.mkdir(wslCodex, { recursive: true });
+      } else if (kase.wsl === "populated") {
+        await writeCodexRollout(wslCodex, "2026-07-31", "test-uuid-wsl", WSL_TOKENS);
+      }
+
+      mockMethod(t, wsl, "discoverWslHome", (providerDir) =>
+        providerDir === ".codex" && kase.wsl !== "missing" ? wslCodex : null,
+      );
+
+      const queuePath = path.join(home, ".tokentracker", "tracker", "queue.jsonl");
+
+      await cmdSync([], {});
+      const first = await readQueue(queuePath);
+
+      const label = `mode=${kase.mode ?? "auto"} wsl=${kase.wsl}`;
+      if (kase.expected === 0) {
+        assert.equal(first.codexCount, 0, `${label}: expected zero codex records, got ${first.codexCount}`);
+        assert.equal(first.codexTokens, 0, `${label}: expected zero codex tokens, got ${first.codexTokens}`);
+      } else {
+        assert.ok(first.codexCount > 0, `${label}: expected codex records, got none`);
+        assert.equal(
+          first.codexTokens,
+          kase.expected,
+          `${label}: expected ${kase.expected} codex tokens, got ${first.codexTokens}`,
+        );
+      }
+
+      if (kase.runTwice) {
+        // CodeRabbit #3: a second sync over the same fixture must be a
+        // no-op — zero new codex records, zero new codex tokens.
+        await cmdSync([], {});
+        const second = await readQueue(queuePath);
+        assert.equal(second.codexCount, first.codexCount, `${label}: second sync added codex records`);
+        assert.equal(second.codexTokens, first.codexTokens, `${label}: second sync added codex tokens`);
+        assert.equal(second.raw, first.raw, `${label}: second sync changed queue.jsonl`);
+      }
+    });
+  });
+}

--- a/test/codex-wsl-shadow.test.js
+++ b/test/codex-wsl-shadow.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const { cmdSync } = require("../src/commands/sync");
+
+// Reproduces the WSL-shadowing bug: resolveInstallPaths in wsl-first mode
+// picks a WSL ~/.codex path that exists but has NO sessions/ subdir (codex is
+// installed on Windows, not in WSL). Before the fix, listRolloutFiles scanned
+// the non-existent WSL sessions/ dir, silently returned 0 files, and all
+// Windows codex usage went missing. After the fix, sync.js verifies sessions/
+// exists before trusting a path, so the Windows install is still scanned.
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codex-wsl-shadow-"));
+  const saved = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    CODEX_HOME: process.env.CODEX_HOME,
+    TOKENTRACKER_WSL_MODE: process.env.TOKENTRACKER_WSL_MODE,
+  };
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    return await fn(home);
+  } finally {
+    process.env.HOME = saved.HOME;
+    process.env.USERPROFILE = saved.USERPROFILE;
+    process.env.CODEX_HOME = saved.CODEX_HOME;
+    process.env.TOKENTRACKER_WSL_MODE = saved.TOKENTRACKER_WSL_MODE;
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeCodexRollout(codexHome, date, uuid, totalTokens = 120) {
+  const [year, month, day] = date.split("-");
+  const dir = path.join(codexHome, "sessions", year, month, day);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `rollout-${date}T00-00-00-${uuid}.jsonl`);
+  const usage = {
+    input_tokens: totalTokens,
+    cached_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: totalTokens,
+  };
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: `${date}T00:00:00.000Z`,
+      payload: {
+        type: "token_count",
+        info: { last_token_usage: usage, total_token_usage: usage },
+      },
+    }) + "\n",
+    "utf8",
+  );
+  return filePath;
+}
+
+test("codex WSL shadow: Windows install is scanned when WSL ~/.codex shell exists without sessions/", async () => {
+  await withTempHome(async (home) => {
+    // Windows-style codex install under the mocked HOME, WITH sessions/.
+    const winCodex = path.join(home, ".codex");
+    await writeCodexRollout(winCodex, "2026-07-31", "test-uuid-1", 120);
+
+    // Force wsl-first mode (the default that triggered the bug).
+    process.env.TOKENTRACKER_WSL_MODE = "wsl-first";
+
+    await cmdSync([], {});
+
+    const queuePath = path.join(home, ".tokentracker", "tracker", "queue.jsonl");
+    const queueContent = await fs.readFile(queuePath, "utf8").catch(() => "");
+    const lines = queueContent.trim() ? queueContent.trim().split("\n") : [];
+    const codexRecords = lines
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter((r) => r && r.source === "codex");
+
+    assert.ok(
+      codexRecords.length > 0,
+      "Windows codex usage must be queued even when a WSL ~/.codex shell exists without sessions/",
+    );
+    const totalTokens = codexRecords.reduce((s, r) => s + (r.total_tokens || 0), 0);
+    assert.ok(
+      totalTokens > 0,
+      `codex token count must be > 0, got ${totalTokens}`,
+    );
+  });
+});

--- a/test/sync-codex-rescan-repair.test.js
+++ b/test/sync-codex-rescan-repair.test.js
@@ -427,7 +427,7 @@ describe("repairCodexRescanInflation (#187) — atomic guarded rebuild", () => {
       assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).offset, 0);
       assert.equal(cursors.files[codexFile].projectOffset, cursors.files[codexFile].offset);
       assert.equal(
-        cursors.files[codexFile].projectFileContext.configPath.endsWith(".git/config"),
+        cursors.files[codexFile].projectFileContext.configPath.endsWith(path.join(".git", "config")),
         true,
       );
       assert.equal(cursors.projectHourly.projects[projectKey].status, "public_verified");


### PR DESCRIPTION
## Summary

`resolveInstallPaths` in `wsl-first`/`native-first` modes returns a **single** path (the preferred install) with `wsl=null`. For codex this is wrong — a user may have it installed in **both** Windows and WSL, and each install has its own `sessions/` tree. Picking one silently drops the other's usage.

Additionally, when the WSL `~/.codex` exists but has **no `sessions/` subdir** (codex installed on Windows, not in WSL), `wsl-first` mode picked the empty WSL shell as the single install, causing `listRolloutFiles` to scan a non-existent `sessions/` dir, silently return 0 files, and **all Windows codex usage went missing**. This reproduced as codex collection suddenly stopping at the date WSL was installed.

## Root cause

`src/lib/wsl-probe.js` `resolveAllWin32Paths` collapses to a single path in all modes except `both`. `discoverWslHome` only checks the WSL `~/.codex` dir **exists**, not that it has a `sessions/` subdir. Combined, a hollow WSL shell won over the real Windows install.

## Fix

In `src/commands/sync.js`, instead of trusting the single-path resolution, collect **every** codex install whose `sessions/` actually exists and push each as its own source. The `codexHashes` event-dedup (keyed by `sessionUUID:eventTimestamp`) makes overlapping scans idempotent even if the same file is reachable from both paths.

```js
const codexSessionsExists = (p) => {
  if (!p) return false;
  try { return fssync.existsSync(path.join(p, "sessions")); } catch { return false; }
};
const codexInstalls = new Set();
if (codexSessionsExists(codexNativeValue)) codexInstalls.add(codexNativeValue);
if (codexSessionsExists(wslCodexDir)) codexInstalls.add(wslCodexDir);
// Also honor resolveInstallPaths pick (env-overridden paths, future logic).
const codexPaths = resolveInstallPaths({ nativeValue: codexNativeValue, wslValue: wslCodexDir });
if (codexPaths.native && codexSessionsExists(codexPaths.native)) codexInstalls.add(codexPaths.native);
if (codexPaths.wsl && codexSessionsExists(codexPaths.wsl)) codexInstalls.add(codexPaths.wsl);
for (const install of codexInstalls) {
  sources.push({ source: "codex", sessionsDir: path.join(install, "sessions"), ... });
}
```

## Scope

- [x] CLI (`src/`)

## Verification

On a machine where WSL Ubuntu has a `~/.codex` shell without `sessions/` and codex is installed on Windows:

- **Before**: `runCodexParse input: 0 files (0 codex)` — `sources=[{sessionsDir:"\\wsl$\Ubuntu\home\kylin\.codex\sessions", exists:false}]`, codex queue records after 2026-07-14: **0**
- **After**: `runCodexParse input: 988 files (988 codex)` — Windows install scanned, codex queue records 2026-07-14 onward: **498** (7/14 → 7/23 recovered; 7/24+ pending cursor reset which is a data-state issue, not a code bug)

## Checklist

- [x] New test `test/codex-wsl-shadow.test.js` passes (verifies Windows install is scanned when WSL shell lacks `sessions/`)
- [x] `install-resolver.test.js`: 28/28 pass
- [x] `dual-install-integration.test.js`: 1/1 pass
- [x] No regression in `codex-source-scoped-cache` / `codex-config-multiline-notify` (38/39 pass; the 1 failure is pre-existing — fails without this PR too)
- [x] Commits follow conventional style (`fix:`)
- [x] PR description explains *why*, not just *what*

## Why both installs, not just fallback

A simpler fix would be "if WSL lacks `sessions/`, fall back to Windows". But that still loses WSL usage when the user genuinely has codex in both environments. Scanning **both** (when each has `sessions/`) is the correct behavior — no usage is dropped regardless of where codex is installed.

## Note on other tools

`every-code`, `claude`, `gemini`, `opencode` use the same `resolveInstallPaths` pattern and may have the same shadowing issue, but they are out of scope for this PR. If maintainers want, I can follow up with the same treatment for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex syncing across native and WSL installations.
  * Prevented empty WSL installations from hiding valid native session data.
  * Included active and archived sessions when available.
  * Prevented duplicate session records during repeated syncs.

* **Tests**
  * Added coverage for missing, empty, and populated WSL installations.
  * Verified supported installation-selection modes and token totals.
  * Improved cross-platform path handling in synchronization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->