### PR TITLE
fix(macos): preserve floating panels when dashboard closes

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/DashboardPresentationPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DashboardPresentationPolicy.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Pure state machine for the app's two presentations:
+/// a background menu-bar agent and a foreground Dashboard window.
+///
+/// Keeping this free of AppKit makes the Dock/close ordering testable without
+/// launching an application. `DashboardPresentationCoordinator` applies the
+/// returned commands to `NSApp` on the main actor.
+enum DashboardPresentationState: Equatable {
+    case menuBar
+    case dashboard
+    case dashboardClosing
+    case terminating
+}
+
+enum DashboardPresentationCommand: Equatable {
+    case useRegularActivationPolicy
+    case useAccessoryActivationPolicy
+    case showDashboardWindow
+}
+
+struct DashboardPresentationPolicy {
+    private(set) var state: DashboardPresentationState = .menuBar
+    private var reopenAfterClose = false
+
+    /// Presenting the Dashboard turns the menu-bar agent into a foreground app.
+    /// Reassert the policy on every request so a prior modal alert cannot leave
+    /// an already-created Dashboard window without a Dock tile.
+    mutating func presentDashboard() -> [DashboardPresentationCommand] {
+        switch state {
+        case .menuBar:
+            state = .dashboard
+            return [.useRegularActivationPolicy, .showDashboardWindow]
+        case .dashboard:
+            return [.useRegularActivationPolicy, .showDashboardWindow]
+        case .dashboardClosing:
+            // AppKit has already accepted the close. Defer recreation until its
+            // closing turn completes instead of trying to resurrect that window.
+            reopenAfterClose = true
+            return [.useRegularActivationPolicy]
+        case .terminating:
+            return []
+        }
+    }
+
+    /// This is intentionally called from `windowShouldClose`, before AppKit
+    /// starts the traffic-light close animation. Changing to `.accessory` from
+    /// `windowWillClose` is too late on recent macOS releases and can leave the
+    /// Dock tile visible until focus changes.
+    mutating func prepareToCloseDashboard() -> [DashboardPresentationCommand] {
+        guard state == .dashboard else { return [] }
+        state = .dashboardClosing
+        return [.useAccessoryActivationPolicy]
+    }
+
+    /// Run after the Dashboard's close has completed. Deliberately do not hide
+    /// `NSApp`: that is a global operation which also hides the independent
+    /// Dynamic Island and desktop-pet panels. `.accessory` already removed the
+    /// Dock tile before the window close began.
+    mutating func completeDashboardClose() -> [DashboardPresentationCommand] {
+        guard state == .dashboardClosing else { return [] }
+        if reopenAfterClose {
+            reopenAfterClose = false
+            state = .dashboard
+            return [.useRegularActivationPolicy, .showDashboardWindow]
+        }
+        state = .menuBar
+        return []
+    }
+
+    mutating func beginTermination() {
+        state = .terminating
+        reopenAfterClose = false
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardPresentationCoordinator.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardPresentationCoordinator.swift
@@ -19,7 +19,8 @@ final class DashboardPresentationCoordinator {
 
     /// Cmd+Q and any future explicit "Close Dashboard" action use the same
     /// `windowShouldClose` path as the traffic-light close button.
-    func closeDashboard() {
+    @discardableResult
+    func closeDashboard() -> Bool {
         DashboardWindowController.shared.closeWindow()
     }
 

--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardPresentationCoordinator.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardPresentationCoordinator.swift
@@ -1,0 +1,60 @@
+import AppKit
+
+/// Owns the app-level presentation contract for the Dashboard window.
+///
+/// `DashboardWindowController` owns the `NSWindow`; this coordinator owns the
+/// process-wide activation policy and the Dock tile. Keeping those roles apart
+/// prevents individual close paths from drifting apart.
+@MainActor
+final class DashboardPresentationCoordinator {
+    static let shared = DashboardPresentationCoordinator()
+
+    private var policy = DashboardPresentationPolicy()
+
+    private init() {}
+
+    func showDashboard() {
+        apply(policy.presentDashboard())
+    }
+
+    /// Cmd+Q and any future explicit "Close Dashboard" action use the same
+    /// `windowShouldClose` path as the traffic-light close button.
+    func closeDashboard() {
+        DashboardWindowController.shared.closeWindow()
+    }
+
+    /// Called by the Dashboard window delegate before AppKit starts closing it.
+    func dashboardWindowShouldClose() -> Bool {
+        apply(policy.prepareToCloseDashboard())
+        return true
+    }
+
+    /// Called from AppKit's `windowWillClose`. Complete the state transition on
+    /// the next main-loop turn, while guarding a concurrent reopen. This never
+    /// hides `NSApp`, because the Dynamic Island and desktop pet are independent
+    /// panels that must remain visible after the Dashboard closes.
+    func dashboardWindowWillClose() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.apply(self.policy.completeDashboardClose())
+        }
+    }
+
+    /// A real quit must not be converted into a menu-bar transition.
+    func prepareForTermination() {
+        policy.beginTermination()
+    }
+
+    private func apply(_ commands: [DashboardPresentationCommand]) {
+        for command in commands {
+            switch command {
+            case .useRegularActivationPolicy:
+                NSApp.setActivationPolicy(.regular)
+            case .useAccessoryActivationPolicy:
+                NSApp.setActivationPolicy(.accessory)
+            case .showDashboardWindow:
+                DashboardWindowController.shared.presentWindow()
+            }
+        }
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
@@ -39,13 +39,14 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
 
     // MARK: - Public
 
-    func showWindow() {
+    /// Window-only presentation. App-wide activation/Dock policy is owned by
+    /// `DashboardPresentationCoordinator` so every open/close entry shares the
+    /// same lifecycle contract.
+    func presentWindow() {
         // Close the menu bar popover.
         for window in NSApp.windows where window.className.contains("Popover") {
             window.close()
         }
-
-        NSApp.setActivationPolicy(.regular)
 
         // Reuse existing window if possible
         if let window {
@@ -328,20 +329,17 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
 
     // MARK: - NSWindowDelegate
 
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender === window else { return true }
+        return DashboardPresentationCoordinator.shared.dashboardWindowShouldClose()
+    }
+
     func windowWillClose(_ notification: Notification) {
-        // Keep webView and window alive so cookies/login state persist.
-        DispatchQueue.main.async { [weak self] in
-            let closingWindow = self?.window
-            let hasOtherVisibleWindows = NSApp.windows.contains {
-                $0.isVisible
-                && !$0.isKind(of: NSPanel.self)
-                && $0 != closingWindow
-            }
-            if !hasOtherVisibleWindows {
-                NSApp.setActivationPolicy(.accessory)
-                NSApp.hide(nil)
-            }
-        }
+        guard let closingWindow = notification.object as? NSWindow,
+              closingWindow === window else { return }
+        // Keep webView and window alive so cookies/login state persist. The
+        // coordinator schedules only the app-level post-close transition.
+        DashboardPresentationCoordinator.shared.dashboardWindowWillClose()
     }
 
     // MARK: - WKScriptMessageHandler
@@ -371,7 +369,7 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
 
     /// Open the dashboard and navigate directly to the Settings page.
     func showSettings() {
-        showWindow()
+        DashboardPresentationCoordinator.shared.showDashboard()
         if let url = URL(string: Constants.serverBaseURL + "/settings?app=1") {
             webView?.load(URLRequest(url: url))
         }
@@ -379,7 +377,7 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
 
     /// Called when `tokentracker://auth/done` deep link is received after browser login.
     func handleAuthDone() {
-        showWindow()
+        DashboardPresentationCoordinator.shared.showDashboard()
         // Reload dashboard so InsForge SDK picks up session from server-side cookie relay
         if let url = URL(string: Constants.serverBaseURL + "?app=1") {
             webView?.load(URLRequest(url: url))
@@ -390,7 +388,7 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
     /// Loads the callback page in the WebView so the SDK can exchange the code using the
     /// PKCE verifier that's already in WebView's sessionStorage.
     func handleAuthCallback(code: String) {
-        showWindow()
+        DashboardPresentationCoordinator.shared.showDashboard()
         let encoded = code.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? code
         let callbackUrl = Constants.serverBaseURL + "/auth/callback?insforge_code=\(encoded)"
         if let url = URL(string: callbackUrl) {

--- a/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DashboardWindowController.swift
@@ -323,8 +323,14 @@ final class DashboardWindowController: NSObject, NSWindowDelegate, WKNavigationD
         }
     }
 
-    func closeWindow() {
-        window?.performClose(nil)
+    /// Requests a close only when the Dashboard is currently visible.
+    /// Returning whether a close began lets Cmd+Q fall back to a real app quit
+    /// when the menu-bar agent has no Dashboard window to close.
+    @discardableResult
+    func closeWindow() -> Bool {
+        guard let window, window.isVisible else { return false }
+        window.performClose(nil)
+        return true
     }
 
     // MARK: - NSWindowDelegate

--- a/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
@@ -140,7 +140,7 @@ final class DesktopPetWindowController: NSObject, NSWindowDelegate {
                 content: ClawdCompanionView(
                     viewModel: viewModel,
                     layout: .floating,
-                    onRequestDashboard: { DashboardWindowController.shared.showWindow() },
+                    onRequestDashboard: { DashboardPresentationCoordinator.shared.showDashboard() },
                     onClosePet: { [weak self] in self?.hide() },
                     onHoverChanged: { [weak self] hovering in self?.handleHover(hovering) },
                     onKeepActive: { [weak self] in self?.keepActive() },

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -1120,7 +1120,7 @@ final class StatusBarController: NSObject {
     }
 
     @objc private func openDashboard() {
-        DashboardWindowController.shared.showWindow()
+        DashboardPresentationCoordinator.shared.showDashboard()
     }
 
     @objc private func openDashboardSettings() {

--- a/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
+++ b/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
@@ -104,8 +104,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DashboardPresentationCoordinator.shared.prepareForTermination()
             return .terminateNow
         }
-        DashboardPresentationCoordinator.shared.closeDashboard()
-        return .terminateCancel
+        if DashboardPresentationCoordinator.shared.closeDashboard() {
+            return .terminateCancel
+        }
+        DashboardPresentationCoordinator.shared.prepareForTermination()
+        return .terminateNow
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
+++ b/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
@@ -87,6 +87,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// to a window-close so the menu bar item stays alive.
     static func requestQuit() {
         userInitiatedQuit = true
+        DashboardPresentationCoordinator.shared.prepareForTermination()
         NSApp.terminate(nil)
     }
 
@@ -99,13 +100,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               event.type == .keyDown,
               event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
               event.charactersIgnoringModifiers?.lowercased() == "q"
-        else { return .terminateNow }
-        // Switch to accessory BEFORE closing the window so the Dock icon drops
-        // immediately; otherwise AppKit delays the update until focus changes.
-        NSApp.setActivationPolicy(.accessory)
-        DashboardWindowController.shared.closeWindow()
-        // Hide after the close animation completes (next runloop).
-        DispatchQueue.main.async { NSApp.hide(nil) }
+        else {
+            DashboardPresentationCoordinator.shared.prepareForTermination()
+            return .terminateNow
+        }
+        DashboardPresentationCoordinator.shared.closeDashboard()
         return .terminateCancel
     }
 
@@ -114,7 +113,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Finder/Dock reopen must explicitly restore the dashboard window.
         // Do not rely on `flag`: the desktop pet or Dynamic Island may count as
         // visible even while the dashboard itself is closed.
-        DashboardWindowController.shared.showWindow()
+        DashboardPresentationCoordinator.shared.showDashboard()
         return false
     }
 
@@ -147,7 +146,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // an SMAppService login launch should remain a quiet menu bar startup.
         if NSAppleEventManager.shared().currentAppleEvent?
             .attributeDescriptor(forKeyword: keyAELaunchedAsLogInItem) == nil {
-            DashboardWindowController.shared.showWindow()
+            DashboardPresentationCoordinator.shared.showDashboard()
         }
 
         Task { @MainActor in
@@ -164,6 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        DashboardPresentationCoordinator.shared.prepareForTermination()
         NSWorkspace.shared.notificationCenter.removeObserver(self)
         serverManager.stopServer()
     }
@@ -240,7 +240,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // The web app's local-only pages (Limits / Skills on
                 // tokentracker.cc) deep-link here via tokentracker://open to
                 // surface the local dashboard window.
-                DashboardWindowController.shared.showWindow()
+                DashboardPresentationCoordinator.shared.showDashboard()
             }
         }
     }

--- a/TokenTrackerBar/TokenTrackerBar/Views/FooterView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/FooterView.swift
@@ -10,7 +10,7 @@ struct FooterView: View {
     var body: some View {
         HStack(spacing: 12) {
             Button {
-                DashboardWindowController.shared.showWindow()
+                DashboardPresentationCoordinator.shared.showDashboard()
             } label: {
                 HStack(spacing: 3) {
                     Image(systemName: "macwindow")

--- a/TokenTrackerBar/TokenTrackerBarTests/DashboardPresentationPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DashboardPresentationPolicyTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+final class DashboardPresentationPolicyTests: XCTestCase {
+    func testPresentingDashboardPromotesMenuBarAgentToRegularApp() {
+        var policy = DashboardPresentationPolicy()
+
+        XCTAssertEqual(
+            policy.presentDashboard(),
+            [.useRegularActivationPolicy, .showDashboardWindow]
+        )
+        XCTAssertEqual(policy.state, .dashboard)
+    }
+
+    func testTrafficLightCloseDemotesBeforeTheWindowFinishesClosingWithoutHidingPanels() {
+        var policy = DashboardPresentationPolicy()
+        _ = policy.presentDashboard()
+
+        XCTAssertEqual(policy.prepareToCloseDashboard(), [.useAccessoryActivationPolicy])
+        XCTAssertEqual(policy.state, .dashboardClosing)
+        XCTAssertEqual(policy.completeDashboardClose(), [])
+        XCTAssertEqual(policy.state, .menuBar)
+    }
+
+    func testReopeningBeforeCloseCompletionDefersFreshWindowPresentation() {
+        var policy = DashboardPresentationPolicy()
+        _ = policy.presentDashboard()
+        _ = policy.prepareToCloseDashboard()
+
+        XCTAssertEqual(policy.presentDashboard(), [.useRegularActivationPolicy])
+        XCTAssertEqual(
+            policy.completeDashboardClose(),
+            [.useRegularActivationPolicy, .showDashboardWindow]
+        )
+        XCTAssertEqual(policy.state, .dashboard)
+    }
+
+    func testTerminationDoesNotScheduleBackgroundPresentation() {
+        var policy = DashboardPresentationPolicy()
+        _ = policy.presentDashboard()
+
+        policy.beginTermination()
+
+        XCTAssertEqual(policy.state, .terminating)
+        XCTAssertEqual(policy.prepareToCloseDashboard(), [])
+        XCTAssertEqual(policy.completeDashboardClose(), [])
+        XCTAssertEqual(policy.presentDashboard(), [])
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -129,6 +129,7 @@ targets:
       - path: TokenTrackerBar/Models/BackgroundRefreshPolicy.swift
       - path: TokenTrackerBar/Models/SyncRequestPolicy.swift
       - path: TokenTrackerBar/Models/UsagePublicationPolicy.swift
+      - path: TokenTrackerBar/Models/DashboardPresentationPolicy.swift
       - path: TokenTrackerBar/Services/ResumableDownloader.swift
       - path: TokenTrackerBar/Services/QueueActivityMonitor.swift
       - path: TokenTrackerBar/Models/CompanionAnimationPolicy.swift

--- a/test/macos-dashboard-window-space.test.js
+++ b/test/macos-dashboard-window-space.test.js
@@ -68,7 +68,7 @@ test("reopening the macOS menu bar app always restores the dashboard", () => {
   )?.[0];
 
   assert.ok(reopenHandler, "AppDelegate should handle Finder/Dock reopen events");
-  assert.match(reopenHandler, /DashboardWindowController\.shared\.showWindow\(\)/);
+  assert.match(reopenHandler, /DashboardPresentationCoordinator\.shared\.showDashboard\(\)/);
   assert.match(
     reopenHandler,
     /return false/,
@@ -89,5 +89,5 @@ test("a normal macOS launch opens the dashboard but a login-item launch stays qu
 
   assert.ok(launchHandler, "AppDelegate should configure initial launch behavior");
   assert.match(launchHandler, /keyAELaunchedAsLogInItem/);
-  assert.match(launchHandler, /DashboardWindowController\.shared\.showWindow\(\)/);
+  assert.match(launchHandler, /DashboardPresentationCoordinator\.shared\.showDashboard\(\)/);
 });

--- a/test/macos-dashboard-window-space.test.js
+++ b/test/macos-dashboard-window-space.test.js
@@ -24,6 +24,13 @@ const desktopPetWindowControllerPath = path.join(
   "Services",
   "DesktopPetWindowController.swift",
 );
+const dashboardPresentationCoordinatorPath = path.join(
+  repoRoot,
+  "TokenTrackerBar",
+  "TokenTrackerBar",
+  "Services",
+  "DashboardPresentationCoordinator.swift",
+);
 
 function read(filePath) {
   return fs.readFileSync(filePath, "utf8");
@@ -90,4 +97,34 @@ test("a normal macOS launch opens the dashboard but a login-item launch stays qu
   assert.ok(launchHandler, "AppDelegate should configure initial launch behavior");
   assert.match(launchHandler, /keyAELaunchedAsLogInItem/);
   assert.match(launchHandler, /DashboardPresentationCoordinator\.shared\.showDashboard\(\)/);
+});
+
+test("Cmd+Q exits when no visible Dashboard close can begin", () => {
+  const appDelegateSource = read(appDelegatePath);
+  const coordinatorSource = read(dashboardPresentationCoordinatorPath);
+  const dashboardWindowControllerSource = read(dashboardWindowControllerPath);
+  const terminationHandler = appDelegateSource.match(
+    /func applicationShouldTerminate\([\s\S]*?\n    }\n\n    func applicationShouldHandleReopen/,
+  )?.[0];
+
+  assert.ok(terminationHandler, "AppDelegate should handle Cmd+Q termination requests");
+  assert.match(
+    terminationHandler,
+    /if DashboardPresentationCoordinator\.shared\.closeDashboard\(\) \{\s*return \.terminateCancel\s*}/,
+    "Cmd+Q should be cancelled only after a visible Dashboard close begins",
+  );
+  assert.match(
+    terminationHandler,
+    /DashboardPresentationCoordinator\.shared\.prepareForTermination\(\)\s*return \.terminateNow/,
+    "Cmd+Q should terminate when no Dashboard window exists or is already closed",
+  );
+  assert.match(
+    coordinatorSource,
+    /func closeDashboard\(\) -> Bool \{\s*DashboardWindowController\.shared\.closeWindow\(\)\s*}/,
+  );
+  assert.match(
+    dashboardWindowControllerSource,
+    /func closeWindow\(\) -> Bool \{\s*guard let window, window\.isVisible else \{ return false \}\s*window\.performClose\(nil\)\s*return true\s*}/,
+    "A hidden or absent Dashboard must report that no close began",
+  );
 });


### PR DESCRIPTION
## Summary

Prevent closing the Dashboard from globally hiding the app, so Dynamic Island and desktop pet panels remain visible while the Dock icon still disappears correctly.

## Scope

- [x] macOS app (`TokenTrackerBar/`)

## Checklist

- [x] macOS unit tests pass
- [x] No user-facing strings added
- [x] Commits follow conventional style
- [x] PR description explains why

## Tests

- `xcodebuild -quiet -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBarTests -configuration Debug -derivedDataPath /private/tmp/tokentracker-dock-tests test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Dashboard presentation, closing, and reopening behavior.
  * Dashboard content and state are preserved when the window closes.
  * Independent panels remain available after closing the Dashboard.

* **Bug Fixes**
  * Improved activation behavior when switching between menu-bar and Dashboard modes.
  * Prevented the Dashboard from reopening during app termination.
  * Improved termination handling when closing the Dashboard with Cmd+Q.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->