### PR TITLE
fix(macOS): hide Dock icon before dashboard closes

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
@@ -323,10 +323,22 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
     }
 
     func closeWindow() {
+        returnToMenuBarMode()
         window?.performClose(nil)
     }
 
     // MARK: - NSWindowDelegate
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard let window, sender === window else { return true }
+
+        // The Dashboard makes the app a regular app so it can own a primary
+        // window. Switch back before the traffic-light close transition starts:
+        // on recent macOS releases, changing the activation policy from
+        // `windowWillClose` can leave the Dock tile visible until focus changes.
+        returnToMenuBarMode()
+        return true
+    }
 
     func windowWillClose(_ notification: Notification) {
         // Keep webView and window alive so cookies/login state persist.
@@ -338,10 +350,16 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
                 && $0 != closingWindow
             }
             if !hasOtherVisibleWindows {
-                NSApp.setActivationPolicy(.accessory)
                 NSApp.hide(nil)
             }
         }
+    }
+
+    /// Returns the app to its normal menu-bar-agent mode without terminating
+    /// the process, so syncing and the status item keep running.
+    private func returnToMenuBarMode() {
+        guard NSApp.activationPolicy() != .accessory else { return }
+        _ = NSApp.setActivationPolicy(.accessory)
     }
 
     // MARK: - WKScriptMessageHandler


### PR DESCRIPTION
## Summary

Return TokenTracker to menu-bar-agent mode before the Dashboard window closes, so clicking the red close button keeps the app running in the menu bar but removes its Dock icon immediately.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [ ] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no new user-facing strings)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

### Rules / invariants

- Closing the Dashboard must not terminate the menu-bar app, sync process, or local server.
- Opening the Dashboard still promotes the app to `.regular` so it can own a primary window and appear in the Dock.
- Closing via the red traffic-light button must switch to `.accessory` before the close transition begins.

### Boundary matrix

| Path | Expected behavior |
| --- | --- |
| Red close button | Dashboard closes; menu-bar app remains; Dock icon disappears |
| `⌘Q` from Dashboard | Downgraded to Dashboard close; menu-bar app remains |
| Explicit Quit action | App terminates and stops its local server |

## Verification

- `xcodebuild ... -configuration Release build` — passed
- App signature verification — passed
- DMG checksum verification — passed
- Manual test on macOS 26.6 — passed

## Known gaps / out of scope

- The generated Xcode scheme has no Test action configured, so the existing macOS unit-test suite could not be invoked through `xcodebuild test`.
- No Windows or Dashboard behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window closing behavior by restoring menu-bar mode before the window closes.
  * Prevented the app from hiding while other visible windows remain open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->