### PR TITLE
fix: correct gpt-5.6 luna/terra short-context pricing

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -171,8 +171,8 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
   "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
-  "gpt-5.6-terra": { input: 2.5, output: 15, cache_read: 0.25, cache_write: 3.125 },
-  "gpt-5.6-luna": { input: 1, output: 6, cache_read: 0.1, cache_write: 1.25 },
+  "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
   "o3": { input: 2, output: 8, cache_read: 0.5 },
   // ── Google Gemini ──

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -147,8 +147,8 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
   "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
-  "gpt-5.6-terra": { input: 2.5, output: 15, cache_read: 0.25, cache_write: 3.125 },
-  "gpt-5.6-luna": { input: 1, output: 6, cache_read: 0.1, cache_write: 1.25 },
+  "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
   "o3": { input: 2, output: 8, cache_read: 0.5 },
   // ── Google Gemini ──

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -172,8 +172,8 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
   "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
-  "gpt-5.6-terra": { input: 2.5, output: 15, cache_read: 0.25, cache_write: 3.125 },
-  "gpt-5.6-luna": { input: 1, output: 6, cache_read: 0.1, cache_write: 1.25 },
+  "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
   "o3": { input: 2, output: 8, cache_read: 0.5 },
   // ── Google Gemini ──

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -144,8 +144,8 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
   "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
-  "gpt-5.6-terra": { input: 2.5, output: 15, cache_read: 0.25, cache_write: 3.125 },
-  "gpt-5.6-luna": { input: 1, output: 6, cache_read: 0.1, cache_write: 1.25 },
+  "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
   "o3": { input: 2, output: 8, cache_read: 0.5 },
   // ── Google Gemini ──

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -167,8 +167,8 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
   "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
-  "gpt-5.6-terra": { input: 2.5, output: 15, cache_read: 0.25, cache_write: 3.125 },
-  "gpt-5.6-luna": { input: 1, output: 6, cache_read: 0.1, cache_write: 1.25 },
+  "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
+  "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
   "o3": { input: 2, output: 8, cache_read: 0.5 },
   // ── Google Gemini ──

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -52,21 +52,21 @@
       "output": 30,
       "cache_read": 0.5,
       "cache_write": 6.25,
-      "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it."
+      "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing short-context: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it."
     },
     "gpt-5.6-terra": {
-      "input": 2.5,
-      "output": 15,
-      "cache_read": 0.25,
-      "cache_write": 3.125,
-      "note": "GPT-5.6 balanced default tier. See gpt-5.6-sol."
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2,
+      "cache_write": 2.5,
+      "note": "GPT-5.6 balanced default tier. Official short-context rates: $2/$12 per MTok (not the earlier $2.5/$15 snapshot). See gpt-5.6-sol."
     },
     "gpt-5.6-luna": {
-      "input": 1,
-      "output": 6,
-      "cache_read": 0.1,
-      "cache_write": 1.25,
-      "note": "GPT-5.6 lightweight/cost-efficient tier. See gpt-5.6-sol."
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02,
+      "cache_write": 0.25,
+      "note": "GPT-5.6 lightweight tier. Official short-context rates: $0.20/$1.20 per MTok (previous curated values $1/$6 overcounted 5x). See gpt-5.6-sol."
     },
     "kiro-agent": {
       "input": 3,

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -130,14 +130,14 @@ test("matcher: GPT-5.6 codex tiers resolve to their real curated rates (not the 
   const litellm = { "gpt-5": { input: 1.25, output: 10, cache_read: 0.125 } };
   const cases = [
     ["gpt-5.6-sol", 5, 30, "curated:exact"],
-    ["gpt-5.6-terra", 2.5, 15, "curated:exact"],
-    ["gpt-5.6-luna", 1, 6, "curated:exact"],
+    ["gpt-5.6-terra", 2, 12, "curated:exact"],
+    ["gpt-5.6-luna", 0.2, 1.2, "curated:exact"],
     // reasoning-effort variants codex appends must still land on the right tier
     ["gpt-5.6-sol-high", 5, 30, null],
     ["gpt-5.6-solhigh", 5, 30, "curated:fuzzy"],
-    ["gpt-5.6-terrahigh", 2.5, 15, "curated:fuzzy"],
+    ["gpt-5.6-terrahigh", 2, 12, "curated:fuzzy"],
     // bare / unknown-tier falls back to the balanced terra tier, never gpt-5
-    ["gpt-5.6", 2.5, 15, "curated:fuzzy"],
+    ["gpt-5.6", 2, 12, "curated:fuzzy"],
   ];
   for (const [model, input, output, source] of cases) {
     const r = matcher.lookupPricing(model, { curated, litellm, source: "codex" });


### PR DESCRIPTION
## Summary

- Fix curated **gpt-5.6-luna** rates: `$1/$6` → **`$0.20/$1.20`** (was ~5× high)
- Fix curated **gpt-5.6-terra** rates: `$2.5/$15` → **`$2/$12`** (was ~1.25× high)
- Keep **gpt-5.6-sol** at `$5/$30` (already correct)
- Mirror the same values in all 5 edge `MODEL_PRICING` blocks (parity-tested)

Closes #417

## Why

TokenTracker bills GPT-5.6 entirely from curated overrides (not yet in LiteLLM). The luna/terra entries no longer match [OpenAI short-context list prices](https://developers.openai.com/api/docs/pricing) or OMP/`@oh-my-pi/pi-catalog` rates, so local cost for those models was inflated.

| Model | Field | Before | After (OpenAI / OMP) |
|-------|-------|--------|----------------------|
| luna | input / output | 1 / 6 | **0.2 / 1.2** |
| luna | cache_read / cache_write | 0.1 / 1.25 | **0.02 / 0.25** |
| terra | input / output | 2.5 / 15 | **2 / 12** |
| terra | cache_read / cache_write | 0.25 / 3.125 | **0.2 / 2.5** |
| sol | input / output | 5 / 30 | 5 / 30 (unchanged) |

## Test plan

- [x] `node --test test/pricing.test.js test/edge-pricing-parity.test.js` (51 pass)
- [x] Confirmed edge pricing blocks stay byte-identical across the 5 edge files
- [ ] After merge: redeploy touched edge functions so cloud cost paths pick up the new rates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reduced GPT-5.6 Terra and Luna pricing across input, output, and cached token usage.
  * Updated pricing displays and account usage calculations to reflect the revised rates.
  * Clarified the GPT-5.6 Sol short-context pricing note.

* **Bug Fixes**
  * Corrected pricing fallbacks so model aliases and usage summaries consistently use the updated rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->