### PR TITLE
fix: treat a blank Claude credential as an expired login

### DIFF
--- a/src/lib/subscriptions.js
+++ b/src/lib/subscriptions.js
@@ -446,6 +446,7 @@ async function readCodexAuthBundle({ home, env } = {}) {
 
 module.exports = {
   collectLocalSubscriptions,
+  detectClaudeCodeCredentialsPresence,
   detectClaudeCodeSubscriptionDetails,
   readClaudeCodeAccessToken,
   readCodexAccessToken,

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -9,6 +9,7 @@ const { performance } = require("node:perf_hooks");
 const { promisify } = require("node:util");
 
 const {
+  detectClaudeCodeCredentialsPresence,
   detectClaudeCodeSubscriptionDetails,
   readClaudeCodeAccessToken,
   readCodexAccessToken,
@@ -188,6 +189,10 @@ function extractClaudeScopedWeekly(body) {
   return out.length > 0 ? out : null;
 }
 
+// Shared by the 401 path below and by the blank-credential path in getUsageLimits:
+// both mean "the CLI login no longer works", and both are fixed the same way.
+const CLAUDE_AUTH_EXPIRED_MESSAGE = "Claude token expired — run `claude` once to refresh.";
+
 async function fetchClaudeUsageLimits(accessToken, { fetchImpl = fetch, maxAttempts = 3 } = {}) {
   const url = "https://api.anthropic.com/api/oauth/usage";
   const headers = {
@@ -198,7 +203,7 @@ async function fetchClaudeUsageLimits(accessToken, { fetchImpl = fetch, maxAttem
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const res = await fetchImpl(url, { method: "GET", headers });
     if (res.status === 401) {
-      const err = new Error("Claude token expired — run `claude` once to refresh.");
+      const err = new Error(CLAUDE_AUTH_EXPIRED_MESSAGE);
       err.code = "AUTH_EXPIRED";
       throw err;
     }
@@ -3243,7 +3248,17 @@ async function fetchUsageLimitsUncached({
 
   let claude;
   if (!claudeToken) {
-    claude = { configured: false };
+    // Claude Code blanks `accessToken`/`refreshToken` in place when its login expires
+    // (macOS Keychain item and .credentials.json alike) instead of removing the entry,
+    // so "no token" is ambiguous: never signed in, or signed in and expired. An entry
+    // that still exists means the latter — reporting `configured: false` there hides the
+    // whole Claude section while the usage bars (parsed from local logs, no auth needed)
+    // keep updating, which reads as "TokenTracker doesn't support my plan" rather than
+    // "your CLI login expired". Existence-only probe: no secret is read here.
+    const credentialsPresent = detectClaudeCodeCredentialsPresence({ platform, securityRunner, home });
+    claude = credentialsPresent
+      ? { configured: true, error: CLAUDE_AUTH_EXPIRED_MESSAGE, auth_action_required: "reauth" }
+      : { configured: false };
   } else if (freshClaudeCache) {
     claude = freshClaudeCache;
   } else if (claudeResult && claudeResult.status === "fulfilled") {

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -1712,6 +1712,10 @@ describe("getUsageLimits", () => {
         }),
       );
 
+      // Throwing alone proves nothing here: provider failures are collected with
+      // allSettled and this branch never reads claudeResult, so a forbidden call
+      // would be swallowed. Track it and assert it never happened.
+      let usageApiCalled = false;
       const result = await getUsageLimits({
         home: tmp,
         platform: "linux",
@@ -1724,6 +1728,7 @@ describe("getUsageLimits", () => {
         },
         fetchImpl(url) {
           if (typeof url === "string" && url === "https://api.anthropic.com/api/oauth/usage") {
+            usageApiCalled = true;
             throw new Error("must not call the usage API without a token");
           }
           return pendingUnlessCodexReset(url);
@@ -1733,6 +1738,7 @@ describe("getUsageLimits", () => {
       assert.equal(result.claude.configured, true);
       assert.match(result.claude.error, /token expired/i);
       assert.equal(result.claude.auth_action_required, "reauth");
+      assert.equal(usageApiCalled, false);
     } finally {
       resetUsageLimitsCache();
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -1692,6 +1692,78 @@ describe("getUsageLimits", () => {
     }
   });
 
+  it("flags reauth when the credential entry exists but its token fields are blank", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-blank-token-"));
+    try {
+      // What an expired Claude Code login actually leaves behind: the entry survives,
+      // the secrets are emptied in place.
+      const claudeDir = path.join(tmp, ".claude");
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeDir, ".credentials.json"),
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "",
+            refreshToken: "",
+            expiresAt: 0,
+            subscriptionType: "max",
+          },
+        }),
+      );
+
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 1000,
+        securityRunner() {
+          return { status: 1, stdout: "" };
+        },
+        commandRunner() {
+          return { status: 1, stdout: "" };
+        },
+        fetchImpl(url) {
+          if (typeof url === "string" && url === "https://api.anthropic.com/api/oauth/usage") {
+            throw new Error("must not call the usage API without a token");
+          }
+          return pendingUnlessCodexReset(url);
+        },
+      });
+
+      assert.equal(result.claude.configured, true);
+      assert.match(result.claude.error, /token expired/i);
+      assert.equal(result.claude.auth_action_required, "reauth");
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("stays unconfigured when no Claude credential entry exists at all", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-no-creds-"));
+    try {
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 1000,
+        securityRunner() {
+          return { status: 1, stdout: "" };
+        },
+        commandRunner() {
+          return { status: 1, stdout: "" };
+        },
+        fetchImpl: pendingUnlessCodexReset,
+      });
+
+      assert.equal(result.claude.configured, false);
+      assert.equal(result.claude.auth_action_required, undefined);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   for (const status of [401, 403, 404]) {
     it(`Codex reset headers do not fetch reset list when wham ${status} returns no-data`, async () => {
       resetUsageLimitsCache();


### PR DESCRIPTION
## Why

When a Claude Code login expires, the credential entry is not removed — the secrets are blanked in place. The macOS Keychain item `Claude Code-credentials` keeps `claudeAiOauth` with `accessToken: ""`, `refreshToken: ""`, `expiresAt: 0`, and all of the metadata (`scopes`, `subscriptionType`, `rateLimitTier`) intact.

`readClaudeCodeAccessToken()` normalizes that empty string to `null`, so `getUsageLimits()` reports `{ configured: false }` and the dashboard hides the Claude section completely — the same rendering as a machine that never installed Claude Code. Meanwhile the usage bars keep updating (parsed from local logs, no auth needed), so the failure reads as "TokenTracker doesn't support my plan" instead of "your CLI login expired". Nothing is logged, and `claude-usage-limits-cache.json` is never written.

`#330` already solved the equivalent case on the wire: a 401 sets `auth_action_required: "reauth"`, which the panel renders as a "Re-auth" badge with a `run \`claude\`` tooltip. The blank-credential case never gets there, because there is no token to send.

Fixes #458

## What

- Tell "never signed in" from "signed in and expired" in the `!claudeToken` branch by reusing `detectClaudeCodeCredentialsPresence()`, which already exists and is existence-only (it reads no secret — on macOS it probes the Keychain without fetching the password).
- Route the second case into the existing reauth path: `configured: true` + `auth_action_required: "reauth"` + the same message the 401 path uses, now shared as `CLAUDE_AUTH_EXPIRED_MESSAGE`.
- A missing credential entry still reports `configured: false`, so machines without Claude Code are unaffected.

No new user-facing strings — `limits.reauth.badge` and `limits.reauth.tooltip` already cover the rendering, and `REAUTH_CLI_COMMANDS` already maps `claude`.

## Tests

Two cases added to `test/usage-limits.test.js`:

- a credential entry whose token fields are blank → `configured: true`, `auth_action_required: "reauth"`, and the usage API is never called (the fake `fetchImpl` throws if it is);
- no credential entry at all → `configured: false`, no reauth flag.

The first fails on `main` (`configured: false`, no flag) and passes with this change. Full suite: `npm test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude authentication status detection when credentials are present but incomplete or missing an access token.
  - Clearly indicates when reauthentication is required instead of incorrectly reporting Claude as unconfigured.
  - Prevents unnecessary usage API requests when credentials are invalid or incomplete.
  - Standardized the authentication-expired message shown for Claude authorization failures.
  - Improved handling of blank credential fields and missing credential entries for more accurate authentication status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->