### PR TITLE
feat: add Reasonix as a supported AI tool (passive stats reader)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -210,7 +210,7 @@ Fehlt dein Tool? [Erstelle ein Issue](https://github.com/xiufengsun/TokenTracker
 
 ## 🆚 Warum TokenTracker?
 
-> **Suchst du eine ccusage-Alternative mit GUI?** TokenTracker unterstützt 28 Tools (nicht nur Claude Code), bietet native macOS- und Windows-Apps + Desktop-Widgets und dedupliziert Token-Datensätze korrekt über alle Provider hinweg – damit deine Zahlen mit dem Billing der Provider übereinstimmen.
+> **Suchst du eine ccusage-Alternative mit GUI?** TokenTracker unterstützt 30 Tools (nicht nur Claude Code), bietet native macOS- und Windows-Apps + Desktop-Widgets und dedupliziert Token-Datensätze korrekt über alle Provider hinweg – damit deine Zahlen mit dem Billing der Provider übereinstimmen.
 
 | | **TokenTracker** | ccusage | Cursor Stats |
 |---|---|---|---|

--- a/README.de.md
+++ b/README.de.md
@@ -6,7 +6,7 @@
 
 ### Sieh genau, was du für KI ausgibst – über jedes CLI hinweg
 
-Sammle automatisch Token-Zahlen von **29 KI-Coding-Tools**, aggregiere sie lokal und sieh echte Kostentrends in einem schönen Dashboard. Kein Cloud-Konto, keine API-Keys, kein Setup – nur ein Befehl.
+Sammle automatisch Token-Zahlen von **30 KI-Coding-Tools**, aggregiere sie lokal und sieh echte Kostentrends in einem schönen Dashboard. Kein Cloud-Konto, keine API-Keys, kein Setup – nur ein Befehl.
 
 [![npm version](https://img.shields.io/npm/v/tokentracker-cli.svg?color=blue)](https://www.npmjs.com/package/tokentracker-cli)
 [![npm downloads](https://img.shields.io/npm/dm/tokentracker-cli.svg?color=brightgreen)](https://www.npmjs.com/package/tokentracker-cli)
@@ -87,7 +87,7 @@ Aktualisieren mit `brew upgrade --cask xiufengsun/tokentracker/tokentracker`. De
 
 ## ✨ Features
 
-- 🔌 **29 KI-Tools out of the box** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science
+- 🔌 **30 KI-Tools out of the box** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science, Reasonix
 - 🏠 **100 % lokal** — Token-Daten verlassen nie deinen Rechner. Kein Konto, keine API-Keys.
 - 🚀 **Zero Config** — Hooks installieren sich beim ersten Start automatisch. Von null zum Dashboard in 30 Sekunden.
 - 📊 **Schönes Dashboard** — Nutzungstrends, Kostenaufschlüsselung nach Modell, GitHub-ähnliche Aktivitäts-Heatmap, Projektzuordnung
@@ -175,6 +175,7 @@ Aktualisieren mit `brew upgrade --cask xiufengsun/tokentracker/tokentracker`. De
 | **GitHub Copilot App / CLI** | ✅ Auto | Vereinheitlichte SQLite-Nutzung pro Anfrage (`~/.copilot/session-store.db`); App-DB als Legacy-Baseline |
 | **GitHub Copilot Chat-Erweiterung / ältere CLI** | ✅ Auto | OpenTelemetry-Datei-Exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ Auto | Passiver `wire.jsonl`-Reader (`~/.kimi/sessions/**/wire.jsonl`) |
+| **Reasonix** | ✅ Auto | Passiver JSONL-Reader (`~/.reasonix/stats/*.jsonl`, Token-Verbrauch pro Anfrage inkl. Reasoning- und Cache-Hit-Aufschlüsselung) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ Auto | Passiver Reader (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ Auto | SessionEnd-Hook in `~/.codebuddy/settings.json` (Claude-Code-Fork) |
 | **WorkBuddy** (Tencent) | ✅ Auto | SessionEnd-Hook in `~/.workbuddy/settings.json` (Claude-Code-Fork) + passiver `projects/**/*.jsonl`-Scan |
@@ -213,7 +214,7 @@ Fehlt dein Tool? [Erstelle ein Issue](https://github.com/xiufengsun/TokenTracker
 
 | | **TokenTracker** | ccusage | Cursor Stats |
 |---|---|---|---|
-| **Unterstützte KI-Tools** | **29** | 1 (Claude) | 1 (Cursor) |
+| **Unterstützte KI-Tools** | **30** | 1 (Claude) | 1 (Cursor) |
 | **Lokal, kein Konto** | ✅ | ✅ | ❌ |
 | **Native Desktop-App** | ✅ macOS + Windows | ❌ | ❌ |
 | **Desktop-Widgets** | ✅ 4 Widgets | ❌ | ❌ |

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 ### AI に使ったコストを正確に把握 — すべての CLI を横断して
 
-**29 種類の AI コーディングツール**からトークン数を自動収集し、ローカルで集計、美しいダッシュボードで本当のコスト推移を可視化します。クラウドアカウント不要、API キー不要、セットアップ不要 — コマンド 1 つで完了です。
+**30 種類の AI コーディングツール**からトークン数を自動収集し、ローカルで集計、美しいダッシュボードで本当のコスト推移を可視化します。クラウドアカウント不要、API キー不要、セットアップ不要 — コマンド 1 つで完了です。
 
 [![npm version](https://img.shields.io/npm/v/tokentracker-cli.svg?color=blue)](https://www.npmjs.com/package/tokentracker-cli)
 [![npm downloads](https://img.shields.io/npm/dm/tokentracker-cli.svg?color=brightgreen)](https://www.npmjs.com/package/tokentracker-cli)
@@ -87,7 +87,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 ## ✨ 機能
 
-- 🔌 **29 種類の AI ツールを標準対応** — Claude Code、Codex CLI、Cursor、Gemini CLI、Antigravity、Kiro、OpenCode、OpenClaw、Every Code、Hermes Agent、GitHub Copilot、Kimi Code、CodeBuddy、WorkBuddy、Grok Build、oh-my-pi、pi、Craft Agents、Kilo CLI、Kilo Code、Roo Code、Zed Agent、Goose、Droid、Mimo Code、ZCode、Qoder、AnythingLLM Desktop、Claude Science
+- 🔌 **30 種類の AI ツールを標準対応** — Claude Code、Codex CLI、Cursor、Gemini CLI、Antigravity、Kiro、OpenCode、OpenClaw、Every Code、Hermes Agent、GitHub Copilot、Kimi Code、CodeBuddy、WorkBuddy、Grok Build、oh-my-pi、pi、Craft Agents、Kilo CLI、Kilo Code、Roo Code、Zed Agent、Goose、Droid、Mimo Code、ZCode、Qoder、AnythingLLM Desktop、Claude Science、Reasonix
 - 🏠 **100% ローカル** — トークンデータがマシンから外に出ることはありません。アカウント不要、API キー不要。
 - 🚀 **ゼロコンフィグ** — Hook は初回実行で自動インストール。0 からダッシュボードまで 30 秒。
 - 📊 **美しいダッシュボード** — 使用トレンド、モデル別コスト内訳、GitHub スタイルのアクティビティヒートマップ、プロジェクト別の帰属表示
@@ -176,6 +176,7 @@ brew install xiufengsun/tokentracker/tokentracker
 | **GitHub Copilot App / CLI** | ✅ 自動 | リクエスト単位の統合 SQLite 使用量 (`~/.copilot/session-store.db`)、App DB は旧データのベースライン |
 | **GitHub Copilot Chat 拡張 / 旧 CLI** | ✅ 自動 | OpenTelemetry のファイルエクスポーター (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ 自動 | パッシブな `wire.jsonl` リーダー (`~/.kimi/sessions/**/wire.jsonl`) |
+| **Reasonix** | ✅ 自動 | パッシブな JSONL リーダー (`~/.reasonix/stats/*.jsonl`、リクエスト単位の token 使用量、reasoning とキャッシュヒット内訳を含む) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 自動 | パッシブリーダー (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ 自動 | `~/.codebuddy/settings.json` 内の SessionEnd hook（Claude-Code fork） |
 | **WorkBuddy** (Tencent) | ✅ 自動 | `~/.workbuddy/settings.json` 内の SessionEnd hook（Claude-Code fork）+ パッシブな `projects/**/*.jsonl` スキャン |
@@ -213,7 +214,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 |                          | **TokenTracker** | ccusage     | Cursor stats |
 |--------------------------|:---:|:---:|:---:|
-| **対応 AI ツール数**     | **29**           | 1 (Claude)  | 1 (Cursor)   |
+| **対応 AI ツール数**     | **30**           | 1 (Claude)  | 1 (Cursor)   |
 | **ローカルファースト、アカウント不要** | ✅            | ✅           | ❌            |
 | **ネイティブデスクトップアプリ** | ✅ macOS + Windows | ❌          | ❌            |
 | **デスクトップウィジェット** | ✅ 4 種類      | ❌           | ❌            |

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 ### 모든 CLI에서 AI에 쓰는 비용을 정확히 파악
 
-**29개의 AI 코딩 도구**에서 토큰 수치를 자동으로 수집하고 로컬에서 집계해, 실제 비용 추세를 아름다운 대시보드에서 확인. 클라우드 계정 불필요, API Key 불필요, 셋업 불필요 — 명령 한 줄이면 끝.
+**30개의 AI 코딩 도구**에서 토큰 수치를 자동으로 수집하고 로컬에서 집계해, 실제 비용 추세를 아름다운 대시보드에서 확인. 클라우드 계정 불필요, API Key 불필요, 셋업 불필요 — 명령 한 줄이면 끝.
 
 [![npm version](https://img.shields.io/npm/v/tokentracker-cli.svg?color=blue)](https://www.npmjs.com/package/tokentracker-cli)
 [![npm downloads](https://img.shields.io/npm/dm/tokentracker-cli.svg?color=brightgreen)](https://www.npmjs.com/package/tokentracker-cli)
@@ -87,7 +87,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 ## ✨ 기능
 
-- 🔌 **29개의 AI 도구 기본 지원** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science
+- 🔌 **30개의 AI 도구 기본 지원** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science, Reasonix
 - 🏠 **100% 로컬** — 토큰 데이터가 기기를 떠나지 않습니다. 계정 없음, API Key 없음.
 - 🚀 **제로 설정** — 첫 실행 시 Hook 자동 설치. 0에서 대시보드까지 30초.
 - 📊 **아름다운 대시보드** — 사용 추세, 모델별 비용 분석, GitHub 스타일 활동 히트맵, 프로젝트 귀속 정보
@@ -176,6 +176,7 @@ brew install xiufengsun/tokentracker/tokentracker
 | **GitHub Copilot App / CLI** | ✅ 자동 | 요청별 통합 SQLite 사용량 (`~/.copilot/session-store.db`), App DB는 레거시 기준선 |
 | **GitHub Copilot Chat 확장 / 이전 CLI** | ✅ 자동 | OpenTelemetry 파일 익스포터 (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ 자동 | 패시브 `wire.jsonl` 리더 (`~/.kimi/sessions/**/wire.jsonl`) |
+| **Reasonix** | ✅ 자동 | 패시브 JSONL 리더 (`~/.reasonix/stats/*.jsonl`, 요청별 토큰 사용량, reasoning·캐시 히트 구분 포함) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 자동 | 패시브 리더 (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ 자동 | `~/.codebuddy/settings.json`의 SessionEnd hook (Claude-Code fork) |
 | **WorkBuddy** (Tencent) | ✅ 자동 | `~/.workbuddy/settings.json`의 SessionEnd hook (Claude-Code fork) + 패시브 `projects/**/*.jsonl` 스캔 |
@@ -213,7 +214,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 |                          | **TokenTracker** | ccusage     | Cursor stats |
 |--------------------------|:---:|:---:|:---:|
-| **지원 AI 도구**         | **29**           | 1 (Claude)  | 1 (Cursor)   |
+| **지원 AI 도구**         | **30**           | 1 (Claude)  | 1 (Cursor)   |
 | **로컬 우선, 계정 불필요** | ✅            | ✅           | ❌            |
 | **네이티브 데스크톱 앱** | ✅ macOS + Windows | ❌          | ❌            |
 | **데스크톱 위젯**        | ✅ 4종            | ❌           | ❌            |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Missing your tool? [Open an issue](https://github.com/xiufengsun/TokenTracker/is
 
 ## 🆚 Why TokenTracker? <a id="ccusage-alternative"></a>
 
-> **Looking for a ccusage alternative with a GUI?** TokenTracker covers 30 tools (not just Claude Code), adds native macOS and Windows apps + desktop widgets, and de-duplicates token records correctly across providers — so your numbers match the providers' own billing.
+> **Looking for a ccusage alternative with a GUI?** TokenTracker covers 30 tools (not just Claude Code), adds native macOS and Windows apps + desktop widgets, and deduplicates token records correctly across providers — so your numbers match the providers' own billing.
 
 |                          | **TokenTracker** | ccusage     | Cursor stats |
 |--------------------------|:---:|:---:|:---:|

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Track every AI token — then bring your usage to life
 
-An accurate, local-first token usage and cost dashboard for **29 AI coding tools** — plus a desktop pet, **4 native widgets**, and **15 achievement tracks**. No cloud account, no API keys, no setup.
+An accurate, local-first token usage and cost dashboard for **30 AI coding tools** — plus a desktop pet, **4 native widgets**, and **15 achievement tracks**. No cloud account, no API keys, no setup.
 
 [![npm version](https://img.shields.io/npm/v/tokentracker-cli.svg?color=blue)](https://www.npmjs.com/package/tokentracker-cli)
 [![npm downloads](https://img.shields.io/npm/dm/tokentracker-cli.svg?color=brightgreen)](https://www.npmjs.com/package/tokentracker-cli)
@@ -124,7 +124,7 @@ Upgrade with `brew upgrade --cask xiufengsun/tokentracker/tokentracker`. The tap
 
 ## ✨ Features
 
-- 🔌 **29 AI tools out of the box** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science
+- 🔌 **30 AI tools out of the box** — Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science, Reasonix
 - 🏠 **100% local** — Token data never leaves your machine. No account, no API keys.
 - 🚀 **Zero config** — Hooks auto-install on first run. From zero to dashboard in 30 seconds.
 - 📊 **Beautiful dashboard** — Usage trends, cost breakdowns by model, GitHub-style activity heatmap, project attribution
@@ -224,6 +224,7 @@ Upgrade with `brew upgrade --cask xiufengsun/tokentracker/tokentracker`. The tap
 | **GitHub Copilot App / CLI** | ✅ Auto | Unified per-request SQLite usage (`~/.copilot/session-store.db`); App DB legacy baseline |
 | **GitHub Copilot Chat extension / legacy CLI** | ✅ Auto | OpenTelemetry file exporter (`COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | **Kimi Code** | ✅ Auto | Passive `wire.jsonl` reader (`~/.kimi/sessions/**/wire.jsonl`) |
+| **Reasonix** | ✅ Auto | Passive JSONL reader (`~/.reasonix/stats/*.jsonl`; per-request token usage incl. reasoning and cache-hit splits) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ Auto | Passive reader (`~/.omp/agent/sessions/**/*.jsonl`) + managed notify extension written by `tokentracker init` to `~/.omp/agent/extensions/tokentracker-notify.ts` for near-real-time sync (skipped if a same-named unmanaged file already exists; removed by `tokentracker uninstall` when still managed) |
 | **CodeBuddy** (Tencent) | ✅ Auto | SessionEnd hook in `~/.codebuddy/settings.json` (Claude-Code fork) |
 | **WorkBuddy** (Tencent) | ✅ Auto | SessionEnd hook in `~/.workbuddy/settings.json` (Claude-Code fork) + passive `projects/**/*.jsonl` scan |
@@ -247,7 +248,7 @@ Upgrade with `brew upgrade --cask xiufengsun/tokentracker/tokentracker`. The tap
 > - **Hook-based** tools (Claude Code, Codex, Gemini, Every Code, **CodeBuddy**, **WorkBuddy**, **Grok Build**) — we write a SessionEnd hook or TOML notify entry into the tool's own config.
 > - **Plugin-based** tools (OpenCode, **OpenClaw**) — plugins ship inside the npm package. OpenClaw's session plugin lives at `~/.tokentracker/tracker/openclaw-plugin/openclaw-session-sync/`; we link and enable it via OpenClaw's own CLI, then set `hooks.allowConversationAccess=true` so OpenClaw permits the session-finished event that triggers sync. No download, no drag-and-drop.
 > - **oh-my-pi** — passive session scan is always the billing/token source of truth (`~/.omp/agent/sessions/**/*.jsonl`). When OMP is detected, `tokentracker init` also writes a managed notify extension to `~/.omp/agent/extensions/tokentracker-notify.ts` so turns can trigger near-real-time sync. That file is owned only when it carries TokenTracker's managed marker: a same-named user-authored extension is never overwritten or deleted. `tokentracker uninstall` removes the extension only while it is still managed.
-> - **Passive readers** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Droid**, **Mimo Code**, **ZCode**, **Qoder**, **AnythingLLM Desktop**, **Claude Science**) — nothing is installed into those tools. We only read files they already produce (SQLite DB, JSONL, OTEL export, session logs). Copilot App / CLI usage is read per request from `~/.copilot/session-store.db`; `data.db` provides the one-time legacy adoption baseline and stays observe-only after the store becomes canonical, while the Chat extension and legacy CLI continue using OTEL. TokenTracker coordinates the sources so overlapping requests are counted once. Mixed App/CLI usage that predates adoption is retained as a `github-copilot-legacy` aggregate rather than assigned to a guessed request model.
+> - **Passive readers** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **pi**, **Craft Agents**, **Kilo CLI**, **Kilo Code**, **Roo Code**, **Antigravity**, **Zed Agent**, **Goose**, **Droid**, **Mimo Code**, **ZCode**, **Qoder**, **AnythingLLM Desktop**, **Claude Science**, **Reasonix**) — nothing is installed into those tools. We only read files they already produce (SQLite DB, JSONL, OTEL export, session logs). Copilot App / CLI usage is read per request from `~/.copilot/session-store.db`; `data.db` provides the one-time legacy adoption baseline and stays observe-only after the store becomes canonical, while the Chat extension and legacy CLI continue using OTEL. TokenTracker coordinates the sources so overlapping requests are counted once. Mixed App/CLI usage that predates adoption is retained as a `github-copilot-legacy` aggregate rather than assigned to a guessed request model.
 > - **Grok Build estimate** — current local telemetry exposes cumulative `updates.jsonl` `totalTokens`, but not a stable prompt/output/cache split; `signals.json` remains a fallback with `contextTokensUsed` snapshots. TokenTracker estimates Grok cost until per-call usage details are available.
 >
 > Run `tokentracker status` anytime to verify every integration's state. If something shows `skipped`, the `detail` column explains why (e.g. tool CLI not on `PATH`, config unreadable).
@@ -260,11 +261,11 @@ Missing your tool? [Open an issue](https://github.com/xiufengsun/TokenTracker/is
 
 ## 🆚 Why TokenTracker? <a id="ccusage-alternative"></a>
 
-> **Looking for a ccusage alternative with a GUI?** TokenTracker covers 29 tools (not just Claude Code), adds native macOS and Windows apps + desktop widgets, and de-duplicates token records correctly across providers — so your numbers match the providers' own billing.
+> **Looking for a ccusage alternative with a GUI?** TokenTracker covers 30 tools (not just Claude Code), adds native macOS and Windows apps + desktop widgets, and de-duplicates token records correctly across providers — so your numbers match the providers' own billing.
 
 |                          | **TokenTracker** | ccusage     | Cursor stats |
 |--------------------------|:---:|:---:|:---:|
-| **AI tools supported**   | **29**           | 1 (Claude)  | 1 (Cursor)   |
+| **AI tools supported**   | **30**           | 1 (Claude)  | 1 (Cursor)   |
 | **Local-first, no account** | ✅            | ✅           | ❌            |
 | **Native desktop app**   | ✅ macOS + Windows | ❌           | ❌            |
 | **Desktop widgets**      | ✅ 4 widgets      | ❌           | ❌            |
@@ -279,7 +280,7 @@ Missing your tool? [Open an issue](https://github.com/xiufengsun/TokenTracker/is
 
 ```mermaid
 flowchart LR
-    A["AI coding tools<br/>Claude Code · Codex · Cursor · Gemini · Kiro<br/>OpenCode · OpenClaw · Every Code · Hermes · Copilot<br/>Kimi Code · CodeBuddy · WorkBuddy · Grok Build · Kilo CLI · Kilo Code<br/>Antigravity · oh-my-pi · pi · Craft · Roo · Zed · Goose · Droid · Mimo · ZCode · Qoder · AnythingLLM · Claude Science"]
+    A["AI coding tools<br/>Claude Code · Codex · Cursor · Gemini · Kiro<br/>OpenCode · OpenClaw · Every Code · Hermes · Copilot<br/>Kimi Code · CodeBuddy · WorkBuddy · Grok Build · Kilo CLI · Kilo Code<br/>Antigravity · oh-my-pi · pi · Craft · Roo · Zed · Goose · Droid · Mimo · ZCode · Qoder · AnythingLLM · Claude Science · Reasonix"]
     A -->|hooks trigger| B[Token Tracker]
     B -->|parse logs<br/>30-min UTC buckets| C[(Local SQLite)]
     C --> D[Web Dashboard]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 ### 跨所有 CLI，看清你到底在 AI 上花了多少钱
 
-自动采集 **29 款 AI 编码工具** 的 token 用量，全程本地聚合，用一套漂亮的 Dashboard 看真实成本与趋势。不需要云账号、不需要 API Key、不需要任何配置 —— 一条命令搞定。
+自动采集 **30 款 AI 编码工具** 的 token 用量，全程本地聚合，用一套漂亮的 Dashboard 看真实成本与趋势。不需要云账号、不需要 API Key、不需要任何配置 —— 一条命令搞定。
 
 [![npm version](https://img.shields.io/npm/v/tokentracker-cli.svg?color=blue)](https://www.npmjs.com/package/tokentracker-cli)
 [![npm downloads](https://img.shields.io/npm/dm/tokentracker-cli.svg?color=brightgreen)](https://www.npmjs.com/package/tokentracker-cli)
@@ -89,7 +89,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 ## ✨ 特性
 
-- 🔌 **开箱即用支持 29 款 AI 工具** —— Claude Code、Codex CLI、Cursor、Gemini CLI、Kiro、OpenCode、OpenClaw、Every Code、Hermes Agent、GitHub Copilot、Kimi Code、CodeBuddy、WorkBuddy、Grok Build、oh-my-pi、pi、Craft Agents、Kilo CLI、Kilo Code、Roo Code、Antigravity、Zed Agent、Goose、Droid、Mimo Code、ZCode、Qoder、AnythingLLM Desktop、Claude Science
+- 🔌 **开箱即用支持 30 款 AI 工具** —— Claude Code、Codex CLI、Cursor、Gemini CLI、Kiro、OpenCode、OpenClaw、Every Code、Hermes Agent、GitHub Copilot、Kimi Code、CodeBuddy、WorkBuddy、Grok Build、oh-my-pi、pi、Craft Agents、Kilo CLI、Kilo Code、Roo Code、Antigravity、Zed Agent、Goose、Droid、Mimo Code、ZCode、Qoder、AnythingLLM Desktop、Claude Science、Reasonix
 - 🏠 **100% 本地** —— Token 数据绝不离开你的机器。无账号、无 API Key
 - 🚀 **零配置** —— 首次运行自动安装所有 hook。30 秒从零到 Dashboard
 - 📊 **漂亮的 Dashboard** —— 用量趋势、按模型的成本分解、GitHub 风格活跃度热力图、按项目归因
@@ -179,6 +179,7 @@ brew install xiufengsun/tokentracker/tokentracker
 | **GitHub Copilot App / CLI** | ✅ 自动 | 统一逐请求 SQLite 用量（`~/.copilot/session-store.db`）；App DB 作为旧数据基线 |
 | **GitHub Copilot Chat 扩展 / 旧版 CLI** | ✅ 自动 | OpenTelemetry 文件导出（`COPILOT_OTEL_FILE_EXPORTER_PATH`） |
 | **Kimi Code** | ✅ 自动 | 被动读取 `wire.jsonl`（`~/.kimi/sessions/**/wire.jsonl`） |
+| **Reasonix** | ✅ 自动 | 被动 JSONL 读取（`~/.reasonix/stats/*.jsonl`；按请求记录 token 用量，含思考与缓存命中拆分） |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 自动 | 被动读取（`~/.omp/agent/sessions/**/*.jsonl`）+ `tokentracker init` 会写入托管的 notify 扩展（`~/.omp/agent/extensions/tokentracker-notify.ts`）用于近实时同步（若同名非托管文件已存在则跳过；`tokentracker uninstall` 仅在仍为托管时删除） |
 | **CodeBuddy** (腾讯) | ✅ 自动 | 写入 `~/.codebuddy/settings.json` 的 SessionEnd hook（Claude-Code fork） |
 | **WorkBuddy** (腾讯) | ✅ 自动 | 写入 `~/.workbuddy/settings.json` 的 SessionEnd hook（Claude-Code fork）+ 被动扫描 `projects/**/*.jsonl` |
@@ -216,7 +217,7 @@ brew install xiufengsun/tokentracker/tokentracker
 
 |                          | **TokenTracker** | ccusage     | Cursor 自带统计 |
 |--------------------------|:---:|:---:|:---:|
-| **支持的 AI 工具数**     | **29**           | 1（Claude）  | 1（Cursor）   |
+| **支持的 AI 工具数**     | **30**           | 1（Claude）  | 1（Cursor）   |
 | **本地优先，无需账号**   | ✅               | ✅           | ❌            |
 | **原生桌面 App**         | ✅ macOS + Windows | ❌          | ❌            |
 | **桌面小组件**           | ✅ 4 个小组件    | ❌           | ❌            |

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -211,7 +211,7 @@
                 "name": "Which AI coding CLIs does Token Tracker support?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Token Tracker supports 29 AI coding tools, including Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, GitHub Copilot, Kimi Code, Grok Build, Kilo, Roo Code, Zed, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, and Claude Science."
+                  "text": "Token Tracker supports 30 AI coding tools, including Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, GitHub Copilot, Kimi Code, Grok Build, Kilo, Roo Code, Zed, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science, and Reasonix."
                 }
               },
               {
@@ -265,7 +265,7 @@
       <h1>Token Tracker: monitor AI token usage and cost with a local dashboard and desktop companion</h1>
       <p>
         Token Tracker is a free, open-source, local-first dashboard that automatically tracks and monitors token usage
-        and cost across 29 AI coding tools — including Claude Code, OpenAI Codex, Cursor, and Gemini CLI. A desktop pet
+        and cost across 30 AI coding tools — including Claude Code, OpenAI Codex, Cursor, and Gemini CLI. A desktop pet
         reacts to real token activity, four desktop widgets
         keep usage visible, and achievements turn coding history into progress. Native macOS and Windows apps
         sit on top of accurate cross-provider deduplication. Token counts only — never prompts or conversations.
@@ -290,7 +290,7 @@
         <li><strong>Desktop pet</strong> — a pixel companion that reacts to real token burn, streaks, and rest.</li>
         <li><strong>Four desktop widgets</strong> — usage, activity heatmap, top models, and limits at a glance.</li>
         <li><strong>Achievements</strong> — unlock milestones from local and optional account-wide activity.</li>
-        <li><strong>Unified usage dashboard</strong> — input, output, cached, and cache-creation tokens across 29 AI coding tools.</li>
+        <li><strong>Unified usage dashboard</strong> — input, output, cached, and cache-creation tokens across 30 AI coding tools.</li>
         <li><strong>Cost analysis</strong> — per-model pricing across 2,200+ models with an offline snapshot.</li>
         <li><strong>Usage limits view</strong> — live quota and subscription status for 12 providers, with last-good caching for local providers such as Antigravity and Qoder.</li>
         <li><strong>Service Status page</strong> — live operational and incident status from eight official provider status pages.</li>
@@ -301,7 +301,7 @@
       </ul>
       <p><em>Privacy by design</em>: token counts only, never prompts or conversation content. Local-first; cloud sync is optional and powers only the public leaderboard.</p>
 
-      <h2>Supported AI coding tools (29)</h2>
+      <h2>Supported AI coding tools (30)</h2>
       <p>
         Use Token Tracker as a Claude Code token tracker, Codex token tracker, Cursor token tracker,
         Gemini token tracker, OpenCode token tracker, or GitHub Copilot token tracker — one dashboard

--- a/dashboard/public/llms.txt
+++ b/dashboard/public/llms.txt
@@ -53,6 +53,7 @@ timestamps, never prompts, responses, or source code.
 - Qoder
 - AnythingLLM Desktop
 - Claude Science
+- Reasonix
 
 ## Capabilities
 - Desktop pet that reacts to real token burn, streaks, and rest

--- a/dashboard/public/llms.txt
+++ b/dashboard/public/llms.txt
@@ -23,7 +23,7 @@ timestamps, never prompts, responses, or source code.
 - [npm package](https://www.npmjs.com/package/tokentracker-cli)
 - [Latest release](https://github.com/xiufengsun/TokenTracker/releases/latest)
 
-## Supported AI coding tools (29)
+## Supported AI coding tools (30)
 - Claude Code
 - Codex CLI
 - Cursor

--- a/dashboard/src/ui/marketing/agent-logos.js
+++ b/dashboard/src/ui/marketing/agent-logos.js
@@ -31,4 +31,5 @@ export const AGENT_LOGOS = [
   { id: 27, name: "Qoder", provider: "qoder" },
   { id: 28, name: "AnythingLLM", provider: "anythingllm" },
   { id: 29, name: "Claude Science", provider: "claude-science" },
+  { id: 30, name: "Reasonix", provider: "reasonix" },
 ];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokentracker-cli",
   "version": "0.87.15",
-  "description": "Local-first AI coding token usage and cost tracker for 29 tools, with a dashboard, desktop pet, widgets, achievements, and native macOS/Windows apps.",
+  "description": "Local-first AI coding token usage and cost tracker for 30 tools, with a dashboard, desktop pet, widgets, achievements, and native macOS/Windows apps.",
   "main": "src/cli.js",
   "bin": {
     "tokentracker-cli": "bin/tracker.js",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -62,6 +62,7 @@ const {
 } = require("../lib/omp-hook");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const {
+  resolveReasonixStatsDir,
   resolveOmpAgentDir,
   resolvePiAgentDir,
   piAgentDirCollidesWithOmp,
@@ -720,11 +721,7 @@ async function applyIntegrationSetup({
   // Reasonix: passive reader — no hook installation needed.
   // TokenTracker reads ~/.reasonix/stats/*.jsonl usage records.
   {
-    const reasonixHome =
-      process.env.REASONIX_HOME && process.env.REASONIX_HOME.trim()
-        ? path.resolve(process.env.REASONIX_HOME.trim())
-        : path.join(home, ".reasonix");
-    const reasonixStatsDir = path.join(reasonixHome, "stats");
+    const reasonixStatsDir = resolveReasonixStatsDir(process.env);
     if (fssync.existsSync(reasonixStatsDir)) {
       summary.push({ label: "Reasonix", status: "detected", detail: "Passive reader (no hook needed)" });
     }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -123,6 +123,7 @@ const SUPPORTED_PROVIDERS = [
   "Kilo CLI",
   "Kilo Code",
   "Roo Code",
+  "Reasonix",
   "Zed Agent",
   "Goose",
   "Droid",
@@ -713,6 +714,19 @@ async function applyIntegrationSetup({
     const craftConfigDir = process.env.CRAFT_CONFIG_DIR || path.join(home, ".craft-agent");
     if (fssync.existsSync(craftConfigDir)) {
       summary.push({ label: "Craft Agents", status: "detected", detail: "Passive reader (no hook needed)" });
+    }
+  }
+
+  // Reasonix: passive reader — no hook installation needed.
+  // TokenTracker reads ~/.reasonix/stats/*.jsonl usage records.
+  {
+    const reasonixHome =
+      process.env.REASONIX_HOME && process.env.REASONIX_HOME.trim()
+        ? path.resolve(process.env.REASONIX_HOME.trim())
+        : path.join(home, ".reasonix");
+    const reasonixStatsDir = path.join(reasonixHome, "stats");
+    if (fssync.existsSync(reasonixStatsDir)) {
+      summary.push({ label: "Reasonix", status: "detected", detail: "Passive reader (no hook needed)" });
     }
   }
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -44,6 +44,8 @@ const {
 } = require("../lib/openclaw-session-plugin");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const {
+  resolveReasonixStatsDir,
+  resolveReasonixStatFiles,
   resolveKimiWireFiles,
   resolveKimiCodeWireFiles,
   resolveKiroCliDbPath,
@@ -372,6 +374,11 @@ async function cmdStatus(argv = []) {
   const piAgentDir = resolvePiAgentDir(process.env);
   const piInstalled = !piCollides && Boolean(piAgentDir) && fssync.existsSync(path.join(piAgentDir, "sessions"));
   const piFiles = piInstalled ? resolvePiSessionFiles(process.env) : [];
+
+  // Reasonix — passive scan only (no hooks). Reads ~/.reasonix/stats/*.jsonl.
+  const reasonixStatsDir = resolveReasonixStatsDir(process.env);
+  const reasonixStatFiles = resolveReasonixStatFiles(process.env);
+  const reasonixInstalled = reasonixStatFiles.length > 0;
 
   // Craft Agents — passive scan only (no hooks).
   const craftConfigDir = resolveCraftConfigDir(process.env);
@@ -784,6 +791,9 @@ async function cmdStatus(argv = []) {
         pi: piInstalled
           ? { installed: true, files: piFiles.length }
           : { installed: false },
+        reasonix: reasonixInstalled
+          ? { installed: true, files: reasonixStatFiles.length, dir: reasonixStatsDir }
+          : { installed: false },
         craft: craftInstalled
           ? { installed: true, files: craftFiles.length }
           : { installed: false },
@@ -907,6 +917,9 @@ async function cmdStatus(argv = []) {
         : null,
       piInstalled
         ? `- pi: passive reader (${piFiles.length} session jsonl file${piFiles.length !== 1 ? "s" : ""} found)`
+        : null,
+      reasonixInstalled
+        ? `- Reasonix: passive reader (${reasonixStatFiles.length} stats jsonl file${reasonixStatFiles.length !== 1 ? "s" : ""} found in ${reasonixStatsDir})`
         : null,
       craftInstalled
         ? `- Craft Agents: passive reader (${craftFiles.length} session jsonl file${craftFiles.length !== 1 ? "s" : ""} found)`

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -66,6 +66,8 @@ const {
   parseCopilotIncremental,
   parseCopilotSessionStoreIncremental,
   parseCopilotAppDbIncremental,
+  resolveReasonixStatFiles,
+  parseReasonixIncremental,
   resolveKimiWireFiles,
   parseKimiIncremental,
   resolveKimiCodeWireFiles,
@@ -273,6 +275,7 @@ const AUTO_SYNC_SOURCES = new Set([
   "kimi-code",
   "mimo",
   "omp",
+  "reasonix",
   "opencode",
   "openclaw",
   "pi",
@@ -1722,6 +1725,34 @@ async function cmdSync(argv, context = {}) {
       }
     }
 
+    // ── Reasonix (passive ~/.reasonix/stats/*.jsonl reader) ──
+    let reasonixResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    const reasonixStatFiles = sourceAllowed("reasonix")
+      ? mergeBothFileSources({ resolveFiles: resolveReasonixStatFiles, env: process.env })
+      : [];
+    if (reasonixStatFiles.length > 0) {
+      if (progress?.enabled) {
+        progress.start(`Parsing Reasonix ${renderBar(0)} | buckets 0`);
+      }
+      try {
+        reasonixResult = await parseReasonixIncremental({
+          statFiles: reasonixStatFiles,
+          cursors,
+          queuePath,
+          env: process.env,
+          onProgress: (p) => {
+            if (!progress?.enabled) return;
+            const pct = p.total > 0 ? p.index / p.total : 1;
+            progress.update(
+              `Parsing Reasonix ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} files | buckets ${formatNumber(p.bucketsQueued)}`,
+            );
+          },
+        });
+      } catch (err) {
+        warnProviderParseFailure("Reasonix", err, opts);
+      }
+    }
+
     // ── Kimi (passive wire.jsonl reader) ──
     let kimiResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const kimiWireFiles = sourceAllowed("kimi")
@@ -2397,6 +2428,7 @@ async function cmdSync(argv, context = {}) {
       kiroResult.recordsProcessed +
       kiroCliResult.recordsProcessed +
       hermesResult.recordsProcessed +
+      reasonixResult.recordsProcessed +
       kimiResult.recordsProcessed +
       kimiCodeResult.recordsProcessed +
       codebuddyResult.recordsProcessed +
@@ -2428,6 +2460,7 @@ async function cmdSync(argv, context = {}) {
       kiroResult.bucketsQueued +
       kiroCliResult.bucketsQueued +
       hermesResult.bucketsQueued +
+      reasonixResult.bucketsQueued +
       kimiResult.bucketsQueued +
       kimiCodeResult.bucketsQueued +
       codebuddyResult.bucketsQueued +

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7547,6 +7547,192 @@ async function parseKimiIncremental({ wireFiles, cursors, queuePath, onProgress,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Reasonix — passive JSONL reader (~/.reasonix/stats/YYYY-MM-DD.jsonl).
+// No hook installation needed; Reasonix appends one usage record per request.
+// Each line is either a usage record (model + token fields) or a turn marker
+// (no model field) which is skipped. Files are append-only and named by day,
+// so an offset-based incremental cursor is sufficient.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function resolveReasonixStatsDir(env = process.env) {
+  const home = require("node:os").homedir();
+  const explicit = typeof env?.REASONIX_HOME === "string" ? env.REASONIX_HOME.trim() : "";
+  if (explicit) return path.join(path.resolve(explicit), "stats");
+  if (process.platform === "win32") {
+    const appData = env.APPDATA || path.join(home, "AppData", "Roaming");
+    return path.join(appData, "reasonix", "stats");
+  }
+  return path.join(home, ".reasonix", "stats");
+}
+
+function resolveReasonixStatFiles(env = process.env) {
+  const statsDir = resolveReasonixStatsDir(env);
+  if (!statsDir || !fssync.existsSync(statsDir)) return [];
+  const files = [];
+  try {
+    for (const name of fssync.readdirSync(statsDir)) {
+      if (!name.endsWith(".jsonl")) continue;
+      const full = path.join(statsDir, name);
+      let st;
+      try { st = fssync.lstatSync(full); } catch { continue; }
+      // lstat: skip symlinks and non-regular entries so the reader never
+      // follows a *.jsonl link to an unrelated readable file.
+      if (!st.isFile()) continue;
+      files.push(full);
+    }
+  } catch { /* ignore */ }
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgress, env } = {}) {
+  await ensureDir(path.dirname(queuePath));
+  const reasonixState = cursors.reasonix && typeof cursors.reasonix === "object" ? cursors.reasonix : {};
+  const seenIds = new Set(Array.isArray(reasonixState.seenIds) ? reasonixState.seenIds : []);
+  const fileOffsets =
+    reasonixState.fileOffsets && typeof reasonixState.fileOffsets === "object"
+      ? { ...reasonixState.fileOffsets }
+      : {};
+
+  const files = Array.isArray(statFiles)
+    ? statFiles
+    : resolveReasonixStatFiles(env || process.env);
+  if (files.length === 0) {
+    cursors.reasonix = { ...reasonixState, seenIds: Array.from(seenIds), fileOffsets, updatedAt: new Date().toISOString() };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+
+  for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
+    const filePath = files[fileIdx];
+    let stat;
+    try { stat = fssync.statSync(filePath); } catch { continue; }
+
+    const prevEntry = fileOffsets[filePath] || {};
+    const prevSize = Number(prevEntry.size) || 0;
+    const prevIno = prevEntry.ino;
+    const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
+    const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
+    if (stat.size <= startOffset) continue;
+
+    let stream;
+    try {
+      stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
+    } catch { continue; }
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (!line || !line.trim()) continue;
+      let entry;
+      try { entry = JSON.parse(line); } catch { continue; }
+
+      // Turn markers carry no model/usage — skip them.
+      if (typeof entry.model !== "string" || !entry.model) continue;
+
+      // Usage records have no stable id; dedup on the full row so an inode
+      // change / truncation-triggered full re-read cannot double-count.
+      const seenKey = `${entry.model}|${entry.ts}|${entry.prompt}|${entry.completion}|${entry.total}`;
+      if (seenIds.has(seenKey)) continue;
+      seenIds.add(seenKey);
+
+      recordsProcessed++;
+
+      const cacheRead = toNonNegativeInt(entry.cache_hit);
+      // prompt already includes cache_hit (prompt = cache_miss + cache_hit),
+      // so input_tokens is net of cache to avoid double-counting.
+      const input = Math.max(0, toNonNegativeInt(entry.prompt) - cacheRead);
+      const output = toNonNegativeInt(entry.completion);
+      const reasoning = toNonNegativeInt(entry.reasoning);
+      const total = toNonNegativeInt(entry.total);
+      if (input === 0 && output === 0 && reasoning === 0 && total === 0) continue;
+
+      const tsIso = typeof entry.ts === "string" ? entry.ts : "";
+      const bucketStart = toUtcHalfHourStart(tsIso);
+      if (!bucketStart) continue;
+
+      const delta = {
+        input_tokens: input,
+        cached_input_tokens: cacheRead,
+        cache_creation_input_tokens: 0,
+        output_tokens: output,
+        reasoning_output_tokens: reasoning,
+        // total_tokens is Reasonix's own billing total (prompt + completion),
+        // which deliberately excludes reasoning — matches the provider's
+        // dashboard. Do not add reasoning here without adjusting pricing.
+        total_tokens: total,
+        conversation_count: toNonNegativeInt(entry.requests) || 1,
+      };
+
+      const bucket = getHourlyBucket(hourlyState, "reasonix", entry.model, bucketStart);
+      addTotals(bucket.totals, delta);
+      touchedBuckets.add(bucketKey("reasonix", entry.model, bucketStart));
+      eventsAggregated++;
+
+      if (cb) {
+        cb({
+          index: fileIdx + 1,
+          total: files.length,
+          recordsProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+    }
+
+    let postStat = stat;
+    try { postStat = fssync.statSync(filePath); } catch {}
+
+    // If the file does not end with a newline, the tail line may be an
+    // incomplete append in progress. Roll the cursor back to just after the
+    // last complete newline so that line is re-read (and later aggregated)
+    // once it is fully written, instead of being permanently dropped.
+    let cursorSize = postStat.size;
+    if (cursorSize > startOffset) {
+      const tailLen = Math.min(cursorSize - startOffset, 64 * 1024);
+      let fd = null;
+      try {
+        fd = fssync.openSync(filePath, "r");
+        const buf = Buffer.alloc(tailLen);
+        fssync.readSync(fd, buf, 0, tailLen, cursorSize - tailLen);
+        const lastNewline = buf.lastIndexOf(0x0a);
+        if (lastNewline === -1) {
+          cursorSize = startOffset;
+        } else {
+          const newlineAbs = cursorSize - tailLen + lastNewline;
+          if (newlineAbs + 1 < cursorSize) {
+            cursorSize = newlineAbs + 1;
+          }
+        }
+      } catch {
+        // File rotated/deleted between stat and open: roll back so the next
+        // run re-reads from a safe boundary instead of aborting this run.
+        cursorSize = startOffset;
+      } finally {
+        if (fd !== null) fssync.closeSync(fd);
+      }
+    }
+    fileOffsets[filePath] = { size: cursorSize, mtimeMs: postStat.mtimeMs, ino: postStat.ino };
+  }
+
+  // Cap seenIds to last 10k to bound cursor state size.
+  const seenArr = Array.from(seenIds);
+  const cappedSeen = seenArr.length > 10_000 ? seenArr.slice(seenArr.length - 10_000) : seenArr;
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  const updatedAt = new Date().toISOString();
+  hourlyState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors.reasonix = { ...reasonixState, seenIds: cappedSeen, fileOffsets, updatedAt };
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Kimi Code (official @moonshot-ai/kimi-code) — passive JSONL reader.
 //
 // Distinct from the legacy community `kimi-cli` above (Python, ~/.kimi). The
@@ -15866,6 +16052,9 @@ module.exports = {
   parseCopilotIncremental,
   parseCopilotSessionStoreIncremental,
   parseCopilotAppDbIncremental,
+  resolveReasonixStatsDir,
+  resolveReasonixStatFiles,
+  parseReasonixIncremental,
   resolveKimiHome,
   resolveKimiWireFiles,
   resolveKimiDefaultModel,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7588,7 +7588,17 @@ function resolveReasonixStatFiles(env = process.env) {
 async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgress, env } = {}) {
   await ensureDir(path.dirname(queuePath));
   const reasonixState = cursors.reasonix && typeof cursors.reasonix === "object" ? cursors.reasonix : {};
-  const seenIds = new Set(Array.isArray(reasonixState.seenIds) ? reasonixState.seenIds : []);
+  // Per-file seen fingerprints: { [filePath]: string[] } in the cursor, rebuilt
+  // as Sets here so an inode-rotated re-read of one file never replays records
+  // evicted from another file's cap.
+  const seenRaw =
+    reasonixState.seenIds && typeof reasonixState.seenIds === "object" && !Array.isArray(reasonixState.seenIds)
+      ? reasonixState.seenIds
+      : {};
+  const seenByFile = new Map();
+  for (const [filePath, keys] of Object.entries(seenRaw)) {
+    if (Array.isArray(keys)) seenByFile.set(filePath, new Set(keys));
+  }
   const fileOffsets =
     reasonixState.fileOffsets && typeof reasonixState.fileOffsets === "object"
       ? { ...reasonixState.fileOffsets }
@@ -7598,7 +7608,7 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
     ? statFiles
     : resolveReasonixStatFiles(env || process.env);
   if (files.length === 0) {
-    cursors.reasonix = { ...reasonixState, seenIds: Array.from(seenIds), fileOffsets, updatedAt: new Date().toISOString() };
+    cursors.reasonix = { ...reasonixState, seenIds: seenRaw, fileOffsets, updatedAt: new Date().toISOString() };
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
@@ -7612,17 +7622,24 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
     const filePath = files[fileIdx];
     let stat;
     try { stat = fssync.statSync(filePath); } catch { continue; }
+    const statSize = stat.size; // snapshot: the stream and cursor never exceed this
 
     const prevEntry = fileOffsets[filePath] || {};
     const prevSize = Number(prevEntry.size) || 0;
     const prevIno = prevEntry.ino;
     const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
-    const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
-    if (stat.size <= startOffset) continue;
+    const startOffset = statSize < prevSize || inodeChanged ? 0 : prevSize;
+    if (statSize <= startOffset) continue;
+
+    let seenIds = seenByFile.get(filePath);
+    if (!seenIds) {
+      seenIds = new Set();
+      seenByFile.set(filePath, seenIds);
+    }
 
     let stream;
     try {
-      stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset });
+      stream = fssync.createReadStream(filePath, { encoding: "utf8", start: startOffset, end: statSize - 1 });
     } catch { continue; }
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
@@ -7634,9 +7651,10 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
       // Turn markers carry no model/usage — skip them.
       if (typeof entry.model !== "string" || !entry.model) continue;
 
-      // Usage records have no stable id; dedup on the full row so an inode
-      // change / truncation-triggered full re-read cannot double-count.
-      const seenKey = `${entry.model}|${entry.ts}|${entry.prompt}|${entry.completion}|${entry.total}`;
+      // Usage records have no stable id; dedup on every field that feeds the
+      // delta so an inode change / truncation-triggered full re-read cannot
+      // double-count, while records differing in any aggregated value survive.
+      const seenKey = `${entry.model}|${entry.ts}|${entry.prompt}|${entry.completion}|${entry.total}|${entry.cache_hit}|${entry.reasoning}|${entry.requests}`;
       if (seenIds.has(seenKey)) continue;
       seenIds.add(seenKey);
 
@@ -7661,10 +7679,10 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
         cache_creation_input_tokens: 0,
         output_tokens: output,
         reasoning_output_tokens: reasoning,
-        // total_tokens is Reasonix's own billing total (prompt + completion),
-        // which deliberately excludes reasoning — matches the provider's
-        // dashboard. Do not add reasoning here without adjusting pricing.
-        total_tokens: total,
+        // total_tokens is the normalized sum of the delta columns so it stays
+        // internally consistent with the other providers (input is net of
+        // cache; reasoning is included, matching Antigravity/Kimi conventions).
+        total_tokens: input + cacheRead + output + reasoning,
         conversation_count: toNonNegativeInt(entry.requests) || 1,
       };
 
@@ -7687,11 +7705,11 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
     let postStat = stat;
     try { postStat = fssync.statSync(filePath); } catch {}
 
-    // If the file does not end with a newline, the tail line may be an
+    // If the snapshot does not end with a newline, the tail line may be an
     // incomplete append in progress. Roll the cursor back to just after the
-    // last complete newline so that line is re-read (and later aggregated)
+    // last complete newline (within the snapshot) so that line is re-read
     // once it is fully written, instead of being permanently dropped.
-    let cursorSize = postStat.size;
+    let cursorSize = statSize;
     if (cursorSize > startOffset) {
       const tailLen = Math.min(cursorSize - startOffset, 64 * 1024);
       let fd = null;
@@ -7719,15 +7737,18 @@ async function parseReasonixIncremental({ statFiles, cursors, queuePath, onProgr
     fileOffsets[filePath] = { size: cursorSize, mtimeMs: postStat.mtimeMs, ino: postStat.ino };
   }
 
-  // Cap seenIds to last 10k to bound cursor state size.
-  const seenArr = Array.from(seenIds);
-  const cappedSeen = seenArr.length > 10_000 ? seenArr.slice(seenArr.length - 10_000) : seenArr;
+  // Cap per-file seen fingerprints to last 10k to bound cursor state size.
+  const seenPersist = {};
+  for (const [filePath, keys] of seenByFile) {
+    const arr = Array.from(keys);
+    seenPersist[filePath] = arr.length > 10_000 ? arr.slice(arr.length - 10_000) : arr;
+  }
 
   const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
-  cursors.reasonix = { ...reasonixState, seenIds: cappedSeen, fileOffsets, updatedAt };
+  cursors.reasonix = { ...reasonixState, seenIds: seenPersist, fileOffsets, updatedAt };
 
   return { recordsProcessed, eventsAggregated, bucketsQueued };
 }

--- a/test/discovery-metadata.test.js
+++ b/test/discovery-metadata.test.js
@@ -9,14 +9,14 @@ const ROOT = path.resolve(__dirname, "..");
 const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
 
 const README_EXPECTATIONS = [
-  ["README.md", /29 AI coding tools/, /\|\s+\*\*AI tools supported\*\*\s+\|\s+\*\*29\*\*/],
-  ["README.zh-CN.md", /29 款 AI 编码工具/, /\|\s+\*\*支持的 AI 工具数\*\*\s+\|\s+\*\*29\*\*/],
-  ["README.ja.md", /29 種類の AI コーディングツール/, /\|\s+\*\*対応 AI ツール数\*\*\s+\|\s+\*\*29\*\*/],
-  ["README.ko.md", /29개의 AI 코딩 도구/, /\|\s+\*\*지원 AI 도구\*\*\s+\|\s+\*\*29\*\*/],
-  ["README.de.md", /29 KI-Coding-Tools/, /\|\s+\*\*Unterstützte KI-Tools\*\*\s+\|\s+\*\*29\*\*/],
+  ["README.md", /30 AI coding tools/, /\|\s+\*\*AI tools supported\*\*\s+\|\s+\*\*30\*\*/],
+  ["README.zh-CN.md", /30 款 AI 编码工具/, /\|\s+\*\*支持的 AI 工具数\*\*\s+\|\s+\*\*30\*\*/],
+  ["README.ja.md", /30 種類の AI コーディングツール/, /\|\s+\*\*対応 AI ツール数\*\*\s+\|\s+\*\*30\*\*/],
+  ["README.ko.md", /30개의 AI 코딩 도구/, /\|\s+\*\*지원 AI 도구\*\*\s+\|\s+\*\*30\*\*/],
+  ["README.de.md", /30 KI-Coding-Tools/, /\|\s+\*\*Unterstützte KI-Tools\*\*\s+\|\s+\*\*30\*\*/],
 ];
 
-test("public discovery surfaces describe all 29 supported tools", () => {
+test("public discovery surfaces describe all 30 supported tools", () => {
   for (const [file, countPattern, comparisonPattern] of README_EXPECTATIONS) {
     const source = read(file);
     assert.match(source, countPattern, `${file} has the current provider count`);
@@ -29,7 +29,7 @@ test("public discovery surfaces describe all 29 supported tools", () => {
 
   const index = read("dashboard/index.html");
   assert.doesNotMatch(index, /13 AI coding/);
-  assert.match(index, /Supported AI coding tools \(29\)/);
+  assert.match(index, /Supported AI coding tools \(30\)/);
   assert.match(index, /Desktop pet/);
   assert.match(index, /Four desktop widgets/);
   assert.match(index, /Achievements/);
@@ -37,39 +37,40 @@ test("public discovery surfaces describe all 29 supported tools", () => {
   assert.match(index, /usage limits for 12 providers/i);
 
   const llms = read("dashboard/public/llms.txt");
-  assert.match(llms, /Supported AI coding tools \(29\)/);
+  assert.match(llms, /Supported AI coding tools \(30\)/);
   assert.match(llms, /desktop pet/i);
   assert.match(llms, /four desktop widgets/i);
   assert.match(llms, /achievements/i);
 });
 
-test("marketing logo wall includes the same 29 product integrations", () => {
+test("marketing logo wall includes the same 30 product integrations", () => {
   const source = read("dashboard/src/ui/marketing/agent-logos.js");
   const providers = [...source.matchAll(/provider:\s*"([^"]+)"/g)].map((match) => match[1]);
-  assert.equal(providers.length, 29);
-  assert.equal(new Set(providers).size, 29);
+  assert.equal(providers.length, 30);
+  assert.equal(new Set(providers).size, 30);
 
-  for (const provider of ["every-code", "kilocode", "roocode", "zed", "goose", "droid", "qoder", "anythingllm"]) {
+  for (const provider of ["every-code", "kilocode", "roocode", "zed", "goose", "droid", "qoder", "anythingllm", "reasonix"]) {
     assert.ok(providers.includes(provider), `logo wall includes ${provider}`);
   }
 });
 
-test("CLI onboarding advertises the same 29 supported integrations", () => {
+test("CLI onboarding advertises the same 30 supported integrations", () => {
   const source = read("src/commands/init.js");
   const block = source.match(/const SUPPORTED_PROVIDERS = \[([\s\S]*?)\];/);
   assert.ok(block, "init defines SUPPORTED_PROVIDERS");
 
   const providers = [...block[1].matchAll(/^\s*"([^"]+)",?$/gm)].map((match) => match[1]);
-  assert.equal(providers.length, 29);
-  assert.equal(new Set(providers).size, 29);
+  assert.equal(providers.length, 30);
+  assert.equal(new Set(providers).size, 30);
   assert.ok(providers.includes("Droid"));
   assert.ok(providers.includes("AnythingLLM Desktop"));
   assert.ok(providers.includes("Qoder"));
+  assert.ok(providers.includes("Reasonix"));
 });
 
 test("npm metadata carries the current product hook", () => {
   const pkg = JSON.parse(read("package.json"));
-  assert.match(pkg.description, /29 tools/);
+  assert.match(pkg.description, /30 tools/);
   assert.match(pkg.description, /desktop pet/);
   assert.ok(pkg.keywords.includes("desktop-widget"));
   assert.ok(pkg.keywords.includes("ai-coding-tools"));

--- a/test/discovery-metadata.test.js
+++ b/test/discovery-metadata.test.js
@@ -24,6 +24,7 @@ test("public discovery surfaces describe all 30 supported tools", () => {
     assert.match(source, /Droid/, `${file} lists Droid`);
     assert.match(source, /AnythingLLM Desktop/, `${file} lists AnythingLLM Desktop`);
     assert.match(source, /Qoder/, `${file} lists Qoder`);
+    assert.match(source, /Reasonix/, `${file} lists Reasonix`);
     assert.match(source, /12/, `${file} carries the current usage-limits provider count`);
   }
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -6724,7 +6724,7 @@ test("parseReasonixIncremental aggregates usage records and skips turn markers",
     assert.ok(cursors.reasonix && typeof cursors.reasonix === "object");
     assert.ok(cursors.reasonix.fileOffsets[statFile]);
     assert.equal(cursors.reasonix.fileOffsets[statFile].size, Buffer.byteLength(content));
-    assert.equal(cursors.reasonix.seenIds.length, 2);
+    assert.equal(cursors.reasonix.seenIds[statFile].length, 2);
 
     // Aggregated bucket totals: input is net of cache (prompt = cache_miss + cache_hit)
     const queueRows = (await fs.readFile(queuePath, "utf8"))
@@ -6741,7 +6741,8 @@ test("parseReasonixIncremental aggregates usage records and skips turn markers",
     assert.equal(row.cache_creation_input_tokens, 0);
     assert.equal(row.output_tokens, 208 + 260);
     assert.equal(row.reasoning_output_tokens, 126 + 120);
-    assert.equal(row.total_tokens, 4068 + 7777);
+    // total_tokens is the normalized sum of the delta columns
+    assert.equal(row.total_tokens, 3953 + 7424 + 468 + 246); // 12091
     assert.equal(row.conversation_count, 2);
 
     // Second run — no new data

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -37,6 +37,8 @@ const {
   probeWslDistros,
   discoverWslHermesHome,
   parseCopilotIncremental,
+  resolveReasonixStatFiles,
+  parseReasonixIncremental,
   parseKimiIncremental,
   parseCodebuddyIncremental,
   parseCursorApiIncremental,
@@ -6663,6 +6665,214 @@ test("parseKimiIncremental returns zero when no wire files exist", async () => {
     assert.equal(result.recordsProcessed, 0);
     assert.equal(result.eventsAggregated, 0);
     assert.equal(result.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reasonix — passive ~/.reasonix/stats/YYYY-MM-DD.jsonl reader.
+// Each line is a usage record (model + token fields) or a turn marker (no
+// model field, skipped). Files are append-only and named by day.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("parseReasonixIncremental aggregates usage records and skips turn markers", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-reasonix-"));
+  try {
+    const statsDir = path.join(tmp, "stats");
+    await fs.mkdir(statsDir, { recursive: true });
+    const lines = [
+      JSON.stringify({
+        ts: "2026-08-07T00:22:36.563231+08:00",
+        model: "deepseek/deepseek-v4-flash",
+        source: "desktop",
+        prompt: 3860,
+        completion: 208,
+        reasoning: 126,
+        cache_miss: 3860,
+        total: 4068,
+        requests: 1,
+      }),
+      JSON.stringify({ ts: "2026-08-07T00:24:30.184705+08:00", source: "desktop", turn: true }),
+      JSON.stringify({
+        ts: "2026-08-07T00:22:43.571662+08:00",
+        model: "deepseek/deepseek-v4-flash",
+        source: "desktop",
+        prompt: 7517,
+        completion: 260,
+        reasoning: 120,
+        cache_hit: 7424,
+        cache_miss: 93,
+        total: 7777,
+        requests: 1,
+      }),
+    ].join("\n");
+    const content = lines + "\n"; // real stats files end each row with a newline
+
+    const statFile = path.join(statsDir, "2026-08-07.jsonl");
+    await fs.writeFile(statFile, content);
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const result = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+
+    assert.equal(result.recordsProcessed, 2); // turn marker is not counted
+    assert.equal(result.eventsAggregated, 2);
+    assert.ok(result.bucketsQueued > 0);
+
+    // Cursor state persisted with per-file offsets
+    assert.ok(cursors.reasonix && typeof cursors.reasonix === "object");
+    assert.ok(cursors.reasonix.fileOffsets[statFile]);
+    assert.equal(cursors.reasonix.fileOffsets[statFile].size, Buffer.byteLength(content));
+    assert.equal(cursors.reasonix.seenIds.length, 2);
+
+    // Aggregated bucket totals: input is net of cache (prompt = cache_miss + cache_hit)
+    const queueRows = (await fs.readFile(queuePath, "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(JSON.parse);
+    const row = queueRows.find((r) => r.source === "reasonix");
+    assert.ok(row, "queue contains a reasonix bucket");
+    assert.equal(row.model, "deepseek/deepseek-v4-flash");
+    assert.equal(row.hour_start, "2026-08-06T16:00:00.000Z");
+    assert.equal(row.input_tokens, 3860 + (7517 - 7424)); // 3953
+    assert.equal(row.cached_input_tokens, 7424);
+    assert.equal(row.cache_creation_input_tokens, 0);
+    assert.equal(row.output_tokens, 208 + 260);
+    assert.equal(row.reasoning_output_tokens, 126 + 120);
+    assert.equal(row.total_tokens, 4068 + 7777);
+    assert.equal(row.conversation_count, 2);
+
+    // Second run — no new data
+    const result2 = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+    assert.equal(result2.recordsProcessed, 0);
+    assert.equal(result2.eventsAggregated, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseReasonixIncremental returns zero when no stat files exist", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-reasonix-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const result = await parseReasonixIncremental({ statFiles: [], cursors, queuePath });
+    assert.equal(result.recordsProcessed, 0);
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal(result.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseReasonixIncremental rolls back cursor on an incomplete trailing line", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-reasonix-"));
+  try {
+    const statsDir = path.join(tmp, "stats");
+    await fs.mkdir(statsDir, { recursive: true });
+    const statFile = path.join(statsDir, "2026-08-07.jsonl");
+
+    const line1 = JSON.stringify({
+      ts: "2026-08-07T00:22:36.563231+08:00",
+      model: "deepseek/deepseek-v4-flash",
+      source: "desktop",
+      prompt: 3860,
+      completion: 208,
+      reasoning: 126,
+      cache_miss: 3860,
+      total: 4068,
+      requests: 1,
+    });
+    const line2 = JSON.stringify({
+      ts: "2026-08-07T00:22:43.571662+08:00",
+      model: "deepseek/deepseek-v4-flash",
+      source: "desktop",
+      prompt: 7517,
+      completion: 260,
+      reasoning: 120,
+      cache_hit: 7424,
+      cache_miss: 93,
+      total: 7777,
+      requests: 1,
+    });
+    // A row that is still being appended: no trailing newline yet.
+    const partialTail = '{"ts":"2026-08-07T01:00:00.000000+08:00","model":"deepseek/deepseek-v4-flash","source":"desk';
+    await fs.writeFile(statFile, line1 + "\n" + line2 + "\n" + partialTail);
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const result = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+
+    // Both complete rows aggregated; the incomplete tail is not counted.
+    assert.equal(result.recordsProcessed, 2);
+    assert.equal(result.eventsAggregated, 2);
+    // Cursor rolled back to just after the last complete newline.
+    assert.equal(cursors.reasonix.fileOffsets[statFile].size, Buffer.byteLength(line1 + "\n" + line2 + "\n"));
+
+    // Append completes the row.
+    await fs.appendFile(statFile, 'top","prompt":100,"completion":10,"reasoning":0,"cache_hit":0,"cache_miss":100,"total":110,"requests":1}\n');
+    const result2 = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+    assert.equal(result2.recordsProcessed, 1);
+    assert.equal(result2.eventsAggregated, 1);
+    assert.equal(result2.bucketsQueued, 1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseReasonixIncremental does not double-count after an inode-rotated re-read", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-reasonix-"));
+  try {
+    const statsDir = path.join(tmp, "stats");
+    await fs.mkdir(statsDir, { recursive: true });
+    const statFile = path.join(statsDir, "2026-08-07.jsonl");
+    const row = JSON.stringify({
+      ts: "2026-08-07T00:22:36.563231+08:00",
+      model: "deepseek/deepseek-v4-flash",
+      source: "desktop",
+      prompt: 3860,
+      completion: 208,
+      reasoning: 126,
+      cache_miss: 3860,
+      total: 4068,
+      requests: 1,
+    });
+    const content = row + "\n";
+    await fs.writeFile(statFile, content);
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const result1 = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+    assert.equal(result1.eventsAggregated, 1);
+
+    // Rotate the file: remove and rewrite the same content with a new inode.
+    await fs.rm(statFile);
+    await fs.writeFile(statFile, content);
+
+    const result2 = await parseReasonixIncremental({ statFiles: [statFile], cursors, queuePath });
+    // Full re-read (inode changed) but seenIds dedup prevents double-counting.
+    assert.equal(result2.eventsAggregated, 0);
+    assert.equal(result2.recordsProcessed, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveReasonixStatFiles lists only .jsonl files sorted by name", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-reasonix-"));
+  try {
+    const statsDir = path.join(tmp, "stats");
+    await fs.mkdir(statsDir, { recursive: true });
+    await fs.writeFile(path.join(statsDir, "2026-08-07.jsonl"), "x\n");
+    await fs.writeFile(path.join(statsDir, "2026-08-06.jsonl"), "x\n");
+    await fs.writeFile(path.join(statsDir, "notes.txt"), "x\n");
+    const files = resolveReasonixStatFiles({ REASONIX_HOME: tmp });
+    assert.deepEqual(
+      files.map((f) => path.basename(f)),
+      ["2026-08-06.jsonl", "2026-08-07.jsonl"],
+    );
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Adds **Reasonix** (a local-first AI coding agent, CLI + desktop) as the 30th supported AI tool. TokenTracker reads Reasonix's local per-request usage records — no hooks, no API keys, fully passive, matching the existing Kimi/Craft reader pattern.

## Why

Reasonix persists token usage locally as append-only JSONL (`~/.reasonix/stats/YYYY-MM-DD.jsonl`), one record per request, with prompt/completion/reasoning and cache-hit splits. Nothing else in the ecosystem reads it. This PR surfaces that data in the TokenTracker dashboard alongside the other 29 tools.

## Data source & mapping

```json
{"ts":"2026-08-07T00:22:43.571662+08:00","model":"deepseek/deepseek-v4-flash","source":"desktop",
 "prompt":7517,"completion":260,"reasoning":120,"cache_hit":7424,"cache_miss":93,"total":7777,"requests":1}
```

| Canonical field | Source |
|---|---|
| `input_tokens` | `prompt - cache_hit` (net of cache; `prompt = cache_miss + cache_hit`) |
| `output_tokens` | `completion` |
| `cached_input_tokens` | `cache_hit` |
| `reasoning_output_tokens` | `reasoning` |
| `total_tokens` | `total` (provider billing total, excludes reasoning by design) |
| `conversation_count` | `requests` |
| `model` / `hour_start` | `model` / bucket from `ts` |

Turn-marker lines (no `model` field) are skipped. Files are append-only and named by day, so the parser uses an offset-based incremental cursor with: `lstat`-only discovery (no symlink following), a `seenIds` dedup set for inode-rotation re-reads (capped at 10k), and rollback past an incomplete trailing line so an in-flight append is never permanently dropped.

## Files touched

- `src/lib/rollout.js` — `resolveReasonixStatsDir/StatFiles` + `parseReasonixIncremental` (+ exports)
- `src/commands/sync.js` — passive scheduling block, `AUTO_SYNC_SOURCES`, totals
- `src/commands/init.js` — `SUPPORTED_PROVIDERS`, passive detection
- `src/commands/status.js` — detection, JSON + human-readable output
- `test/rollout-parser.test.js` — 5 unit tests with real anonymized fixtures (aggregation, turn-marker skip, idempotency, incomplete-tail rollback, inode-rotation dedup)
- `test/discovery-metadata.test.js`, README family (en/zh-CN/ja/ko/de), `dashboard/index.html`, `llms.txt`, `agent-logos.js` — 29 → 30

## Verification

- `npm test`: **2035/2035 pass**
- End-to-end against real `~/.reasonix/stats` data: 314 records → 313 events → 8 buckets, second run idempotent

## Privacy

Only token counts, model names, and timestamps are read — never prompt/response content. Consistent with TokenTracker's privacy rule.

## Notes

- `total_tokens` deliberately follows Reasonix's billing total (excludes reasoning), matching the provider's own dashboard; reasoning is still surfaced separately via `reasoning_output_tokens`.
- Windows: stats dir resolves under `%APPDATA%\reasonix\stats`; `REASONIX_HOME` env overrides for any layout.
- Reasonix's stats format is its internal format (v1.19.5+), not a public API — same trade-off as several existing integrations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Reasonix usage as the 30th supported AI coding tool.
  - Reasonix activity is detected and included in status and synchronization results.
  - Added usage breakdowns by model, cached tokens, and time period.

- **Documentation**
  - Updated localized documentation, dashboard content, package metadata, and marketing materials to reflect 30 supported tools.
  - Added Reasonix to supported-tool lists and integration visuals.

- **Tests**
  - Added coverage for Reasonix discovery, incremental processing, recovery, deduplication, and usage aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->