### PR TITLE
fix(codebuddy): collect traces as authoritative token source, fix 90% undercounting

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -226,6 +226,15 @@ const LEGACY_BASE_URL_MIGRATION_NOTE = "reset_after_legacy_baseurl_migration_202
 // the same migration without this ceiling when the history needs a deeper scan.
 const CODEX_BACKGROUND_LINEAGE_SCAN_MAX_BYTES = 1024 * 1024;
 const DROID_DUP_SESSION_REPAIR_KEY = "droidDupSessionInflationRepair_2026_06";
+// One-time repair (PR #399 blocker): pre-tracedSessionIds CodeBuddy versions
+// aggregated jsonl message tokens into hourly buckets even for sessions that
+// ALSO had a trace file. tracedSessionIds is a forward-only blacklist — it
+// suppresses jsonl parsed after the trace within one run but cannot roll back
+// jsonl contributions an older version already aggregated (buckets key on
+// codebuddy|model|halfHour, with no session dimension). The first post-upgrade
+// sync would stack the trace total on top of the stale jsonl total. Guarded
+// atomic rebuild — see repairCodebuddyTraceJsonlOverlap.
+const CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY = "codebuddyTraceJsonlOverlapRepair_2026_08";
 const CODEX_COLD_SCAN_AUDIT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const NOTIFY_LOCK_WAIT_MS = 130_000;
 const NOTIFY_LOCK_POLL_MS = 5_000;
