### PR TITLE
fix(mac): animate Dynamic Island toggle transitions

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -42,3 +42,44 @@ enum DynamicIslandInteractionPolicy {
         hovering && pointerInsideInteractiveRegion
     }
 }
+
+/// Timing and geometry for the island's centered visibility mask.
+enum DynamicIslandVisibilityPolicy {
+    static let showDuration: Double = 0.28
+    static let hideDuration: Double = 0.28
+    /// Lets SwiftUI commit the hidden frame before the panel leaves.
+    static let hideSettleDelay: Double = 0.05
+    static var hideCompletionDelay: Double { hideDuration + hideSettleDelay }
+    static let centerPointWidth: CGFloat = 1
+
+    static func revealWidth(
+        progress: CGFloat,
+        fullWidth: CGFloat,
+        centerGapWidth: CGFloat,
+        hasNotch: Bool,
+        isDismissing: Bool = false
+    ) -> CGFloat {
+        let full = max(0, fullWidth)
+        // The close endpoint must clear the notch's rounded lower corners.
+        let hiddenWidth = hasNotch && !isDismissing
+            ? max(0, centerGapWidth)
+            : centerPointWidth
+        let start = min(full, hiddenWidth)
+        let clampedProgress = min(1, max(0, progress))
+        return start + (full - start) * clampedProgress
+    }
+}
+
+/// Rejects stale delayed completions after rapid toggles.
+struct DynamicIslandVisibilityTransitionTracker {
+    private(set) var current = 0
+
+    mutating func begin() -> Int {
+        current &+= 1
+        return current
+    }
+
+    func owns(_ transition: Int) -> Bool {
+        transition == current
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -88,6 +88,10 @@ struct DynamicIslandGeometry: Equatable {
 @MainActor
 final class DynamicIslandState: ObservableObject {
     @Published var isExpanded = false
+    /// 0 = hidden, 1 = fully revealed through a centered mask.
+    @Published var visibilityProgress: CGFloat = 0
+    /// Selects the center-point endpoint while closing.
+    @Published var isVisibilityDismissing = false
     @Published var geometry = DynamicIslandGeometry.simulated
     /// Actual rendered height of the expanded island, reported by the SwiftUI
     /// view's GeometryReader after layout. Drives the expanded hit-test rect so
@@ -129,6 +133,10 @@ final class DynamicIslandController: NSObject {
     /// hit-test wrapper).
     private var hostingController: NSHostingController<DynamicIslandView>?
     private var collapseWorkItem: DispatchWorkItem?
+    private var visibilityWorkItem: DispatchWorkItem?
+    private var visibilityTransitions = DynamicIslandVisibilityTransitionTracker()
+    /// Keeps the transparent panel click-through during transitions.
+    private var acceptsIslandInteraction = false
     private var observers: [NSObjectProtocol] = []
     /// While > 0 a tray menu spawned from the island is open; hover-out must
     /// not collapse the island under the menu.
@@ -155,6 +163,7 @@ final class DynamicIslandController: NSObject {
     }
 
     deinit {
+        visibilityWorkItem?.cancel()
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -177,16 +186,109 @@ final class DynamicIslandController: NSObject {
     func show() {
         let panel = panel ?? makePanel()
         self.panel = panel
-        repositionPanel()
-        panel.orderFrontRegardless()
+        let wasVisible = state.isPanelVisible && panel.isVisible
+        let transition = beginVisibilityTransition()
+
+        // Always reveal from the compact, non-interactive state.
+        state.isVisibilityDismissing = false
+        state.isExpanded = false
         state.isPanelVisible = true
+        acceptsIslandInteraction = false
+        repositionPanel()
+
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            state.visibilityProgress = 1
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+            acceptsIslandInteraction = true
+            panel.updateHitRegion()
+            return
+        }
+
+        if !wasVisible {
+            // Avoid a full-width flash before SwiftUI renders the start mask.
+            state.visibilityProgress = 0
+            panel.alphaValue = 0
+        }
+        panel.orderFrontRegardless()
+
+        // Commit the start mask before revealing a newly shown panel.
+        DispatchQueue.main.async { [weak self, weak panel] in
+            guard let self, let panel,
+                  self.visibilityTransitions.owns(transition),
+                  self.isEnabled
+            else { return }
+            panel.alphaValue = 1
+            withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: DynamicIslandVisibilityPolicy.showDuration)) {
+                self.state.visibilityProgress = 1
+            }
+            self.scheduleVisibilityCompletion(
+                after: DynamicIslandVisibilityPolicy.showDuration,
+                transition: transition
+            ) { controller in
+                guard controller.isEnabled else { return }
+                controller.acceptsIslandInteraction = true
+                controller.panel?.updateHitRegion()
+            }
+        }
     }
 
     func hide() {
         collapseWorkItem?.cancel()
-        state.isExpanded = false
-        state.isPanelVisible = false
-        panel?.orderOut(nil)
+        collapseWorkItem = nil
+        let transition = beginVisibilityTransition()
+        acceptsIslandInteraction = false
+        panel?.updateHitRegion()
+        state.isVisibilityDismissing = true
+
+        guard let panel, state.isPanelVisible, panel.isVisible else {
+            state.isExpanded = false
+            state.visibilityProgress = 0
+            state.isPanelVisible = false
+            panel?.orderOut(nil)
+            return
+        }
+
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            state.isExpanded = false
+            state.visibilityProgress = 0
+            state.isPanelVisible = false
+            panel.orderOut(nil)
+            return
+        }
+
+        withAnimation(.timingCurve(0.4, 0, 0.2, 1, duration: DynamicIslandVisibilityPolicy.hideDuration)) {
+            state.isExpanded = false
+            state.visibilityProgress = 0
+        }
+        scheduleVisibilityCompletion(
+            after: DynamicIslandVisibilityPolicy.hideCompletionDelay,
+            transition: transition
+        ) { controller in
+            guard !controller.isEnabled else { return }
+            controller.state.isPanelVisible = false
+            controller.panel?.orderOut(nil)
+        }
+    }
+
+    private func beginVisibilityTransition() -> Int {
+        visibilityWorkItem?.cancel()
+        visibilityWorkItem = nil
+        return visibilityTransitions.begin()
+    }
+
+    private func scheduleVisibilityCompletion(
+        after delay: TimeInterval,
+        transition: Int,
+        completion: @escaping @MainActor (DynamicIslandController) -> Void
+    ) {
+        let item = DispatchWorkItem { [weak self] in
+            guard let self, self.visibilityTransitions.owns(transition) else { return }
+            self.visibilityWorkItem = nil
+            completion(self)
+        }
+        visibilityWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
     }
 
     // MARK: - Hover-driven expand / collapse
@@ -369,7 +471,7 @@ final class DynamicIslandController: NSObject {
     /// Interactive rect of the black shape, in panel contentView coordinates
     /// (AppKit: origin bottom-left). Used so transparent chrome click-throughs.
     fileprivate func hitRectInPanel() -> NSRect {
-        guard let panel else { return .zero }
+        guard acceptsIslandInteraction, let panel else { return .zero }
         let geo = state.geometry
         let panelW = panel.frame.width
         let panelH = panel.frame.height

--- a/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
@@ -68,6 +68,14 @@ struct DynamicIslandView: View {
             ? max(DynamicIslandGeometry.expandedWidth, geo.collapsedWidth)
             : geo.collapsedWidth
         let shoulderRadius = expanded ? CGFloat(8) : min(6, geo.collapsedHeight / 4)
+        let renderedWidth = islandWidth + shoulderRadius * 2
+        let revealWidth = DynamicIslandVisibilityPolicy.revealWidth(
+            progress: state.visibilityProgress,
+            fullWidth: renderedWidth,
+            centerGapWidth: geo.centerGapWidth,
+            hasNotch: geo.hasNotch,
+            isDismissing: state.isVisibilityDismissing
+        )
         let shape = IslandRoundedRectangle(
             topShoulderRadius: shoulderRadius,
             bottomRadius: expanded ? 22 : min(12, geo.collapsedHeight / 2.5)
@@ -127,6 +135,11 @@ struct DynamicIslandView: View {
         )
         .onPreferenceChange(IslandRenderedHeightKey.self) { h in
             onExpandedHeightChanged(h)
+        }
+        // Reveal from the center without scaling the contents.
+        .mask(alignment: .center) {
+            Rectangle()
+                .frame(width: revealWidth)
         }
         // Top-align inside the always-expanded panel so height/width springs
         // grow downward / outward instead of from the view's center (which

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -46,4 +46,105 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
             )
         )
     }
+
+    func testNotchedRevealStartsBehindHardwareNotchAndExpandsSymmetrically() {
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 0,
+                fullWidth: 320,
+                centerGapWidth: 120,
+                hasNotch: true
+            ),
+            120
+        )
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 0.5,
+                fullWidth: 320,
+                centerGapWidth: 120,
+                hasNotch: true
+            ),
+            220
+        )
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 1,
+                fullWidth: 320,
+                centerGapWidth: 120,
+                hasNotch: true
+            ),
+            320
+        )
+    }
+
+    func testSimulatedRevealStartsAtCenterWithoutStretchingPastBounds() {
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 0,
+                fullWidth: 160,
+                centerGapWidth: 28,
+                hasNotch: false
+            ),
+            DynamicIslandVisibilityPolicy.centerPointWidth
+        )
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: -1,
+                fullWidth: 160,
+                centerGapWidth: 28,
+                hasNotch: false
+            ),
+            DynamicIslandVisibilityPolicy.centerPointWidth
+        )
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 2,
+                fullWidth: 160,
+                centerGapWidth: 28,
+                hasNotch: false
+            ),
+            160
+        )
+    }
+
+    func testNotchedDismissalFinishesFullyBehindHardwareNotch() {
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 0,
+                fullWidth: 320,
+                centerGapWidth: 120,
+                hasNotch: true,
+                isDismissing: true
+            ),
+            DynamicIslandVisibilityPolicy.centerPointWidth
+        )
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.revealWidth(
+                progress: 1,
+                fullWidth: 320,
+                centerGapWidth: 120,
+                hasNotch: true,
+                isDismissing: true
+            ),
+            320
+        )
+    }
+
+    func testHideCompletionIncludesCompositorSettleDelay() {
+        XCTAssertEqual(
+            DynamicIslandVisibilityPolicy.hideCompletionDelay,
+            DynamicIslandVisibilityPolicy.hideDuration + DynamicIslandVisibilityPolicy.hideSettleDelay
+        )
+    }
+
+    func testLatestVisibilityTransitionOwnsDelayedCompletion() {
+        var tracker = DynamicIslandVisibilityTransitionTracker()
+        let opening = tracker.begin()
+        let closing = tracker.begin()
+        let reopening = tracker.begin()
+
+        XCTAssertFalse(tracker.owns(opening))
+        XCTAssertFalse(tracker.owns(closing))
+        XCTAssertTrue(tracker.owns(reopening))
+    }
 }


### PR DESCRIPTION
Thank you, as always, for all the hard work on this project.

This pull request adds opening and closing animations tied to the Dynamic Island toggle. When toggling Dynamic Island, I noticed that the previous transition created a brief but noticeable visual separation from the top edge of the screen.

This change makes the island expand outward from the center when enabled and contract back into the center when disabled, creating a smoother and more elegant transition. The implementation uses a centered mask, keeps the panel fixed to the top edge, and safely handles rapid toggles and the final compositor frame.

Thank you again for all your work on this project.

## Validation

- `xcodebuild -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBarTests -destination 'platform=macOS' test` — 122 tests passed
- `xcodebuild -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Release build` — succeeded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Dynamic Island show and hide animations with smooth, notch-aware reveal behavior.
  * Prevented interaction until the island is fully visible.
  * Added support for reduced-motion settings.
  * Improved handling of rapid visibility toggles to prevent outdated transitions from completing.
  * Preserved the island during dismissal animations before hiding it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->