### PR TITLE
fix(mac): interpolate value/cost in pet limit reset and today-cost strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
           npm ci
           node --test test/openclaw-parser.test.js
 
+      - name: Test macOS native pet limit reset interpolation
+        run: node --test test/native-pet-limit-reset.test.js
+
       - name: Install xcodegen
         run: brew install xcodegen
 

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -212,10 +212,10 @@ enum Strings {
     static var petLimitLow: String { t("low", "余量偏低", "餘量偏低", "残りわずか", "얼마 안 남음") }
     static var petLimitSomeLeft: String { t("some left", "还有余量", "還有餘量", "残りあり", "남아 있음") }
     static func petLimitReset(_ value: String) -> String {
-        t("in (value)", "(value)后重置", "(value)後重置", "(value)でリセット", "(value) 후 초기화")
+        t("in \(value)", "\(value)后重置", "\(value)後重置", "\(value)でリセット", "\(value) 후 초기화")
     }
     static func petCostToday(_ cost: String) -> String {
-        t("(cost) today", "今日 (cost)", "今日 (cost)", "今日 (cost)", "오늘 (cost)")
+        t("\(cost) today", "今日 \(cost)", "今日 \(cost)", "今日 \(cost)", "오늘 \(cost)")
     }
 
 

--- a/test/native-pet-limit-reset.test.js
+++ b/test/native-pet-limit-reset.test.js
@@ -30,14 +30,11 @@ test("native pet reset strings interpolate the supplied reset value", (t) => {
     harnessPath,
     `import Foundation
 
-func fail(_ message: String) -> Never {
-    FileHandle.standardError.write(Data(message.utf8))
-    exit(1)
-}
+var failures: [String] = []
 
 func requireEqual(_ actual: String, _ expected: String, _ locale: String) {
     if actual != expected {
-        fail("\\(locale): expected \\(expected), got \\(actual)\\n")
+        failures.append("\\(locale): expected \\(expected), got \\(actual)")
     }
 }
 
@@ -46,7 +43,7 @@ let cost = "$1.23"
 let sharedDefaults = UserDefaults(suiteName: WidgetSharedConstants.appGroupIdentifier)
 let originalStandardPreference = UserDefaults.standard.object(forKey: NativeLocalization.preferenceKey)
 let originalSharedPreference = sharedDefaults?.object(forKey: NativeLocalization.preferenceKey)
-defer {
+func restorePreferences() {
     if let originalStandardPreference {
         UserDefaults.standard.set(originalStandardPreference, forKey: NativeLocalization.preferenceKey)
     } else {
@@ -58,6 +55,7 @@ defer {
         sharedDefaults?.removeObject(forKey: NativeLocalization.preferenceKey)
     }
 }
+defer { restorePreferences() }
 let cases = [
     (NativeLocalization.englishLocale, "in \\(value)", "\\(cost) today"),
     (NativeLocalization.chineseLocale, "\\(value)后重置", "今日 \\(cost)"),
@@ -70,6 +68,11 @@ for (locale, expected, expectedCost) in cases {
     NativeLocalization.storePreference(locale)
     requireEqual(Strings.petLimitReset(value), expected, locale)
     requireEqual(Strings.petCostToday(cost), expectedCost, "\\(locale) cost")
+}
+if !failures.isEmpty {
+    restorePreferences()
+    FileHandle.standardError.write(Data(failures.joined(separator: "\\n").appending("\\n").utf8))
+    exit(1)
 }
 `,
     "utf8",

--- a/test/native-pet-limit-reset.test.js
+++ b/test/native-pet-limit-reset.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const repoPath = (relativePath) => path.join(__dirname, "..", relativePath);
+
+test("native pet reset strings interpolate the supplied reset value", (t) => {
+  if (process.platform !== "darwin") {
+    t.skip("requires macOS Swift runtime");
+    return;
+  }
+
+  const swiftc = spawnSync("xcrun", ["--find", "swiftc"], { encoding: "utf8" });
+  if (swiftc.status !== 0) {
+    t.skip("requires xcrun swiftc");
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-pet-reset-"));
+  const harnessPath = path.join(tempDir, "main.swift");
+  const binaryPath = path.join(tempDir, "pet-reset");
+  const value = "8/12 05:09";
+
+  fs.writeFileSync(
+    harnessPath,
+    `import Foundation
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data(message.utf8))
+    exit(1)
+}
+
+func requireEqual(_ actual: String, _ expected: String, _ locale: String) {
+    if actual != expected {
+        fail("\\(locale): expected \\(expected), got \\(actual)\\n")
+    }
+}
+
+let value = "${value}"
+let cost = "$1.23"
+let sharedDefaults = UserDefaults(suiteName: WidgetSharedConstants.appGroupIdentifier)
+let originalStandardPreference = UserDefaults.standard.object(forKey: NativeLocalization.preferenceKey)
+let originalSharedPreference = sharedDefaults?.object(forKey: NativeLocalization.preferenceKey)
+defer {
+    if let originalStandardPreference {
+        UserDefaults.standard.set(originalStandardPreference, forKey: NativeLocalization.preferenceKey)
+    } else {
+        UserDefaults.standard.removeObject(forKey: NativeLocalization.preferenceKey)
+    }
+    if let originalSharedPreference {
+        sharedDefaults?.set(originalSharedPreference, forKey: NativeLocalization.preferenceKey)
+    } else {
+        sharedDefaults?.removeObject(forKey: NativeLocalization.preferenceKey)
+    }
+}
+let cases = [
+    (NativeLocalization.englishLocale, "in \\(value)", "\\(cost) today"),
+    (NativeLocalization.chineseLocale, "\\(value)后重置", "今日 \\(cost)"),
+    (NativeLocalization.traditionalChineseLocale, "\\(value)後重置", "今日 \\(cost)"),
+    (NativeLocalization.japaneseLocale, "\\(value)でリセット", "今日 \\(cost)"),
+    (NativeLocalization.koreanLocale, "\\(value) 후 초기화", "오늘 \\(cost)"),
+]
+
+for (locale, expected, expectedCost) in cases {
+    NativeLocalization.storePreference(locale)
+    requireEqual(Strings.petLimitReset(value), expected, locale)
+    requireEqual(Strings.petCostToday(cost), expectedCost, "\\(locale) cost")
+}
+`,
+    "utf8",
+  );
+
+  try {
+    const build = spawnSync(
+      "xcrun",
+      [
+        "swiftc",
+        repoPath("TokenTrackerBar/Shared/WidgetSnapshot.swift"),
+        repoPath("TokenTrackerBar/Shared/NativeLocalization.swift"),
+        repoPath("TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift"),
+        repoPath("TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift"),
+        repoPath("TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift"),
+        harnessPath,
+        "-o",
+        binaryPath,
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(build.status, 0, build.stderr || build.stdout);
+
+    const run = spawnSync(binaryPath, [], { encoding: "utf8" });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

The desktop pet bubble on macOS showed the literal text `(value)` and `(cost)` instead of the actual usage-limit reset time and daily cost. `Strings.petLimitReset(_:)` and `Strings.petCostToday(_:)` accept a parameter but passed it to `t()` as the literal string `"(value)"` / `"(cost)"` — never as Swift string interpolation — so `t()` returned that text verbatim across all five locales.

This switches both helpers to Swift string interpolation `\\(value)` / `\_(cost)` in every locale column (en / zh-CN / zh-TW / ja / ko), matching the interpolation style already used elsewhere in `Strings.swift` (e.g. `"\(subject) limit reset 🎉"`). It also adds a native test that compiles `Strings.swift` with a harness, cycles each locale preference, and asserts the interpolated output for both functions across all five locales.

**Before** (zh-CN): `(value)后重置` and `今日 (cost)`
**After** (zh-CN): `8/12 05:09后重置` and `今日 $1.23`

## Scope

- [x] macOS app (`TokenTrackerBar/`)

## Checklist

- [x] Commits follow conventional style (`fix:`)
- [x] PR description explains *why*, not just *what*
- [x] No new user-facing strings (existing strings corrected, no `copy.csv` change needed)

## Verification

- `node --test test/pet-parity.test.js` — 16/16 pass (no cross-platform parity regression).
- The new `test/native-pet-limit-reset.test.js` compiles `Strings.swift` + a harness via `xcrun swiftc` and asserts all five locales. It is macOS-only and skips cleanly on other platforms / when `swiftc` is missing.

## Limitations

- **The macOS app was not built or run locally.** Verification is limited to the native test harness, which compiles the relevant Swift sources (`Strings.swift`, `NativeLocalization.swift`, `WidgetSnapshot.swift`, `MenuBarDisplayPreferences.swift`, `UsageLimits.swift`) directly with `swiftc` rather than building the full Xcode project. A full `xcodegen generate` + Xcode build was not performed, so visual confirmation of the pet bubble in the running app is still pending from a maintainer (or a local build on macOS).
- The fix is a two-line string-interpolation correction with no logic change, so the regression surface is intentionally narrow.

## Repro

Open the macOS menu-bar pet while a provider has an active usage limit. The reset line reads `(value)后重置` / `in (value)` instead of the real reset time, and the today-cost line reads `今日 (cost)` instead of the real cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pet limit reset and daily pet cost messages to display the relevant values instead of placeholder text.

* **Tests**
  * Added macOS coverage for localized pet reset and cost messages in English, Simplified Chinese, Traditional Chinese, Japanese, and Korean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->