### PR TITLE
fix: harden cross-root scans and release checks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,21 +43,31 @@ jobs:
       - name: Verify version commit and check npm
         id: version-check
         run: |
+          set -euo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           PARENT_VERSION=$(git show HEAD^:package.json 2>/dev/null | node -e \
-            "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{process.stdout.write(JSON.parse(s).version||'')}catch{}})" || true)
+            "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const v=JSON.parse(s).version;if(typeof v!=='string'||!v)throw new Error('parent package version is missing');process.stdout.write(v)})")
           if [ "$PARENT_VERSION" = "$PACKAGE_VERSION" ]; then
             echo "eligible=false" >> "$GITHUB_OUTPUT"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "package.json version did not change in this tested commit; skipping publish."
             exit 0
           fi
           echo "eligible=true" >> "$GITHUB_OUTPUT"
-          if npm view tokentracker-cli@"$PACKAGE_VERSION" version 2>/dev/null; then
+          npm_result=$(mktemp)
+          npm_error=$(mktemp)
+          trap 'rm -f "$npm_result" "$npm_error"' EXIT
+          if npm view tokentracker-cli@"$PACKAGE_VERSION" version --json >"$npm_result" 2>"$npm_error"; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            lookup_code=$(node -e "const fs=require('fs');try{const r=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(r?.error?.code||'')}catch{}" "$npm_result")
+            if [ "$lookup_code" = "E404" ]; then
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+            else
+              cat "$npm_error" >&2
+              echo "npm registry lookup failed without a confirmed E404" >&2
+              exit 1
+            fi
           fi
 
       - name: Install root dependencies
@@ -85,9 +95,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Skip notice
-        if: steps.version-check.outputs.eligible != 'true' || steps.version-check.outputs.exists == 'true'
-        run: echo "v${{ steps.version-check.outputs.version }} already published, skipping."
+      - name: Skip unchanged-version commit
+        if: steps.version-check.outputs.eligible != 'true'
+        env:
+          PACKAGE_VERSION: ${{ steps.version-check.outputs.version }}
+        run: printf 'v%s was not changed by this commit; skipping publish.\n' "$PACKAGE_VERSION"
+
+      - name: Skip already-published version
+        if: steps.version-check.outputs.eligible == 'true' && steps.version-check.outputs.exists == 'true'
+        env:
+          PACKAGE_VERSION: ${{ steps.version-check.outputs.version }}
+        run: printf 'v%s is already published; skipping.\n' "$PACKAGE_VERSION"
 
       # Notify homebrew-tokentracker tap to bump the Formula immediately.
       # If HOMEBREW_DISPATCH_TOKEN is not set, this step silently no-ops and

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,6 +48,8 @@ jobs:
           echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           PARENT_VERSION=$(git show HEAD^:package.json 2>/dev/null | node -e \
             "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const v=JSON.parse(s).version;if(typeof v!=='string'||!v)throw new Error('parent package version is missing');process.stdout.write(v)})")
+          node -e "const {assertReleaseVersion}=require('./scripts/version-files.cjs');assertReleaseVersion(process.argv[1],'package.json version');assertReleaseVersion(process.argv[2],'parent package.json version')" \
+            "$PACKAGE_VERSION" "$PARENT_VERSION"
           if [ "$PARENT_VERSION" = "$PACKAGE_VERSION" ]; then
             echo "eligible=false" >> "$GITHUB_OUTPUT"
             echo "package.json version did not change in this tested commit; skipping publish."

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -38,7 +38,7 @@ targets:
         PRODUCT_NAME: TokenTracker
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.88.2"
+        MARKETING_VERSION: "0.88.3"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -89,7 +89,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.88.2"
+        MARKETING_VERSION: "0.88.3"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/TokenTrackerLinux/package-lock.json
+++ b/TokenTrackerLinux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-linux",
-      "version": "0.88.2",
+      "version": "0.88.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
         "pngjs": "^7.0.0"

--- a/TokenTrackerLinux/package.json
+++ b/TokenTrackerLinux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
+++ b/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: local
 pkgname=tokentracker-linux
-pkgver=0.88.2
+pkgver=0.88.3
 pkgrel=1
 pkgdesc='Local TokenTracker Linux desktop client for Arch KDE'
 arch=('x86_64')

