### PR TITLE
fix(macos): compare widget usage with calendar yesterday

### DIFF
--- a/TokenTrackerBar/Shared/WidgetSnapshot.swift
+++ b/TokenTrackerBar/Shared/WidgetSnapshot.swift
@@ -98,12 +98,14 @@ public struct WidgetSnapshot: Codable, Equatable {
 
     // MARK: - Derived
 
-    /// Tokens used yesterday, derived from `dailyTrend`. The trend is sorted
-    /// oldest-first; the last entry represents today, so yesterday is the
-    /// second-to-last entry. Returns 0 when not enough data is available.
+    /// Tokens used on the calendar day before this snapshot was generated.
+    /// `dailyTrend` contains only active days, so array position cannot identify yesterday.
     public var yesterdayTokens: Int {
-        guard dailyTrend.count >= 2 else { return 0 }
-        return dailyTrend[dailyTrend.count - 2].totalTokens
+        let calendar = Calendar.current
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: generatedAt) else {
+            return 0
+        }
+        return dailyTrend.first { calendar.isDate($0.day, inSameDayAs: yesterday) }?.totalTokens ?? 0
     }
 
     /// Delta (percent) between today and yesterday. Returns nil when there

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -84,8 +84,8 @@ enum WidgetSnapshotWriter {
         // (the /tokentracker-usage-summary endpoint omits it from
         // `rolling.*`). Fire two extra parallel summary calls scoped to
         // 7-day and 30-day ranges so the widget can show real cost numbers.
-        async let last7dCost = fetchRangeCost(daysBack: 6)
-        async let last30dCost = fetchRangeCost(daysBack: 29)
+        async let last7dCost = fetchRangeCost(daysBack: 6, endingAt: inputs.capturedAt)
+        async let last30dCost = fetchRangeCost(daysBack: 29, endingAt: inputs.capturedAt)
         let (cost7d, cost30d) = await (last7dCost, last30dCost)
 
         // Superseded while awaiting the cost fetches — drop this stale write.
@@ -114,14 +114,13 @@ enum WidgetSnapshotWriter {
     /// Bumped at the start of every `update`; stale calls bail before writing.
     private static var updateGeneration = 0
 
-    /// Fetches a `UsageSummaryResponse` for `[N days ago, today]` and pulls
+    /// Fetches a `UsageSummaryResponse` for `[N days ago, captured day]` and pulls
     /// out the top-level `total_cost_usd`. Returns 0 on any failure so the
     /// widget keeps rendering rather than getting stuck on an error path.
-    private static func fetchRangeCost(daysBack: Int) async -> Double {
-        let from = DateHelpers.daysAgoString(daysBack)
-        let to = DateHelpers.todayString()
+    private static func fetchRangeCost(daysBack: Int, endingAt date: Date) async -> Double {
+        let range = DateHelpers.dayRange(daysBack: daysBack, endingAt: date)
         do {
-            let resp = try await APIClient.shared.fetchSummary(from: from, to: to)
+            let resp = try await APIClient.shared.fetchSummary(from: range.from, to: range.to)
             return parseCost(resp.totals.totalCostUsd)
         } catch {
             logger.warning("widget cost fetch \(daysBack)d failed: \(error.localizedDescription)")

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -17,9 +17,8 @@ enum WidgetSnapshotWriter {
 
     /// Immutable snapshot of the fields we read off `DashboardViewModel`.
     /// Captured synchronously on the main actor BEFORE we suspend on any
-    /// async work, so a concurrent `loadAll()` running while we're awaiting
-    /// the cost fetches can't smear two refreshes together in one widget
-    /// snapshot.
+    /// async work. `capturedAt` is supplied by `loadAll()` so the queried data
+    /// and the resulting widget snapshot share one calendar-day reference.
     private struct VMInputs {
         let capturedAt: Date
         let serverOnline: Bool
@@ -52,9 +51,9 @@ enum WidgetSnapshotWriter {
         }
     }
 
-    static func update(from vm: DashboardViewModel) async {
+    static func update(from vm: DashboardViewModel, capturedAt: Date) async {
         // Monotonic ticket (main-actor serialized): if a newer update starts
-        // while we're suspended on the cost fetches below, this call is stale
+        // while we're suspended on the range fetches below, this call is stale
         // and must not write — otherwise its older snapshot could land after
         // (and clobber) the newer one.
         updateGeneration += 1
@@ -63,9 +62,8 @@ enum WidgetSnapshotWriter {
         // STEP 1 — synchronously freeze every VM field we will need. After
         // this point we never touch `vm` again. This is the fix for the
         // race where a second loadAll() could mutate the view model while
-        // we're awaiting the cost fetches below, producing a snapshot that
+        // we're awaiting the range fetches below, producing a snapshot that
         // mixed two different refreshes.
-        let capturedAt = Date()
         let inputs = VMInputs(
             capturedAt: capturedAt,
             serverOnline: vm.serverOnline,
@@ -80,18 +78,25 @@ enum WidgetSnapshotWriter {
             usageLimits: vm.usageLimits
         )
 
-        // STEP 2 — the dashboard's `rollingSummary` does NOT include cost
-        // (the /tokentracker-usage-summary endpoint omits it from
-        // `rolling.*`). Fire two extra parallel summary calls scoped to
-        // 7-day and 30-day ranges so the widget can show real cost numbers.
-        async let last7dCost = fetchRangeCost(daysBack: 6, endingAt: inputs.capturedAt)
-        async let last30dCost = fetchRangeCost(daysBack: 29, endingAt: inputs.capturedAt)
-        let (cost7d, cost30d) = await (last7dCost, last30dCost)
+        // STEP 2 — `rolling.*` omits cost and is anchored to the server's live
+        // clock. Fetch explicit captured ranges so every displayed field in
+        // each period comes from one response and one calendar window.
+        let last7dRange = DateHelpers.dayRange(daysBack: 6, endingAt: inputs.capturedAt)
+        let last30dRange = DateHelpers.dayRange(daysBack: 29, endingAt: inputs.capturedAt)
+        async let last7dSummary = fetchRangeSummary(last7dRange)
+        async let last30dSummary = fetchRangeSummary(last30dRange)
+        let (summary7d, summary30d) = await (last7dSummary, last30dSummary)
 
-        // Superseded while awaiting the cost fetches — drop this stale write.
+        // Superseded while awaiting the range fetches — drop this stale write.
         guard ticket == updateGeneration else { return }
 
-        let snapshot = buildSnapshot(from: inputs, cost7d: cost7d, cost30d: cost30d)
+        let snapshot = buildSnapshot(
+            from: inputs,
+            last7dSummary: summary7d,
+            last30dSummary: summary30d,
+            last7dRange: last7dRange,
+            last30dRange: last30dRange
+        )
         // Write off the main actor on a serial queue (no main-thread file IO,
         // no torn concurrent writes); the generation guard above is what
         // keeps stale snapshots from overwriting newer ones.
@@ -114,17 +119,18 @@ enum WidgetSnapshotWriter {
     /// Bumped at the start of every `update`; stale calls bail before writing.
     private static var updateGeneration = 0
 
-    /// Fetches a `UsageSummaryResponse` for `[N days ago, captured day]` and pulls
-    /// out the top-level `total_cost_usd`. Returns 0 on any failure so the
-    /// widget keeps rendering rather than getting stuck on an error path.
-    private static func fetchRangeCost(daysBack: Int, endingAt date: Date) async -> Double {
-        let range = DateHelpers.dayRange(daysBack: daysBack, endingAt: date)
+    /// Fetches all totals for an explicit captured range. Returns nil on any
+    /// failure so the widget can fall back to matching dashboard rolling fields.
+    private static func fetchRangeSummary(
+        _ range: (from: String, to: String)
+    ) async -> UsageSummaryResponse? {
         do {
-            let resp = try await APIClient.shared.fetchSummary(from: range.from, to: range.to)
-            return parseCost(resp.totals.totalCostUsd)
+            return try await APIClient.shared.fetchSummary(from: range.from, to: range.to)
         } catch {
-            logger.warning("widget cost fetch \(daysBack)d failed: \(error.localizedDescription)")
-            return 0
+            logger.warning(
+                "widget range fetch \(range.from)-\(range.to) failed: \(error.localizedDescription)"
+            )
+            return nil
         }
     }
 
@@ -132,13 +138,21 @@ enum WidgetSnapshotWriter {
 
     private static func buildSnapshot(
         from inputs: VMInputs,
-        cost7d: Double,
-        cost30d: Double
+        last7dSummary: UsageSummaryResponse?,
+        last30dSummary: UsageSummaryResponse?,
+        last7dRange: (from: String, to: String),
+        last30dRange: (from: String, to: String)
     ) -> WidgetSnapshot {
-        var last7d = rollingTotals(from: inputs.rollingSummary?.rolling.last7d)
-        last7d.costUsd = cost7d
-        var last30d = rollingTotals(from: inputs.rollingSummary?.rolling.last30d)
-        last30d.costUsd = cost30d
+        let last7d = rangeTotals(
+            from: last7dSummary,
+            fallback: inputs.rollingSummary?.rolling.last7d,
+            expectedRange: last7dRange
+        )
+        let last30d = rangeTotals(
+            from: last30dSummary,
+            fallback: inputs.rollingSummary?.rolling.last30d,
+            expectedRange: last30dRange
+        )
 
         // All-time total — pair the tokens/cost with the heatmap's all-time
         // active-days so widgets can show a consistent "lifetime" row.
@@ -187,6 +201,28 @@ enum WidgetSnapshotWriter {
             conversations: window.totals.conversationCount,
             activeDays: window.activeDays
         )
+    }
+
+    private static func rangeTotals(
+        from summary: UsageSummaryResponse?,
+        fallback: RollingPeriod?,
+        expectedRange: (from: String, to: String)
+    ) -> PeriodTotals {
+        if let summary,
+           summary.from == expectedRange.from,
+           summary.to == expectedRange.to {
+            var totals = periodTotals(from: summary)
+            totals.activeDays = summary.days
+            return totals
+        }
+        // A server-clock fallback from another day would recreate the same
+        // cross-midnight tear, so fail closed unless its range matches exactly.
+        guard let fallback,
+              fallback.from == expectedRange.from,
+              fallback.to == expectedRange.to else {
+            return .empty
+        }
+        return rollingTotals(from: fallback)
     }
 
     private static func trendPoints(from daily: [DailyEntry]) -> [DailyPoint] {

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -21,6 +21,7 @@ enum WidgetSnapshotWriter {
     /// the cost fetches can't smear two refreshes together in one widget
     /// snapshot.
     private struct VMInputs {
+        let capturedAt: Date
         let serverOnline: Bool
         let todaySummary: UsageSummaryResponse?
         let summary: UsageSummaryResponse?
@@ -64,7 +65,9 @@ enum WidgetSnapshotWriter {
         // race where a second loadAll() could mutate the view model while
         // we're awaiting the cost fetches below, producing a snapshot that
         // mixed two different refreshes.
+        let capturedAt = Date()
         let inputs = VMInputs(
+            capturedAt: capturedAt,
             serverOnline: vm.serverOnline,
             todaySummary: vm.todaySummary,
             summary: vm.summary,
@@ -144,7 +147,7 @@ enum WidgetSnapshotWriter {
         total.activeDays = inputs.heatmap?.activeDays ?? total.activeDays
 
         return WidgetSnapshot(
-            generatedAt: Date(),
+            generatedAt: inputs.capturedAt,
             serverOnline: inputs.serverOnline,
             today: periodTotals(from: inputs.todaySummary),
             last7d: last7d,

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/DateHelpers.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/DateHelpers.swift
@@ -81,8 +81,11 @@ enum DateHelpers {
     }
 
     /// Returns (from, to) date strings for a given period.
-    static func rangeForPeriod(_ period: Period) -> (from: String, to: String) {
-        let now = Date()
+    static func rangeForPeriod(
+        _ period: Period,
+        referenceDate: Date = Date()
+    ) -> (from: String, to: String) {
+        let now = referenceDate
         let today = localDayFormatter.string(from: now)
 
         switch period {
@@ -113,7 +116,7 @@ enum DateHelpers {
             // Last 24 months
             let start = localCalendar.date(byAdding: .month, value: -24, to: now) ?? now
             guard let monthStart = localCalendar.date(from: localCalendar.dateComponents([.year, .month], from: start)) else {
-                return (from: monthsAgoString(24), to: today)
+                return (from: localDayFormatter.string(from: start), to: today)
             }
             return (from: localDayFormatter.string(from: monthStart), to: today)
         }

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/DateHelpers.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/DateHelpers.swift
@@ -40,6 +40,15 @@ enum DateHelpers {
 		return localDayFormatter.string(from: date)
 	}
 
+	/// Returns an inclusive local-day range ending on the provided date.
+	static func dayRange(daysBack: Int, endingAt date: Date) -> (from: String, to: String) {
+		let fromDate = localCalendar.date(byAdding: .day, value: -daysBack, to: date) ?? date
+		return (
+			from: localDayFormatter.string(from: fromDate),
+			to: localDayFormatter.string(from: date)
+		)
+	}
+
 	/// Parses a "YYYY-MM-DD" string into a Date in the current local time zone.
 	static func parseDay(_ s: String) -> Date? {
 		let result = localDayFormatter.date(from: s)

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -144,10 +144,14 @@ class DashboardViewModel: ObservableObject {
             return
         }
 
-        let range = DateHelpers.rangeForPeriod(period)
-        let rollingFrom = DateHelpers.daysAgoString(30)
-        let rollingTo = DateHelpers.todayString()
-        let totalRange = DateHelpers.rangeForPeriod(.total)
+        // Keep every date-scoped query and the resulting widget snapshot on one
+        // calendar-day reference even when the refresh crosses local midnight.
+        let capturedAt = Date()
+        let range = DateHelpers.rangeForPeriod(period, referenceDate: capturedAt)
+        let rollingRange = DateHelpers.dayRange(daysBack: 30, endingAt: capturedAt)
+        let rollingFrom = rollingRange.from
+        let rollingTo = rollingRange.to
+        let totalRange = DateHelpers.rangeForPeriod(.total, referenceDate: capturedAt)
 
         var errorCount = 0
         var firstError: String?
@@ -157,10 +161,9 @@ class DashboardViewModel: ObservableObject {
             // Today summary (always today for summary cards)
             group.addTask { @MainActor in
                 do {
-                    let today = DateHelpers.todayString()
                     let result = try await APIClient.shared.fetchSummaryWithSource(
-                        from: today,
-                        to: today
+                        from: rollingTo,
+                        to: rollingTo
                     )
                     self.todaySummary = result.summary
                     self.summaryPublicationState.record(
@@ -306,7 +309,7 @@ class DashboardViewModel: ObservableObject {
 
         // Push the latest data to the widget snapshot file so the desktop
         // widgets pick it up on their next timeline reload.
-        await WidgetSnapshotWriter.update(from: self)
+        await WidgetSnapshotWriter.update(from: self, capturedAt: capturedAt)
         await finishDataLoad(allowPendingRefresh: errorCount == 0)
     }
 

--- a/TokenTrackerBar/TokenTrackerBarTests/DateHelpersTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DateHelpersTests.swift
@@ -3,9 +3,21 @@ import XCTest
 final class DateHelpersTests: XCTestCase {
 
     func testDayRangeEndsAtProvidedCaptureDate() {
+        let range = DateHelpers.dayRange(daysBack: 6, endingAt: makeCaptureDate())
+
+        XCTAssertEqual("\(range.from)...\(range.to)", "2026-08-04...2026-08-10")
+    }
+
+    func testPeriodRangeUsesProvidedCaptureDate() {
+        let range = DateHelpers.rangeForPeriod(.day, referenceDate: makeCaptureDate())
+
+        XCTAssertEqual("\(range.from)...\(range.to)", "2026-08-10...2026-08-10")
+    }
+
+    private func makeCaptureDate() -> Date {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = .current
-        let capturedAt = calendar.date(
+        return calendar.date(
             from: DateComponents(
                 year: 2026,
                 month: 8,
@@ -15,9 +27,5 @@ final class DateHelpersTests: XCTestCase {
                 second: 59
             )
         )!
-
-        let range = DateHelpers.dayRange(daysBack: 6, endingAt: capturedAt)
-
-        XCTAssertEqual("\(range.from)...\(range.to)", "2026-08-04...2026-08-10")
     }
 }

--- a/TokenTrackerBar/TokenTrackerBarTests/DateHelpersTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DateHelpersTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+final class DateHelpersTests: XCTestCase {
+
+    func testDayRangeEndsAtProvidedCaptureDate() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let capturedAt = calendar.date(
+            from: DateComponents(
+                year: 2026,
+                month: 8,
+                day: 10,
+                hour: 23,
+                minute: 59,
+                second: 59
+            )
+        )!
+
+        let range = DateHelpers.dayRange(daysBack: 6, endingAt: capturedAt)
+
+        XCTAssertEqual("\(range.from)...\(range.to)", "2026-08-04...2026-08-10")
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBarTests/WidgetSnapshotTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/WidgetSnapshotTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+final class WidgetSnapshotTests: XCTestCase {
+
+    func testYesterdayDeltaIsUnavailableWhenDailyTrendSkipsYesterday() {
+        let snapshot = WidgetSnapshot(
+            generatedAt: date(year: 2026, month: 8, day: 10),
+            today: PeriodTotals(tokens: 200),
+            dailyTrend: [
+                DailyPoint(
+                    day: date(year: 2026, month: 8, day: 7),
+                    totalTokens: 100,
+                    costUsd: 0
+                ),
+                DailyPoint(
+                    day: date(year: 2026, month: 8, day: 10),
+                    totalTokens: 200,
+                    costUsd: 0
+                ),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.yesterdayTokens, 0)
+        XCTAssertNil(snapshot.todayDeltaPercent)
+    }
+
+    func testYesterdayUsesTheSnapshotGenerationDate() {
+        let snapshot = WidgetSnapshot(
+            generatedAt: date(year: 2024, month: 2, day: 10),
+            today: PeriodTotals(tokens: 150),
+            dailyTrend: [
+                DailyPoint(
+                    day: date(year: 2024, month: 2, day: 9),
+                    totalTokens: 75,
+                    costUsd: 0
+                ),
+                DailyPoint(
+                    day: date(year: 2024, month: 2, day: 10),
+                    totalTokens: 150,
+                    costUsd: 0
+                ),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.yesterdayTokens, 75)
+        XCTAssertEqual(snapshot.todayDeltaPercent, 100)
+    }
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -133,6 +133,7 @@ targets:
       - path: TokenTrackerBar/Services/QueueActivityMonitor.swift
       - path: TokenTrackerBar/Models/CompanionAnimationPolicy.swift
       - path: TokenTrackerBar/Models/ServerHealthCheckPolicy.swift
+      - path: TokenTrackerBar/Utilities/DateHelpers.swift
       # WeeklyLimitResetDetector's window labels come from Strings, which
       # resolves the locale via Shared/NativeLocalization (Shared is
       # Foundation-only by design, so pulling the whole dir stays cheap).


### PR DESCRIPTION
## Summary

Fix the macOS widget's "vs. yesterday" comparison so sparse daily trends and every date-sensitive part of a refresh use the actual captured calendar day.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Why

`dailyTrend` contains only days with recorded usage. Treating its second-to-last entry as yesterday can therefore compare today with an older active day and display a misleading percentage.

For example, a trend containing Aug 7 and Aug 10 previously treated Aug 7 as the Aug 9 baseline.

The dashboard also constructed its data ranges before an asynchronous task group, while the widget writer captured its timestamp only after every request completed. A refresh crossing local midnight could therefore label Aug 10 data as Aug 11, report a misleading 0% delta, and combine explicit cost windows with server-clock rolling totals from another day.

## What changed

- Resolve yesterday relative to `WidgetSnapshot.generatedAt`.
- Match the corresponding calendar day in `dailyTrend` instead of relying on array position.
- Capture one refresh timestamp before `DashboardViewModel.loadAll()` constructs any date-scoped data query.
- Derive selected, today, rolling, daily, hourly, total, and supplemental widget ranges from that timestamp.
- Pass the same timestamp to `WidgetSnapshotWriter` for `generatedAt`.
- Build each widget 7-day and 30-day period from one explicit captured-range summary response, including tokens, cost, conversations, and active days.
- Accept a fallback rolling period only when its declared `from` and `to` match the captured range exactly; otherwise fail closed with an empty period.
- Preserve the existing unavailable-baseline behavior when yesterday is absent.
- Add focused regression tests for missing yesterday data, historical snapshots, explicit local-day ranges, and period ranges with an injected reference date.

This does not change the API, snapshot schema, backend aggregation, widget UI, or user-facing copy.

## Validation

- Deterministic load-crossing-midnight harness — RED: Aug 11 / 0% / `2026-08-05...2026-08-11`; GREEN: Aug 10 / 100% / `2026-08-04...2026-08-10`
- Deterministic rolling-window harness — RED: live-window tokens plus captured cost; GREEN: all period fields from the captured-range response
- Deterministic failed-fallback harness — RED: 800 mismatched tokens; GREEN: empty period
- Focused `DateHelpersTests` typecheck — passed
- Changed Swift source parse — passed
- `xcrun swiftc -typecheck TokenTrackerBar/Shared/WidgetSnapshot.swift` — passed
- `node --test test/macos-background-sync-source.test.js` — passed (1/1)
- `git diff --check origin/main...HEAD` — passed
- Standards review for the selected P2 — passed with no findings
- Spec review — passed with no findings
- Focused local `xcodebuild test` — blocked before test loading because the local Xcode installation is missing `CoreSimulator.framework`; the upstream macOS CI lane remains the authoritative XCTest run

## Checklist

- [ ] `npm test` passes (not run locally; this change is isolated to the macOS Swift target)
- [x] No new user-facing strings were added
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

No listed risk-layer triggers apply. The change is a local capture-time and derived-value correction in the macOS widget snapshot model.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected yesterday’s token usage to use the calendar day before the snapshot date.
  * Returns zero when no data is available for yesterday.
  * Handles trends correctly even when today and yesterday are not the final entries.
  * Ensures dashboard refreshes, snapshot timestamps, and usage ranges consistently reflect one capture time.
  * Improves accuracy of seven-day and 30-day summaries across date boundaries.

* **Tests**
  * Added coverage for missing data, date handling, token totals, percentage changes, date ranges, and snapshot timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