@@ -1772,6 +1781,26 @@ async function cmdSync(argv, context = {}) {
     const codebuddyFiles = sourceAllowed("codebuddy")
       ? mergeBothFileSources({ resolveFiles: resolveCodebuddyProjectFiles, env: process.env })
       : [];
+    // One-time historical repair (PR #399): roll back the pre-tracedSessionIds
+    // trace+jsonl double count BEFORE the parse below (and before any upload
+    // this sync — the repair rewrites queue.jsonl and resets the upload
+    // offset). Sentinel-gated: O(1) no-op once completed. See
+    // repairCodebuddyTraceJsonlOverlap for the guard/rebuild/commit design.
+    if (sourceAllowed("codebuddy")) {
+      try {
+        await repairCodebuddyTraceJsonlOverlap({
+          cursors,
+          queuePath,
+          queueStatePath,
+          codebuddyFiles,
+          env: process.env,
+        });
+      } catch (err) {
+        // The repair is designed to fail closed (live state untouched, no
+        // sentinel) so a later sync can retry; never let it break the sync.
+        warnProviderParseFailure("CodeBuddy trace/jsonl overlap repair", err, opts);
+      }
+    }
     if (codebuddyFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing CodeBuddy ${renderBar(0)} | buckets 0`);
@@ -2732,6 +2761,7 @@ module.exports = {
   repairCodexRescanInflation,
   repairCodexForkReplayInflation,
   repairCodexInterleavedUsageInflation,
+  repairCodebuddyTraceJsonlOverlap,
   repairDroidDuplicateSessionInflation,
   repairMimoClaudeMislabel,
   reincludeClaudeMemObserverFiles,
@@ -2747,6 +2777,7 @@ module.exports = {
   CODEX_FORK_REPLAY_REPAIR_KEY,
   CODEX_USAGE_LINEAGE_REPAIR_KEY,
   DROID_DUP_SESSION_REPAIR_KEY,
+  CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY,
   CLAUDE_MEM_OBSERVER_REINCLUDE_KEY,
   GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY,
   CLOUD_CONVERSATIONS_BACKFILL_KEY,
@@ -4263,6 +4294,255 @@ async function repairCodexForkReplayInflation({
     migrationKey: CODEX_FORK_REPLAY_REPAIR_KEY,
     uploadNote: "reset_after_codex_fork_replay_2026_07",
   });
+}
+
+// One-time repair (PR #399 blocker): rebuild codebuddy hourly buckets that
+// pre-tracedSessionIds versions inflated by counting BOTH the trace file and
+// the jsonl messages of the same session. tracedSessionIds is a forward-only
+// blacklist: it suppresses jsonl parsed after the trace within one run, but
+// cannot roll back jsonl contributions an older version already aggregated —
+// buckets key on codebuddy|model|halfHour with no session dimension, and
+// seenIds stores message IDs without their token contributions, so no
+// surgical per-session subtraction is possible after the fact. The only
+// correct fix is a full rebuild with the trace-authoritative parser.
+//
+// Mirrors the repairCodexRescanInflation (#187) skeleton:
+//   1. sentinel gate (ISO string = final, {skipped:true} = retry next sync);
+//   2. fast path: no 'codebuddy|' bucket key → finalize in O(1);
+//   3. reproducibility guard: every file in cursors.codebuddy.fileOffsets must
+//      be present in THIS sync's discovered codebuddyFiles (codebuddy jsonl/
+//      traces are never moved/archived like codex sessions, so a plain path
+//      check suffices — no UUID relocation). A missing file defers the whole
+//      repair with a retryable sentinel; forward tracedSessionIds still stops
+//      NEW double-counting in the meantime;
+//   4. atomic rebuild into a THROWAWAY cursors + tmp queue using the CURRENT
+//      parser (trace-first sort + tracedSessionIds reproduces the
+//      trace-authoritative history; any failure leaves ALL live state
+//      untouched and sets no sentinel — never a clear-then-parse, whose
+//      failure would permanently zero history, see the codex comment ~3920);
+//   5. commit: strip codebuddy rows from queue.jsonl (atomic tmp+rename),
+//      swap the codebuddy buckets/groupQueued, replace cursors.codebuddy
+//      wholesale (seenIds/seenTraceIds/tracedSessionIds/fileOffsets are
+//      regenerated together — the old IDs belong to the inflated history),
+//      append all-zero retraction rows for live keys the rebuild did NOT
+//      reproduce (the cloud overwrite-upserts by key, so a locally deleted
+//      key would otherwise stay stale-high forever), and reset the upload
+//      offset so the corrected queue re-uploads BEFORE any upload this sync.
+// The rebuilt fileOffsets sit at EOF, so the regular codebuddy parse later in
+// the same sync is a natural no-op and cannot double-count.
+async function repairCodebuddyTraceJsonlOverlap({
+  cursors,
+  queuePath,
+  queueStatePath,
+  codebuddyFiles,
+  env = process.env,
+}) {
+  if (!cursors || typeof cursors !== "object") return false;
+  const migrations = (cursors.migrations ||= {});
+  // Same completed-vs-skipped semantics as the codex repairs: an ISO string
+  // is final; a {skipped:true} object MUST be retried — the skip condition
+  // (e.g. a temporarily missing file) can clear on a later sync.
+  const prior = migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY];
+  if (prior && !(typeof prior === "object" && prior.skipped)) return false;
+
+  const liveBuckets =
+    cursors.hourly && typeof cursors.hourly === "object" && cursors.hourly.buckets && typeof cursors.hourly.buckets === "object"
+      ? cursors.hourly.buckets
+      : {};
+  const liveCodebuddyKeys = Object.keys(liveBuckets).filter((k) => k.startsWith("codebuddy|"));
+
+  // Fast path: fresh install, or codebuddy never aggregated anything — there
+  // is no history that could be inflated. Finalize in O(1).
+  if (liveCodebuddyKeys.length === 0) {
+    migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] = new Date().toISOString();
+    return false;
+  }
+
+  const discovered = new Set();
+  for (const entry of Array.isArray(codebuddyFiles) ? codebuddyFiles : []) {
+    const fp = typeof entry === "string" ? entry : entry?.path;
+    if (fp) discovered.add(fp);
+  }
+
+  // Reproducibility guard: the rebuild re-creates buckets ONLY from the files
+  // discovered this sync. If any file that previously contributed is gone
+  // from disk, clearing the live buckets would lose that history — defer.
+  const cbState =
+    cursors.codebuddy && typeof cursors.codebuddy === "object" ? cursors.codebuddy : {};
+  const fileOffsets =
+    cbState.fileOffsets && typeof cbState.fileOffsets === "object" ? cbState.fileOffsets : {};
+  for (const fp of Object.keys(fileOffsets)) {
+    if (discovered.has(fp)) continue;
+    migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] = {
+      skipped: true,
+      reason: "codebuddy_file_unreproducible",
+      at: new Date().toISOString(),
+    };
+    return false;
+  }
+
+  // Atomic rebuild into throwaway state. The parse enqueues the rebuilt
+  // codebuddy rows into tmpQueue and regenerates the full codebuddy cursor
+  // state from byte zero.
+  let rebuilt;
+  const tmpQueue = `${queuePath}.codebuddyrebuild.${process.pid}.${Date.now()}`;
+  try {
+    const tmpCursors = {
+      version: 1,
+      codebuddy: {},
+      hourly: { buckets: {}, groupQueued: {} },
+    };
+    // CRITICAL: sort trace files before jsonl files so tracedSessionIds is
+    // populated before any jsonl line is read. parseCodebuddyIncremental's
+    // internal file loop processes files in array order; if jsonl comes first
+    // it would be counted BEFORE the trace establishes tracedSessionIds,
+    // re-introducing the double count this repair is meant to eliminate.
+    const sortedFiles = (Array.isArray(codebuddyFiles) ? codebuddyFiles : []).slice().sort((a, b) => {
+      const aKind = typeof a === "string" ? "jsonl" : (a?.kind || "jsonl");
+      const bKind = typeof b === "string" ? "jsonl" : (b?.kind || "jsonl");
+      if (aKind === "trace" && bKind !== "trace") return -1;
+      if (aKind !== "trace" && bKind === "trace") return 1;
+      const aPath = typeof a === "string" ? a : (a?.path || "");
+      const bPath = typeof b === "string" ? b : (b?.path || "");
+      return aPath.localeCompare(bPath);
+    });
+    await parseCodebuddyIncremental({
+      projectFiles: sortedFiles,
+      cursors: tmpCursors,
+      queuePath: tmpQueue,
+      env,
+    });
+    let tmpRaw = "";
+    try {
+      tmpRaw = await fs.readFile(tmpQueue, "utf8");
+    } catch (e) {
+      if (e?.code !== "ENOENT") throw e;
+    }
+    rebuilt = {
+      buckets: (tmpCursors.hourly && tmpCursors.hourly.buckets) || {},
+      groupQueued: (tmpCursors.hourly && tmpCursors.hourly.groupQueued) || {},
+      codebuddy:
+        tmpCursors.codebuddy && typeof tmpCursors.codebuddy === "object"
+          ? tmpCursors.codebuddy
+          : {},
+      queueRows: tmpRaw.split("\n").filter((l) => l.trim()),
+    };
+  } catch (e) {
+    console.error(
+      "[sync] codebuddy trace/jsonl overlap repair: rebuild failed, leaving all data untouched:",
+      e?.message || e,
+    );
+    return false;
+  } finally {
+    await fs.rm(tmpQueue, { force: true }).catch(() => {});
+  }
+
+  // SANITY: live codebuddy history exists but the rebuild produced no
+  // codebuddy buckets at all → treat as a failed rebuild and retry next sync
+  // (never zero out live history on an unreproducible parse).
+  const rebuiltCodebuddyKeys = Object.keys(rebuilt.buckets).filter((k) => k.startsWith("codebuddy|"));
+  if (rebuiltCodebuddyKeys.length === 0) {
+    console.error(
+      "[sync] codebuddy trace/jsonl overlap repair: rebuild produced 0 codebuddy buckets over a non-empty live history — skipping to avoid data loss",
+    );
+    return false;
+  }
+
+  // COMMIT (only after a verified rebuild). A crash partway leaves the
+  // migration key unset, so the next sync re-runs the deterministic rebuild
+  // and converges.
+  //
+  // All-zero retraction rows for every live codebuddy key the rebuild did not
+  // reproduce (mirrors migrateRolloutCumulativeDeltaBuckets): the cloud
+  // overwrite-upserts by key, so without these the inflated keys would stay
+  // stale-high even after the queue strip.
+  const retractions = [];
+  for (const key of liveCodebuddyKeys) {
+    if (Object.prototype.hasOwnProperty.call(rebuilt.buckets, key)) continue;
+    const [, model, ...hourParts] = key.split("|");
+    retractions.push(
+      JSON.stringify({
+        source: "codebuddy",
+        model: model || "unknown",
+        hour_start: hourParts.join("|"),
+        input_tokens: 0,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 0,
+        billable_total_tokens: 0,
+        conversation_count: 0,
+      }),
+    );
+  }
+
+  // 1. queue.jsonl: drop ALL codebuddy rows (inflated or not), append the
+  //    rebuilt rows plus the retraction rows (atomic tmp+rename so a crash
+  //    never loses OTHER providers' pending upload rows).
+  if (typeof queuePath === "string" && queuePath) {
+    let raw = "";
+    try {
+      raw = await fs.readFile(queuePath, "utf8");
+    } catch (e) {
+      if (e?.code !== "ENOENT") throw e;
+    }
+    const kept = [];
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch (_e) {
+        kept.push(line);
+        continue;
+      }
+      if (row?.source === "codebuddy") continue;
+      kept.push(line);
+    }
+    await ensureDir(path.dirname(queuePath));
+    const tmp = `${queuePath}.tmp.${process.pid}.${Date.now()}`;
+    await fs.writeFile(tmp, kept.concat(rebuilt.queueRows, retractions).join("\n") + "\n", "utf8");
+    await fs.rename(tmp, queuePath);
+  }
+
+  // 2. Swap the live codebuddy hourly state for the rebuilt one, and install
+  //    the rebuilt codebuddy cursor state wholesale.
+  const liveHourly = (cursors.hourly ||= { buckets: {}, groupQueued: {} });
+  liveHourly.buckets ||= {};
+  liveHourly.groupQueued ||= {};
+  for (const k of Object.keys(liveHourly.buckets)) {
+    if (k.startsWith("codebuddy|")) delete liveHourly.buckets[k];
+  }
+  for (const k of Object.keys(liveHourly.groupQueued)) {
+    if (k.startsWith("codebuddy|")) delete liveHourly.groupQueued[k];
+  }
+  for (const [k, v] of Object.entries(rebuilt.buckets)) {
+    if (k.startsWith("codebuddy|")) liveHourly.buckets[k] = v;
+  }
+  for (const [k, v] of Object.entries(rebuilt.groupQueued)) {
+    if (k.startsWith("codebuddy|")) liveHourly.groupQueued[k] = v;
+  }
+  cursors.codebuddy = rebuilt.codebuddy;
+
+  // 3. Reset the cloud upload offset so the corrected queue (rebuilt rows +
+  //    zero retractions) re-uploads and overwrite-upserts the inflated keys.
+  //    Other sources re-upsert idempotently (last emission per key wins).
+  if (typeof queueStatePath === "string" && queueStatePath) {
+    let uploadState = {};
+    try {
+      uploadState = JSON.parse(await fs.readFile(queueStatePath, "utf8"));
+    } catch (_e) {
+      uploadState = {};
+    }
+    uploadState.offset = 0;
+    uploadState.updatedAt = new Date().toISOString();
+    uploadState.note = "reset_after_codebuddy_trace_overlap_2026_08";
+    await fs.writeFile(queueStatePath, JSON.stringify(uploadState));
+  }
+
+  migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] = new Date().toISOString();
+  return true;
 }
 
 // Rebuild historical Codex usage only when a rollout proves that the old

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -9073,7 +9073,7 @@ async function parseWorkbuddyIncremental({
           cache_creation_input_tokens: cacheCreation,
           output_tokens: completionTokens,
           reasoning_output_tokens: reasoningTokens,
-          total_tokens: inputTokens,
+          total_tokens: inputTokens + completionTokens + cacheRead + cacheCreation + reasoningTokens,
           conversation_count: prevUsed === 0 || isReset ? 1 : 0,
         };
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -8883,8 +8883,8 @@ async function parseWorkbuddyIncremental({
       const messageId =
         typeof entry.id === "string" && entry.id
           ? entry.id
-          : typeof provider?.messageId === "string" && provider.messageId
-            ? provider.messageId
+          : typeof provider?.messageId === "string" && provider?.messageId
+            ? provider?.messageId
             : tsMs != null
               ? `${sessionId}:${tsMs}`
               : null;
@@ -8954,8 +8954,8 @@ async function parseWorkbuddyIncremental({
       if (!bucketStart) continue;
 
       const model =
-        normalizeModelInput(provider.model) ||
-        normalizeModelInput(provider.requestModelId) ||
+        normalizeModelInput(provider?.model) ||
+        normalizeModelInput(provider?.requestModelId) ||
         normalizeModelInput(entry.model) ||
         fallbackModel;
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7842,6 +7842,12 @@ function resolveCodebuddyDefaultModel(env = process.env) {
 
 function resolveCodebuddyProjectFiles(env = process.env) {
   const codebuddyHome = resolveCodebuddyHome(env);
+  // Each entry is { path, kind } where kind ∈ {"jsonl", "log", "trace"}.
+  // "trace" files are ~/.codebuddy/traces/<pid>/trace_*.json — the authoritative
+  // token source written by CodeBuddy CLI's OpenTelemetry-style trace exporter.
+  // Newer CodeBuddy versions stop writing providerData.rawUsage on every
+  // assistant message in ~/.codebuddy/projects/**/*.jsonl (only ~10% of
+  // messages carry it), so the traces dir is the only complete source.
   const files = [];
 
   // 1. Recursive JSONL scan in codebuddyHome/projects
@@ -7863,72 +7869,113 @@ function resolveCodebuddyProjectFiles(env = process.env) {
             } catch { continue; }
           }
           if (isDir) walkJsonl(full);
-          else if (isFile && entry.name.endsWith(".jsonl")) files.push(full);
+          else if (isFile && entry.name.endsWith(".jsonl")) files.push({ path: full, kind: "jsonl" });
         }
       };
       walkJsonl(projectsDir);
     }
-  }
 
-  // 2. Active IDE extension logs scan
-  const logRoots = [];
-  const home = env.HOME || require("node:os").homedir();
-
-  if (process.platform === "darwin") {
-    const appSupport = path.join(home, "Library", "Application Support");
-    logRoots.push({ dir: path.join(appSupport, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(appSupport, "Code", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(appSupport, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
-    logRoots.push({ dir: path.join(appSupport, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
-  } else if (process.platform === "win32") {
-    const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
-    const localAppData = env.LOCALAPPDATA || path.join(home, "AppData", "Local");
-    logRoots.push({ dir: path.join(appData, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(appData, "Code", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(localAppData, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
-    logRoots.push({ dir: path.join(localAppData, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
-  } else {
-    const xdgConfig = env.XDG_CONFIG_HOME || path.join(home, ".config");
-    const xdgData = env.XDG_DATA_HOME || path.join(home, ".local", "share");
-    logRoots.push({ dir: path.join(xdgConfig, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(xdgConfig, "Code", "logs"), pattern: "codebuddy-extension-log" });
-    logRoots.push({ dir: path.join(xdgData, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
-    logRoots.push({ dir: path.join(xdgData, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
-  }
-
-  for (const root of logRoots) {
-    if (!fssync.existsSync(root.dir)) continue;
-    const walkLogs = (dir) => {
-      let entries;
-      try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
-      for (const entry of entries) {
-        const full = path.join(dir, entry.name);
-        let isDir = entry.isDirectory();
-        let isFile = entry.isFile();
-        if (!isDir && !isFile) {
-          try {
-            const st = fssync.statSync(full);
-            isDir = st.isDirectory();
-            isFile = st.isFile();
-          } catch { continue; }
+    // 1b. Recursive trace JSON scan in codebuddyHome/traces/<pid>/trace_*.json
+    //     Each file is a single JSON object { trace: {...}, spans: [...] } with
+    //     trace.totalTokens, trace.modelInfo.{totalInputTokens,totalOutputTokens,
+    //     totalCachedTokens,callCount}, trace.sessionId, trace.startedAt.
+    //     100% field stability verified on 286 real traces (2026-07).
+    const tracesDir = path.join(codebuddyHome, "traces");
+    if (fssync.existsSync(tracesDir)) {
+      const walkTraces = (dir) => {
+        let entries;
+        try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+        for (const entry of entries) {
+          const full = path.join(dir, entry.name);
+          let isDir = entry.isDirectory();
+          let isFile = entry.isFile();
+          if (!isDir && !isFile) {
+            try {
+              const st = fssync.statSync(full);
+              isDir = st.isDirectory();
+              isFile = st.isFile();
+            } catch { continue; }
+          }
+          if (isDir) walkTraces(full);
+          else if (isFile && entry.name.startsWith("trace_") && entry.name.endsWith(".json")) {
+            files.push({ path: full, kind: "trace" });
+          }
         }
-        if (isDir) {
-          walkLogs(full);
-        } else if (isFile && entry.name.endsWith(".log")) {
-          if (root.pattern === "*.log") {
-            files.push(full);
-          } else if (root.pattern === "codebuddy-extension-log") {
-            if (full.toLowerCase().includes("tencent-cloud.coding-copilot")) {
-              files.push(full);
+      };
+      walkTraces(tracesDir);
+    }
+  }
+
+  // 2. Active IDE extension logs scan.
+  //    DEFAULT DISABLED: extension logs overlap with the jsonl session log and
+  //    use a different dedup key namespace (codebuddy:extension-log:agentId:sec
+  //    vs jsonl's entry.uuid), causing the same LLM round-trip to be counted
+  //    twice — observed 3x inflation on a real machine (45.9M vs true 15.3M).
+  //    The traces dir (added above) is the authoritative source; jsonl is the
+  //    fallback for sessions without traces. Extension logs are only consulted
+  //    when explicitly enabled via TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=1, for
+  //    users on older CodeBuddy builds that have neither traces nor rawUsage.
+  const enableLogFallback = String(env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK || "").trim() === "1";
+  if (enableLogFallback) {
+    const logRoots = [];
+    const home = env.HOME || require("node:os").homedir();
+
+    if (process.platform === "darwin") {
+      const appSupport = path.join(home, "Library", "Application Support");
+      logRoots.push({ dir: path.join(appSupport, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(appSupport, "Code", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(appSupport, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
+      logRoots.push({ dir: path.join(appSupport, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
+    } else if (process.platform === "win32") {
+      const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
+      const localAppData = env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+      logRoots.push({ dir: path.join(appData, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(appData, "Code", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(localAppData, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
+      logRoots.push({ dir: path.join(localAppData, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
+    } else {
+      const xdgConfig = env.XDG_CONFIG_HOME || path.join(home, ".config");
+      const xdgData = env.XDG_DATA_HOME || path.join(home, ".local", "share");
+      logRoots.push({ dir: path.join(xdgConfig, "CodeBuddy CN", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(xdgConfig, "Code", "logs"), pattern: "codebuddy-extension-log" });
+      logRoots.push({ dir: path.join(xdgData, "CodeBuddyExtension", "Logs", "CodeBuddyIDE"), pattern: "*.log" });
+      logRoots.push({ dir: path.join(xdgData, "CodeBuddyExtension", "Logs", "VSCode"), pattern: "*.log" });
+    }
+
+    for (const root of logRoots) {
+      if (!fssync.existsSync(root.dir)) continue;
+      const walkLogs = (dir) => {
+        let entries;
+        try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+        for (const entry of entries) {
+          const full = path.join(dir, entry.name);
+          let isDir = entry.isDirectory();
+          let isFile = entry.isFile();
+          if (!isDir && !isFile) {
+            try {
+              const st = fssync.statSync(full);
+              isDir = st.isDirectory();
+              isFile = st.isFile();
+            } catch { continue; }
+          }
+          if (isDir) {
+            walkLogs(full);
+          } else if (isFile && entry.name.endsWith(".log")) {
+            if (root.pattern === "*.log") {
+              files.push({ path: full, kind: "log" });
+            } else if (root.pattern === "codebuddy-extension-log") {
+              if (full.toLowerCase().includes("tencent-cloud.coding-copilot")) {
+                files.push({ path: full, kind: "log" });
+              }
             }
           }
         }
-      }
-    };
-    walkLogs(root.dir);
+      };
+      walkLogs(root.dir);
+    }
   }
 
-  files.sort((a, b) => a.localeCompare(b));
+  files.sort((a, b) => a.path.localeCompare(b.path));
   return files;
 }
 
@@ -7981,6 +8028,22 @@ async function parseCodebuddyIncremental({
   const seenIds = new Set(
     Array.isArray(codebuddyState.seenIds) ? codebuddyState.seenIds : [],
   );
+  // Separate dedup namespace for trace files — keyed by traceId (globally
+  // unique, 100% present in real traces). Kept separate from seenIds (which
+  // holds jsonl/log message IDs) so a session that has BOTH a trace file and
+  // a jsonl file does not double-count: the trace is workflow-level (one trace
+  // per agent workflow), the jsonl is message-level, and their token totals
+  // are not additive — we prefer the trace (authoritative) and skip the jsonl
+  // messages for sessions covered by traces.
+  const seenTraceIds = new Set(
+    Array.isArray(codebuddyState.seenTraceIds) ? codebuddyState.seenTraceIds : [],
+  );
+  // Sessions that have at least one trace file with totalTokens > 0. For these
+  // sessions we skip jsonl message parsing to avoid double-counting (the trace
+  // already carries the complete workflow-level token total).
+  const tracedSessionIds = new Set(
+    Array.isArray(codebuddyState.tracedSessionIds) ? codebuddyState.tracedSessionIds : [],
+  );
   const fileOffsets =
     codebuddyState.fileOffsets && typeof codebuddyState.fileOffsets === "object"
       ? { ...codebuddyState.fileOffsets }
@@ -7999,6 +8062,8 @@ async function parseCodebuddyIncremental({
     cursors.codebuddy = {
       ...codebuddyState,
       seenIds: Array.from(seenIds),
+      seenTraceIds: Array.from(seenTraceIds),
+      tracedSessionIds: Array.from(tracedSessionIds),
       fileOffsets,
       updatedAt: new Date().toISOString(),
     };
@@ -8012,9 +8077,111 @@ async function parseCodebuddyIncremental({
   let eventsAggregated = 0;
 
   for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
-    const filePath = files[fileIdx];
+    const fileEntry = files[fileIdx];
+    // Accept both new-style {path, kind} entries and legacy bare-string paths.
+    const filePath = typeof fileEntry === "string" ? fileEntry : fileEntry?.path;
+    const fileKind = typeof fileEntry === "string"
+      ? (filePath.endsWith(".log") ? "log" : "jsonl")
+      : (fileEntry?.kind || "jsonl");
+    if (!filePath) continue;
     let stat;
     try { stat = fssync.statSync(filePath); } catch { continue; }
+
+    // ── Trace JSON branch ────────────────────────────────────────────────
+    // Each trace file is a single JSON object { trace, spans }. Read the whole
+    // file (not incremental) because traces are write-once: a trace is
+    // finalized when the workflow ends, so a file that hasn't grown since the
+    // last sync carries no new data. Dedup by traceId (globally unique).
+    if (fileKind === "trace") {
+      const prevTraceEntry = fileOffsets[filePath] || {};
+      const prevTraceSize = Number(prevTraceEntry.size) || 0;
+      const prevTraceIno = prevTraceEntry.ino;
+      const traceInodeChanged = typeof prevTraceIno === "number" && prevTraceIno !== stat.ino;
+      if (stat.size === prevTraceSize && !traceInodeChanged && prevTraceSize > 0) continue;
+      if (stat.size === 0) continue;
+
+      let traceObj;
+      try {
+        const raw = fssync.readFileSync(filePath, "utf8");
+        traceObj = JSON.parse(raw);
+      } catch { continue; }
+
+      const trace = traceObj && typeof traceObj === "object" ? traceObj.trace : null;
+      if (!trace || typeof trace !== "object") continue;
+      const traceId = typeof trace.traceId === "string" ? trace.traceId : null;
+      if (!traceId) continue;
+      if (seenTraceIds.has(traceId)) continue;
+
+      const traceTotalTokens = toNonNegativeInt(trace.totalTokens);
+      if (traceTotalTokens === 0) {
+        seenTraceIds.add(traceId);
+        continue;
+      }
+
+      const mi = trace.modelInfo && typeof trace.modelInfo === "object" ? trace.modelInfo : {};
+      const miInput = toNonNegativeInt(mi.totalInputTokens);
+      const miOutput = toNonNegativeInt(mi.totalOutputTokens);
+      const miCached = toNonNegativeInt(mi.totalCachedTokens);
+      // modelInfo is the authoritative breakdown. trace.totalTokens (top level)
+      // == totalInputTokens + totalOutputTokens (excludes cached). Queue
+      // convention: cached is separate from input (matches jsonl branch).
+      const traceInputTokens = Math.max(0, miInput - miCached);
+      const traceCachedTokens = miCached;
+      const traceOutputTokens = miOutput;
+      const traceCacheCreation = 0; // trace does not carry cache_creation
+      const traceReasoningTokens = 0;
+
+      if (traceInputTokens === 0 && traceOutputTokens === 0 && traceCachedTokens === 0) {
+        seenTraceIds.add(traceId);
+        continue;
+      }
+
+      const startedAt = typeof trace.startedAt === "string" ? trace.startedAt : null;
+      if (!startedAt) { seenTraceIds.add(traceId); continue; }
+      const traceBucketStart = toUtcHalfHourStart(startedAt);
+      if (!traceBucketStart) { seenTraceIds.add(traceId); continue; }
+
+      const models = Array.isArray(mi.models) ? mi.models : [];
+      const traceModel = normalizeModelInput(models[0]) || fallbackModel;
+      const traceSessionId = typeof trace.sessionId === "string" && trace.sessionId ? trace.sessionId : null;
+      if (traceSessionId) tracedSessionIds.add(traceSessionId);
+
+      const traceDelta = {
+        input_tokens: traceInputTokens,
+        cached_input_tokens: traceCachedTokens,
+        cache_creation_input_tokens: traceCacheCreation,
+        output_tokens: traceOutputTokens,
+        reasoning_output_tokens: traceReasoningTokens,
+        total_tokens: traceInputTokens + traceOutputTokens + traceCachedTokens + traceCacheCreation + traceReasoningTokens,
+        conversation_count: 1,
+      };
+
+      const traceBucket = getHourlyBucket(hourlyState, "codebuddy", traceModel, traceBucketStart);
+      addTotals(traceBucket.totals, traceDelta);
+      touchedBuckets.add(bucketKey("codebuddy", traceModel, traceBucketStart));
+      seenTraceIds.add(traceId);
+      recordsProcessed++;
+      eventsAggregated++;
+
+      fileOffsets[filePath] = {
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        ino: stat.ino,
+      };
+
+      if (cb) {
+        cb({
+          index: fileIdx + 1,
+          total: files.length,
+          filePath,
+          recordsProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+      continue;
+    }
+    // ── End trace JSON branch ────────────────────────────────────────────
 
     const prevEntry = fileOffsets[filePath] || {};
     const prevSize = Number(prevEntry.size) || 0;
@@ -8184,12 +8351,22 @@ async function parseCodebuddyIncremental({
 
         const provider = entry.providerData;
         const rawUsage = provider && typeof provider === "object" ? provider.rawUsage : null;
-        if (!rawUsage || typeof rawUsage !== "object") continue;
+        // Fallback: newer CodeBuddy versions stop writing providerData.rawUsage
+        // on most assistant messages (~90% of messages lack it). The same
+        // token data is available on the top-level `usage` field (camelCase
+        // convention: inputTokens/outputTokens/inputTokensDetails[].cached_tokens).
+        // Use it when rawUsage is absent so we don't silently drop 90% of usage.
+        const topUsage = !rawUsage && entry.usage && typeof entry.usage === "object" ? entry.usage : null;
+        if (!rawUsage && !topUsage) continue;
 
         const sessionId =
           typeof entry.sessionId === "string" && entry.sessionId
             ? entry.sessionId
             : path.basename(filePath, ".jsonl");
+        // Skip jsonl message parsing for sessions already covered by trace
+        // files — the trace carries the complete workflow-level total and
+        // counting jsonl messages too would double-count.
+        if (tracedSessionIds.has(sessionId)) continue;
         const tsMs =
           Number.isFinite(Number(entry.timestamp)) && Number(entry.timestamp) > 0
             ? Number(entry.timestamp)
@@ -8207,17 +8384,31 @@ async function parseCodebuddyIncremental({
 
         recordsProcessed++;
 
-        const promptTokens = toNonNegativeInt(rawUsage.prompt_tokens);
-        const completionTokens = toNonNegativeInt(rawUsage.completion_tokens);
-        const details =
-          rawUsage.prompt_tokens_details && typeof rawUsage.prompt_tokens_details === "object"
-            ? rawUsage.prompt_tokens_details
-            : {};
-        const cachedTokens = toNonNegativeInt(details.cached_tokens);
-        const cacheReadAlt = toNonNegativeInt(rawUsage.cache_read_input_tokens);
-        const cacheCreation = toNonNegativeInt(rawUsage.cache_creation_input_tokens);
-        const reasoningTokens = toNonNegativeInt(details.reasoning_tokens);
-
+        let promptTokens, completionTokens, cachedTokens, cacheReadAlt, cacheCreation, reasoningTokens;
+        if (rawUsage) {
+          promptTokens = toNonNegativeInt(rawUsage.prompt_tokens);
+          completionTokens = toNonNegativeInt(rawUsage.completion_tokens);
+          const details =
+            rawUsage.prompt_tokens_details && typeof rawUsage.prompt_tokens_details === "object"
+              ? rawUsage.prompt_tokens_details
+              : {};
+          cachedTokens = toNonNegativeInt(details.cached_tokens);
+          cacheReadAlt = toNonNegativeInt(rawUsage.cache_read_input_tokens);
+          cacheCreation = toNonNegativeInt(rawUsage.cache_creation_input_tokens);
+          reasoningTokens = toNonNegativeInt(details.reasoning_tokens);
+        } else {
+          // topUsage fallback (camelCase)
+          promptTokens = toNonNegativeInt(topUsage.inputTokens ?? topUsage.prompt_tokens);
+          completionTokens = toNonNegativeInt(topUsage.outputTokens ?? topUsage.completion_tokens);
+          const inputDetails = Array.isArray(topUsage.inputTokensDetails)
+            ? topUsage.inputTokensDetails[0]
+            : (topUsage.inputTokensDetails && typeof topUsage.inputTokensDetails === "object"
+              ? topUsage.inputTokensDetails : {});
+          cachedTokens = toNonNegativeInt(inputDetails?.cached_tokens);
+          cacheReadAlt = 0;
+          cacheCreation = toNonNegativeInt(topUsage.cache_creation_input_tokens);
+          reasoningTokens = toNonNegativeInt(inputDetails?.reasoning_tokens);
+        }
         const cacheRead = Math.max(cachedTokens, cacheReadAlt);
         const inputTokens = Math.max(0, promptTokens - cacheRead);
 
@@ -8300,10 +8491,19 @@ async function parseCodebuddyIncremental({
   });
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
+  // Cap trace dedup sets too (same 10k convention as seenIds).
+  const seenTraceArr = Array.from(seenTraceIds);
+  const cappedSeenTraces =
+    seenTraceArr.length > 10_000 ? seenTraceArr.slice(seenTraceArr.length - 10_000) : seenTraceArr;
+  const tracedSessionArr = Array.from(tracedSessionIds);
+  const cappedTracedSessions =
+    tracedSessionArr.length > 10_000 ? tracedSessionArr.slice(tracedSessionArr.length - 10_000) : tracedSessionArr;
   cursors.hourly = hourlyState;
   cursors.codebuddy = {
     ...codebuddyState,
     seenIds: cappedSeen,
+    seenTraceIds: cappedSeenTraces,
+    tracedSessionIds: cappedTracedSessions,
     fileOffsets,
     logModelsByAgent: cappedLogModelsByAgent,
     updatedAt,
@@ -8394,30 +8594,63 @@ function resolveWorkbuddyDefaultModel(env = process.env) {
 function resolveWorkbuddyProjectFiles(env = process.env) {
   const workbuddyHome = resolveWorkbuddyHome(env);
   if (!workbuddyHome) return [];
-  const projectsDir = path.join(workbuddyHome, "projects");
-  if (!fssync.existsSync(projectsDir)) return [];
   const files = [];
-  const walk = (dir) => {
-    let entries;
-    try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      let isDir = entry.isDirectory();
-      let isFile = entry.isFile();
-      // Resolve symlinks defensively (Dirent flags are false for symlinks).
-      if (!isDir && !isFile) {
-        try {
-          const st = fssync.statSync(full);
-          isDir = st.isDirectory();
-          isFile = st.isFile();
-        } catch { continue; }
+
+  // 1. JSONL session logs under projects/
+  const projectsDir = path.join(workbuddyHome, "projects");
+  if (fssync.existsSync(projectsDir)) {
+    const walk = (dir) => {
+      let entries;
+      try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        let isDir = entry.isDirectory();
+        let isFile = entry.isFile();
+        // Resolve symlinks defensively (Dirent flags are false for symlinks).
+        if (!isDir && !isFile) {
+          try {
+            const st = fssync.statSync(full);
+            isDir = st.isDirectory();
+            isFile = st.isFile();
+          } catch { continue; }
+        }
+        if (isDir) walk(full);
+        else if (isFile && entry.name.endsWith(".jsonl")) files.push({ path: full, kind: "jsonl" });
       }
-      if (isDir) walk(full);
-      else if (isFile && entry.name.endsWith(".jsonl")) files.push(full);
-    }
-  };
-  walk(projectsDir);
-  files.sort((a, b) => a.localeCompare(b));
+    };
+    walk(projectsDir);
+  }
+
+  // 2. Trace JSON files under traces/<pid>/trace_*.json
+  //    Same format as ~/.codebuddy/traces — WorkBuddy is the renamed successor
+  //    of CodeBuddy and writes traces with the same { trace, spans } schema.
+  //    See codebuddy trace branch in parseCodebuddyIncremental for field docs.
+  const tracesDir = path.join(workbuddyHome, "traces");
+  if (fssync.existsSync(tracesDir)) {
+    const walkTraces = (dir) => {
+      let entries;
+      try { entries = fssync.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        let isDir = entry.isDirectory();
+        let isFile = entry.isFile();
+        if (!isDir && !isFile) {
+          try {
+            const st = fssync.statSync(full);
+            isDir = st.isDirectory();
+            isFile = st.isFile();
+          } catch { continue; }
+        }
+        if (isDir) walkTraces(full);
+        else if (isFile && entry.name.startsWith("trace_") && entry.name.endsWith(".json")) {
+          files.push({ path: full, kind: "trace" });
+        }
+      }
+    };
+    walkTraces(tracesDir);
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
   return files;
 }
 
@@ -8434,6 +8667,10 @@ async function parseWorkbuddyIncremental({
     cursors.workbuddy && typeof cursors.workbuddy === "object" ? cursors.workbuddy : {};
   const seenIds = new Set(
     Array.isArray(workbuddyState.seenIds) ? workbuddyState.seenIds : [],
+  );
+  // Trace dedup — separate namespace from jsonl seenIds, keyed by traceId.
+  const seenTraceIds = new Set(
+    Array.isArray(workbuddyState.seenTraceIds) ? workbuddyState.seenTraceIds : [],
   );
   const fileOffsets =
     workbuddyState.fileOffsets && typeof workbuddyState.fileOffsets === "object"
@@ -8462,6 +8699,7 @@ async function parseWorkbuddyIncremental({
     cursors.workbuddy = {
       ...workbuddyState,
       seenIds: Array.from(seenIds),
+      seenTraceIds: Array.from(seenTraceIds),
       fileOffsets,
       sqliteSessions,
       detailedSessions,
@@ -8477,9 +8715,87 @@ async function parseWorkbuddyIncremental({
   let eventsAggregated = 0;
 
   for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
-    const filePath = files[fileIdx];
+    const fileEntry = files[fileIdx];
+    // Accept both new-style {path, kind} entries and legacy bare-string paths.
+    const filePath = typeof fileEntry === "string" ? fileEntry : fileEntry?.path;
+    const fileKind = typeof fileEntry === "string" ? "jsonl" : (fileEntry?.kind || "jsonl");
+    if (!filePath) continue;
     let stat;
     try { stat = fssync.statSync(filePath); } catch { continue; }
+
+    // ── Trace JSON branch (same schema as codebuddy traces) ─────────────
+    if (fileKind === "trace") {
+      const prevTraceEntry = fileOffsets[filePath] || {};
+      const prevTraceSize = Number(prevTraceEntry.size) || 0;
+      const prevTraceIno = prevTraceEntry.ino;
+      const traceInodeChanged = typeof prevTraceIno === "number" && prevTraceIno !== stat.ino;
+      if (stat.size === prevTraceSize && !traceInodeChanged && prevTraceSize > 0) continue;
+      if (stat.size === 0) continue;
+
+      let traceObj;
+      try {
+        const raw = fssync.readFileSync(filePath, "utf8");
+        traceObj = JSON.parse(raw);
+      } catch { continue; }
+
+      const trace = traceObj && typeof traceObj === "object" ? traceObj.trace : null;
+      if (!trace || typeof trace !== "object") continue;
+      const traceId = typeof trace.traceId === "string" ? trace.traceId : null;
+      if (!traceId) continue;
+      if (seenTraceIds.has(traceId)) continue;
+
+      const traceTotalTokens = toNonNegativeInt(trace.totalTokens);
+      if (traceTotalTokens === 0) {
+        seenTraceIds.add(traceId);
+        continue;
+      }
+
+      const mi = trace.modelInfo && typeof trace.modelInfo === "object" ? trace.modelInfo : {};
+      const miInput = toNonNegativeInt(mi.totalInputTokens);
+      const miOutput = toNonNegativeInt(mi.totalOutputTokens);
+      const miCached = toNonNegativeInt(mi.totalCachedTokens);
+      const traceInputTokens = Math.max(0, miInput - miCached);
+      const traceCachedTokens = miCached;
+      const traceOutputTokens = miOutput;
+
+      if (traceInputTokens === 0 && traceOutputTokens === 0 && traceCachedTokens === 0) {
+        seenTraceIds.add(traceId);
+        continue;
+      }
+
+      const startedAt = typeof trace.startedAt === "string" ? trace.startedAt : null;
+      if (!startedAt) { seenTraceIds.add(traceId); continue; }
+      const traceBucketStart = toUtcHalfHourStart(startedAt);
+      if (!traceBucketStart) { seenTraceIds.add(traceId); continue; }
+
+      const models = Array.isArray(mi.models) ? mi.models : [];
+      const traceModel = normalizeModelInput(models[0]) || fallbackModel;
+
+      const traceDelta = {
+        input_tokens: traceInputTokens,
+        cached_input_tokens: traceCachedTokens,
+        cache_creation_input_tokens: 0,
+        output_tokens: traceOutputTokens,
+        reasoning_output_tokens: 0,
+        total_tokens: traceInputTokens + traceOutputTokens + traceCachedTokens,
+        conversation_count: 1,
+      };
+
+      const traceBucket = getHourlyBucket(hourlyState, "workbuddy", traceModel, traceBucketStart);
+      addTotals(traceBucket.totals, traceDelta);
+      touchedBuckets.add(bucketKey("workbuddy", traceModel, traceBucketStart));
+      seenTraceIds.add(traceId);
+      recordsProcessed++;
+      eventsAggregated++;
+
+      fileOffsets[filePath] = { size: stat.size, mtimeMs: stat.mtimeMs, ino: stat.ino };
+
+      if (cb) {
+        cb({ index: fileIdx + 1, total: files.length, filePath, recordsProcessed, eventsAggregated, bucketsQueued: touchedBuckets.size });
+      }
+      continue;
+    }
+    // ── End trace JSON branch ────────────────────────────────────────────
 
     const prevEntry = fileOffsets[filePath] || {};
     const prevSize = Number(prevEntry.size) || 0;
@@ -8509,7 +8825,11 @@ async function parseWorkbuddyIncremental({
       // messages AND function_call records. Aggregate them all; dedup per id.
       const provider = entry.providerData;
       const rawUsage = provider && typeof provider === "object" ? provider.rawUsage : null;
-      if (!rawUsage || typeof rawUsage !== "object") continue;
+      // Fallback: older WorkBuddy sessions (pre-2026-05) only write
+      // providerData.model without rawUsage, and some carry the camelCase
+      // top-level `usage` field instead. Use it when rawUsage is absent.
+      const topUsage = !rawUsage && entry.usage && typeof entry.usage === "object" ? entry.usage : null;
+      if (!rawUsage && !topUsage) continue;
 
       const sessionId =
         typeof entry.sessionId === "string" && entry.sessionId
@@ -8537,30 +8857,42 @@ async function parseWorkbuddyIncremental({
 
       recordsProcessed++;
 
-      const promptTokens = toNonNegativeInt(rawUsage.prompt_tokens);
-      const completionTokens = toNonNegativeInt(rawUsage.completion_tokens);
-      const promptDetails =
-        rawUsage.prompt_tokens_details && typeof rawUsage.prompt_tokens_details === "object"
-          ? rawUsage.prompt_tokens_details
-          : {};
-      const completionDetails =
-        rawUsage.completion_tokens_details && typeof rawUsage.completion_tokens_details === "object"
-          ? rawUsage.completion_tokens_details
-          : {};
-
-      // Cache reads are mirrored across up to three fields depending on which
-      // upstream the auto-router used; take the largest non-zero mirror.
-      const cacheRead = Math.max(
-        toNonNegativeInt(rawUsage.cache_read_input_tokens),
-        toNonNegativeInt(promptDetails.cached_tokens),
-        toNonNegativeInt(rawUsage.prompt_cache_hit_tokens),
-      );
-      const cacheCreation = toNonNegativeInt(rawUsage.cache_creation_input_tokens);
+      let promptTokens, completionTokens, promptDetails, completionDetails, cacheRead, cacheCreation, reasoningTokens;
+      if (rawUsage) {
+        promptTokens = toNonNegativeInt(rawUsage.prompt_tokens);
+        completionTokens = toNonNegativeInt(rawUsage.completion_tokens);
+        promptDetails =
+          rawUsage.prompt_tokens_details && typeof rawUsage.prompt_tokens_details === "object"
+            ? rawUsage.prompt_tokens_details
+            : {};
+        completionDetails =
+          rawUsage.completion_tokens_details && typeof rawUsage.completion_tokens_details === "object"
+            ? rawUsage.completion_tokens_details
+            : {};
+        cacheRead = Math.max(
+          toNonNegativeInt(rawUsage.cache_read_input_tokens),
+          toNonNegativeInt(promptDetails.cached_tokens),
+          toNonNegativeInt(rawUsage.prompt_cache_hit_tokens),
+        );
+        cacheCreation = toNonNegativeInt(rawUsage.cache_creation_input_tokens);
+      } else {
+        // topUsage fallback (camelCase convention used by some WorkBuddy versions)
+        promptTokens = toNonNegativeInt(topUsage.inputTokens ?? topUsage.prompt_tokens);
+        completionTokens = toNonNegativeInt(topUsage.outputTokens ?? topUsage.completion_tokens);
+        const inputDetails = Array.isArray(topUsage.inputTokensDetails)
+          ? (topUsage.inputTokensDetails[0] || {})
+          : (topUsage.inputTokensDetails && typeof topUsage.inputTokensDetails === "object"
+            ? topUsage.inputTokensDetails : {});
+        promptDetails = inputDetails;
+        completionDetails = {};
+        cacheRead = toNonNegativeInt(inputDetails.cached_tokens);
+        cacheCreation = toNonNegativeInt(topUsage.cache_creation_input_tokens);
+      }
       // prompt_tokens is the FULL prompt: subtract BOTH reads and writes so
       // input_tokens is pure non-cached input (no double-counting cache writes).
       const inputTokens = Math.max(0, promptTokens - cacheRead - cacheCreation);
       // completion_tokens INCLUDES reasoning (verified: total == prompt+completion).
-      const reasoningTokens = Math.min(completionTokens, toNonNegativeInt(completionDetails.reasoning_tokens));
+      reasoningTokens = Math.min(completionTokens, toNonNegativeInt(completionDetails.reasoning_tokens));
       const outputTokens = Math.max(0, completionTokens - reasoningTokens);
 
       if (
@@ -8749,9 +9081,13 @@ async function parseWorkbuddyIncremental({
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
+  const seenTraceArr = Array.from(seenTraceIds);
+  const cappedSeenTraces =
+    seenTraceArr.length > 10_000 ? seenTraceArr.slice(seenTraceArr.length - 10_000) : seenTraceArr;
   cursors.workbuddy = {
     ...workbuddyState,
     seenIds: cappedSeen,
+    seenTraceIds: cappedSeenTraces,
     fileOffsets,
     sqliteSessions: cappedSqliteSessions,
     detailedSessions: cappedDetailedSessions,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7975,7 +7975,18 @@ function resolveCodebuddyProjectFiles(env = process.env) {
     }
   }
 
-  files.sort((a, b) => a.path.localeCompare(b.path));
+  // Sort: trace files first so tracedSessionIds is populated before jsonl
+  // parsing — this lets the jsonl branch skip sessions already covered by a
+  // trace and avoid double-counting.
+  files.sort((a, b) => {
+    const aKind = typeof a === "string" ? "jsonl" : (a?.kind || "jsonl");
+    const bKind = typeof b === "string" ? "jsonl" : (b?.kind || "jsonl");
+    if (aKind === "trace" && bKind !== "trace") return -1;
+    if (aKind !== "trace" && bKind === "trace") return 1;
+    const aPath = typeof a === "string" ? a : (a?.path || "");
+    const bPath = typeof b === "string" ? b : (b?.path || "");
+    return aPath.localeCompare(bPath);
+  });
   return files;
 }
 
@@ -8388,14 +8399,23 @@ async function parseCodebuddyIncremental({
         if (rawUsage) {
           promptTokens = toNonNegativeInt(rawUsage.prompt_tokens);
           completionTokens = toNonNegativeInt(rawUsage.completion_tokens);
-          const details =
+          const promptDetails =
             rawUsage.prompt_tokens_details && typeof rawUsage.prompt_tokens_details === "object"
               ? rawUsage.prompt_tokens_details
               : {};
-          cachedTokens = toNonNegativeInt(details.cached_tokens);
+          const completionDetails =
+            rawUsage.completion_tokens_details && typeof rawUsage.completion_tokens_details === "object"
+              ? rawUsage.completion_tokens_details
+              : {};
+          cachedTokens = toNonNegativeInt(promptDetails.cached_tokens);
           cacheReadAlt = toNonNegativeInt(rawUsage.cache_read_input_tokens);
           cacheCreation = toNonNegativeInt(rawUsage.cache_creation_input_tokens);
-          reasoningTokens = toNonNegativeInt(details.reasoning_tokens);
+          // reasoning_tokens lives in completion_tokens_details (verified on real
+          // CodeBuddy data: prompt_tokens_details.reasoning_tokens is always 0,
+          // completion_tokens_details.reasoning_tokens carries the actual value).
+          // completion_tokens INCLUDES reasoning, so subtract to avoid double-count.
+          reasoningTokens = Math.min(completionTokens, toNonNegativeInt(completionDetails.reasoning_tokens));
+          completionTokens = Math.max(0, completionTokens - reasoningTokens);
         } else {
           // topUsage fallback (camelCase)
           promptTokens = toNonNegativeInt(topUsage.inputTokens ?? topUsage.prompt_tokens);
@@ -8404,10 +8424,15 @@ async function parseCodebuddyIncremental({
             ? topUsage.inputTokensDetails[0]
             : (topUsage.inputTokensDetails && typeof topUsage.inputTokensDetails === "object"
               ? topUsage.inputTokensDetails : {});
+          const outputDetails = Array.isArray(topUsage.outputTokensDetails)
+            ? topUsage.outputTokensDetails[0]
+            : (topUsage.outputTokensDetails && typeof topUsage.outputTokensDetails === "object"
+              ? topUsage.outputTokensDetails : {});
           cachedTokens = toNonNegativeInt(inputDetails?.cached_tokens);
           cacheReadAlt = 0;
           cacheCreation = toNonNegativeInt(topUsage.cache_creation_input_tokens);
-          reasoningTokens = toNonNegativeInt(inputDetails?.reasoning_tokens);
+          reasoningTokens = Math.min(completionTokens, toNonNegativeInt(outputDetails?.reasoning_tokens));
+          completionTokens = Math.max(0, completionTokens - reasoningTokens);
         }
         const cacheRead = Math.max(cachedTokens, cacheReadAlt);
         const inputTokens = Math.max(0, promptTokens - cacheRead);
@@ -8650,7 +8675,16 @@ function resolveWorkbuddyProjectFiles(env = process.env) {
     walkTraces(tracesDir);
   }
 
-  files.sort((a, b) => a.path.localeCompare(b.path));
+  // Sort: trace files first (same rationale as codebuddy — see above).
+  files.sort((a, b) => {
+    const aKind = typeof a === "string" ? "jsonl" : (a?.kind || "jsonl");
+    const bKind = typeof b === "string" ? "jsonl" : (b?.kind || "jsonl");
+    if (aKind === "trace" && bKind !== "trace") return -1;
+    if (aKind !== "trace" && bKind === "trace") return 1;
+    const aPath = typeof a === "string" ? a : (a?.path || "");
+    const bPath = typeof b === "string" ? b : (b?.path || "");
+    return aPath.localeCompare(bPath);
+  });
   return files;
 }
 
@@ -8844,10 +8878,12 @@ async function parseWorkbuddyIncremental({
           : null;
       // One usage record per LLM round-trip; the response id is the most stable
       // dedup key, then providerData.messageId, then session+timestamp.
+      // Use optional chaining — provider (entry.providerData) may be null when
+      // only the top-level `usage` field is present (topUsage fallback path).
       const messageId =
         typeof entry.id === "string" && entry.id
           ? entry.id
-          : typeof provider.messageId === "string" && provider.messageId
+          : typeof provider?.messageId === "string" && provider.messageId
             ? provider.messageId
             : tsMs != null
               ? `${sessionId}:${tsMs}`
@@ -8884,7 +8920,10 @@ async function parseWorkbuddyIncremental({
           : (topUsage.inputTokensDetails && typeof topUsage.inputTokensDetails === "object"
             ? topUsage.inputTokensDetails : {});
         promptDetails = inputDetails;
-        completionDetails = {};
+        completionDetails = Array.isArray(topUsage.outputTokensDetails)
+          ? (topUsage.outputTokensDetails[0] || {})
+          : (topUsage.outputTokensDetails && typeof topUsage.outputTokensDetails === "object"
+            ? topUsage.outputTokensDetails : {});
         cacheRead = toNonNegativeInt(inputDetails.cached_tokens);
         cacheCreation = toNonNegativeInt(topUsage.cache_creation_input_tokens);
       }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7840,6 +7840,101 @@ function resolveCodebuddyDefaultModel(env = process.env) {
   return fallback;
 }
 
+// Sniff the head of a CodeBuddy session jsonl for assistant messages that
+// carry token usage. Two-stage per line: a cheap substring screen for
+// "rawUsage"/"usage" and then JSON.parse to confirm the line is really a
+// type=message/role=assistant record with a usage object (the substring alone
+// could appear in unrelated string values). Reads at most the first 64KB and
+// inspects at most the first 100 lines — bounded I/O, safe on huge logs.
+// Truncated tail lines (partial final line inside the 64KB window) fail
+// JSON.parse and are skipped. Any parse error on the file itself → false.
+function sniffCodebuddyJsonlHasUsage(filePath) {
+  let fd;
+  try {
+    fd = fssync.openSync(filePath, "r");
+  } catch { return false; }
+  let head;
+  try {
+    const buf = Buffer.alloc(64 * 1024);
+    const bytesRead = fssync.readSync(fd, buf, 0, buf.length, 0);
+    head = buf.toString("utf8", 0, bytesRead);
+  } catch { return false; } finally {
+    try { fssync.closeSync(fd); } catch {}
+  }
+  if (!head.includes("\"rawUsage\"") && !head.includes("\"usage\"")) return false;
+  const lines = head.split("\n");
+  const limit = Math.min(lines.length, 100);
+  for (let i = 0; i < limit; i++) {
+    const line = lines[i];
+    if (!line || (line.indexOf("\"rawUsage\"") === -1 && line.indexOf("\"usage\"") === -1)) continue;
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (!entry || entry.type !== "message" || entry.role !== "assistant") continue;
+    const provider = entry.providerData;
+    const rawUsage = provider && typeof provider === "object" ? provider.rawUsage : null;
+    if (rawUsage && typeof rawUsage === "object") return true;
+    if (entry.usage && typeof entry.usage === "object") return true;
+  }
+  return false;
+}
+
+// Property key used to carry the log-fallback decision from
+// resolveCodebuddyProjectFiles (where the gate runs) to
+// parseCodebuddyProjectFiles (where it is persisted as diagnostics) without
+// re-sniffing every jsonl head. Attached as a non-index property on the
+// returned array; survives sort() because sort mutates in place.
+const CODEBUDDY_LOG_FALLBACK_INFO = "__codebuddyLogFallbackInfo";
+
+// Three-state gate for the legacy IDE extension-log fallback:
+//   TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=1 → force-on   (debug; known to
+//                                                        double-count vs jsonl)
+//   TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=0 → force-off  (new escape hatch)
+//   unset                                 → auto:
+//     (a) any trace file discovered        → off (traces are authoritative)
+//     (b) else any jsonl carries usage     → off (jsonl branch produces data)
+//     (c) else                             → on  (pre-2026-04 CodeBuddy: no
+//                                                 traces, jsonl has no
+//                                                 rawUsage/usage — extension
+//                                                 logs are the ONLY source)
+// Auto-on is physically incapable of double-counting: it only triggers when
+// the jsonl branch would produce zero records (no file carries usage) and
+// there are no traces, so the dedup-namespace collision that caused the
+// historical 3x inflation is unreachable on the auto path.
+// Returns { enabled, mode, reason, traceFiles, jsonlFiles, jsonlWithUsage } —
+// everything after `enabled` is diagnostics only.
+function detectCodebuddyLogFallback(env, files) {
+  const raw = String(env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK || "").trim();
+  const list = Array.isArray(files) ? files : [];
+  let traceFiles = 0;
+  const jsonlPaths = [];
+  for (const f of list) {
+    const kind = typeof f === "string"
+      ? (f.endsWith(".log") ? "log" : "jsonl")
+      : (f?.kind || "jsonl");
+    const p = typeof f === "string" ? f : f?.path;
+    if (kind === "trace") traceFiles++;
+    else if (kind === "jsonl" && p) jsonlPaths.push(p);
+  }
+  if (raw === "1") {
+    return { enabled: true, mode: "force-on", reason: "env_forced_on", traceFiles, jsonlFiles: jsonlPaths.length, jsonlWithUsage: 0 };
+  }
+  if (raw === "0") {
+    return { enabled: false, mode: "force-off", reason: "env_forced_off", traceFiles, jsonlFiles: jsonlPaths.length, jsonlWithUsage: 0 };
+  }
+  if (traceFiles > 0) {
+    return { enabled: false, mode: "auto-off", reason: "traces_present", traceFiles, jsonlFiles: jsonlPaths.length, jsonlWithUsage: 0 };
+  }
+  for (const p of jsonlPaths) {
+    if (sniffCodebuddyJsonlHasUsage(p)) {
+      // Any single jsonl with usage is enough — the jsonl branch will produce
+      // records, so enabling logs would re-introduce the namespace double
+      // count. Early exit keeps the sniff O(first-hit) on modern installs.
+      return { enabled: false, mode: "auto-off", reason: "jsonl_usage_present", traceFiles, jsonlFiles: jsonlPaths.length, jsonlWithUsage: 1 };
+    }
+  }
+  return { enabled: true, mode: "auto-on", reason: "no_traces_no_jsonl_usage", traceFiles, jsonlFiles: jsonlPaths.length, jsonlWithUsage: 0 };
+}
+
 function resolveCodebuddyProjectFiles(env = process.env) {
   const codebuddyHome = resolveCodebuddyHome(env);
   // Each entry is { path, kind } where kind ∈ {"jsonl", "log", "trace"}.
@@ -7907,16 +8002,21 @@ function resolveCodebuddyProjectFiles(env = process.env) {
   }
 
   // 2. Active IDE extension logs scan.
-  //    DEFAULT DISABLED: extension logs overlap with the jsonl session log and
-  //    use a different dedup key namespace (codebuddy:extension-log:agentId:sec
-  //    vs jsonl's entry.uuid), causing the same LLM round-trip to be counted
-  //    twice — observed 3x inflation on a real machine (45.9M vs true 15.3M).
-  //    The traces dir (added above) is the authoritative source; jsonl is the
-  //    fallback for sessions without traces. Extension logs are only consulted
-  //    when explicitly enabled via TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=1, for
-  //    users on older CodeBuddy builds that have neither traces nor rawUsage.
-  const enableLogFallback = String(env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK || "").trim() === "1";
-  if (enableLogFallback) {
+  //    Extension logs overlap with the jsonl session log and use a different
+  //    dedup key namespace (codebuddy:extension-log:agentId:sec vs jsonl's
+  //    entry.uuid), so counting both double-counts the same LLM round-trip —
+  //    observed 3x inflation on a real machine (45.9M vs true 15.3M). They
+  //    are therefore gated by detectCodebuddyLogFallback: enabled only when
+  //    forced (=1, debug) or when auto-detection finds NEITHER trace files
+  //    NOR any jsonl assistant message with usage — i.e. pre-2026-04
+  //    CodeBuddy builds where extension logs are the only usage source.
+  //    Auto-on cannot double-count because the jsonl branch yields zero
+  //    records in exactly that situation. See detectCodebuddyLogFallback.
+  const logFallbackInfo = detectCodebuddyLogFallback(env, files);
+  // Stash the decision on the array so parseCodebuddyIncremental can persist
+  // it as diagnostics without re-sniffing every jsonl head.
+  try { files[CODEBUDDY_LOG_FALLBACK_INFO] = logFallbackInfo; } catch {}
+  if (logFallbackInfo.enabled) {
     const logRoots = [];
     const home = env.HOME || require("node:os").homedir();
 
@@ -8068,6 +8168,15 @@ async function parseCodebuddyIncremental({
     ? projectFiles
     : resolveCodebuddyProjectFiles(env || process.env);
   const fallbackModel = defaultModel || resolveCodebuddyDefaultModel(env || process.env);
+  // Observational diagnostics for the extension-log fallback gate — recorded
+  // in cursors.codebuddy.logFallback so silent auto-on/off decisions are
+  // visible after the fact. Reuses the decision made inside
+  // resolveCodebuddyProjectFiles when available (avoids re-sniffing); when
+  // files were passed in explicitly we recompute deterministically from the
+  // given list. NOT used for any correctness decision in this function.
+  const logFallbackInfo =
+    (files && files[CODEBUDDY_LOG_FALLBACK_INFO]) ||
+    detectCodebuddyLogFallback(env || process.env, files);
 
   if (files.length === 0) {
     cursors.codebuddy = {
@@ -8076,6 +8185,7 @@ async function parseCodebuddyIncremental({
       seenTraceIds: Array.from(seenTraceIds),
       tracedSessionIds: Array.from(tracedSessionIds),
       fileOffsets,
+      logFallback: { ...logFallbackInfo, detectedAt: new Date().toISOString() },
       updatedAt: new Date().toISOString(),
     };
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -8531,6 +8641,10 @@ async function parseCodebuddyIncremental({
     tracedSessionIds: cappedTracedSessions,
     fileOffsets,
     logModelsByAgent: cappedLogModelsByAgent,
+    // Diagnostics only (see detectCodebuddyLogFallback): which log-fallback
+    // mode was in effect this run and why. Additive/optional — old cursors
+    // simply lack the key.
+    logFallback: { ...logFallbackInfo, detectedAt: updatedAt },
     updatedAt,
   };
 
@@ -8706,6 +8820,16 @@ async function parseWorkbuddyIncremental({
   const seenTraceIds = new Set(
     Array.isArray(workbuddyState.seenTraceIds) ? workbuddyState.seenTraceIds : [],
   );
+  // Sessions covered by at least one trace file that passed all usage gates
+  // below. For these sessions we skip BOTH the jsonl branch and the sqlite
+  // fallback (priority: trace > jsonl/detailed > sqlite) because the trace
+  // already carries the complete workflow-level token total — counting jsonl
+  // or sqlite rows too would double-count (mirrors codebuddy's
+  // tracedSessionIds at ~8055). Missing on old cursors → empty set, which
+  // keeps the new field additive and backward compatible.
+  const tracedSessionIds = new Set(
+    Array.isArray(workbuddyState.tracedSessionIds) ? workbuddyState.tracedSessionIds : [],
+  );
   const fileOffsets =
     workbuddyState.fileOffsets && typeof workbuddyState.fileOffsets === "object"
       ? { ...workbuddyState.fileOffsets }
@@ -8734,6 +8858,7 @@ async function parseWorkbuddyIncremental({
       ...workbuddyState,
       seenIds: Array.from(seenIds),
       seenTraceIds: Array.from(seenTraceIds),
+      tracedSessionIds: Array.from(tracedSessionIds),
       fileOffsets,
       sqliteSessions,
       detailedSessions,
@@ -8804,6 +8929,12 @@ async function parseWorkbuddyIncremental({
 
       const models = Array.isArray(mi.models) ? mi.models : [];
       const traceModel = normalizeModelInput(models[0]) || fallbackModel;
+      // Mark the session as trace-covered ONLY after all usage/timestamp
+      // gates above passed (zero-token / missing startedAt traces returned
+      // earlier and intentionally do NOT suppress jsonl — for those, jsonl
+      // remains the authoritative usage source). Same placement as codebuddy.
+      const traceSessionId = typeof trace.sessionId === "string" && trace.sessionId ? trace.sessionId : null;
+      if (traceSessionId) tracedSessionIds.add(traceSessionId);
 
       const traceDelta = {
         input_tokens: traceInputTokens,
@@ -8869,6 +9000,11 @@ async function parseWorkbuddyIncremental({
         typeof entry.sessionId === "string" && entry.sessionId
           ? entry.sessionId
           : path.basename(filePath, ".jsonl");
+      // Skip sessions already covered by a trace file — the trace carries the
+      // complete workflow-level total. Trace-first sort in
+      // resolveWorkbuddyProjectFiles guarantees tracedSessionIds is populated
+      // before any jsonl line is read within a run.
+      if (tracedSessionIds.has(sessionId)) continue;
       if (Object.prototype.hasOwnProperty.call(sqliteSessions, sessionId)) {
         continue;
       }
@@ -9030,6 +9166,12 @@ async function parseWorkbuddyIncremental({
         if (!row || typeof row !== "object") continue;
         const sessionId = typeof row.session_id === "string" ? row.session_id.trim() : "";
         if (!sessionId) continue;
+        // Trace-covered sessions win over the sqlite fallback too. CRITICAL:
+        // this check must come BEFORE the detailedSessions check — the jsonl
+        // branch now skips traced sessions without populating
+        // detailedSessions, so without this guard the sqlite fallback would
+        // count the session and re-create the double count (trace+sqlite).
+        if (tracedSessionIds.has(sessionId)) continue;
         if (detailedSessions[sessionId] || detailedSessionsWithUsage.has(sessionId)) continue;
 
         const usedNow = toNonNegativeInt(row.used);
@@ -9123,10 +9265,19 @@ async function parseWorkbuddyIncremental({
   const seenTraceArr = Array.from(seenTraceIds);
   const cappedSeenTraces =
     seenTraceArr.length > 10_000 ? seenTraceArr.slice(seenTraceArr.length - 10_000) : seenTraceArr;
+  // Cap tracedSessionIds to the last 10k (same convention as seenIds /
+  // seenTraceIds). Evicted sessions are still protected by seenIds /
+  // fileOffsets for already-read jsonl lines, so only genuinely new jsonl
+  // lines for a very old traced session could leak — accepted trade-off,
+  // identical to codebuddy.
+  const tracedSessionArr = Array.from(tracedSessionIds);
+  const cappedTracedSessions =
+    tracedSessionArr.length > 10_000 ? tracedSessionArr.slice(tracedSessionArr.length - 10_000) : tracedSessionArr;
   cursors.workbuddy = {
     ...workbuddyState,
     seenIds: cappedSeen,
     seenTraceIds: cappedSeenTraces,
+    tracedSessionIds: cappedTracedSessions,
     fileOffsets,
     sqliteSessions: cappedSqliteSessions,
     detailedSessions: cappedDetailedSessions,
@@ -15610,6 +15761,7 @@ module.exports = {
   resolveCodebuddyHome,
   resolveCodebuddyProjectFiles,
   resolveCodebuddyDefaultModel,
+  detectCodebuddyLogFallback,
   parseCodebuddyIncremental,
   resolveWorkbuddyHome,
   resolveWorkbuddyProjectFiles,

--- a/test/codebuddy-log-fallback.test.js
+++ b/test/codebuddy-log-fallback.test.js
@@ -1,0 +1,217 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  resolveCodebuddyProjectFiles,
+  detectCodebuddyLogFallback,
+  parseCodebuddyIncremental,
+} = require("../src/lib/rollout");
+
+// PR #399 Blocker #3: pre-2026-04 CodeBuddy has neither ~/.codebuddy/traces/
+// nor rawUsage/usage on jsonl assistant messages, so the only usage source is
+// the IDE extension log's [AgentReporter] lines. The old hard env gate
+// (TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=1, default off) silently zeroed these
+// users. The gate is now three-state: =1 force-on, =0 force-off, unset =
+// auto (off when traces exist or any jsonl carries usage; on only when
+// neither does — the one situation where logs cannot double-count).
+
+const ENV_KEYS = [
+  "HOME", "USERPROFILE", "CODEBUDDY_HOME",
+  "APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+  "TOKENTRACKER_CODEBUDDY_LOG_FALLBACK",
+];
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-cb-logfb-"));
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.CODEBUDDY_HOME = path.join(home, ".codebuddy");
+    process.env.APPDATA = path.join(home, "AppData", "Roaming");
+    process.env.LOCALAPPDATA = path.join(home, "AppData", "Local");
+    process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+    process.env.XDG_DATA_HOME = path.join(home, ".local", "share");
+    delete process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    return await fn(home, process.env.CODEBUDDY_HOME);
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+// Write an extension log (one Model prepared + two usage lines) into the
+// platform-appropriate log root that resolveCodebuddyProjectFiles scans.
+async function writeExtensionLog(home) {
+  let logDir;
+  if (process.platform === "darwin") {
+    logDir = path.join(home, "Library", "Application Support", "Code", "logs", "tencent-cloud.coding-copilot");
+  } else if (process.platform === "win32") {
+    logDir = path.join(process.env.APPDATA, "Code", "logs", "tencent-cloud.coding-copilot");
+  } else {
+    logDir = path.join(process.env.XDG_CONFIG_HOME, "Code", "logs", "tencent-cloud.coding-copilot");
+  }
+  await fs.mkdir(logDir, { recursive: true });
+  await fs.writeFile(
+    path.join(logDir, "codebuddy-extension-log.log"),
+    [
+      "[2026/7/31 00:00:01.000] [info] [CraftInvokableAgent] [agent-1] Model prepared: GLM 5.2 (glm-5.2)",
+      '[2026/7/31 00:00:02.000] [info] [AgentReporter] [agent-1] Agent execution successful with usage: {"inputTokens":3000,"outputTokens":400,"totalTokens":3400}',
+      '[2026/7/31 00:00:03.000] [info] [AgentReporter] [agent-1] Agent execution successful with usage: {"inputTokens":5000,"outputTokens":600,"totalTokens":5600}',
+    ].join("\n") + "\n",
+  );
+}
+
+// Legacy jsonl: assistant message whose providerData carries ONLY the model —
+// no rawUsage, no top-level usage (pre-2026-04 shape, always dropped by the
+// jsonl branch).
+function legacyJsonlLine() {
+  return JSON.stringify({
+    id: "x1",
+    timestamp: 1753900800000,
+    type: "message",
+    role: "assistant",
+    sessionId: "sess-old",
+    providerData: { model: "glm-4" },
+  });
+}
+
+async function queueTotal(queuePath, source) {
+  let raw = "";
+  try { raw = await fs.readFile(queuePath, "utf8"); } catch { return 0; }
+  let sum = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    if (row.source === source) sum += row.total_tokens;
+  }
+  return sum;
+}
+
+test("codebuddy log fallback: legacy install (no traces, jsonl without usage) auto-enables extension logs", async () => {
+  await withTempHome(async (home, cbHome) => {
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "projects", "p", "sess-old.jsonl"), legacyJsonlLine() + "\n");
+    await writeExtensionLog(home);
+
+    const files = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(files.some((f) => f.kind === "log"), "auto mode must include extension logs for legacy installs");
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+    assert.equal(await queueTotal(queuePath, "codebuddy"), 9000); // 3400 + 5600
+    assert.equal(cursors.codebuddy.logFallback.mode, "auto-on");
+    assert.equal(cursors.codebuddy.logFallback.reason, "no_traces_no_jsonl_usage");
+  });
+});
+
+test("codebuddy log fallback: traces present → auto-off (no 3x inflation regression)", async () => {
+  await withTempHome(async (home, cbHome) => {
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "projects", "p", "sess-old.jsonl"), legacyJsonlLine() + "\n");
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(
+      path.join(cbHome, "traces", "1", "trace_a.json"),
+      JSON.stringify({
+        trace: {
+          traceId: "ta",
+          sessionId: "sess-old",
+          startedAt: "2026-07-31T00:00:00.000Z",
+          totalTokens: 100,
+          modelInfo: { models: ["glm-5.2"], totalInputTokens: 80, totalOutputTokens: 20, totalCachedTokens: 0 },
+        },
+        spans: [],
+      }),
+    );
+    await writeExtensionLog(home);
+
+    const files = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(!files.some((f) => f.kind === "log"), "traces are authoritative — logs must stay off");
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+    assert.equal(await queueTotal(queuePath, "codebuddy"), 100); // trace only
+    assert.equal(cursors.codebuddy.logFallback.mode, "auto-off");
+    assert.equal(cursors.codebuddy.logFallback.reason, "traces_present");
+  });
+});
+
+test("codebuddy log fallback: jsonl carrying usage → auto-off (sniff)", async () => {
+  await withTempHome(async (home, cbHome) => {
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    await fs.writeFile(
+      path.join(cbHome, "projects", "p", "s.jsonl"),
+      JSON.stringify({
+        id: "u1",
+        timestamp: 1753900800000,
+        type: "message",
+        role: "assistant",
+        sessionId: "s",
+        providerData: { model: "glm-5.2", rawUsage: { prompt_tokens: 100, completion_tokens: 10 } },
+      }) + "\n",
+    );
+    await writeExtensionLog(home);
+
+    const files = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(!files.some((f) => f.kind === "log"), "jsonl with usage → logs must stay off");
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+    assert.equal(await queueTotal(queuePath, "codebuddy"), 110); // jsonl only
+    assert.equal(cursors.codebuddy.logFallback.mode, "auto-off");
+    assert.equal(cursors.codebuddy.logFallback.reason, "jsonl_usage_present");
+  });
+});
+
+test("codebuddy log fallback: env overrides — =0 forces off, =1 forces on", async () => {
+  await withTempHome(async (home, cbHome) => {
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "projects", "p", "sess-old.jsonl"), legacyJsonlLine() + "\n");
+    await writeExtensionLog(home);
+
+    process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK = "0";
+    const offFiles = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(!offFiles.some((f) => f.kind === "log"));
+    const cursorsOff = { version: 1 };
+    const queueOff = path.join(home, "queue-off.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: offFiles, cursors: cursorsOff, queuePath: queueOff, env: process.env });
+    assert.equal(await queueTotal(queueOff, "codebuddy"), 0);
+    assert.equal(cursorsOff.codebuddy.logFallback.mode, "force-off");
+
+    process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK = "1";
+    const onFiles = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(onFiles.some((f) => f.kind === "log"));
+    const cursorsOn = { version: 1 };
+    const queueOn = path.join(home, "queue-on.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: onFiles, cursors: cursorsOn, queuePath: queueOn, env: process.env });
+    assert.equal(await queueTotal(queueOn, "codebuddy"), 9000);
+    assert.equal(cursorsOn.codebuddy.logFallback.mode, "force-on");
+  });
+});
+
+test("codebuddy log fallback: sniff is robust — empty and corrupt-head jsonl do not crash or falsely enable", async () => {
+  await withTempHome(async (home, cbHome) => {
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "projects", "p", "empty.jsonl"), "");
+    await fs.writeFile(path.join(cbHome, "projects", "p", "corrupt.jsonl"), "{not json\n\"usage\" also not json\n");
+    // detectCodebuddyLogFallback is pure detection; with no usage anywhere it
+    // must return auto-on (logs are the only source) without throwing.
+    const files = [
+      { path: path.join(cbHome, "projects", "p", "empty.jsonl"), kind: "jsonl" },
+      { path: path.join(cbHome, "projects", "p", "corrupt.jsonl"), kind: "jsonl" },
+    ];
+    const info = detectCodebuddyLogFallback(process.env, files);
+    assert.equal(info.mode, "auto-on");
+    assert.equal(info.jsonlFiles, 2);
+  });
+});

--- a/test/codebuddy-trace-overlap-repair.test.js
+++ b/test/codebuddy-trace-overlap-repair.test.js
@@ -1,0 +1,299 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  resolveCodebuddyProjectFiles,
+  parseCodebuddyIncremental,
+} = require("../src/lib/rollout");
+const {
+  repairCodebuddyTraceJsonlOverlap,
+  CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY,
+} = require("../src/commands/sync");
+
+// PR #399 Blocker #1: pre-tracedSessionIds CodeBuddy versions aggregated
+// jsonl tokens into hourly buckets even for sessions that also had a trace
+// file. tracedSessionIds is forward-only (suppresses jsonl parsed after the
+// trace within one run) and buckets carry no session dimension, so the stale
+// jsonl contribution could only be rolled back by a guarded rebuild. These
+// tests pin the one-time repair: sentinel semantics, the reproducibility
+// guard, the atomic rebuild + queue strip + zero retractions + upload offset
+// reset, and no-op convergence afterwards.
+
+const HALF_HOUR = "2026-07-31T00:00:00.000Z";
+const TS_MS = Date.parse("2026-07-31T00:15:00.000Z"); // inside the …00:00 half-hour bucket
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-cb-repair-"));
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, CODEBUDDY_HOME: process.env.CODEBUDDY_HOME, TOKENTRACKER_CODEBUDDY_LOG_FALLBACK: process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK };
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.CODEBUDDY_HOME = path.join(home, ".codebuddy");
+    delete process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    return await fn(home, process.env.CODEBUDDY_HOME);
+  } finally {
+    process.env.HOME = saved.HOME;
+    process.env.USERPROFILE = saved.USERPROFILE;
+    if (saved.CODEBUDDY_HOME === undefined) delete process.env.CODEBUDDY_HOME;
+    else process.env.CODEBUDDY_HOME = saved.CODEBUDDY_HOME;
+    if (saved.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK === undefined) delete process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    else process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK = saved.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+function jsonlLine({ id, ts, sessionId, promptTokens, completionTokens, cachedTokens }) {
+  const pt = promptTokens ?? 20000;
+  const ct = completionTokens ?? 500;
+  return JSON.stringify({
+    id: id ?? "r1",
+    timestamp: ts ?? TS_MS,
+    type: "message",
+    role: "assistant",
+    sessionId: sessionId ?? "sess-rep-001",
+    providerData: {
+      model: "glm-5.2",
+      rawUsage: {
+        prompt_tokens: pt,
+        completion_tokens: ct,
+        total_tokens: pt + ct,
+        prompt_tokens_details: { cached_tokens: cachedTokens ?? 0, reasoning_tokens: 0 },
+        completion_tokens_details: { reasoning_tokens: 0 },
+      },
+    },
+  });
+}
+
+function traceJson({ traceId, sessionId, startedAt }) {
+  return {
+    trace: {
+      traceId: traceId ?? "tr1",
+      sessionId: sessionId ?? "sess-rep-001",
+      startedAt: startedAt ?? HALF_HOUR,
+      endedAt: "2026-07-31T00:01:00.000Z",
+      status: "ok",
+      totalTokens: 10000,
+      modelInfo: { models: ["glm-5.2"], totalInputTokens: 9000, totalOutputTokens: 1000, totalCachedTokens: 5000 },
+    },
+    spans: [],
+  };
+}
+
+function codebuddyBucketTotals(cursors) {
+  return Object.keys(cursors.hourly?.buckets || {})
+    .filter((k) => k.startsWith("codebuddy|"))
+    .sort()
+    .map((k) => ({ key: k, total: cursors.hourly.buckets[k].totals.total_tokens }));
+}
+
+async function queueRows(queuePath) {
+  let raw = "";
+  try { raw = await fs.readFile(queuePath, "utf8"); } catch { return []; }
+  return raw.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+}
+
+test("repairCodebuddyTraceJsonlOverlap: upgrade regression — legacy jsonl bucket is rebuilt to the trace-only value", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const sid = "sess-rep-001";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, jsonlLine({ sessionId: sid }) + "\n");
+
+    // Simulate the LEGACY write path: jsonl-only parse (no traces on disk
+    // yet), then drop tracedSessionIds so the cursor looks pre-upgrade.
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    const queueStatePath = path.join(home, "queue.state.json");
+    await parseCodebuddyIncremental({ projectFiles: [{ path: jsonlPath, kind: "jsonl" }], cursors, queuePath, env: process.env });
+    let buckets = codebuddyBucketTotals(cursors);
+    assert.equal(buckets.length, 1);
+    assert.equal(buckets[0].total, 20500);
+    delete cursors.codebuddy.tracedSessionIds;
+    await fs.writeFile(queueStatePath, JSON.stringify({ offset: 999, updatedAt: "old" }));
+
+    // The trace file appears (upgrade). Without the repair, the next parse
+    // would stack 10000 onto the stale 20500 bucket.
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "traces", "1", "trace_r.json"), JSON.stringify(traceJson({ sessionId: sid })));
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+
+    const ran = await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath, codebuddyFiles: allFiles, env: process.env });
+    assert.equal(ran, true);
+
+    buckets = codebuddyBucketTotals(cursors);
+    assert.deepEqual(buckets.map((b) => b.total), [10000], "bucket rebuilt to the trace-only value");
+
+    // queue.jsonl: only the rebuilt codebuddy rows remain (no stale 20500).
+    const rows = await queueRows(queuePath);
+    const cbTotal = rows.filter((r) => r.source === "codebuddy").reduce((s, r) => s + r.total_tokens, 0);
+    assert.equal(cbTotal, 10000);
+
+    // Upload offset reset so the corrected queue overwrites the cloud.
+    const upState = JSON.parse(await fs.readFile(queueStatePath, "utf8"));
+    assert.equal(upState.offset, 0);
+    assert.equal(upState.note, "reset_after_codebuddy_trace_overlap_2026_08");
+
+    // Completed sentinel is a final ISO string.
+    assert.ok(typeof cursors.migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] === "string");
+
+    // The regular parse later in the same sync is a natural no-op (rebuilt
+    // fileOffsets sit at EOF) and cannot re-inflate.
+    const after = await parseCodebuddyIncremental({ projectFiles: allFiles, cursors, queuePath, env: process.env });
+    assert.equal(after.eventsAggregated, 0);
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [10000]);
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: idempotent — completed sentinel short-circuits the second run", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const sid = "sess-rep-001";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, jsonlLine({ sessionId: sid }) + "\n");
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "traces", "1", "trace_r.json"), JSON.stringify(traceJson({ sessionId: sid })));
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: [{ path: jsonlPath, kind: "jsonl" }], cursors, queuePath, env: process.env });
+    delete cursors.codebuddy.tracedSessionIds;
+
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+    assert.equal(await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath: null, codebuddyFiles: allFiles, env: process.env }), true);
+    const before = JSON.stringify(cursors.hourly.buckets);
+    assert.equal(await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath: null, codebuddyFiles: allFiles, env: process.env }), false);
+    assert.equal(JSON.stringify(cursors.hourly.buckets), before, "second run must not touch buckets");
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: forward behavior — post-repair jsonl appends stay suppressed by tracedSessionIds", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const sid = "sess-rep-001";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, jsonlLine({ sessionId: sid }) + "\n");
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(path.join(cbHome, "traces", "1", "trace_r.json"), JSON.stringify(traceJson({ sessionId: sid })));
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: [{ path: jsonlPath, kind: "jsonl" }], cursors, queuePath, env: process.env });
+    delete cursors.codebuddy.tracedSessionIds;
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+    await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath: null, codebuddyFiles: allFiles, env: process.env });
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [10000]);
+
+    // New assistant message appended to the traced session's jsonl AFTER the
+    // repair must be skipped (tracedSessionIds covers the session).
+    await fs.appendFile(jsonlPath, jsonlLine({ id: "r2", sessionId: sid, promptTokens: 4000, completionTokens: 100 }) + "\n");
+    const again = await parseCodebuddyIncremental({ projectFiles: resolveCodebuddyProjectFiles(process.env), cursors, queuePath, env: process.env });
+    assert.equal(again.eventsAggregated, 0);
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [10000]);
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: guard — a deleted contributing file defers with a retryable skipped sentinel", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const gonePath = path.join(cbHome, "projects", "p", "gone.jsonl");
+    const liveKey = `codebuddy|glm-5.2|${HALF_HOUR}`;
+    const cursors = {
+      version: 1,
+      migrations: {},
+      hourly: { buckets: { [liveKey]: { totals: { total_tokens: 20500 } } }, groupQueued: {} },
+      codebuddy: { fileOffsets: { [gonePath]: { size: 100, mtimeMs: 1, ino: 1 } } },
+    };
+    const ran = await repairCodebuddyTraceJsonlOverlap({
+      cursors,
+      queuePath: path.join(home, "queue.jsonl"),
+      queueStatePath: null,
+      codebuddyFiles: [],
+      env: process.env,
+    });
+    assert.equal(ran, false);
+    const sentinel = cursors.migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY];
+    assert.equal(sentinel.skipped, true);
+    assert.equal(sentinel.reason, "codebuddy_file_unreproducible");
+    // Live history untouched.
+    assert.equal(cursors.hourly.buckets[liveKey].totals.total_tokens, 20500);
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: fast path — no codebuddy buckets finalizes in O(1)", async () => {
+  await withTempHome(async (home) => {
+    const cursors = { version: 1, migrations: {}, hourly: { buckets: {}, groupQueued: {} } };
+    const ran = await repairCodebuddyTraceJsonlOverlap({
+      cursors,
+      queuePath: path.join(home, "queue.jsonl"),
+      queueStatePath: null,
+      codebuddyFiles: [],
+      env: process.env,
+    });
+    assert.equal(ran, false);
+    assert.ok(typeof cursors.migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] === "string");
+    assert.deepEqual(cursors.hourly.buckets, {});
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: adjacent-bucket case — stale jsonl key gets a zero retraction, trace key is rebuilt", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const sid = "sess-rep-adj";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    // jsonl message at 00:15 (bucket …00:00), trace startedAt 00:45 (bucket
+    // …00:30) — the repair must redistribute across adjacent half-hours.
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, jsonlLine({ sessionId: sid, ts: TS_MS }) + "\n");
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(
+      path.join(cbHome, "traces", "1", "trace_adj.json"),
+      JSON.stringify(traceJson({ traceId: "tr-adj", sessionId: sid, startedAt: "2026-07-31T00:45:00.000Z" })),
+    );
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: [{ path: jsonlPath, kind: "jsonl" }], cursors, queuePath, env: process.env });
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [20500]);
+    delete cursors.codebuddy.tracedSessionIds;
+
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+    await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath: null, codebuddyFiles: allFiles, env: process.env });
+
+    const buckets = codebuddyBucketTotals(cursors);
+    assert.equal(buckets.length, 1);
+    assert.ok(buckets[0].key.endsWith("|2026-07-31T00:30:00.000Z"), "only the trace bucket survives");
+    assert.equal(buckets[0].total, 10000);
+
+    // The stale …00:00 jsonl key was deleted locally — the queue must carry a
+    // zero retraction for it so the cloud overwrite-upsert clears it too.
+    const rows = await queueRows(queuePath);
+    const zeroRetractions = rows.filter(
+      (r) => r.source === "codebuddy" && r.total_tokens === 0 && r.hour_start === "2026-07-31T00:00:00.000Z",
+    );
+    assert.equal(zeroRetractions.length, 1, "stale jsonl bucket must be retracted with a zero row");
+    const rebuiltRows = rows.filter((r) => r.source === "codebuddy" && r.total_tokens > 0);
+    assert.equal(rebuiltRows.reduce((s, r) => s + r.total_tokens, 0), 10000);
+  });
+});
+
+test("repairCodebuddyTraceJsonlOverlap: jsonl-only history rebuilds deterministically (no churn without traces)", async () => {
+  await withTempHome(async (home, cbHome) => {
+    const sid = "sess-plain";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, jsonlLine({ sessionId: sid }) + "\n");
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: [{ path: jsonlPath, kind: "jsonl" }], cursors, queuePath, env: process.env });
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [20500]);
+    delete cursors.codebuddy.tracedSessionIds;
+
+    // No traces directory at all — the rebuild must reproduce the same total.
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+    const ran = await repairCodebuddyTraceJsonlOverlap({ cursors, queuePath, queueStatePath: null, codebuddyFiles: allFiles, env: process.env });
+    assert.equal(ran, true);
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [20500], "jsonl-only history is reproduced unchanged");
+  });
+});

--- a/test/codebuddy-traces.test.js
+++ b/test/codebuddy-traces.test.js
@@ -13,23 +13,23 @@ const {
 function traceJson({ traceId, sessionId, startedAt, totalTokens, miInput, miOutput, miCached, model }) {
   return {
     trace: {
-      traceId: traceId || "trace_test_001",
+      traceId: traceId ?? "trace_test_001",
       name: "Agent workflow",
       workerPid: 12345,
       workerHostname: "test",
-      startedAt: startedAt || "2026-07-31T00:00:00.000Z",
+      startedAt: startedAt ?? "2026-07-31T00:00:00.000Z",
       endedAt: "2026-07-31T00:01:00.000Z",
       duration: 60000,
       status: "ok",
       spanCount: 6,
-      totalTokens: totalTokens || 1208838,
-      sessionId: sessionId || "sess-001",
+      totalTokens: totalTokens ?? 1208838,
+      sessionId: sessionId ?? "sess-001",
       agentName: "cli",
       modelInfo: {
-        models: [model || "glm-5.2"],
-        totalInputTokens: miInput || 1206233,
-        totalOutputTokens: miOutput || 2605,
-        totalCachedTokens: miCached || 1196800,
+        models: [model ?? "glm-5.2"],
+        totalInputTokens: miInput ?? 1206233,
+        totalOutputTokens: miOutput ?? 2605,
+        totalCachedTokens: miCached ?? 1196800,
         lastCallInputTokens: 1206233,
         callCount: 6,
       },
@@ -40,21 +40,23 @@ function traceJson({ traceId, sessionId, startedAt, totalTokens, miInput, miOutp
 
 // JSONL fixture: a single assistant message with providerData.rawUsage.
 function jsonlLine({ ts, uuid, sessionId, promptTokens, completionTokens, cachedTokens, reasoningTokens, model }) {
+  const pt = promptTokens ?? 71161;
+  const ct = completionTokens ?? 2305;
   return JSON.stringify({
-    id: uuid || "msg-001",
-    timestamp: ts || 1753900800000,
+    id: uuid ?? "msg-001",
+    timestamp: ts ?? 1753900800000,
     type: "message",
     role: "assistant",
-    sessionId: sessionId || "sess-001",
+    sessionId: sessionId ?? "sess-001",
     content: [{ type: "output_text", text: "..." }],
     providerData: {
-      model: model || "glm-5.2",
+      model: model ?? "glm-5.2",
       rawUsage: {
-        prompt_tokens: promptTokens || 71161,
-        completion_tokens: completionTokens || 2305,
-        total_tokens: (promptTokens || 71161) + (completionTokens || 2305),
-        prompt_tokens_details: { cached_tokens: cachedTokens || 62656, reasoning_tokens: 0 },
-        completion_tokens_details: { reasoning_tokens: reasoningTokens || 999 },
+        prompt_tokens: pt,
+        completion_tokens: ct,
+        total_tokens: pt + ct,
+        prompt_tokens_details: { cached_tokens: cachedTokens ?? 62656, reasoning_tokens: 0 },
+        completion_tokens_details: { reasoning_tokens: reasoningTokens ?? 999 },
       },
     },
   });
@@ -74,7 +76,7 @@ async function withTempHome(fn) {
   } finally {
     process.env.HOME = saved.HOME;
     process.env.USERPROFILE = saved.USERPROFILE;
-    if (saved.CODEX_HOME === undefined) delete process.env.CODEBUDDY_HOME;
+    if (saved.CODEBUDDY_HOME === undefined) delete process.env.CODEBUDDY_HOME;
     else process.env.CODEBUDDY_HOME = saved.CODEBUDDY_HOME;
     await fs.rm(home, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/codebuddy-traces.test.js
+++ b/test/codebuddy-traces.test.js
@@ -1,0 +1,176 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  resolveCodebuddyProjectFiles,
+  parseCodebuddyIncremental,
+} = require("../src/lib/rollout");
+
+// Trace JSON fixture: a single finalized trace with modelInfo breakdown.
+function traceJson({ traceId, sessionId, startedAt, totalTokens, miInput, miOutput, miCached, model }) {
+  return {
+    trace: {
+      traceId: traceId || "trace_test_001",
+      name: "Agent workflow",
+      workerPid: 12345,
+      workerHostname: "test",
+      startedAt: startedAt || "2026-07-31T00:00:00.000Z",
+      endedAt: "2026-07-31T00:01:00.000Z",
+      duration: 60000,
+      status: "ok",
+      spanCount: 6,
+      totalTokens: totalTokens || 1208838,
+      sessionId: sessionId || "sess-001",
+      agentName: "cli",
+      modelInfo: {
+        models: [model || "glm-5.2"],
+        totalInputTokens: miInput || 1206233,
+        totalOutputTokens: miOutput || 2605,
+        totalCachedTokens: miCached || 1196800,
+        lastCallInputTokens: 1206233,
+        callCount: 6,
+      },
+    },
+    spans: [],
+  };
+}
+
+// JSONL fixture: a single assistant message with providerData.rawUsage.
+function jsonlLine({ ts, uuid, sessionId, promptTokens, completionTokens, cachedTokens, reasoningTokens, model }) {
+  return JSON.stringify({
+    id: uuid || "msg-001",
+    timestamp: ts || 1753900800000,
+    type: "message",
+    role: "assistant",
+    sessionId: sessionId || "sess-001",
+    content: [{ type: "output_text", text: "..." }],
+    providerData: {
+      model: model || "glm-5.2",
+      rawUsage: {
+        prompt_tokens: promptTokens || 71161,
+        completion_tokens: completionTokens || 2305,
+        total_tokens: (promptTokens || 71161) + (completionTokens || 2305),
+        prompt_tokens_details: { cached_tokens: cachedTokens || 62656, reasoning_tokens: 0 },
+        completion_tokens_details: { reasoning_tokens: reasoningTokens || 999 },
+      },
+    },
+  });
+}
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-cb-traces-"));
+  const saved = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    CODEBUDDY_HOME: process.env.CODEBUDDY_HOME,
+  };
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    return await fn(home);
+  } finally {
+    process.env.HOME = saved.HOME;
+    process.env.USERPROFILE = saved.USERPROFILE;
+    if (saved.CODEX_HOME === undefined) delete process.env.CODEBUDDY_HOME;
+    else process.env.CODEBUDDY_HOME = saved.CODEBUDDY_HOME;
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test("resolveCodebuddyProjectFiles discovers trace_*.json under traces/<pid>/", async () => {
+  await withTempHome(async (home) => {
+    const codebuddyHome = path.join(home, ".codebuddy");
+    const tracesDir = path.join(codebuddyHome, "traces", "12345");
+    await fs.mkdir(tracesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tracesDir, "trace_abc.json"),
+      JSON.stringify(traceJson({})),
+    );
+    // Also create a non-trace json to ensure it's skipped.
+    await fs.writeFile(path.join(tracesDir, "other.json"), "{}");
+
+    const files = resolveCodebuddyProjectFiles({ CODEBUDDY_HOME: codebuddyHome });
+    const traceFiles = files.filter((f) => typeof f === "object" && f.kind === "trace");
+    assert.equal(traceFiles.length, 1, "exactly one trace file");
+    assert.ok(traceFiles[0].path.endsWith("trace_abc.json"));
+  });
+});
+
+test("parseCodebuddyIncremental: trace is counted once, second run is idempotent", async () => {
+  await withTempHome(async (home) => {
+    const codebuddyHome = path.join(home, ".codebuddy");
+    const tracesDir = path.join(codebuddyHome, "traces", "12345");
+    await fs.mkdir(tracesDir, { recursive: true });
+    const tracePath = path.join(tracesDir, "trace_abc.json");
+    await fs.writeFile(tracePath, JSON.stringify(traceJson({ traceId: "trace_dup_001" })));
+
+    const queuePath = path.join(home, "queue.jsonl");
+    const cursors = { codebuddy: {}, hourly: { version: 1, buckets: {}, groupQueued: {} } };
+
+    // First parse.
+    const r1 = await parseCodebuddyIncremental({
+      cursors,
+      queuePath,
+      env: { CODEBUDDY_HOME: codebuddyHome, HOME: home, USERPROFILE: home },
+    });
+    assert.ok(r1.eventsAggregated > 0, "first run aggregates events");
+
+    // Second parse — should be idempotent (traceId dedup).
+    const r2 = await parseCodebuddyIncremental({
+      cursors,
+      queuePath,
+      env: { CODEBUDDY_HOME: codebuddyHome, HOME: home, USERPROFILE: home },
+    });
+    assert.equal(r2.eventsAggregated, 0, "second run adds nothing (traceId dedup)");
+  });
+});
+
+test("parseCodebuddyIncremental: session with BOTH trace and jsonl is counted once (no double-count)", async () => {
+  await withTempHome(async (home) => {
+    const codebuddyHome = path.join(home, ".codebuddy");
+    const tracesDir = path.join(codebuddyHome, "traces", "12345");
+    const projectsDir = path.join(codebuddyHome, "projects", "cwd-1");
+    await fs.mkdir(tracesDir, { recursive: true });
+    await fs.mkdir(projectsDir, { recursive: true });
+
+    const sessionId = "sess-both-001";
+    // Trace: totalTokens = 10000
+    await fs.writeFile(
+      path.join(tracesDir, "trace_both.json"),
+      JSON.stringify(traceJson({
+        traceId: "trace_both_001",
+        sessionId,
+        totalTokens: 10000,
+        miInput: 9000,
+        miOutput: 1000,
+        miCached: 5000,
+      })),
+    );
+    // JSONL: same sessionId, rawUsage with prompt_tokens=20000
+    await fs.writeFile(
+      path.join(projectsDir, `${sessionId}.jsonl`),
+      jsonlLine({ sessionId, promptTokens: 20000, completionTokens: 500, cachedTokens: 0 }) + "\n",
+    );
+
+    const queuePath = path.join(home, "queue.jsonl");
+    const cursors = { codebuddy: {}, hourly: { version: 1, buckets: {}, groupQueued: {} } };
+
+    await parseCodebuddyIncremental({
+      cursors,
+      queuePath,
+      env: { CODEBUDDY_HOME: codebuddyHome, HOME: home, USERPROFILE: home },
+    });
+
+    // Read queue — the jsonl message should have been skipped (tracedSessionIds).
+    const queueContent = await fs.readFile(queuePath, "utf8").catch(() => "");
+    const records = queueContent.trim() ? queueContent.trim().split("\n").map((l) => JSON.parse(l)) : [];
+    // Trace contributes 10000 total (miInput + miOutput = 9000 + 1000).
+    // JSONL contributes 0 (skipped by tracedSessionIds).
+    // If double-counted, total would be 10000 + 20500 = 30500.
+    const totalTokens = records.reduce((s, r) => s + (r.total_tokens || 0), 0);
+    assert.equal(totalTokens, 10000, "trace + jsonl same session = counted once (trace wins)");
+  });
+});

--- a/test/codebuddy-upgrade-fixtures.test.js
+++ b/test/codebuddy-upgrade-fixtures.test.js
@@ -1,0 +1,285 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+
+const {
+  resolveCodebuddyProjectFiles,
+  parseCodebuddyIncremental,
+  resolveWorkbuddyProjectFiles,
+  parseWorkbuddyIncremental,
+} = require("../src/lib/rollout");
+const {
+  repairCodebuddyTraceJsonlOverlap,
+  CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY,
+} = require("../src/commands/sync");
+
+// PR #399 upgrade-fixture regression suite. One test per blocker, each
+// replaying the exact upgrade scenario that motivated the fix:
+//   a. Blocker #1 — pre-tracedSessionIds cursors already hold jsonl-only
+//      buckets; after upgrade the trace for the same session appears. The
+//      one-time repair must rebuild history to the trace-authoritative value.
+//   b. Blocker #2 — WorkBuddy fresh install ingests a session's trace AND
+//      jsonl in one run; tracedSessionIds must suppress the jsonl branch.
+//   c. Blocker #3 — legacy CodeBuddy (no traces/, jsonl without rawUsage)
+//      must auto-enable the extension-log fallback instead of going silent.
+
+const ENV_KEYS = [
+  "HOME", "USERPROFILE", "CODEBUDDY_HOME", "WORKBUDDY_HOME",
+  "APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+  "TOKENTRACKER_CODEBUDDY_LOG_FALLBACK",
+];
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-upgrade-fix-"));
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.APPDATA = path.join(home, "AppData", "Roaming");
+    process.env.LOCALAPPDATA = path.join(home, "AppData", "Local");
+    process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+    process.env.XDG_DATA_HOME = path.join(home, ".local", "share");
+    delete process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    delete process.env.CODEBUDDY_HOME;
+    delete process.env.WORKBUDDY_HOME;
+    return await fn(home);
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+// Both the jsonl message ts and the trace startedAt land inside the same
+// half-hour bucket (…00:00) so the pre-fix double count hits one bucket.
+const HALF_HOUR = "2026-07-31T00:00:00.000Z";
+const TS_MS = Date.parse("2026-07-31T00:15:00.000Z");
+
+function cbTraceJson({ traceId, sessionId, startedAt, totalTokens }) {
+  return {
+    trace: {
+      traceId: traceId ?? "tr-upg-001",
+      sessionId: sessionId ?? "sess-upg-001",
+      startedAt: startedAt ?? HALF_HOUR,
+      endedAt: "2026-07-31T00:01:00.000Z",
+      status: "ok",
+      totalTokens: totalTokens ?? 10000,
+      modelInfo: { models: ["glm-5.2"], totalInputTokens: 9000, totalOutputTokens: 1000, totalCachedTokens: 5000 },
+    },
+    spans: [],
+  };
+}
+
+// Modern CodeBuddy jsonl: assistant message carrying providerData.rawUsage.
+function cbJsonlLine({ id, ts, sessionId, promptTokens, completionTokens }) {
+  const pt = promptTokens ?? 20000;
+  const ct = completionTokens ?? 500;
+  return JSON.stringify({
+    id: id ?? "m-upg-1",
+    timestamp: ts ?? TS_MS,
+    type: "message",
+    role: "assistant",
+    sessionId: sessionId ?? "sess-upg-001",
+    providerData: {
+      model: "glm-5.2",
+      rawUsage: {
+        prompt_tokens: pt,
+        completion_tokens: ct,
+        total_tokens: pt + ct,
+        prompt_tokens_details: { cached_tokens: 0, reasoning_tokens: 0 },
+        completion_tokens_details: { reasoning_tokens: 0 },
+      },
+    },
+  });
+}
+
+function codebuddyBucketTotals(cursors) {
+  return Object.keys(cursors.hourly?.buckets || {})
+    .filter((k) => k.startsWith("codebuddy|"))
+    .sort()
+    .map((k) => ({ key: k, total: cursors.hourly.buckets[k].totals.total_tokens }));
+}
+
+async function queueTotal(queuePath, source) {
+  let raw = "";
+  try { raw = await fs.readFile(queuePath, "utf8"); } catch { return 0; }
+  let sum = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    if (row.source === source) sum += row.total_tokens;
+  }
+  return sum;
+}
+
+test("Blocker #1 upgrade: legacy jsonl bucket 20500 is rebuilt to the trace-only 10000", async () => {
+  await withTempHome(async (home) => {
+    const cbHome = path.join(home, ".codebuddy");
+    process.env.CODEBUDDY_HOME = cbHome;
+    const sid = "sess-upg-001";
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    const jsonlPath = path.join(cbHome, "projects", "p", `${sid}.jsonl`);
+    await fs.writeFile(jsonlPath, cbJsonlLine({ sessionId: sid }) + "\n");
+
+    // Simulate the LEGACY (pre-tracedSessionIds) state: parse jsonl-only so
+    // the 20500 bucket exists, then drop tracedSessionIds from the cursor.
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({
+      projectFiles: [{ path: jsonlPath, kind: "jsonl" }],
+      cursors,
+      queuePath,
+      env: process.env,
+    });
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [20500], "legacy bucket is 20500");
+    delete cursors.codebuddy.tracedSessionIds;
+
+    // Upgrade: the trace file for the SAME session appears on disk.
+    await fs.mkdir(path.join(cbHome, "traces", "1"), { recursive: true });
+    await fs.writeFile(
+      path.join(cbHome, "traces", "1", "trace_upg.json"),
+      JSON.stringify(cbTraceJson({ sessionId: sid })),
+    );
+
+    // The one-time repair runs before the regular parse inside sync.
+    const allFiles = resolveCodebuddyProjectFiles(process.env);
+    const ran = await repairCodebuddyTraceJsonlOverlap({
+      cursors,
+      queuePath,
+      queueStatePath: null,
+      codebuddyFiles: allFiles,
+      env: process.env,
+    });
+    assert.equal(ran, true, "repair must run on first post-upgrade sync");
+
+    // Trace is authoritative: the stale jsonl contribution is rolled back,
+    // NOT stacked (pre-fix would yield 30500).
+    assert.deepEqual(
+      codebuddyBucketTotals(cursors).map((b) => b.total),
+      [10000],
+      "bucket rebuilt to the trace-only value (trace wins over legacy jsonl)",
+    );
+    assert.equal(await queueTotal(queuePath, "codebuddy"), 10000, "queue holds no stale 20500 rows");
+    assert.ok(
+      typeof cursors.migrations[CODEBUDDY_TRACE_OVERLAP_REPAIR_KEY] === "string",
+      "completion sentinel persisted",
+    );
+
+    // Same-sync regular parse converges: rebuilt fileOffsets sit at EOF.
+    const after = await parseCodebuddyIncremental({ projectFiles: allFiles, cursors, queuePath, env: process.env });
+    assert.equal(after.eventsAggregated, 0, "same-sync parse is a no-op after repair");
+    assert.deepEqual(codebuddyBucketTotals(cursors).map((b) => b.total), [10000]);
+  });
+});
+
+test("Blocker #2 upgrade: workbuddy session with BOTH trace and jsonl is counted once", async () => {
+  await withTempHome(async (home) => {
+    const wbHome = path.join(home, ".workbuddy");
+    process.env.WORKBUDDY_HOME = wbHome;
+    const sid = "sess-both-001";
+    await fs.mkdir(path.join(wbHome, "traces", "12345"), { recursive: true });
+    await fs.mkdir(path.join(wbHome, "projects", "cwd-1"), { recursive: true });
+
+    // Trace: totalTokens = 10000 (9000 - 5000 cached + 1000 out + 5000 cached).
+    await fs.writeFile(
+      path.join(wbHome, "traces", "12345", "trace_both.json"),
+      JSON.stringify({
+        trace: {
+          traceId: "trace_both_001",
+          sessionId: sid,
+          startedAt: HALF_HOUR,
+          endedAt: "2026-07-31T00:01:00.000Z",
+          status: "ok",
+          totalTokens: 10000,
+          modelInfo: { models: ["glm-5.2"], totalInputTokens: 9000, totalOutputTokens: 1000, totalCachedTokens: 5000 },
+        },
+        spans: [],
+      }),
+    );
+    // Same session's jsonl: rawUsage prompt 20000 + completion 500 = 20500.
+    await fs.writeFile(
+      path.join(wbHome, "projects", "cwd-1", `${sid}.jsonl`),
+      JSON.stringify({
+        id: "m-wb-1",
+        timestamp: TS_MS,
+        sessionId: sid,
+        providerData: {
+          model: "glm-5.2",
+          rawUsage: { prompt_tokens: 20000, completion_tokens: 500, total_tokens: 20500 },
+        },
+      }) + "\n",
+    );
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseWorkbuddyIncremental({
+      projectFiles: resolveWorkbuddyProjectFiles(process.env),
+      cursors,
+      queuePath,
+      env: process.env,
+    });
+
+    // Double-counted would be 10000 + 20500 = 30500; trace must win.
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 10000, "trace + jsonl same session = counted once");
+    assert.ok(
+      Array.isArray(cursors.workbuddy.tracedSessionIds) && cursors.workbuddy.tracedSessionIds.includes(sid),
+      "tracedSessionIds persists the trace-covered session",
+    );
+  });
+});
+
+test("Blocker #3 upgrade: legacy CodeBuddy (no traces, jsonl without rawUsage) collects via extension-log fallback", async () => {
+  await withTempHome(async (home) => {
+    const cbHome = path.join(home, ".codebuddy");
+    process.env.CODEBUDDY_HOME = cbHome;
+    await fs.mkdir(path.join(cbHome, "projects", "p"), { recursive: true });
+    // Pre-2026-04 jsonl shape: providerData carries ONLY the model — no
+    // rawUsage, no top-level usage — so the jsonl branch drops every line.
+    await fs.writeFile(
+      path.join(cbHome, "projects", "p", "sess-old.jsonl"),
+      JSON.stringify({
+        id: "x1",
+        timestamp: TS_MS,
+        type: "message",
+        role: "assistant",
+        sessionId: "sess-old",
+        providerData: { model: "glm-4" },
+      }) + "\n",
+    );
+    // No ~/.codebuddy/traces/ directory at all. The only usage source is the
+    // IDE extension log under the platform log root.
+    let logDir;
+    if (process.platform === "darwin") {
+      logDir = path.join(home, "Library", "Application Support", "Code", "logs", "tencent-cloud.coding-copilot");
+    } else if (process.platform === "win32") {
+      logDir = path.join(process.env.APPDATA, "Code", "logs", "tencent-cloud.coding-copilot");
+    } else {
+      logDir = path.join(process.env.XDG_CONFIG_HOME, "Code", "logs", "tencent-cloud.coding-copilot");
+    }
+    await fs.mkdir(logDir, { recursive: true });
+    await fs.writeFile(
+      path.join(logDir, "codebuddy-extension-log.log"),
+      [
+        "[2026/7/31 00:00:01.000] [info] [CraftInvokableAgent] [agent-1] Model prepared: GLM 5.2 (glm-5.2)",
+        '[2026/7/31 00:00:02.000] [info] [AgentReporter] [agent-1] Agent execution successful with usage: {"inputTokens":3000,"outputTokens":400,"totalTokens":3400}',
+        '[2026/7/31 00:00:03.000] [info] [AgentReporter] [agent-1] Agent execution successful with usage: {"inputTokens":5000,"outputTokens":600,"totalTokens":5600}',
+      ].join("\n") + "\n",
+    );
+
+    // env unset → auto mode must turn the fallback ON for this legacy shape.
+    const files = resolveCodebuddyProjectFiles(process.env);
+    assert.ok(files.some((f) => f.kind === "log"), "auto mode includes extension logs for legacy installs");
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseCodebuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+    assert.equal(await queueTotal(queuePath, "codebuddy"), 9000, "legacy install collects 3400 + 5600 from logs");
+    assert.equal(cursors.codebuddy.logFallback.mode, "auto-on");
+    assert.equal(cursors.codebuddy.logFallback.reason, "no_traces_no_jsonl_usage");
+  });
+});

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -7065,7 +7065,12 @@ test("parseCodebuddyIncremental keeps extension log model across incremental tai
 
 test("resolveCodebuddyProjectFiles walks ~/.codebuddy/projects/<cwd>/*.jsonl and skips others", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-codebuddy-"));
+  const savedLogFallback = process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
   try {
+    // Force-off the extension-log fallback so auto-mode doesn't scan the real
+    // host's CodeBuddyExtension logs (the tmp dir has jsonl files, but the
+    // three-state auto gate would still enable logs if jsonl lacks usage).
+    process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK = "0";
     const projectsDir = path.join(tmp, "projects");
     const cwdA = path.join(projectsDir, "cwd-a");
     const cwdB = path.join(projectsDir, "cwd-b");
@@ -7075,12 +7080,19 @@ test("resolveCodebuddyProjectFiles walks ~/.codebuddy/projects/<cwd>/*.jsonl and
     await fs.writeFile(path.join(cwdA, "ignored.txt"), "");
     await fs.writeFile(path.join(cwdB, "s2.jsonl"), "");
 
-    const files = resolveCodebuddyProjectFiles({ CODEBUDDY_HOME: tmp });
+    const files = resolveCodebuddyProjectFiles({
+      CODEBUDDY_HOME: tmp,
+      // Force-off the extension-log fallback so auto-mode doesn't scan the real
+      // host's CodeBuddyExtension logs.
+      TOKENTRACKER_CODEBUDDY_LOG_FALLBACK: "0",
+    });
     // resolveCodebuddyProjectFiles returns {path, kind} objects (jsonl | trace | log).
     const paths = files.map((f) => (typeof f === "string" ? f : f.path));
     assert.equal(paths.length, 2);
     assert.ok(paths.every((f) => f.endsWith(".jsonl")));
   } finally {
+    if (savedLogFallback === undefined) delete process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK;
+    else process.env.TOKENTRACKER_CODEBUDDY_LOG_FALLBACK = savedLogFallback;
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -7076,8 +7076,10 @@ test("resolveCodebuddyProjectFiles walks ~/.codebuddy/projects/<cwd>/*.jsonl and
     await fs.writeFile(path.join(cwdB, "s2.jsonl"), "");
 
     const files = resolveCodebuddyProjectFiles({ CODEBUDDY_HOME: tmp });
-    assert.equal(files.length, 2);
-    assert.ok(files.every((f) => f.endsWith(".jsonl")));
+    // resolveCodebuddyProjectFiles returns {path, kind} objects (jsonl | trace | log).
+    const paths = files.map((f) => (typeof f === "string" ? f : f.path));
+    assert.equal(paths.length, 2);
+    assert.ok(paths.every((f) => f.endsWith(".jsonl")));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -7230,9 +7232,11 @@ test("resolveWorkbuddyProjectFiles recurses into nested subagent logs and skips 
     await fs.writeFile(path.join(toolResults, "chatcmpl-tool-x.txt"), ""); // must be ignored
 
     const files = resolveWorkbuddyProjectFiles({ WORKBUDDY_HOME: tmp });
-    assert.equal(files.length, 3, "main log + 2 nested subagent logs");
-    assert.ok(files.every((f) => f.endsWith(".jsonl")));
-    assert.ok(files.some((f) => f.includes(path.join("subagents", "agent-aaa.jsonl"))));
+    // resolveWorkbuddyProjectFiles returns {path, kind} objects (jsonl | trace).
+    const paths = files.map((f) => (typeof f === "string" ? f : f.path));
+    assert.equal(paths.length, 3, "main log + 2 nested subagent logs");
+    assert.ok(paths.every((f) => f.endsWith(".jsonl")));
+    assert.ok(paths.some((f) => f.includes(path.join("subagents", "agent-aaa.jsonl"))));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/workbuddy-traces.test.js
+++ b/test/workbuddy-traces.test.js
@@ -1,0 +1,207 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const { test } = require("node:test");
+// child_process is used only for sqlite3 write fixtures; route them through
+// in-process node:sqlite (see helpers/sqlite-write) to avoid per-statement spawns.
+const { sqliteOnlyCp: cp } = require("./helpers/sqlite-write");
+
+const {
+  resolveWorkbuddyProjectFiles,
+  parseWorkbuddyIncremental,
+} = require("../src/lib/rollout");
+
+// PR #399 Blocker #2: WorkBuddy fresh-install double count. A session with
+// BOTH a trace file and a jsonl log was counted twice because the trace
+// branch never recorded trace.sessionId into a tracedSessionIds set (the
+// CodeBuddy equivalent existed). These tests pin the mirrored mechanism:
+// restore, add-after-gates in the trace branch, suppression in BOTH the jsonl
+// branch and the sqlite fallback, and capped persistence.
+
+function traceJson({ traceId, sessionId, startedAt, totalTokens, miInput, miOutput, miCached, model }) {
+  return {
+    trace: {
+      traceId: traceId ?? "trace_test_001",
+      name: "Agent workflow",
+      startedAt: startedAt ?? "2026-07-31T00:00:00.000Z",
+      endedAt: "2026-07-31T00:01:00.000Z",
+      status: "ok",
+      totalTokens: totalTokens ?? 10000,
+      sessionId: sessionId ?? "sess-both-001",
+      modelInfo: {
+        models: [model ?? "glm-5.2"],
+        totalInputTokens: miInput ?? 9000,
+        totalOutputTokens: miOutput ?? 1000,
+        totalCachedTokens: miCached ?? 5000,
+      },
+    },
+    spans: [],
+  };
+}
+
+function jsonlLine({ id, ts, sessionId, promptTokens, completionTokens, model }) {
+  const pt = promptTokens ?? 20000;
+  const ct = completionTokens ?? 500;
+  return JSON.stringify({
+    id: id ?? "m1",
+    timestamp: ts ?? 1753900800000,
+    sessionId: sessionId ?? "sess-both-001",
+    providerData: {
+      model: model ?? "glm-5.2",
+      rawUsage: { prompt_tokens: pt, completion_tokens: ct, total_tokens: pt + ct },
+    },
+  });
+}
+
+async function withTempHome(fn) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-wb-traces-"));
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORKBUDDY_HOME: process.env.WORKBUDDY_HOME };
+  const wbHome = path.join(home, ".workbuddy");
+  try {
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.WORKBUDDY_HOME = wbHome;
+    return await fn(home, wbHome);
+  } finally {
+    process.env.HOME = saved.HOME;
+    process.env.USERPROFILE = saved.USERPROFILE;
+    if (saved.WORKBUDDY_HOME === undefined) delete process.env.WORKBUDDY_HOME;
+    else process.env.WORKBUDDY_HOME = saved.WORKBUDDY_HOME;
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+async function queueTotal(queuePath, source) {
+  let raw = "";
+  try { raw = await fs.readFile(queuePath, "utf8"); } catch { return 0; }
+  let sum = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    if (row.source === source) sum += row.total_tokens;
+  }
+  return sum;
+}
+
+test("parseWorkbuddyIncremental: session with BOTH trace and jsonl is counted once (trace wins)", async () => {
+  await withTempHome(async (home, wbHome) => {
+    await fs.mkdir(path.join(wbHome, "traces", "12345"), { recursive: true });
+    await fs.mkdir(path.join(wbHome, "projects", "cwd-1"), { recursive: true });
+    await fs.writeFile(
+      path.join(wbHome, "traces", "12345", "trace_both.json"),
+      JSON.stringify(traceJson({ traceId: "trace_both_001" })),
+    );
+    await fs.writeFile(
+      path.join(wbHome, "projects", "cwd-1", "sess-both-001.jsonl"),
+      jsonlLine({}) + "\n",
+    );
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    const files = resolveWorkbuddyProjectFiles(process.env);
+    await parseWorkbuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+
+    // trace contributes 9000-5000+1000+5000 = 10000; jsonl would add 20500.
+    // Double-counted would be 30500.
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 10000);
+    assert.ok(
+      Array.isArray(cursors.workbuddy.tracedSessionIds) &&
+        cursors.workbuddy.tracedSessionIds.includes("sess-both-001"),
+      "tracedSessionIds must persist the trace-covered session",
+    );
+
+    // Idempotency: a second run on the same fixture aggregates nothing.
+    const second = await parseWorkbuddyIncremental({ projectFiles: files, cursors, queuePath, env: process.env });
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 10000);
+  });
+});
+
+test("parseWorkbuddyIncremental: trace-covered session is also skipped by the sqlite fallback", async () => {
+  await withTempHome(async (home, wbHome) => {
+    await fs.mkdir(path.join(wbHome, "traces", "12345"), { recursive: true });
+    await fs.writeFile(
+      path.join(wbHome, "traces", "12345", "trace_both.json"),
+      JSON.stringify(traceJson({ traceId: "trace_both_001" })),
+    );
+    // sqlite has cumulative usage for the SAME session. Without the
+    // tracedSessionIds guard in the sqlite loop, suppressing the jsonl branch
+    // would just shift the double count to trace+sqlite.
+    const dbPath = path.join(wbHome, "workbuddy.db");
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      [
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, cwd TEXT, model TEXT);",
+        "CREATE TABLE session_usage (session_id TEXT PRIMARY KEY, used INTEGER, size INTEGER, updated_at INTEGER, credit_json TEXT);",
+        "INSERT INTO sessions VALUES ('sess-both-001','/tmp/project','auto');",
+        "INSERT INTO session_usage VALUES ('sess-both-001',7777,0,1780000000000,'{}');",
+      ].join(" "),
+    ]);
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseWorkbuddyIncremental({
+      projectFiles: resolveWorkbuddyProjectFiles(process.env),
+      cursors,
+      queuePath,
+      env: process.env,
+    });
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 10000);
+  });
+});
+
+test("parseWorkbuddyIncremental: jsonl-only and trace-only sessions are both still counted", async () => {
+  await withTempHome(async (home, wbHome) => {
+    await fs.mkdir(path.join(wbHome, "traces", "1"), { recursive: true });
+    await fs.mkdir(path.join(wbHome, "projects", "cwd-1"), { recursive: true });
+    await fs.writeFile(
+      path.join(wbHome, "traces", "1", "trace_only.json"),
+      JSON.stringify(traceJson({ traceId: "trace_only_001", sessionId: "sess-trace-only" })),
+    );
+    await fs.writeFile(
+      path.join(wbHome, "projects", "cwd-1", "sess-jsonl-only.jsonl"),
+      jsonlLine({ id: "m-j", sessionId: "sess-jsonl-only", promptTokens: 2000, completionTokens: 100 }) + "\n",
+    );
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseWorkbuddyIncremental({
+      projectFiles: resolveWorkbuddyProjectFiles(process.env),
+      cursors,
+      queuePath,
+      env: process.env,
+    });
+    // 10000 (trace) + 2100 (jsonl) — independent sessions, no suppression.
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 12100);
+  });
+});
+
+test("parseWorkbuddyIncremental: zero-token trace does NOT suppress its session's jsonl", async () => {
+  await withTempHome(async (home, wbHome) => {
+    await fs.mkdir(path.join(wbHome, "traces", "9"), { recursive: true });
+    await fs.mkdir(path.join(wbHome, "projects", "c"), { recursive: true });
+    // A trace carrying no usage records only seenTraceIds — the jsonl branch
+    // must remain authoritative for the session. This pins the placement of
+    // tracedSessionIds.add AFTER all usage gates in the trace branch.
+    await fs.writeFile(
+      path.join(wbHome, "traces", "9", "trace_z.json"),
+      JSON.stringify(traceJson({ traceId: "trace_zero", sessionId: "sess-z", totalTokens: 0, miInput: 0, miOutput: 0, miCached: 0 })),
+    );
+    await fs.writeFile(
+      path.join(wbHome, "projects", "c", "sess-z.jsonl"),
+      jsonlLine({ id: "m-z", sessionId: "sess-z", promptTokens: 700, completionTokens: 100 }) + "\n",
+    );
+
+    const cursors = { version: 1 };
+    const queuePath = path.join(home, "queue.jsonl");
+    await parseWorkbuddyIncremental({
+      projectFiles: resolveWorkbuddyProjectFiles(process.env),
+      cursors,
+      queuePath,
+      env: process.env,
+    });
+    assert.equal(await queueTotal(queuePath, "workbuddy"), 800);
+    assert.ok(!cursors.workbuddy.tracedSessionIds.includes("sess-z"));
+  });
+});


### PR DESCRIPTION
## Summary

CodeBuddy CLI writes authoritative token usage to `~/.codebuddy/traces/<pid>/trace_*.json` (and `~/.workbuddy/traces/` for WorkBuddy). Each trace JSON carries `trace.modelInfo.{totalInputTokens, totalOutputTokens, totalCachedTokens, callCount}` with 100% field stability (verified on 286 real traces).

The existing jsonl reader only sees **~10% of messages** — 90% of assistant messages in newer CodeBuddy versions (glm-5.2) lack `providerData.rawUsage` in `~/.codebuddy/projects/**/*.jsonl`. This causes massive undercounting.

Additionally, the extension-log path overlaps with the jsonl path using a different dedup key namespace, causing **3x inflation** when both are active.

## Root cause

1. **Traces dir not scanned** — `resolveCodebuddyProjectFiles` only scanned `projects/` and extension logs, never `traces/`
2. **90% of jsonl messages lack rawUsage** — newer CodeBuddy (glm-5.2) stops writing `providerData.rawUsage` on most assistant messages; token data only exists in traces
3. **Extension-log double-counting** — jsonl and extension-log use different dedup keys (`entry.uuid` vs `codebuddy:extension-log:agentId:sec`), so the same LLM round-trip is counted twice
4. **WorkBuddy rawUsage fallback missing** — older WorkBuddy sessions only write `providerData.model` without `rawUsage`; some carry the camelCase top-level `usage` field instead

## Fix

1. **`resolveCodebuddyProjectFiles`**: scan `traces/` dir, return `{path, kind}` objects (`jsonl | trace | log`)
2. **`parseCodebuddyIncremental`**: add trace JSON branch — read `modelInfo`, dedup by `traceId`, skip jsonl messages for traced sessions (`tracedSessionIds`) to avoid double-counting
3. **`resolveWorkbuddyProjectFiles`**: same `traces/` scan (WorkBuddy is the renamed successor of CodeBuddy, same trace schema)
4. **`parseWorkbuddyIncremental`**: same trace JSON branch
5. **WorkBuddy rawUsage fallback**: when `providerData.rawUsage` is absent, fall back to top-level `usage` field (camelCase convention)
6. **Extension-log parsing**: default disabled (`TOKENTRACKER_CODEBUDDY_LOG_FALLBACK=1` to enable) — overlaps with jsonl, different dedup namespace, causes 3x inflation
7. **File sort order**: trace files sorted before jsonl files so `tracedSessionIds` is populated before jsonl parsing (prevents double-counting sessions with both trace and jsonl)
8. **Reasoning tokens**: read from `completion_tokens_details` (not `prompt_tokens_details`), subtract from `completionTokens` to avoid double-counting
9. **WorkBuddy sqlite fallback**: fix `total_tokens = inputTokens` → `total_tokens = input + output + cacheRead + cacheCreation + reasoning` (pre-existing bug in main)

## Token math (trace branch)

```
input_tokens        = modelInfo.totalInputTokens - modelInfo.totalCachedTokens
cached_input_tokens = modelInfo.totalCachedTokens
output_tokens       = modelInfo.totalOutputTokens
total_tokens        = input + cached + output  (= modelInfo.totalInputTokens + totalOutputTokens)
```

This matches the jsonl branch convention (cached is separate from input).

## Scope

- [x] CLI (`src/lib/rollout.js`)
- [x] Tests (`test/codebuddy-traces.test.js`, `test/rollout-parser.test.js`)

## Verification (real machine, 2026-07-31)

| Metric | Before | After |
|---|---|---|
| codebuddy 7/31 total | 15.3M (jsonl only, 90% missing) | **129.5M** |
| codebuddy 7/31 (traces alone) | — | 103.8M (modelInfo.input + output) |
| 10-day total (codebuddy + workbuddy) | — | **386M** |
| Double-counting | 45.9M (3x inflated) | eliminated (tracedSessionIds dedup) |

## Tests

- `test/codebuddy-traces.test.js`: 3/3 pass (trace discovery, idempotent re-parse, trace+jsonl dedup)
- `test/rollout-parser.test.js`: 230 pass / 1 fail (#154 pre-existing, unrelated)
- `test/install-resolver.test.js`: 28/28 pass
- `test/dual-install-integration.test.js`: 1/1 pass
- `test/codex-wsl-shadow.test.js`: 1/1 pass
- No regression in existing tests

## Commits (6, based on main)

| Commit | Description |
|---|---|
| `db578b1` | Main fix: traces collection + workbuddy rawUsage fallback + extension-log opt-out |
| `fe52757` | Test adaptation for `{path, kind}` return type |
| `cfd0eac` | Fix reasoning double-count, provider null pointer, trace sort order |
| `5039510` | Fix CODEBUDDY_HOME cleanup typo, `??` nullish fallback |
| `8f1be2c` | WorkBuddy `provider.model`/`messageId` optional chaining |
| `6016d91` | WorkBuddy sqlite fallback `total_tokens` formula fix (pre-existing bug) |

## CodeRabbit review

All actionable comments addressed:
- ✅ reasoning double-count (completion_details + subtract)
- ✅ provider null pointer (optional chaining throughout)
- ✅ file sort order (trace before jsonl)
- ✅ trace-specific tests added
- ✅ CODEBUDDY_HOME cleanup typo
- ✅ `||` → `??` nullish fallback
- ✅ Pre-existing sqlite fallback bug fixed

## Checklist

- [x] Commits follow conventional style (`fix:`, `test:`)
- [x] PR description explains *why*, not just *what*
- [x] Verified against authoritative data (traces dir)
- [x] All CodeRabbit actionable comments resolved
- [x] Tests added for new functionality (trace discovery, dedup, idempotency)

## Note

This PR is independent of #397 (codex WSL shadowing fix). Both touch `src/lib/rollout.js` but in different functions (codebuddy/workbuddy collectors vs codex sources builder). If #397 merges first, this should rebase cleanly.