--- a/TokenTrackerLinux/src-tauri/Cargo.lock
+++ b/TokenTrackerLinux/src-tauri/Cargo.lock
@@ -3613,6 +3613,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tokentracker-linux"
 version = "0.88.3"
 dependencies = [
+ "libc",
  "once_cell",
  "serde",
  "serde_json",

--- a/TokenTrackerLinux/src-tauri/Cargo.lock
+++ b/TokenTrackerLinux/src-tauri/Cargo.lock
@@ -3611,7 +3611,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokentracker-linux"
-version = "0.88.2"
+version = "0.88.3"
 dependencies = [
  "once_cell",
  "serde",

--- a/TokenTrackerLinux/src-tauri/Cargo.toml
+++ b/TokenTrackerLinux/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokentracker-linux"
-version = "0.88.2"
+version = "0.88.3"
 description = "TokenTracker Linux desktop client"
 authors = ["TokenTracker"]
 edition = "2021"

--- a/TokenTrackerLinux/src-tauri/Cargo.toml
+++ b/TokenTrackerLinux/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-single-instance = "2"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+libc = "0.2"
 
 [dev-dependencies]
 # Used by tests/capabilities.rs to parse `capabilities/*.json` with Tauri's own

--- a/TokenTrackerLinux/src-tauri/src/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/src/oauth.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::Mutex;
@@ -111,6 +112,9 @@ fn run_command_with_timeout(
     description: &str,
     timeout: Duration,
 ) -> Result<Output, String> {
+    // xdg-mime is commonly a shell script. Isolate its whole process tree so
+    // timing out the parent cannot leave a helper running after app startup.
+    command.process_group(0);
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = command
         .spawn()
@@ -127,7 +131,13 @@ fn run_command_with_timeout(
                     .map_err(|error| format!("failed to collect {description} output: {error}"));
             }
             None if Instant::now() >= deadline => {
-                let _ = child.kill();
+                let process_group = -(child.id() as libc::pid_t);
+                // SAFETY: the child was spawned as the leader of a new process
+                // group, and a negative pid targets that exact group on Unix.
+                let group_result = unsafe { libc::kill(process_group, libc::SIGKILL) };
+                if group_result != 0 {
+                    let _ = child.kill();
+                }
                 let _ = child.wait();
                 return Err(format!(
                     "{description} timed out after {} ms",
@@ -186,7 +196,14 @@ pub fn ensure_appimage_protocol_registration() -> Result<bool, String> {
         Duration::from_secs(3),
     )?;
     let registered = String::from_utf8_lossy(&query.stdout).trim().to_string();
-    if !query.status.success() || registered != desktop_name {
+    if !query.status.success() {
+        return Err(format!(
+            "xdg-mime verification exited with {}: {}",
+            query.status,
+            String::from_utf8_lossy(&query.stderr).trim()
+        ));
+    }
+    if registered != desktop_name {
         return Err(format!(
             "protocol registration did not read back (expected {desktop_name}, got {registered:?})"
         ));
@@ -218,14 +235,41 @@ mod appimage_registration_tests {
 
     #[test]
     fn command_timeout_terminates_a_stuck_process() {
+        let pid_path = std::env::temp_dir().join(format!(
+            "tokentracker-timeout-child-{}.pid",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&pid_path);
         let started = Instant::now();
-        let result = run_command_with_timeout(
-            Command::new("sh").args(["-c", "sleep 2"]),
-            "timeout probe",
-            Duration::from_millis(50),
-        );
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "sleep 10 & echo $! > \"$1\"; wait", "sh"])
+            .arg(&pid_path);
+        let result =
+            run_command_with_timeout(&mut command, "timeout probe", Duration::from_millis(250));
         assert!(result.unwrap_err().contains("timed out"));
-        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        let descendant_pid: libc::pid_t = fs::read_to_string(&pid_path)
+            .expect("background child pid should be recorded before timeout")
+            .trim()
+            .parse()
+            .expect("background child pid should be numeric");
+        let gone_by = Instant::now() + Duration::from_secs(1);
+        loop {
+            // SAFETY: signal 0 only probes whether this recorded pid exists.
+            let exists = unsafe { libc::kill(descendant_pid, 0) } == 0
+                || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+            if !exists {
+                break;
+            }
+            assert!(
+                Instant::now() < gone_by,
+                "background child survived timeout"
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+        let _ = fs::remove_file(pid_path);
     }
 }
 

--- a/TokenTrackerLinux/src-tauri/src/oauth.rs
+++ b/TokenTrackerLinux/src-tauri/src/oauth.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Manager, Url};
 
@@ -86,14 +88,55 @@ pub fn appimage_desktop_entry(appimage: &Path) -> Option<String> {
     ))
 }
 
-fn user_applications_dir() -> Option<PathBuf> {
-    if let Some(value) = std::env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
-        return Some(PathBuf::from(value).join("applications"));
+fn applications_dir(xdg_data_home: Option<PathBuf>, home: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(value) = xdg_data_home.filter(|value| value.is_absolute()) {
+        return Some(value.join("applications"));
     }
-    std::env::var_os("HOME")
+    home.filter(|value| value.is_absolute())
+        .map(|value| value.join(".local/share/applications"))
+}
+
+fn user_applications_dir() -> Option<PathBuf> {
+    let xdg_data_home = std::env::var_os("XDG_DATA_HOME")
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .map(|home| home.join(".local/share/applications"))
+        .map(PathBuf::from);
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    applications_dir(xdg_data_home, home)
+}
+
+fn run_command_with_timeout(
+    command: &mut Command,
+    description: &str,
+    timeout: Duration,
+) -> Result<Output, String> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to run {description}: {error}"))?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child
+            .try_wait()
+            .map_err(|error| format!("failed while waiting for {description}: {error}"))?
+        {
+            Some(_) => {
+                return child
+                    .wait_with_output()
+                    .map_err(|error| format!("failed to collect {description} output: {error}"));
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "{description} timed out after {} ms",
+                    timeout.as_millis()
+                ));
+            }
+            None => thread::sleep(Duration::from_millis(25)),
+        }
+    }
 }
 
 /// Register the custom callback scheme for a directly launched AppImage.
@@ -124,18 +167,24 @@ pub fn ensure_appimage_protocol_registration() -> Result<bool, String> {
         .and_then(|()| fs::rename(&temporary, &desktop_path))
         .map_err(|error| format!("failed to write {}: {error}", desktop_path.display()))?;
 
-    let status = Command::new("xdg-mime")
-        .args(["default", desktop_name, "x-scheme-handler/tokentracker"])
-        .status()
-        .map_err(|error| format!("failed to run xdg-mime: {error}"))?;
-    if !status.success() {
-        return Err(format!("xdg-mime exited with {status}"));
+    let registration = run_command_with_timeout(
+        Command::new("xdg-mime").args(["default", desktop_name, "x-scheme-handler/tokentracker"]),
+        "xdg-mime registration",
+        Duration::from_secs(3),
+    )?;
+    if !registration.status.success() {
+        return Err(format!(
+            "xdg-mime registration exited with {}: {}",
+            registration.status,
+            String::from_utf8_lossy(&registration.stderr).trim()
+        ));
     }
 
-    let query = Command::new("xdg-mime")
-        .args(["query", "default", "x-scheme-handler/tokentracker"])
-        .output()
-        .map_err(|error| format!("failed to verify xdg-mime registration: {error}"))?;
+    let query = run_command_with_timeout(
+        Command::new("xdg-mime").args(["query", "default", "x-scheme-handler/tokentracker"]),
+        "xdg-mime verification",
+        Duration::from_secs(3),
+    )?;
     let registered = String::from_utf8_lossy(&query.stdout).trim().to_string();
     if !query.status.success() || registered != desktop_name {
         return Err(format!(
@@ -143,6 +192,41 @@ pub fn ensure_appimage_protocol_registration() -> Result<bool, String> {
         ));
     }
     Ok(true)
+}
+
+#[cfg(test)]
+mod appimage_registration_tests {
+    use super::*;
+
+    #[test]
+    fn relative_xdg_data_home_falls_back_to_absolute_home() {
+        assert_eq!(
+            applications_dir(
+                Some(PathBuf::from("relative-data")),
+                Some(PathBuf::from("/home/dev")),
+            ),
+            Some(PathBuf::from("/home/dev/.local/share/applications"))
+        );
+        assert_eq!(
+            applications_dir(
+                Some(PathBuf::from("/data/dev")),
+                Some(PathBuf::from("/home/dev"))
+            ),
+            Some(PathBuf::from("/data/dev/applications"))
+        );
+    }
+
+    #[test]
+    fn command_timeout_terminates_a_stuck_process() {
+        let started = Instant::now();
+        let result = run_command_with_timeout(
+            Command::new("sh").args(["-c", "sleep 2"]),
+            "timeout probe",
+            Duration::from_millis(50),
+        );
+        assert!(result.unwrap_err().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
 }
 
 pub fn callback_url(base: &str, code: &str) -> Option<String> {

--- a/TokenTrackerLinux/src-tauri/tauri.conf.json
+++ b/TokenTrackerLinux/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TokenTracker",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "identifier": "cc.tokentracker.linux",
   "build": {
     "beforeDevCommand": "",

--- a/TokenTrackerWin/TokenTrackerWin.csproj
+++ b/TokenTrackerWin/TokenTrackerWin.csproj
@@ -22,7 +22,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>assets\trayicon.ico</ApplicationIcon>
     <!-- Keep in sync with package.json / project.yml on release. -->
-    <Version>0.88.2</Version>
+    <Version>0.88.3</Version>
     <Product>TokenTracker</Product>
     <Company>TokenTracker</Company>
     <!-- App UI strings live in TrayStrings/NativeLocalization (no .resx), so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-cli",
-      "version": "0.88.2",
+      "version": "0.88.3",
       "license": "MIT",
       "dependencies": {
         "@mongodb-js/zstd": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.88.2",
+  "version": "0.88.3",
   "description": "Local-first AI coding token usage and cost tracker for 29 tools, with a dashboard, desktop pet, widgets, achievements, and native macOS/Windows apps.",
   "main": "src/cli.js",
   "bin": {

--- a/scripts/version-files.cjs
+++ b/scripts/version-files.cjs
@@ -1,6 +1,15 @@
 const fs = require('fs');
 const path = require('path');
 
+const RELEASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function assertReleaseVersion(version, label = 'Version') {
+  if (typeof version !== 'string' || !RELEASE_VERSION_PATTERN.test(version)) {
+    throw new Error(`${label} must be a stable x.y.z version, got ${JSON.stringify(version)}`);
+  }
+  return version;
+}
+
 const VERSION_FILES = [
   {
     label: 'package.json',
@@ -178,4 +187,10 @@ function findVersionMismatches(root, version) {
     .map(({ label, version: actual }) => ({ label, expected: version, actual }));
 }
 
-module.exports = { readCanonicalVersion, collectVersionEntries, syncVersions, findVersionMismatches };
+module.exports = {
+  assertReleaseVersion,
+  readCanonicalVersion,
+  collectVersionEntries,
+  syncVersions,
+  findVersionMismatches,
+};

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -1062,6 +1062,10 @@ async function* readCodexObjects(filePath, diagnostics, fileIndex, options = {})
   yield* reader(filePath, diagnostics, fileIndex, options);
 }
 
+function isRecoverableGroupedReadError(error) {
+  return ["ENOENT", "EACCES", "EPERM", "EISDIR", "EIO", "ESTALE"].includes(error?.code);
+}
+
 async function* iterateCodexObjects(filePaths, diagnostics, options = {}) {
   if (filePaths.length <= 1) {
     for await (const record of readCodexObjects(filePaths[0], diagnostics, 0, options)) {
@@ -1075,11 +1079,18 @@ async function* iterateCodexObjects(filePaths, diagnostics, options = {}) {
   // suppress byte-semantically identical records from different files so the
   // cumulative baseline is established exactly once.
   const records = [];
+  let scannedFiles = 0;
   for (let fileIndex = 0; fileIndex < filePaths.length; fileIndex += 1) {
-    for await (const record of readCodexObjects(filePaths[fileIndex], diagnostics, fileIndex)) {
-      records.push(record);
+    try {
+      for await (const record of readCodexObjects(filePaths[fileIndex], diagnostics, fileIndex)) {
+        records.push(record);
+      }
+      scannedFiles += 1;
+    } catch (error) {
+      if (!isRecoverableGroupedReadError(error)) throw error;
     }
   }
+  if (!scannedFiles) throw new Error("all grouped Codex rollout files failed during read");
   records.sort((a, b) => {
     const aTimestamp = typeof a.obj?.timestamp === "string" ? a.obj.timestamp : "";
     const bTimestamp = typeof b.obj?.timestamp === "string" ? b.obj.timestamp : "";

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -1081,10 +1081,12 @@ async function* iterateCodexObjects(filePaths, diagnostics, options = {}) {
   const records = [];
   let scannedFiles = 0;
   for (let fileIndex = 0; fileIndex < filePaths.length; fileIndex += 1) {
+    const fileRecords = [];
     try {
       for await (const record of readCodexObjects(filePaths[fileIndex], diagnostics, fileIndex)) {
-        records.push(record);
+        fileRecords.push(record);
       }
+      for (const record of fileRecords) records.push(record);
       scannedFiles += 1;
     } catch (error) {
       if (!isRecoverableGroupedReadError(error)) throw error;

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -250,8 +250,19 @@ function finalizeRecord(record) {
   return record;
 }
 
+function readableSessionPaths(filePath) {
+  const candidates = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const readable = candidates.filter((value) => sessionFileStatKey(value));
+  if (!readable.length) {
+    throw new Error("session files vanished before they could be scanned");
+  }
+  return readable;
+}
+
 async function scanClaudeSession(filePath) {
-  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  // Native and WSL mounts can disappear independently after discovery. Keep
+  // the surviving mirror instead of dropping the whole logical session.
+  const filePaths = readableSessionPaths(filePath);
   const primaryFilePath = filePaths[0] || String(filePath || "");
   const tokens = emptyTotals();
   // One logical cross-root group is cached and scanned as a unit, so widening
@@ -377,7 +388,7 @@ async function scanClaudeSession(filePath) {
 }
 
 async function scanCodexDeliverySignals(filePath) {
-  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const filePaths = readableSessionPaths(filePath);
   const bounds = emptyBounds();
   let turns = 0;
   let editTurns = 0;
@@ -456,7 +467,7 @@ async function scanCodexDeliverySignals(filePath) {
 }
 
 async function scanCodexSession(filePath) {
-  const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
+  const filePaths = readableSessionPaths(filePath);
   const primaryFilePath = filePaths[0] || String(filePath || "");
   const [parsed, signals] = await Promise.all([
     parseCodexRolloutFile(filePaths, { seenTokenEvents: new Set() }),
@@ -1034,8 +1045,8 @@ function loadCodexTitleIndex(filePath) {
 // touching updates.jsonl on some partial flushes).
 function analyticsEntryStatKey(source, filePath) {
   const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
-  const sessionStats = filePaths.map((value) => sessionFileStatKey(value));
-  if (sessionStats.some((value) => !value)) return null;
+  const sessionStats = filePaths.map((value) => sessionFileStatKey(value) || "missing");
+  if (sessionStats.every((value) => value === "missing")) return null;
   const sessionStat = sessionStats.join("|");
   if (source === "codex") {
     const titleStats = filePaths.map((value) => (
@@ -1446,4 +1457,5 @@ module.exports = {
   sessionsToCsv,
   providerRoots,
   dedupeClaudeFilesAcrossRoots,
+  analyticsEntryStatKey,
 };

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -259,6 +259,10 @@ function readableSessionPaths(filePath) {
   return readable;
 }
 
+function isRecoverableSessionReadError(error) {
+  return ["ENOENT", "EACCES", "EPERM", "EISDIR", "EIO", "ESTALE"].includes(error?.code);
+}
+
 async function scanClaudeSession(filePath) {
   // Native and WSL mounts can disappear independently after discovery. Keep
   // the surviving mirror instead of dropping the whole logical session.
@@ -300,68 +304,76 @@ async function scanClaudeSession(filePath) {
   // already present in an earlier root. Hashes stay in-memory only, preserving
   // the metadata-only persistence contract.
   const priorRecordHashes = new Set();
+  let scannedFiles = 0;
   for (const currentFilePath of filePaths) {
     const currentRecordHashes = new Set();
-    const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
-    const lines = readline.createInterface({ input, crlfDelay: Infinity });
-    for await (const line of lines) {
-      if (filePaths.length > 1) {
-        const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
-        if (priorRecordHashes.has(recordHash)) continue;
-        currentRecordHashes.add(recordHash);
-      }
-      let obj;
-      try { obj = JSON.parse(line); } catch { continue; }
-      updateBounds(bounds, obj.timestamp || obj.message?.timestamp);
-      if (typeof obj.sessionId === "string" && obj.sessionId) {
-        rawSessionId = obj.sessionId;
-        observedSessionId = obj.sessionId;
-      }
-      if (typeof obj.cwd === "string" && obj.cwd) cwd = obj.cwd;
-      // Claude writes its own generated one-line summary as an "ai-title" record.
-      // It is agent-authored metadata (not the raw prompt body); keep the latest.
-      if (obj.type === "ai-title" && typeof obj.aiTitle === "string") {
-        const cleaned = cleanSessionTitle(obj.aiTitle);
-        if (cleaned) aiTitle = cleaned;
-        continue;
-      }
-      if (obj.type === "user") {
-        const prompt = extractClaudePrompt(obj);
-        if (!prompt) continue;
-        const fingerprint = promptFingerprint(prompt);
-        if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
-        lastPromptFingerprint = fingerprint;
-        closeTurn();
-        turns += 1;
-        continue;
-      }
-      if (obj.type !== "assistant" || !obj.message) continue;
-      const dedupKey = claudeMessageDedupKey(obj);
-      if (dedupKey && seenMessages.has(dedupKey)) continue;
-      if (dedupKey) seenMessages.add(dedupKey);
-      // Claude writes internal summary/observer messages with model
-      // "<synthetic>". They are not a billable model and can appear after the
-      // real assistant messages in the same session. Keep the latest real
-      // model instead of letting that marker overwrite it.
-      const candidateModel = normalizeSessionModel(obj.message.model);
-      if (candidateModel) model = candidateModel;
-      addTotals(tokens, tokenTotals(obj.message.usage));
-      const content = Array.isArray(obj.message.content) ? obj.message.content : [];
-      for (const block of content) {
-        if (!block || block.type !== "tool_use") continue;
-        const name = String(block.name || "").toLowerCase();
-        if (EDIT_TOOLS.has(name)) currentHadEdit = true;
-        if (name === "agent" || name === "task") {
-          subagentCalls += 1;
-          const subtype = typeof block.input?.subagent_type === "string"
-            ? block.input.subagent_type.trim().slice(0, 64)
-            : "unspecified";
-          subagentTypes.set(subtype || "unspecified", (subagentTypes.get(subtype || "unspecified") || 0) + 1);
+    try {
+      const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
+      const lines = readline.createInterface({ input, crlfDelay: Infinity });
+      for await (const line of lines) {
+        if (filePaths.length > 1) {
+          const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
+          if (priorRecordHashes.has(recordHash)) continue;
+          currentRecordHashes.add(recordHash);
+        }
+        let obj;
+        try { obj = JSON.parse(line); } catch { continue; }
+        updateBounds(bounds, obj.timestamp || obj.message?.timestamp);
+        if (typeof obj.sessionId === "string" && obj.sessionId) {
+          rawSessionId = obj.sessionId;
+          observedSessionId = obj.sessionId;
+        }
+        if (typeof obj.cwd === "string" && obj.cwd) cwd = obj.cwd;
+        // Claude writes its own generated one-line summary as an "ai-title" record.
+        // It is agent-authored metadata (not the raw prompt body); keep the latest.
+        if (obj.type === "ai-title" && typeof obj.aiTitle === "string") {
+          const cleaned = cleanSessionTitle(obj.aiTitle);
+          if (cleaned) aiTitle = cleaned;
+          continue;
+        }
+        if (obj.type === "user") {
+          const prompt = extractClaudePrompt(obj);
+          if (!prompt) continue;
+          const fingerprint = promptFingerprint(prompt);
+          if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+          lastPromptFingerprint = fingerprint;
+          closeTurn();
+          turns += 1;
+          continue;
+        }
+        if (obj.type !== "assistant" || !obj.message) continue;
+        const dedupKey = claudeMessageDedupKey(obj);
+        if (dedupKey && seenMessages.has(dedupKey)) continue;
+        if (dedupKey) seenMessages.add(dedupKey);
+        // Claude writes internal summary/observer messages with model
+        // "<synthetic>". They are not a billable model and can appear after the
+        // real assistant messages in the same session. Keep the latest real
+        // model instead of letting that marker overwrite it.
+        const candidateModel = normalizeSessionModel(obj.message.model);
+        if (candidateModel) model = candidateModel;
+        addTotals(tokens, tokenTotals(obj.message.usage));
+        const content = Array.isArray(obj.message.content) ? obj.message.content : [];
+        for (const block of content) {
+          if (!block || block.type !== "tool_use") continue;
+          const name = String(block.name || "").toLowerCase();
+          if (EDIT_TOOLS.has(name)) currentHadEdit = true;
+          if (name === "agent" || name === "task") {
+            subagentCalls += 1;
+            const subtype = typeof block.input?.subagent_type === "string"
+              ? block.input.subagent_type.trim().slice(0, 64)
+              : "unspecified";
+            subagentTypes.set(subtype || "unspecified", (subagentTypes.get(subtype || "unspecified") || 0) + 1);
+          }
         }
       }
+      scannedFiles += 1;
+    } catch (error) {
+      if (!isRecoverableSessionReadError(error)) throw error;
+    } finally {
+      for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
     }
-    for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
   }
+  if (!scannedFiles) throw new Error("all grouped Claude session files failed during read");
   closeTurn();
   return finalizeRecord({
     version: SIDECAR_VERSION,
@@ -415,46 +427,54 @@ async function scanCodexDeliverySignals(filePath) {
   }
 
   const priorRecordHashes = new Set();
+  let scannedFiles = 0;
   for (const currentFilePath of filePaths) {
     const currentRecordHashes = new Set();
-    const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
-    const lines = readline.createInterface({ input, crlfDelay: Infinity });
-    for await (const line of lines) {
-      if (filePaths.length > 1) {
-        const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
-        if (priorRecordHashes.has(recordHash)) continue;
-        currentRecordHashes.add(recordHash);
+    try {
+      const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
+      const lines = readline.createInterface({ input, crlfDelay: Infinity });
+      for await (const line of lines) {
+        if (filePaths.length > 1) {
+          const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
+          if (priorRecordHashes.has(recordHash)) continue;
+          currentRecordHashes.add(recordHash);
+        }
+        let obj;
+        try { obj = JSON.parse(line); } catch { continue; }
+        updateBounds(bounds, obj.timestamp);
+        if (obj.type === "turn_context") {
+          hasTurnContext = true;
+          beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
+          continue;
+        }
+        const prompt = extractCodexPrompt(obj);
+        if (prompt) {
+          const fingerprint = promptFingerprint(prompt);
+          if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+          lastPromptFingerprint = fingerprint;
+          if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
+          continue;
+        }
+        if (obj.type !== "response_item") continue;
+        const toolNames = extractCodexSignalTools(obj.payload);
+        if (!toolNames.length) continue;
+        if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
+        if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
+        for (const name of toolNames) {
+          if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
+          subagentCalls += 1;
+          const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
+          subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
+        }
       }
-      let obj;
-      try { obj = JSON.parse(line); } catch { continue; }
-      updateBounds(bounds, obj.timestamp);
-      if (obj.type === "turn_context") {
-        hasTurnContext = true;
-        beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
-        continue;
-      }
-      const prompt = extractCodexPrompt(obj);
-      if (prompt) {
-        const fingerprint = promptFingerprint(prompt);
-        if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
-        lastPromptFingerprint = fingerprint;
-        if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
-        continue;
-      }
-      if (obj.type !== "response_item") continue;
-      const toolNames = extractCodexSignalTools(obj.payload);
-      if (!toolNames.length) continue;
-      if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
-      if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
-      for (const name of toolNames) {
-        if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
-        subagentCalls += 1;
-        const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
-        subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
-      }
+      scannedFiles += 1;
+    } catch (error) {
+      if (!isRecoverableSessionReadError(error)) throw error;
+    } finally {
+      for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
     }
-    for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
   }
+  if (!scannedFiles) throw new Error("all grouped Codex signal files failed during read");
   closeTurn();
   return {
     bounds,

--- a/test/npm-publish-workflow.test.js
+++ b/test/npm-publish-workflow.test.js
@@ -85,6 +85,30 @@ test("workflow checks version before publishing", () => {
     content.includes("outputs.eligible == 'true'"),
     "publish steps must require an exact version-changing commit"
   );
+  assert.ok(content.includes("set -euo pipefail"), "provenance checks must fail closed");
+  assert.ok(
+    !content.includes("JSON.parse(s).version||'')}catch{}})\" || true"),
+    "parent version lookup must not swallow checkout or JSON errors",
+  );
+  assert.ok(
+    content.includes('r?.error?.code') && content.includes('= "E404"'),
+    "only a confirmed npm E404 may be treated as unpublished",
+  );
+  assert.ok(
+    content.includes("npm registry lookup failed without a confirmed E404"),
+    "other registry failures must stop publication",
+  );
+});
+
+test("workflow skip notices are reason-specific and avoid expression injection", () => {
+  const content = loadWorkflow();
+  assert.ok(content.includes("Skip unchanged-version commit"));
+  assert.ok(content.includes("Skip already-published version"));
+  assert.ok(content.includes("PACKAGE_VERSION: ${{ steps.version-check.outputs.version }}"));
+  assert.ok(
+    !content.includes('run: echo "v${{ steps.version-check.outputs.version }}'),
+    "step outputs must not be interpolated directly into shell source",
+  );
 });
 
 test("workflow builds dashboard before publish", () => {

--- a/test/npm-publish-workflow.test.js
+++ b/test/npm-publish-workflow.test.js
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const { test } = require("node:test");
 const fs = require("node:fs");
 const path = require("node:path");
+const { assertReleaseVersion } = require("../scripts/version-files.cjs");
 
 const WORKFLOW_PATH = path.join(
   __dirname,
@@ -98,6 +99,11 @@ test("workflow checks version before publishing", () => {
     content.includes("npm registry lookup failed without a confirmed E404"),
     "other registry failures must stop publication",
   );
+  assert.ok(
+    content.includes("assertReleaseVersion(process.argv[1]") &&
+      content.includes("assertReleaseVersion(process.argv[2]"),
+    "current and parent package versions must be validated before npm lookup",
+  );
 });
 
 test("workflow skip notices are reason-specific and avoid expression injection", () => {
@@ -109,6 +115,14 @@ test("workflow skip notices are reason-specific and avoid expression injection",
     !content.includes('run: echo "v${{ steps.version-check.outputs.version }}'),
     "step outputs must not be interpolated directly into shell source",
   );
+});
+
+test("publish version validation rejects malformed current and parent versions", () => {
+  assert.equal(assertReleaseVersion("0.88.3", "current"), "0.88.3");
+  for (const invalid of ["", "v0.88.3", "0.88", "0.88.3-beta.1", "01.2.3"]) {
+    assert.throws(() => assertReleaseVersion(invalid, "current"), /stable x\.y\.z/);
+    assert.throws(() => assertReleaseVersion(invalid, "parent"), /stable x\.y\.z/);
+  }
 });
 
 test("workflow builds dashboard before publish", () => {

--- a/test/session-analytics-claude-cross-root-dedup.test.js
+++ b/test/session-analytics-claude-cross-root-dedup.test.js
@@ -24,6 +24,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { Readable } = require("node:stream");
 
 const {
   analyticsEntryStatKey,
@@ -240,6 +241,47 @@ test("Claude and Codex keep a surviving mirror when another grouped path vanishe
     assert.equal(codexSession.total_tokens, 11);
     const codexAfterOpenFailure = await scanCodexSession([readFailure, codex]);
     assert.equal(codexAfterOpenFailure.total_tokens, 11);
+  });
+});
+
+test("Codex discards records staged before a grouped mirror fails mid-read", async () => {
+  await withTmp(async (tmp) => {
+    const usage = (input, output) => ({
+      input_tokens: input,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: output,
+      reasoning_output_tokens: 0,
+      total_tokens: input + output,
+    });
+    const rows = (input, output, suffix) => [
+      { timestamp: `2026-08-08T04:00:0${suffix}Z`, type: "session_meta", payload: { id: UUID_A, cwd: "/repo", model_provider: "openai" } },
+      { timestamp: `2026-08-08T04:00:1${suffix}Z`, type: "turn_context", payload: { turn_id: `turn-${suffix}`, cwd: "/repo", model: "gpt-test" } },
+      { timestamp: `2026-08-08T04:00:2${suffix}Z`, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(input, output), total_token_usage: usage(input, output) } } },
+    ];
+    const poisonedRows = rows(900, 99, "0");
+    const survivingRows = rows(8, 3, "1");
+    const broken = seedRoot(tmp, "codex-broken", UUID_A, 1_000_000, `${poisonedRows.map(JSON.stringify).join("\n")}\n`);
+    const survivor = seedRoot(tmp, "codex-survivor", UUID_A, 2_000_000, `${survivingRows.map(JSON.stringify).join("\n")}\n`);
+    const originalCreateReadStream = fs.createReadStream;
+    fs.createReadStream = function createFailingReadStream(filePath, options) {
+      if (filePath !== broken) return originalCreateReadStream.call(this, filePath, options);
+      return Readable.from((async function* failAfterCompleteRows() {
+        yield Buffer.from(`${poisonedRows.map(JSON.stringify).join("\n")}\n`);
+        const error = new Error("simulated stale mount after a partial read");
+        error.code = "ESTALE";
+        throw error;
+      })());
+    };
+
+    try {
+      const session = await scanCodexSession([broken, survivor]);
+      assert.equal(session.total_tokens, 11, "the failed mirror's staged usage must not leak into the union");
+      assert.equal(session.tokens.input_tokens, 8);
+      assert.equal(session.tokens.output_tokens, 3);
+    } finally {
+      fs.createReadStream = originalCreateReadStream;
+    }
   });
 });
 

--- a/test/session-analytics-claude-cross-root-dedup.test.js
+++ b/test/session-analytics-claude-cross-root-dedup.test.js
@@ -26,6 +26,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  analyticsEntryStatKey,
   dedupeClaudeFilesAcrossRoots,
   scanClaudeSession,
   scanCodexSession,
@@ -194,9 +195,45 @@ test("Claude cross-root union counts a shared prefix once and both divergent tai
 
     const session = await scanClaudeSession([native, wsl]);
     assert.equal(session.turns, 1);
+    assert.equal(session.retry_turns, 0, "the shared prompt must be hash-deduped");
     assert.equal(session.tokens.input_tokens, 60);
     assert.equal(session.tokens.output_tokens, 6);
     assert.equal(session.total_tokens, 66);
+  });
+});
+
+test("Claude and Codex keep a surviving mirror when another grouped path vanishes", async () => {
+  await withTmp(async (tmp) => {
+    const missing = path.join(tmp, "unmounted", `${UUID_A}.jsonl`);
+    const claudeRow = {
+      type: "assistant",
+      sessionId: UUID_A,
+      cwd: "/repo",
+      timestamp: "2026-08-08T03:00:00Z",
+      message: {
+        id: "m-survivor",
+        model: "claude-test",
+        usage: { input_tokens: 7, output_tokens: 2 },
+        content: [],
+      },
+    };
+    const claude = seedRoot(tmp, "claude-native", UUID_A, 1_000_000, `${JSON.stringify(claudeRow)}\n`);
+    assert.match(
+      analyticsEntryStatKey("claude", [missing, claude]),
+      /^missing\|/,
+      "one missing mirror must invalidate the cache without dropping the surviving group",
+    );
+    const claudeSession = await scanClaudeSession([missing, claude]);
+    assert.equal(claudeSession.total_tokens, 9);
+
+    const codexRows = [
+      { timestamp: "2026-08-08T03:01:00Z", type: "session_meta", payload: { id: UUID_A, cwd: "/repo", model_provider: "openai" } },
+      { timestamp: "2026-08-08T03:01:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: "/repo", model: "gpt-test" } },
+      { timestamp: "2026-08-08T03:01:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 } } } },
+    ];
+    const codex = seedRoot(tmp, "codex-native", UUID_A, 1_000_000, `${codexRows.map(JSON.stringify).join("\n")}\n`);
+    const codexSession = await scanCodexSession([missing, codex]);
+    assert.equal(codexSession.total_tokens, 11);
   });
 });
 

--- a/test/session-analytics-claude-cross-root-dedup.test.js
+++ b/test/session-analytics-claude-cross-root-dedup.test.js
@@ -205,6 +205,8 @@ test("Claude cross-root union counts a shared prefix once and both divergent tai
 test("Claude and Codex keep a surviving mirror when another grouped path vanishes", async () => {
   await withTmp(async (tmp) => {
     const missing = path.join(tmp, "unmounted", `${UUID_A}.jsonl`);
+    const readFailure = path.join(tmp, "read-failure");
+    fs.mkdirSync(readFailure);
     const claudeRow = {
       type: "assistant",
       sessionId: UUID_A,
@@ -225,6 +227,8 @@ test("Claude and Codex keep a surviving mirror when another grouped path vanishe
     );
     const claudeSession = await scanClaudeSession([missing, claude]);
     assert.equal(claudeSession.total_tokens, 9);
+    const claudeAfterOpenFailure = await scanClaudeSession([readFailure, claude]);
+    assert.equal(claudeAfterOpenFailure.total_tokens, 9);
 
     const codexRows = [
       { timestamp: "2026-08-08T03:01:00Z", type: "session_meta", payload: { id: UUID_A, cwd: "/repo", model_provider: "openai" } },
@@ -234,6 +238,8 @@ test("Claude and Codex keep a surviving mirror when another grouped path vanishe
     const codex = seedRoot(tmp, "codex-native", UUID_A, 1_000_000, `${codexRows.map(JSON.stringify).join("\n")}\n`);
     const codexSession = await scanCodexSession([missing, codex]);
     assert.equal(codexSession.total_tokens, 11);
+    const codexAfterOpenFailure = await scanCodexSession([readFailure, codex]);
+    assert.equal(codexAfterOpenFailure.total_tokens, 11);
   });
 });
 


### PR DESCRIPTION
## Summary

- keep a grouped Claude/Codex session when one native/WSL mirror vanishes
- reject relative XDG data paths and bound AppImage xdg-mime registration
- make npm provenance and registry checks fail closed
- release v0.88.3

## Validation

- `npm run ci:local`
- `cargo fmt --check`
- `cargo test` (52 tests)
- `cargo clippy --all-targets -- -D warnings`
- npm E404 provenance branch: `eligible=true`, `exists=false`
- macOS arm64 EmbeddedServer bundle + Debug Xcode build
- app bundle source/version SHA and Info.plist version readback

Release note: Harden cross-root session scanning, AppImage startup registration, and npm release provenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the application and package version to **0.88.3** across supported platforms.
  - Added safer Linux application-directory resolution and improved handling of timed system commands.

- **Bug Fixes**
  - Improved Linux application protocol registration with clearer failure reporting.
  - Session analytics now continues using available data when mirrored files are missing or inaccessible.
  - Improved detection of duplicate Claude retry turns.

- **Release Improvements**
  - Strengthened release-version and publishing validation.
  - Clarified skip notifications for unchanged or already-published releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->