### PR TITLE
fix: repair cross-platform session and release consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # A main commit that changes package.json is the immutable npm candidate.
+  # Cancelling it lets a later, same-version commit publish code that never
+  # existed at the version bump SHA. Keep main runs; only supersede PR runs.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
           persist-credentials: false
 
       - uses: actions/setup-node@v7
@@ -36,12 +37,23 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      # Skip if this version is already published
-      - name: Check if version exists on npm
+      # Only the commit that actually changed package.json may publish. This
+      # prevents a later same-version main commit from becoming the package
+      # provenance when the version commit's CI finishes earlier or later.
+      - name: Verify version commit and check npm
         id: version-check
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          PARENT_VERSION=$(git show HEAD^:package.json 2>/dev/null | node -e \
+            "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{process.stdout.write(JSON.parse(s).version||'')}catch{}})" || true)
+          if [ "$PARENT_VERSION" = "$PACKAGE_VERSION" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "package.json version did not change in this tested commit; skipping publish."
+            exit 0
+          fi
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
           if npm view tokentracker-cli@"$PACKAGE_VERSION" version 2>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -49,11 +61,11 @@ jobs:
           fi
 
       - name: Install root dependencies
-        if: steps.version-check.outputs.exists == 'false'
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'false'
         run: npm ci
 
       - name: Install dashboard dependencies
-        if: steps.version-check.outputs.exists == 'false'
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'false'
         run: npm ci --prefix dashboard
 
       # InsForge URL + anon key are public client-side values shipped in every
@@ -61,27 +73,27 @@ jobs:
       # empty strings — breaks leaderboard fetch and disables cloud OAuth.
       # `dashboard/.env.local` is gitignored so CI cannot read it.
       - name: Build dashboard
-        if: steps.version-check.outputs.exists == 'false'
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'false'
         env:
           VITE_INSFORGE_BASE_URL: https://srctyff5.us-east.insforge.app
           VITE_INSFORGE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3OC0xMjM0LTU2NzgtOTBhYi1jZGVmMTIzNDU2NzgiLCJlbWFpbCI6ImFub25AaW5zZm9yZ2UuY29tIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODExNDU5NDd9.T0auta_IrVIh0uXW1bob5QSnzvsnJmN28r5XkSGEuQY
         run: npm run dashboard:build
 
       - name: Publish to npm
-        if: steps.version-check.outputs.exists == 'false'
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip notice
-        if: steps.version-check.outputs.exists == 'true'
+        if: steps.version-check.outputs.eligible != 'true' || steps.version-check.outputs.exists == 'true'
         run: echo "v${{ steps.version-check.outputs.version }} already published, skipping."
 
       # Notify homebrew-tokentracker tap to bump the Formula immediately.
       # If HOMEBREW_DISPATCH_TOKEN is not set, this step silently no-ops and
       # the tap's own hourly cron picks up the new version within ~1 hour.
       - name: Dispatch homebrew tap update
-        if: steps.version-check.outputs.exists == 'false'
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'false'
         env:
           HOMEBREW_DISPATCH_TOKEN: ${{ secrets.HOMEBREW_DISPATCH_TOKEN }}
           VERSION: ${{ steps.version-check.outputs.version }}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -38,7 +38,7 @@ targets:
         PRODUCT_NAME: TokenTracker
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.88.1"
+        MARKETING_VERSION: "0.88.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -89,7 +89,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.88.1"
+        MARKETING_VERSION: "0.88.2"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/TokenTrackerLinux/README.md
+++ b/TokenTrackerLinux/README.md
@@ -99,12 +99,10 @@ Google/GitHub sign-in needs `http://127.0.0.1:17680/auth/callback`, so if
 something else already holds 17680 the app falls back to a random port and OAuth
 will not complete until 17680 is free again.
 
-> **AppImage caveat:** the `tokentracker://` deep-link scheme is registered by the
-> installed `.desktop` file, which the Arch package installs but a bare AppImage
-> does not. This only affects the custom-scheme callback path; the loopback
-> redirect above is what the browser flow actually uses, so sign-in still works.
-> Use the Arch package (or install the AppImage with a tool like `appimaged`) if
-> you need the `tokentracker://` handler.
+The AppImage registers a per-user `.desktop` handler for the
+`tokentracker://` OAuth callback on first launch and refreshes it whenever the
+AppImage moves. This requires `xdg-mime` (normally provided by `xdg-utils`). The
+Arch package installs the equivalent handler system-wide.
 
 ## Logs
 

--- a/TokenTrackerLinux/package-lock.json
+++ b/TokenTrackerLinux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-linux",
-      "version": "0.88.1",
+      "version": "0.88.2",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
         "pngjs": "^7.0.0"

--- a/TokenTrackerLinux/package.json
+++ b/TokenTrackerLinux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
+++ b/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: local
 pkgname=tokentracker-linux
-pkgver=0.88.1
+pkgver=0.88.2
 pkgrel=1
 pkgdesc='Local TokenTracker Linux desktop client for Arch KDE'
 arch=('x86_64')

--- a/TokenTrackerLinux/src-tauri/Cargo.lock
+++ b/TokenTrackerLinux/src-tauri/Cargo.lock
@@ -3611,7 +3611,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokentracker-linux"
-version = "0.88.1"
+version = "0.88.2"
 dependencies = [
  "once_cell",
  "serde",

--- a/TokenTrackerLinux/src-tauri/Cargo.toml
+++ b/TokenTrackerLinux/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokentracker-linux"
-version = "0.88.1"
+version = "0.88.2"
 description = "TokenTracker Linux desktop client"
 authors = ["TokenTracker"]
 edition = "2021"

--- a/TokenTrackerLinux/src-tauri/src/main.rs
+++ b/TokenTrackerLinux/src-tauri/src/main.rs
@@ -235,6 +235,9 @@ fn main() {
             tray::show_main_window(app);
         }))
         .setup(move |app| {
+            if let Err(error) = oauth::ensure_appimage_protocol_registration() {
+                eprintln!("[TokenTracker] AppImage OAuth callback registration failed: {error}");
+            }
             tray::install(app)?;
 
             for arg in &initial_args {

--- a/TokenTrackerLinux/src-tauri/src/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/src/oauth.rs
@@ -125,11 +125,7 @@ pub fn ensure_appimage_protocol_registration() -> Result<bool, String> {
         .map_err(|error| format!("failed to write {}: {error}", desktop_path.display()))?;
 
     let status = Command::new("xdg-mime")
-        .args([
-            "default",
-            desktop_name,
-            "x-scheme-handler/tokentracker",
-        ])
+        .args(["default", desktop_name, "x-scheme-handler/tokentracker"])
         .status()
         .map_err(|error| format!("failed to run xdg-mime: {error}"))?;
     if !status.success() {

--- a/TokenTrackerLinux/src-tauri/src/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/src/oauth.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Mutex;
 
 use tauri::{AppHandle, Manager, Url};
@@ -57,6 +60,93 @@ pub fn is_allowed_oauth_url(raw: &str) -> bool {
     Url::parse(raw)
         .map(|url| url.scheme() == "https" && url.host_str().is_some())
         .unwrap_or(false)
+}
+
+fn desktop_exec_quote(path: &Path) -> Option<String> {
+    let raw = path.to_str()?;
+    if raw.is_empty() || raw.chars().any(|ch| matches!(ch, '\n' | '\r' | '\0')) {
+        return None;
+    }
+    // Desktop Entry Exec quoting: backslash-escape characters that retain a
+    // special meaning inside double quotes. `%` must also be doubled or it is
+    // interpreted as a field code before the real `%u` argument.
+    let escaped = raw
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('`', "\\`")
+        .replace('$', "\\$")
+        .replace('%', "%%");
+    Some(format!("\"{escaped}\""))
+}
+
+pub fn appimage_desktop_entry(appimage: &Path) -> Option<String> {
+    let executable = desktop_exec_quote(appimage)?;
+    Some(format!(
+        "[Desktop Entry]\nType=Application\nName=TokenTracker\nComment=Local AI token usage tracker\nExec={executable} %u\nIcon=tokentracker-linux\nTerminal=false\nCategories=Development;Utility;\nStartupNotify=true\nMimeType=x-scheme-handler/tokentracker;\nX-AppImage-Integrate=false\n"
+    ))
+}
+
+fn user_applications_dir() -> Option<PathBuf> {
+    if let Some(value) = std::env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(value).join("applications"));
+    }
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(|home| home.join(".local/share/applications"))
+}
+
+/// Register the custom callback scheme for a directly launched AppImage.
+///
+/// Arch installs the repository's desktop file system-wide. A bare AppImage
+/// has no installer, so without this per-user entry the browser cannot return
+/// the PKCE code to the already-running process. Registration happens before
+/// the dashboard is shown and is refreshed on every launch in case the user
+/// moved or renamed the AppImage.
+pub fn ensure_appimage_protocol_registration() -> Result<bool, String> {
+    let Some(appimage_raw) = std::env::var_os("APPIMAGE").filter(|value| !value.is_empty()) else {
+        return Ok(false);
+    };
+    let appimage = PathBuf::from(appimage_raw);
+    if !appimage.is_absolute() || !appimage.is_file() {
+        return Err("APPIMAGE must point to an existing absolute file".to_string());
+    }
+    let applications_dir = user_applications_dir()
+        .ok_or_else(|| "HOME/XDG_DATA_HOME is unavailable for protocol registration".to_string())?;
+    fs::create_dir_all(&applications_dir)
+        .map_err(|error| format!("failed to create {}: {error}", applications_dir.display()))?;
+    let desktop_name = "tokentracker-appimage.desktop";
+    let desktop_path = applications_dir.join(desktop_name);
+    let content = appimage_desktop_entry(&appimage)
+        .ok_or_else(|| "AppImage path cannot be represented in a desktop entry".to_string())?;
+    let temporary = desktop_path.with_extension(format!("desktop.{}.tmp", std::process::id()));
+    fs::write(&temporary, content)
+        .and_then(|()| fs::rename(&temporary, &desktop_path))
+        .map_err(|error| format!("failed to write {}: {error}", desktop_path.display()))?;
+
+    let status = Command::new("xdg-mime")
+        .args([
+            "default",
+            desktop_name,
+            "x-scheme-handler/tokentracker",
+        ])
+        .status()
+        .map_err(|error| format!("failed to run xdg-mime: {error}"))?;
+    if !status.success() {
+        return Err(format!("xdg-mime exited with {status}"));
+    }
+
+    let query = Command::new("xdg-mime")
+        .args(["query", "default", "x-scheme-handler/tokentracker"])
+        .output()
+        .map_err(|error| format!("failed to verify xdg-mime registration: {error}"))?;
+    let registered = String::from_utf8_lossy(&query.stdout).trim().to_string();
+    if !query.status.success() || registered != desktop_name {
+        return Err(format!(
+            "protocol registration did not read back (expected {desktop_name}, got {registered:?})"
+        ));
+    }
+    Ok(true)
 }
 
 pub fn callback_url(base: &str, code: &str) -> Option<String> {

--- a/TokenTrackerLinux/src-tauri/tauri.conf.json
+++ b/TokenTrackerLinux/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TokenTracker",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "identifier": "cc.tokentracker.linux",
   "build": {
     "beforeDevCommand": "",

--- a/TokenTrackerLinux/src-tauri/tests/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/tests/oauth.rs
@@ -147,5 +147,8 @@ fn appimage_desktop_entry_registers_the_callback_and_quotes_the_path() {
 
 #[test]
 fn appimage_desktop_entry_rejects_control_characters() {
-    assert_eq!(appimage_desktop_entry(Path::new("/tmp/bad\nname.AppImage")), None);
+    assert_eq!(
+        appimage_desktop_entry(Path::new("/tmp/bad\nname.AppImage")),
+        None
+    );
 }

--- a/TokenTrackerLinux/src-tauri/tests/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/tests/oauth.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use tokentracker_linux::oauth::{
-    callback_url, is_allowed_oauth_url, parse_auth_callback, PendingAuthCode,
+    appimage_desktop_entry, callback_url, is_allowed_oauth_url, parse_auth_callback,
+    PendingAuthCode,
 };
 
 #[test]
@@ -126,4 +129,23 @@ fn pending_auth_code_is_consumed_once_and_latest_wins() {
 
     assert_eq!(pending.take().as_deref(), Some("second"));
     assert_eq!(pending.take(), None);
+}
+
+#[test]
+fn appimage_desktop_entry_registers_the_callback_and_quotes_the_path() {
+    let entry = appimage_desktop_entry(Path::new(
+        "/home/dev/Token Tracker 100%/$`\"\\/TokenTracker-linux.AppImage",
+    ))
+    .expect("valid AppImage path");
+
+    assert!(entry.contains(
+        "Exec=\"/home/dev/Token Tracker 100%%/\\$\\`\\\"\\\\/TokenTracker-linux.AppImage\" %u"
+    ));
+    assert!(entry.contains("MimeType=x-scheme-handler/tokentracker;"));
+    assert!(entry.contains("X-AppImage-Integrate=false"));
+}
+
+#[test]
+fn appimage_desktop_entry_rejects_control_characters() {
+    assert_eq!(appimage_desktop_entry(Path::new("/tmp/bad\nname.AppImage")), None);
 }

--- a/TokenTrackerWin/TokenTrackerWin.csproj
+++ b/TokenTrackerWin/TokenTrackerWin.csproj
@@ -22,7 +22,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>assets\trayicon.ico</ApplicationIcon>
     <!-- Keep in sync with package.json / project.yml on release. -->
-    <Version>0.88.1</Version>
+    <Version>0.88.2</Version>
     <Product>TokenTracker</Product>
     <Company>TokenTracker</Company>
     <!-- App UI strings live in TrayStrings/NativeLocalization (no .resx), so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-cli",
-      "version": "0.88.1",
+      "version": "0.88.2",
       "license": "MIT",
       "dependencies": {
         "@mongodb-js/zstd": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "description": "Local-first AI coding token usage and cost tracker for 29 tools, with a dashboard, desktop pet, widgets, achievements, and native macOS/Windows apps.",
   "main": "src/cli.js",
   "bin": {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -458,10 +458,12 @@ async function cmdSync(argv, context = {}) {
     process.stderr.write(await recordSyncSkip(trackerDir, lockPath));
     return;
   }
-  await clearSyncSkip(trackerDir);
-
   let progress = null;
   try {
+    // Marker cleanup can fail for reasons other than ENOENT (permissions, or a
+    // directory replacing the expected file). Keep it inside the lease's
+    // try/finally so an auxiliary diagnostic never strands the sync lock.
+    await clearSyncSkip(trackerDir);
     progress = !opts.auto ? createProgress({ stream: process.stdout }) : null;
     const configPath = path.join(trackerDir, "config.json");
     const cursorsPath = path.join(trackerDir, "cursors.json");

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -1233,7 +1233,11 @@ async function parseOpencodeIncremental({
     const size = Number.isFinite(st.size) ? st.size : 0;
     const mtimeMs = Number.isFinite(st.mtimeMs) ? st.mtimeMs : 0;
     const unchanged =
-      prev && prev.inode === inode && prev.size === size && prev.mtimeMs === mtimeMs;
+      prev &&
+      prev.inode === inode &&
+      prev.size === size &&
+      prev.mtimeMs === mtimeMs &&
+      prev.opencodeForkRepairVersion === 1;
     if (unchanged) {
       filesProcessed += 1;
       if (cb) {
@@ -1287,6 +1291,7 @@ async function parseOpencodeIncremental({
       mtimeMs,
       lastTotals: result.lastTotals,
       messageKey: result.messageKey || null,
+      opencodeForkRepairVersion: 1,
       updatedAt: new Date().toISOString(),
     };
 
@@ -1300,6 +1305,7 @@ async function parseOpencodeIncremental({
         messageKey: result.messageKey,
         totals: result.lastTotals,
         fingerprint: result.fingerprint || null,
+        dedupedForkCopy: result.dedupedForkCopy === true,
       });
     }
 
@@ -2630,16 +2636,41 @@ async function parseOpencodeMessageFile({
   // `Session.fork` re-materialises the parent's prefix under new message ids in
   // a new session — count it once (issue #426, see deriveOpencodeMessageFingerprint).
   const fingerprint = deriveOpencodeMessageFingerprint({ msg, totals: currentTotals, source });
-  if (!lastTotals && isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey)) {
-    return { messageKey, lastTotals: null, fingerprint, eventsAggregated: 0, shouldUpdate: false };
+  if (isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey)) {
+    if (lastTotals && prev?.dedupedForkCopy !== true) {
+      repairCountedOpencodeForkCopy({
+        msg,
+        totals: lastTotals,
+        source,
+        hourlyState,
+        touchedBuckets,
+        projectState,
+        projectTouchedBuckets,
+        projectRef,
+        projectKey,
+      });
+    }
+    return {
+      messageKey,
+      lastTotals: currentTotals,
+      fingerprint,
+      dedupedForkCopy: true,
+      eventsAggregated: 0,
+      shouldUpdate: prev?.dedupedForkCopy !== true || !lastTotals,
+    };
   }
 
-  const delta = diffGeminiTotals(currentTotals, lastTotals);
+  // A formerly deduped copy can become a genuinely distinct in-place update.
+  // Its prior totals were removed from the buckets, so re-add the full current
+  // snapshot instead of only the delta from the suppressed value.
+  const effectiveLastTotals = prev?.dedupedForkCopy === true ? null : lastTotals;
+  const delta = diffGeminiTotals(currentTotals, effectiveLastTotals);
   if (!delta || isAllZeroUsage(delta)) {
     return {
       messageKey,
       lastTotals: currentTotals,
       fingerprint,
+      dedupedForkCopy: false,
       eventsAggregated: 0,
       shouldUpdate: true,
     };
@@ -2686,6 +2717,7 @@ async function parseOpencodeMessageFile({
     messageKey,
     lastTotals: currentTotals,
     fingerprint,
+    dedupedForkCopy: false,
     eventsAggregated: 1,
     shouldUpdate: true,
   };
@@ -3276,13 +3308,15 @@ function deriveOpencodeMessageFingerprint({ msg, totals, source }) {
   return crypto.createHash("sha256").update(raw).digest("base64url").slice(0, 22);
 }
 
-// `fingerprint -> messageKey` for the messages already counted in this cursor
-// namespace. Rebuilt per parse run; entries written before this version carry no
-// fingerprint and simply do not participate (no retroactive rewrite of history).
+// `fingerprint -> messageKey` for counted messages in this cursor namespace.
+// Rebuilt per parse run. Pre-#426 entries are fingerprinted as they are read;
+// the first claims ownership and later cross-session matches are retracted from
+// persisted buckets once. Tombstoned copies never claim ownership themselves.
 function buildOpencodeFingerprintIndex(messageIndex) {
   const byFingerprint = new Map();
   if (!messageIndex || typeof messageIndex !== "object") return byFingerprint;
   for (const [key, entry] of Object.entries(messageIndex)) {
+    if (entry?.dedupedForkCopy === true) continue;
     const fingerprint = entry && typeof entry.fingerprint === "string" ? entry.fingerprint : null;
     if (fingerprint && !byFingerprint.has(fingerprint)) byFingerprint.set(fingerprint, key);
   }
@@ -3314,13 +3348,25 @@ function isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey) {
 // cursor untouched. A falsy `fingerprint` means "unknown" and preserves whatever
 // the entry already carried; a new one releases the old claim so a stale
 // mid-stream snapshot cannot shadow an unrelated message later.
-function recordOpencodeMessage({ messageIndex, fingerprintIndex, messageKey, totals, fingerprint }) {
+function recordOpencodeMessage({
+  messageIndex,
+  fingerprintIndex,
+  messageKey,
+  totals,
+  fingerprint,
+  dedupedForkCopy = false,
+}) {
   if (!messageIndex || !messageKey) return;
   const prev = messageIndex[messageKey];
   const prevTotals = prev && typeof prev.lastTotals === "object" ? prev.lastTotals : null;
   const prevFingerprint = prev && typeof prev.fingerprint === "string" ? prev.fingerprint : null;
   const nextFingerprint = fingerprint || prevFingerprint;
-  if (sameGeminiTotals(totals, prevTotals) && prevFingerprint === nextFingerprint) return;
+  const prevDeduped = prev?.dedupedForkCopy === true;
+  if (
+    sameGeminiTotals(totals, prevTotals) &&
+    prevFingerprint === nextFingerprint &&
+    prevDeduped === Boolean(dedupedForkCopy)
+  ) return;
 
   if (fingerprintIndex && prevFingerprint && prevFingerprint !== nextFingerprint) {
     if (fingerprintIndex.get(prevFingerprint) === messageKey) {
@@ -3329,10 +3375,50 @@ function recordOpencodeMessage({ messageIndex, fingerprintIndex, messageKey, tot
   }
   const entry = { lastTotals: totals, updatedAt: new Date().toISOString() };
   if (nextFingerprint) entry.fingerprint = nextFingerprint;
+  if (dedupedForkCopy) entry.dedupedForkCopy = true;
   messageIndex[messageKey] = entry;
-  if (fingerprintIndex && nextFingerprint && !fingerprintIndex.has(nextFingerprint)) {
+  if (
+    fingerprintIndex &&
+    nextFingerprint &&
+    !dedupedForkCopy &&
+    !fingerprintIndex.has(nextFingerprint)
+  ) {
     fingerprintIndex.set(nextFingerprint, messageKey);
   }
+}
+
+function repairCountedOpencodeForkCopy({
+  msg,
+  totals,
+  source,
+  hourlyState,
+  touchedBuckets,
+  projectState,
+  projectTouchedBuckets,
+  projectRef,
+  projectKey,
+}) {
+  const timestampMs = coerceEpochMs(msg?.time?.completed) || coerceEpochMs(msg?.time?.created);
+  if (!timestampMs) return false;
+  const bucketStart = toUtcHalfHourStart(new Date(timestampMs).toISOString());
+  if (!bucketStart) return false;
+  const model = normalizeModelInput(msg?.modelID || msg?.model || msg?.modelId) || DEFAULT_MODEL;
+  const counted = { ...totals, conversation_count: 1 };
+  const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
+  subtractTotals(bucket.totals, counted);
+  touchedBuckets.add(bucketKey(source, model, bucketStart));
+  if (projectKey && projectState && projectTouchedBuckets) {
+    const projectBucket = getProjectBucket(
+      projectState,
+      projectKey,
+      source,
+      bucketStart,
+      projectRef,
+    );
+    subtractTotals(projectBucket.totals, counted);
+    projectTouchedBuckets.add(projectBucketKey(projectKey, source, bucketStart));
+  }
+  return true;
 }
 
 function getHourlyBucket(state, source, model, hourStart) {
@@ -4390,19 +4476,53 @@ async function parseOpencodeDbIncremental({
       continue;
     }
 
-    // A fork copy of an already-counted turn contributes nothing — skip it
-    // outright so it never claims an index entry of its own (issue #426).
+    // A fork copy of an already-counted turn contributes nothing. Existing
+    // pre-#426 cursor entries were already added to hourly/project buckets;
+    // retract those once, then persist a tombstone so a later sync is a no-op.
     const fingerprint = deriveOpencodeMessageFingerprint({
       msg,
       totals: currentTotals,
       source: defaultSource,
     });
-    if (!lastTotals && isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey)) {
+    if (isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey)) {
+      let projectContext = null;
+      if (lastTotals && prev?.dedupedForkCopy !== true && projectEnabled) {
+        projectContext = await resolveProjectContextForDb({
+          msg,
+          dbPath,
+          projectMetaCache,
+          publicRepoCache,
+          publicRepoResolver,
+          projectState,
+        });
+      }
+      if (lastTotals && prev?.dedupedForkCopy !== true) {
+        repairCountedOpencodeForkCopy({
+          msg,
+          totals: lastTotals,
+          source: defaultSource,
+          hourlyState,
+          touchedBuckets,
+          projectState,
+          projectTouchedBuckets,
+          projectRef: projectContext?.projectRef || null,
+          projectKey: projectContext?.projectKey || null,
+        });
+      }
+      recordOpencodeMessage({
+        messageIndex,
+        fingerprintIndex,
+        messageKey,
+        totals: currentTotals,
+        fingerprint,
+        dedupedForkCopy: true,
+      });
       messagesProcessed += 1;
       continue;
     }
 
-    const delta = diffGeminiTotals(currentTotals, lastTotals);
+    const effectiveLastTotals = prev?.dedupedForkCopy === true ? null : lastTotals;
+    const delta = diffGeminiTotals(currentTotals, effectiveLastTotals);
     if (!delta || isAllZeroUsage(delta)) {
       // Refresh the index even without a delta: normalization may have changed,
       // and pre-#426 entries need their fingerprint backfilled so a fork taken
@@ -4413,6 +4533,7 @@ async function parseOpencodeDbIncremental({
         messageKey,
         totals: currentTotals,
         fingerprint,
+        dedupedForkCopy: false,
       });
       messagesProcessed += 1;
       if (cb) {
@@ -4476,6 +4597,7 @@ async function parseOpencodeDbIncremental({
       messageKey,
       totals: currentTotals,
       fingerprint,
+      dedupedForkCopy: false,
     });
     messagesProcessed += 1;
     eventsAggregated += 1;

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -52,7 +52,9 @@ const wsl = require("./wsl-probe");
 // v10 adds Grok Build sessions (~/.grok/sessions/**/updates.jsonl), scanned
 // from turn_completed.usage + tool_call metadata. Bump so Claude/Codex rows
 // stay valid while Grok entries appear on the next full rebuild.
-const SIDECAR_VERSION = 10;
+// v11 groups native/WSL copies of one logical Claude/Codex session and scans
+// their union, deduping shared records while retaining divergent tails.
+const SIDECAR_VERSION = 11;
 const EDIT_TOOLS = new Set([
   "apply_patch",
   "edit",
@@ -249,20 +251,12 @@ function finalizeRecord(record) {
 }
 
 async function scanClaudeSession(filePath) {
-  const input = fs.createReadStream(filePath, { encoding: "utf8" });
-  const lines = readline.createInterface({ input, crlfDelay: Infinity });
+  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const primaryFilePath = filePaths[0] || String(filePath || "");
   const tokens = emptyTotals();
-  // Per-file, deliberately. rollout.js persists its dedup set across files to
-  // catch cross-file duplicates, but that is only sound there because it owns a
-  // single global total. Here each file becomes an independently cached row, so
-  // a cross-file set would make a row's tokens depend on which other files were
-  // scanned first — and the incremental cache reuses rows without replaying
-  // that state. Measured cost of the per-file scope on real data: 808 assistant
-  // messages appear in more than one file (fork/resume replays history into a
-  // new session file), inflating per-session tokens by ~1.5% in aggregate.
-  // Fixing it needs a deterministic owner (e.g. earliest started_at) plus
-  // message keys persisted per row — a sidecar redesign, not a one-liner. Do
-  // NOT "fix" this by widening the set without solving the cache interaction.
+  // One logical cross-root group is cached and scanned as a unit, so widening
+  // this set across that group stays deterministic. Unrelated files (including
+  // same-UUID siblings inside one root) are never grouped here.
   const seenMessages = new Set();
   const bounds = emptyBounds();
   // The basename keeps grouping stable for files that never write a sessionId
@@ -270,7 +264,7 @@ async function scanClaudeSession(filePath) {
   // session_id — otherwise non-session logs under ~/.claude/projects (e.g.
   // skill-injections.jsonl, journal.jsonl) yield `claude --resume journal`,
   // a command that always fails.
-  let rawSessionId = path.basename(filePath, ".jsonl");
+  let rawSessionId = path.basename(primaryFilePath, ".jsonl");
   let observedSessionId = null;
   let cwd = null;
   let model = "unknown";
@@ -290,56 +284,72 @@ async function scanClaudeSession(filePath) {
   }
   let lastPromptFingerprint = null;
 
-  for await (const line of lines) {
-    let obj;
-    try { obj = JSON.parse(line); } catch { continue; }
-    updateBounds(bounds, obj.timestamp || obj.message?.timestamp);
-    if (typeof obj.sessionId === "string" && obj.sessionId) {
-      rawSessionId = obj.sessionId;
-      observedSessionId = obj.sessionId;
-    }
-    if (typeof obj.cwd === "string" && obj.cwd) cwd = obj.cwd;
-    // Claude writes its own generated one-line summary as an "ai-title" record.
-    // It is agent-authored metadata (not the raw prompt body); keep the latest.
-    if (obj.type === "ai-title" && typeof obj.aiTitle === "string") {
-      const cleaned = cleanSessionTitle(obj.aiTitle);
-      if (cleaned) aiTitle = cleaned;
-      continue;
-    }
-    if (obj.type === "user") {
-      const prompt = extractClaudePrompt(obj);
-      if (!prompt) continue;
-      const fingerprint = promptFingerprint(prompt);
-      if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
-      lastPromptFingerprint = fingerprint;
-      closeTurn();
-      turns += 1;
-      continue;
-    }
-    if (obj.type !== "assistant" || !obj.message) continue;
-    const dedupKey = claudeMessageDedupKey(obj);
-    if (dedupKey && seenMessages.has(dedupKey)) continue;
-    if (dedupKey) seenMessages.add(dedupKey);
-    // Claude writes internal summary/observer messages with model
-    // "<synthetic>". They are not a billable model and can appear after the
-    // real assistant messages in the same session. Keep the latest real
-    // model instead of letting that marker overwrite it.
-    const candidateModel = normalizeSessionModel(obj.message.model);
-    if (candidateModel) model = candidateModel;
-    addTotals(tokens, tokenTotals(obj.message.usage));
-    const content = Array.isArray(obj.message.content) ? obj.message.content : [];
-    for (const block of content) {
-      if (!block || block.type !== "tool_use") continue;
-      const name = String(block.name || "").toLowerCase();
-      if (EDIT_TOOLS.has(name)) currentHadEdit = true;
-      if (name === "agent" || name === "task") {
-        subagentCalls += 1;
-        const subtype = typeof block.input?.subagent_type === "string"
-          ? block.input.subagent_type.trim().slice(0, 64)
-          : "unspecified";
-        subagentTypes.set(subtype || "unspecified", (subagentTypes.get(subtype || "unspecified") || 0) + 1);
+  // A native path and a WSL path can expose the same logical session with a
+  // shared prefix and different tails. Scan every tail, but suppress records
+  // already present in an earlier root. Hashes stay in-memory only, preserving
+  // the metadata-only persistence contract.
+  const priorRecordHashes = new Set();
+  for (const currentFilePath of filePaths) {
+    const currentRecordHashes = new Set();
+    const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
+    const lines = readline.createInterface({ input, crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (filePaths.length > 1) {
+        const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
+        if (priorRecordHashes.has(recordHash)) continue;
+        currentRecordHashes.add(recordHash);
+      }
+      let obj;
+      try { obj = JSON.parse(line); } catch { continue; }
+      updateBounds(bounds, obj.timestamp || obj.message?.timestamp);
+      if (typeof obj.sessionId === "string" && obj.sessionId) {
+        rawSessionId = obj.sessionId;
+        observedSessionId = obj.sessionId;
+      }
+      if (typeof obj.cwd === "string" && obj.cwd) cwd = obj.cwd;
+      // Claude writes its own generated one-line summary as an "ai-title" record.
+      // It is agent-authored metadata (not the raw prompt body); keep the latest.
+      if (obj.type === "ai-title" && typeof obj.aiTitle === "string") {
+        const cleaned = cleanSessionTitle(obj.aiTitle);
+        if (cleaned) aiTitle = cleaned;
+        continue;
+      }
+      if (obj.type === "user") {
+        const prompt = extractClaudePrompt(obj);
+        if (!prompt) continue;
+        const fingerprint = promptFingerprint(prompt);
+        if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+        lastPromptFingerprint = fingerprint;
+        closeTurn();
+        turns += 1;
+        continue;
+      }
+      if (obj.type !== "assistant" || !obj.message) continue;
+      const dedupKey = claudeMessageDedupKey(obj);
+      if (dedupKey && seenMessages.has(dedupKey)) continue;
+      if (dedupKey) seenMessages.add(dedupKey);
+      // Claude writes internal summary/observer messages with model
+      // "<synthetic>". They are not a billable model and can appear after the
+      // real assistant messages in the same session. Keep the latest real
+      // model instead of letting that marker overwrite it.
+      const candidateModel = normalizeSessionModel(obj.message.model);
+      if (candidateModel) model = candidateModel;
+      addTotals(tokens, tokenTotals(obj.message.usage));
+      const content = Array.isArray(obj.message.content) ? obj.message.content : [];
+      for (const block of content) {
+        if (!block || block.type !== "tool_use") continue;
+        const name = String(block.name || "").toLowerCase();
+        if (EDIT_TOOLS.has(name)) currentHadEdit = true;
+        if (name === "agent" || name === "task") {
+          subagentCalls += 1;
+          const subtype = typeof block.input?.subagent_type === "string"
+            ? block.input.subagent_type.trim().slice(0, 64)
+            : "unspecified";
+          subagentTypes.set(subtype || "unspecified", (subagentTypes.get(subtype || "unspecified") || 0) + 1);
+        }
       }
     }
+    for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
   }
   closeTurn();
   return finalizeRecord({
@@ -352,7 +362,7 @@ async function scanClaudeSession(filePath) {
     // wrote one — the UI then falls back to the project name.
     title: aiTitle,
     source: "claude",
-    project_key: projectKey(cwd, filePath),
+    project_key: projectKey(cwd, primaryFilePath),
     project_ref: cwd || null,
     model,
     ...bounds,
@@ -367,9 +377,8 @@ async function scanClaudeSession(filePath) {
 }
 
 async function scanCodexDeliverySignals(filePath) {
+  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   const bounds = emptyBounds();
-  const input = fs.createReadStream(filePath, { encoding: "utf8" });
-  const lines = readline.createInterface({ input, crlfDelay: Infinity });
   let turns = 0;
   let editTurns = 0;
   let retryTurns = 0;
@@ -394,34 +403,46 @@ async function scanCodexDeliverySignals(filePath) {
     turns += 1;
   }
 
-  for await (const line of lines) {
-    let obj;
-    try { obj = JSON.parse(line); } catch { continue; }
-    updateBounds(bounds, obj.timestamp);
-    if (obj.type === "turn_context") {
-      hasTurnContext = true;
-      beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
-      continue;
+  const priorRecordHashes = new Set();
+  for (const currentFilePath of filePaths) {
+    const currentRecordHashes = new Set();
+    const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
+    const lines = readline.createInterface({ input, crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (filePaths.length > 1) {
+        const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
+        if (priorRecordHashes.has(recordHash)) continue;
+        currentRecordHashes.add(recordHash);
+      }
+      let obj;
+      try { obj = JSON.parse(line); } catch { continue; }
+      updateBounds(bounds, obj.timestamp);
+      if (obj.type === "turn_context") {
+        hasTurnContext = true;
+        beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
+        continue;
+      }
+      const prompt = extractCodexPrompt(obj);
+      if (prompt) {
+        const fingerprint = promptFingerprint(prompt);
+        if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+        lastPromptFingerprint = fingerprint;
+        if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
+        continue;
+      }
+      if (obj.type !== "response_item") continue;
+      const toolNames = extractCodexSignalTools(obj.payload);
+      if (!toolNames.length) continue;
+      if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
+      if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
+      for (const name of toolNames) {
+        if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
+        subagentCalls += 1;
+        const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
+        subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
+      }
     }
-    const prompt = extractCodexPrompt(obj);
-    if (prompt) {
-      const fingerprint = promptFingerprint(prompt);
-      if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
-      lastPromptFingerprint = fingerprint;
-      if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
-      continue;
-    }
-    if (obj.type !== "response_item") continue;
-    const toolNames = extractCodexSignalTools(obj.payload);
-    if (!toolNames.length) continue;
-    if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
-    if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
-    for (const name of toolNames) {
-      if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
-      subagentCalls += 1;
-      const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
-      subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
-    }
+    for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
   }
   closeTurn();
   return {
@@ -435,9 +456,11 @@ async function scanCodexDeliverySignals(filePath) {
 }
 
 async function scanCodexSession(filePath) {
+  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const primaryFilePath = filePaths[0] || String(filePath || "");
   const [parsed, signals] = await Promise.all([
-    parseCodexRolloutFile(filePath),
-    scanCodexDeliverySignals(filePath),
+    parseCodexRolloutFile(filePaths, { seenTokenEvents: new Set() }),
+    scanCodexDeliverySignals(filePaths),
   ]);
   const parsedModel = normalizeSessionModel(parsed.model);
   const provider = normalizeSessionModel(parsed.provider);
@@ -450,16 +473,17 @@ async function scanCodexSession(filePath) {
   // Codex's own thread title from session_index.jsonl (Codex-authored
   // metadata, keyed by session id). Null when Codex never named the thread —
   // the UI then falls back to the project name.
-  const titleIndex = loadCodexTitleIndex(filePath);
-  const title = (parsed.sessionId && titleIndex.get(parsed.sessionId)) || null;
+  const title = parsed.sessionId
+    ? filePaths.map(loadCodexTitleIndex).map((index) => index.get(parsed.sessionId)).find(Boolean) || null
+    : null;
   return finalizeRecord({
     version: SIDECAR_VERSION,
-    session_hash: sessionHash("codex", parsed.sessionId || filePath),
+    session_hash: sessionHash("codex", parsed.sessionId || primaryFilePath),
     session_id: parsed.sessionId || null,
     // Local-only: stripped in summarizeSessions before any cloud/CSV export.
     title,
     source: "codex",
-    project_key: projectKey(parsed.cwd, filePath),
+    project_key: projectKey(parsed.cwd, primaryFilePath),
     project_ref: parsed.cwd || null,
     model,
     ...signals.bounds,
@@ -795,7 +819,10 @@ function providerRoots(home, providerDir, env, deps = {}) {
   return [...new Set(roots)];
 }
 
-// Collapse the same Claude session discovered under more than one root.
+// Group one logical session discovered under more than one root. A group is
+// scanned as a unit so identical prefixes count once while divergent tails are
+// both retained. Same-UUID siblings inside one Claude root stay separate: the
+// path alone cannot prove which one a file in another root mirrors.
 //
 // Codex gets this from its session-id pass below; Claude only ever had per-file
 // message dedup (`claudeMessageDedupKey` inside `scanClaudeSession`), which
@@ -809,13 +836,9 @@ function providerRoots(home, providerDir, env, deps = {}) {
 // single-install machines are unaffected, and two same-named files inside one
 // tree stay distinct (unproven identity must not delete a session). A basename
 // without a session UUID never participates either.
-function dedupeClaudeFilesAcrossRoots(groups) {
+function groupClaudeFilesAcrossRoots(groups) {
   const rootGroups = (groups || []).filter((group) => Array.isArray(group) && group.length > 0);
-  if (rootGroups.length <= 1) return [...new Set(rootGroups[0] || [])];
-
-  const mtimeOf = (filePath) => {
-    try { return fs.statSync(filePath).mtimeMs; } catch { return -Infinity; }
-  };
+  if (rootGroups.length <= 1) return [...new Set(rootGroups[0] || [])].map((filePath) => [filePath]);
   const sessionIdOf = (filePath) =>
     path.basename(filePath).match(/^([0-9a-f-]{36})\.jsonl$/i)?.[1] || null;
 
@@ -836,31 +859,85 @@ function dedupeClaudeFilesAcrossRoots(groups) {
     }
   }
 
-  // Preserve root order for everything kept, so native precedence is stable.
+  const groupedBySession = new Map();
+  for (const group of rootGroups) {
+    for (const filePath of group) {
+      const id = sessionIdOf(filePath);
+      if (!id || ambiguous.has(id)) continue;
+      if (!groupedBySession.has(id)) groupedBySession.set(id, []);
+      const paths = groupedBySession.get(id);
+      if (!paths.includes(filePath)) paths.push(filePath);
+    }
+  }
+
+  // Preserve root order and the first path as the representative cache key.
   const ordered = [];
-  const winnerBySession = new Map();
+  const emitted = new Set();
   for (const group of rootGroups) {
     for (const filePath of group) {
       const id = sessionIdOf(filePath);
       if (!id || ambiguous.has(id)) {
-        if (!ordered.includes(filePath)) ordered.push(filePath);
+        if (!emitted.has(filePath)) {
+          ordered.push([filePath]);
+          emitted.add(filePath);
+        }
         continue;
       }
-      const previous = winnerBySession.get(id);
-      if (previous === undefined) {
-        winnerBySession.set(id, filePath);
-        ordered.push(filePath);
-        continue;
-      }
-      if (previous === filePath) continue;
-      // Same session in an earlier root: keep the newer file, mirroring Codex.
-      if (mtimeOf(filePath) > mtimeOf(previous)) {
-        winnerBySession.set(id, filePath);
-        ordered[ordered.indexOf(previous)] = filePath;
-      }
+      if (emitted.has(id)) continue;
+      ordered.push(groupedBySession.get(id) || [filePath]);
+      emitted.add(id);
     }
   }
-  return [...new Set(ordered)];
+  return ordered;
+}
+
+function sameFileContent(filePaths) {
+  if (!Array.isArray(filePaths) || filePaths.length <= 1) return true;
+  try {
+    const first = fs.readFileSync(filePaths[0]);
+    return filePaths.slice(1).every((filePath) => {
+      const candidate = fs.readFileSync(filePath);
+      return candidate.length === first.length && candidate.equals(first);
+    });
+  } catch {
+    return false;
+  }
+}
+
+// Compatibility helper used by focused discovery tests and callers that only
+// need a flat list. Only byte-identical mirrors collapse; divergent copies are
+// all returned so no transcript tail is discarded.
+function dedupeClaudeFilesAcrossRoots(groups) {
+  const mtimeOf = (filePath) => {
+    try { return fs.statSync(filePath).mtimeMs; } catch { return -Infinity; }
+  };
+  const out = [];
+  for (const filePaths of groupClaudeFilesAcrossRoots(groups)) {
+    if (filePaths.length <= 1 || !sameFileContent(filePaths)) {
+      out.push(...filePaths);
+      continue;
+    }
+    out.push(filePaths.reduce((winner, candidate) => (
+      mtimeOf(candidate) > mtimeOf(winner) ? candidate : winner
+    )));
+  }
+  return [...new Set(out)];
+}
+
+function groupCodexFiles(filePaths) {
+  const ordered = [];
+  const bySession = new Map();
+  for (const filePath of [...new Set(filePaths || [])]) {
+    const id = path.basename(filePath).match(/([0-9a-f-]{36})\.jsonl$/i)?.[1] || filePath;
+    let group = bySession.get(id);
+    if (!group) {
+      group = [];
+      bySession.set(id, group);
+      ordered.push(group);
+    }
+    group.push(filePath);
+  }
+  return ordered;
 }
 
 async function discoverSessionFiles(home, env = process.env, deps = {}) {
@@ -873,26 +950,17 @@ async function discoverSessionFiles(home, env = process.env, deps = {}) {
     Promise.all(codexRoots.map((r) => listRolloutFilesDeep(path.join(r, "archived_sessions")))),
     listGrokSessionFiles(path.join(grokHome, "sessions")),
   ]);
-  const allClaude = dedupeClaudeFilesAcrossRoots(claudeGroups);
+  const allClaude = groupClaudeFilesAcrossRoots(claudeGroups);
   const codex = [...new Set(codexGroups.flat())];
   const archived = [...new Set(archivedGroups.flat())];
   // Claude Memory stores thousands of background observer transcripts beside
   // real Claude Code sessions. They contain <synthetic>/haiku bookkeeping and
   // no user coding outcome, so scanning them both slows the card dramatically
   // and dilutes its efficiency metrics.
-  const claude = allClaude.filter((filePath) => !filePath
+  const claude = allClaude.filter((filePaths) => !filePaths.some((filePath) => filePath
     .split(path.sep)
-    .some((segment) => segment.endsWith(CLAUDE_MEM_OBSERVER_PROJECT_SUFFIX)));
-  const codexBySession = new Map();
-  const mtimeOf = (filePath) => {
-    try { return fs.statSync(filePath).mtimeMs; } catch { return -Infinity; }
-  };
-  for (const filePath of [...codex, ...archived]) {
-    const id = path.basename(filePath).match(/([0-9a-f-]{36})\.jsonl$/i)?.[1] || filePath;
-    const previous = codexBySession.get(id);
-    if (!previous || mtimeOf(filePath) > mtimeOf(previous)) codexBySession.set(id, filePath);
-  }
-  return { claude, codex: [...codexBySession.values()], grok };
+    .some((segment) => segment.endsWith(CLAUDE_MEM_OBSERVER_PROJECT_SUFFIX))));
+  return { claude, codex: groupCodexFiles([...codex, ...archived]), grok };
 }
 
 function filesSignature(files) {
@@ -907,9 +975,10 @@ function filesSignature(files) {
 }
 
 function sessionFileCacheKey(source, filePath) {
+  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   return crypto
     .createHash("sha256")
-    .update(`${source}\0${path.resolve(filePath)}`)
+    .update(`${source}\0${filePaths.map((value) => path.resolve(value)).join("\0")}`)
     .digest("hex")
     .slice(0, 24);
 }
@@ -964,13 +1033,19 @@ function loadCodexTitleIndex(filePath) {
 // Grok titles live in sibling summary.json (and signals can change without
 // touching updates.jsonl on some partial flushes).
 function analyticsEntryStatKey(source, filePath) {
-  const sessionStat = sessionFileStatKey(filePath);
-  if (!sessionStat) return sessionStat;
+  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const sessionStats = filePaths.map((value) => sessionFileStatKey(value));
+  if (sessionStats.some((value) => !value)) return null;
+  const sessionStat = sessionStats.join("|");
   if (source === "codex") {
-    return `${sessionStat}|title-index:${sessionFileStatKey(codexTitleIndexPathFor(filePath)) || "missing"}`;
+    const titleStats = filePaths.map((value) => (
+      sessionFileStatKey(codexTitleIndexPathFor(value)) || "missing"
+    ));
+    return `${sessionStat}|title-index:${titleStats.join("|")}`;
   }
   if (source === "grok") {
-    return `${sessionStat}|summary:${sessionFileStatKey(grokSummaryPathFor(filePath)) || "missing"}|signals:${sessionFileStatKey(grokSignalsPathFor(filePath)) || "missing"}`;
+    const primary = filePaths[0];
+    return `${sessionStat}|summary:${sessionFileStatKey(grokSummaryPathFor(primary)) || "missing"}|signals:${sessionFileStatKey(grokSignalsPathFor(primary)) || "missing"}`;
   }
   return sessionStat;
 }
@@ -1011,9 +1086,9 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   // per-file dependency check below on the next refresh. Grok titles/metadata
   // live in sibling summary.json / signals.json next to updates.jsonl.
   const signature = filesSignature([
-    ...discovered.claude,
-    ...discovered.codex,
-    ...discovered.codex.map(codexTitleIndexPathFor).filter(Boolean),
+    ...discovered.claude.flat(),
+    ...discovered.codex.flat(),
+    ...discovered.codex.flat().map(codexTitleIndexPathFor).filter(Boolean),
     ...discovered.grok,
     ...discovered.grok.map(grokSummaryPathFor),
     ...discovered.grok.map(grokSignalsPathFor),
@@ -1035,8 +1110,8 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
   const nextFiles = {};
   const sessions = [];
   const entries = [
-    ...discovered.claude.map((filePath) => ({ source: "claude", filePath, scan: scanClaudeSession })),
-    ...discovered.codex.map((filePath) => ({ source: "codex", filePath, scan: scanCodexSession })),
+    ...discovered.claude.map((filePaths) => ({ source: "claude", filePath: filePaths, scan: scanClaudeSession })),
+    ...discovered.codex.map((filePaths) => ({ source: "codex", filePath: filePaths, scan: scanCodexSession })),
     ...discovered.grok.map((filePath) => ({ source: "grok", filePath, scan: scanGrokSession })),
   ];
   // Files we could not turn into a row (permission denied, half-written line,

--- a/test/npm-publish-workflow.test.js
+++ b/test/npm-publish-workflow.test.js
@@ -10,6 +10,7 @@ const WORKFLOW_PATH = path.join(
   "workflows",
   "npm-publish.yml"
 );
+const CI_WORKFLOW_PATH = path.join(__dirname, "..", ".github", "workflows", "ci.yml");
 
 function loadWorkflow() {
   return fs.readFileSync(WORKFLOW_PATH, "utf8");
@@ -27,6 +28,14 @@ test("workflow triggers only after canonical CI completes on main", () => {
   assert.ok(
     content.includes("branches: [main]"),
     "should target main branch only"
+  );
+});
+
+test("canonical CI never cancels an in-flight main version commit", () => {
+  const content = fs.readFileSync(CI_WORKFLOW_PATH, "utf8");
+  assert.ok(
+    content.includes("cancel-in-progress: ${{ github.event_name == 'pull_request' }}"),
+    "main CI runs must survive later pushes so npm remains pinned to the version commit",
   );
 });
 
@@ -50,6 +59,7 @@ test("successful push CI gates publish and the exact tested SHA is checked out",
     content.includes("ref: ${{ github.event.workflow_run.head_sha }}"),
     "publish must build the exact commit that passed CI"
   );
+  assert.ok(content.includes("fetch-depth: 2"), "publish must inspect the tested commit's parent");
   assert.ok(!content.includes("\n  test:"), "must not maintain a weaker duplicate test job");
 });
 
@@ -66,6 +76,14 @@ test("workflow checks version before publishing", () => {
   assert.ok(
     content.includes("npm view tokentracker-cli"),
     "should check if version already exists on npm"
+  );
+  assert.ok(
+    content.includes("git show HEAD^:package.json"),
+    "only the tested commit that changed package.json may publish"
+  );
+  assert.ok(
+    content.includes("outputs.eligible == 'true'"),
+    "publish steps must require an exact version-changing commit"
   );
 });
 

--- a/test/opencode-fork-dedup.test.js
+++ b/test/opencode-fork-dedup.test.js
@@ -185,6 +185,75 @@ test("parseOpencodeDbIncremental dedupes a fork discovered in a LATER sync run",
   });
 });
 
+test("parseOpencodeDbIncremental repairs fork copies counted before fingerprints existed", async () => {
+  await withTmp(async (tmp) => {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = newCursors();
+    const base = Date.parse(HOUR);
+    const parent = msg({
+      id: "msg_parent",
+      sessionID: "ses_parent",
+      created: base + 1000,
+      input: 1000,
+      output: 100,
+    });
+    const fork = msg({
+      id: "msg_fork",
+      sessionID: "ses_fork",
+      created: base + 1000,
+      input: 1000,
+      output: 100,
+    });
+
+    await parseOpencodeDbIncremental({
+      dbMessages: [parent],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+
+    // Recreate the state shipped before #426: both session/message ids were
+    // present and both snapshots had already been added to the same bucket.
+    const parentEntry = cursors.opencode.messages["ses_parent|msg_parent"];
+    cursors.opencode.messages["ses_fork|msg_fork"] = {
+      lastTotals: { ...parentEntry.lastTotals },
+      fingerprint: parentEntry.fingerprint,
+      updatedAt: new Date().toISOString(),
+    };
+    const bucket = Object.values(cursors.hourly.buckets)[0];
+    for (const key of Object.keys(bucket.totals)) bucket.totals[key] *= 2;
+    bucket.queuedKey = null;
+
+    const repaired = await parseOpencodeDbIncremental({
+      dbMessages: [parent, fork],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+    assert.equal(repaired.eventsAggregated, 0);
+    assert.equal((await queueTotals(queuePath)).input_tokens, 1000);
+    assert.equal((await queueTotals(queuePath)).output_tokens, 100);
+    assert.equal(bucket.totals.conversation_count, 1);
+    assert.equal(
+      cursors.opencode.messages["ses_fork|msg_fork"].dedupedForkCopy,
+      true,
+    );
+
+    const afterRepair = await queueTotals(queuePath);
+    await parseOpencodeDbIncremental({
+      dbMessages: [parent, fork],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+    assert.deepEqual(await queueTotals(queuePath), afterRepair, "repair must be idempotent");
+    assert.equal(bucket.totals.conversation_count, 1);
+  });
+});
+
 test("parseOpencodeDbIncremental dedupes a fork seen BEFORE its parent (order independence)", async () => {
   await withTmp(async (tmp) => {
     const queuePath = path.join(tmp, "queue.jsonl");

--- a/test/session-analytics-claude-cross-root-dedup.test.js
+++ b/test/session-analytics-claude-cross-root-dedup.test.js
@@ -25,24 +25,34 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { dedupeClaudeFilesAcrossRoots } = require("../src/lib/session-analytics");
+const {
+  dedupeClaudeFilesAcrossRoots,
+  scanClaudeSession,
+  scanCodexSession,
+} = require("../src/lib/session-analytics");
 
 function withTmp(fn) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-claude-roots-"));
   try {
-    return fn(dir);
-  } finally {
+    const result = fn(dir);
+    if (result && typeof result.then === "function") {
+      return result.finally(() => fs.rmSync(dir, { recursive: true, force: true }));
+    }
     fs.rmSync(dir, { recursive: true, force: true });
+    return result;
+  } catch (error) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
   }
 }
 
 // One session file per root, same basename UUID -> the same session reachable
 // under two path spellings.
-function seedRoot(base, name, uuid, mtimeMs) {
+function seedRoot(base, name, uuid, mtimeMs, content = "{}\n") {
   const dir = path.join(base, name, "projects", "-Users-dev-app");
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, `${uuid}.jsonl`);
-  fs.writeFileSync(filePath, "{}\n");
+  fs.writeFileSync(filePath, content);
   if (mtimeMs) fs.utimesSync(filePath, mtimeMs / 1000, mtimeMs / 1000);
   return filePath;
 }
@@ -147,5 +157,80 @@ test("ordering follows the root order so native precedence is stable", () => {
     const wslB = seedRoot(tmp, "wsl", UUID_B, 1_000_000);
 
     assert.deepEqual(dedupeClaudeFilesAcrossRoots([[nativeA], [wslB]]), [nativeA, wslB]);
+  });
+});
+
+test("divergent same-UUID Claude copies are retained instead of choosing by mtime", () => {
+  withTmp((tmp) => {
+    const native = seedRoot(tmp, "native", UUID_A, 1_000_000, "{\"native\":true}\n");
+    const wsl = seedRoot(tmp, "wsl", UUID_A, 2_000_000, "{\"wsl\":true}\n");
+
+    assert.deepEqual(dedupeClaudeFilesAcrossRoots([[native], [wsl]]), [native, wsl]);
+  });
+});
+
+test("Claude cross-root union counts a shared prefix once and both divergent tails", async () => {
+  await withTmp(async (tmp) => {
+    const row = (id, input, output, timestamp) => ({
+      type: "assistant",
+      sessionId: UUID_A,
+      cwd: "/repo",
+      timestamp,
+      message: {
+        id,
+        model: "claude-test",
+        usage: { input_tokens: input, output_tokens: output },
+        content: [],
+      },
+    });
+    const common = [
+      { type: "user", sessionId: UUID_A, cwd: "/repo", timestamp: "2026-08-08T01:00:00Z", message: { content: "go" } },
+      row("m-common", 10, 1, "2026-08-08T01:00:01Z"),
+    ];
+    const nativeRows = [...common, row("m-native", 20, 2, "2026-08-08T01:00:02Z")];
+    const wslRows = [...common, row("m-wsl", 30, 3, "2026-08-08T01:00:03Z")];
+    const native = seedRoot(tmp, "native", UUID_A, 1_000_000, `${nativeRows.map(JSON.stringify).join("\n")}\n`);
+    const wsl = seedRoot(tmp, "wsl", UUID_A, 2_000_000, `${wslRows.map(JSON.stringify).join("\n")}\n`);
+
+    const session = await scanClaudeSession([native, wsl]);
+    assert.equal(session.turns, 1);
+    assert.equal(session.tokens.input_tokens, 60);
+    assert.equal(session.tokens.output_tokens, 6);
+    assert.equal(session.total_tokens, 66);
+  });
+});
+
+test("Codex cross-root union counts duplicate token events once and divergent tails", async () => {
+  await withTmp(async (tmp) => {
+    const usage = (input, output) => ({
+      input_tokens: input,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: output,
+      reasoning_output_tokens: 0,
+      total_tokens: input + output,
+    });
+    const common = [
+      { timestamp: "2026-08-08T02:00:00Z", type: "session_meta", payload: { id: UUID_A, cwd: "/repo", model_provider: "openai" } },
+      { timestamp: "2026-08-08T02:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: "/repo", model: "gpt-test" } },
+      { timestamp: "2026-08-08T02:00:02Z", type: "event_msg", payload: { type: "user_message", message: "go" } },
+      { timestamp: "2026-08-08T02:00:03Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(100, 10), total_token_usage: usage(100, 10) } } },
+    ];
+    const nativeRows = [
+      ...common,
+      { timestamp: "2026-08-08T02:00:04Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(20, 2), total_token_usage: usage(120, 12) } } },
+    ];
+    const wslRows = [
+      ...common,
+      { timestamp: "2026-08-08T02:00:05Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(30, 3), total_token_usage: usage(130, 13) } } },
+    ];
+    const native = seedRoot(tmp, "native", UUID_A, 1_000_000, `${nativeRows.map(JSON.stringify).join("\n")}\n`);
+    const wsl = seedRoot(tmp, "wsl", UUID_A, 2_000_000, `${wslRows.map(JSON.stringify).join("\n")}\n`);
+
+    const session = await scanCodexSession([native, wsl]);
+    assert.equal(session.tokens.input_tokens, 150);
+    assert.equal(session.tokens.output_tokens, 15);
+    assert.equal(session.total_tokens, 165);
+    assert.equal(session.turns, 1);
   });
 });

--- a/test/sync-lock-debris.test.js
+++ b/test/sync-lock-debris.test.js
@@ -246,3 +246,20 @@ test("sync clears a stale skip marker once the lock is acquired again", async ()
     assert.equal(await exists(markerPath), false);
   });
 });
+
+test("sync releases its lock when stale skip marker cleanup fails", async () => {
+  await withTempHome(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(path.join(trackerDir, "sync.skip.json"), { recursive: true });
+
+    await assert.rejects(cmdSync(["--auto"]), (error) => (
+      error?.code === "EISDIR" || error?.code === "EPERM"
+    ));
+
+    assert.equal(
+      await exists(path.join(trackerDir, "sync.lock")),
+      false,
+      "marker cleanup errors must not strand the acquired sync lease",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- retain divergent native/WSL Claude and Codex session tails while deduplicating shared records
- repair historical OpenCode fork overcount and guarantee sync-lock cleanup
- register AppImage OAuth callback handlers on first launch
- bind npm publication to the exact version-changing CI commit
- release v0.88.2

## Validation

- `npm run ci:local` (2127 tests and validators)
- 39 targeted regression tests, including idempotent repair and divergent tails
- macOS arm64 EmbeddedServer bundle + Debug Xcode build
- SHA-256 match between app-bundled and source server files

Release note: Fix cross-platform session deduplication, historical OpenCode overcount, AppImage OAuth callbacks, and release provenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux AppImage installations now register and refresh the `tokentracker://` sign-in callback automatically.
  - Session analytics now combines matching native and WSL records while preserving legitimate differences.

- **Bug Fixes**
  - Corrected duplicate forked-message counting and repaired affected totals.
  - Improved synchronization recovery when cleanup fails, ensuring locks are released.
  - Publishing now skips unchanged package versions and avoids duplicate releases.

- **Documentation**
  - Updated Linux sign-in guidance for AppImage and Arch installations.

- **Release**
  - Updated application and package versions to 0.88.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->