### PR TITLE
fix(macos): 修复 Qoder CN 限额图标与菜单栏语言

### DIFF
--- a/TokenTrackerBar/Shared/NativeLocalization.swift
+++ b/TokenTrackerBar/Shared/NativeLocalization.swift
@@ -38,10 +38,13 @@ public enum NativeLocalization {
     }
 
     public static var currentPreference: String {
-        if let shared = sharedDefaults?.string(forKey: preferenceKey) {
-            return normalizePreference(shared)
+        // The dashboard writes the main-app preference. Prefer it when present
+        // so an old widget App Group value cannot force the menu bar back to a
+        // previous language after an update.
+        if let local = UserDefaults.standard.string(forKey: preferenceKey) {
+            return normalizePreference(local)
         }
-        return normalizePreference(UserDefaults.standard.string(forKey: preferenceKey))
+        return normalizePreference(sharedDefaults?.string(forKey: preferenceKey))
     }
 
     public static var currentResolvedLocale: String {
@@ -75,5 +78,11 @@ public enum NativeLocalization {
         let normalized = normalizePreference(value)
         UserDefaults.standard.set(normalized, forKey: preferenceKey)
         sharedDefaults?.set(normalized, forKey: preferenceKey)
+    }
+
+    /// Repair an App Group preference left behind by an older build.
+    public static func synchronizeSharedPreference() {
+        guard let local = UserDefaults.standard.string(forKey: preferenceKey) else { return }
+        sharedDefaults?.set(normalizePreference(local), forKey: preferenceKey)
     }
 }

--- a/TokenTrackerBar/TokenTrackerBar/Models/LimitsSettingsStore.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/LimitsSettingsStore.swift
@@ -63,7 +63,7 @@ final class LimitsSettingsStore: ObservableObject {
         "copilot": "CopilotLogo",
         "antigravity": "AntigravityLogo",
         "qoder": "QoderLogo",
-        "qoderCn": "QoderLogo",
+        "qoderCn": "QoderCnLogo",
     ]
 
     // MARK: - Published state

--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -14,10 +14,11 @@ struct UsageLimitsResponse: Codable, Equatable {
     let zcode: ZcodeLimits?
     let opencodeGo: OpencodeGoLimits?
     let qoder: QoderLimits?
+    let qoderCn: QoderLimits?
 
     enum CodingKeys: String, CodingKey {
         case fetchedAt = "fetched_at"
-        case claude, codex, cursor, gemini, kimi, kiro, grok, antigravity, copilot, zcode, qoder
+        case claude, codex, cursor, gemini, kimi, kiro, grok, antigravity, copilot, zcode, qoder, qoderCn
         case opencodeGo = "opencodeGo"
     }
 }
@@ -534,6 +535,7 @@ extension UsageLimitsResponse {
             (zcode?.configured ?? false, zcode?.error),
             (opencodeGo?.configured ?? false, opencodeGo?.error),
             (qoder?.configured ?? false, qoder?.error),
+            (qoderCn?.configured ?? false, qoderCn?.error),
         ]
         return providers.contains { $0.0 && $0.1 == nil }
     }

--- a/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
@@ -241,14 +241,14 @@ extension UsageLimitsResponse {
         }
         if let qoder {
             addGeneric("qoder", qoder.configured, qoder.error, [
-                ("primary", "Credits", qoder.primaryWindow),
-                ("secondary", "Ultimate Free Calls", qoder.secondaryWindow),
+                ("primary", Strings.qoderPlanLabel, qoder.primaryWindow),
+                ("secondary", Strings.qoderBonusLabel, qoder.secondaryWindow),
             ])
         }
         if let qoderCn {
             addGeneric("qoderCn", qoderCn.configured, qoderCn.error, [
-                ("primary", "Credits", qoderCn.primaryWindow),
-                ("secondary", "Ultimate Free Calls", qoderCn.secondaryWindow),
+                ("primary", Strings.qoderPlanLabel, qoderCn.primaryWindow),
+                ("secondary", Strings.qoderBonusLabel, qoderCn.secondaryWindow),
             ])
         }
 

--- a/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
@@ -245,6 +245,12 @@ extension UsageLimitsResponse {
                 ("secondary", "Ultimate Free Calls", qoder.secondaryWindow),
             ])
         }
+        if let qoderCn {
+            addGeneric("qoderCn", qoderCn.configured, qoderCn.error, [
+                ("primary", "Credits", qoderCn.primaryWindow),
+                ("secondary", "Ultimate Free Calls", qoderCn.secondaryWindow),
+            ])
+        }
 
         return out
     }

--- a/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
+++ b/TokenTrackerBar/TokenTrackerBar/TokenTrackerBarApp.swift
@@ -122,6 +122,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         removeLegacyAppBundleIfNeeded()
+        NativeLocalization.synchronizeSharedPreference()
 
         statusBarController = StatusBarController(
             viewModel: viewModel,

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -71,6 +71,11 @@ enum Strings {
     static var kimiTotalLabel: String { t("Total", "总量", "總量", "合計", "총량") }
     static var kiroMonthLabel: String { t("Month", "本月", "本月", "今月", "이번 달") }
     static var kiroBonusLabel: String { t("Bonus", "奖励", "獎勵", "ボーナス", "보너스") }
+    // Qoder / Qoder CN plan and bonus windows — shared by the menu-bar panel
+    // (UsageLimitsView) and the reset notification detector so both surfaces
+    // render the same label.
+    static var qoderPlanLabel: String { t("Plan", "套餐", "套餐", "プラン", "플랜") }
+    static var qoderBonusLabel: String { t("Bonus", "奖励", "獎勵", "ボーナス", "보너스") }
     static var grokMonthLabel: String { t("Month", "月度", "月度", "月間", "월간") }
     static var grokWeekLabel: String { t("Weekly", "周", "週", "週間", "주간") }
     static var grokDayLabel: String { t("Daily", "日", "日", "日", "일") }

--- a/TokenTrackerBar/TokenTrackerBar/Views/LimitsSettingsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/LimitsSettingsView.swift
@@ -126,7 +126,7 @@ struct LimitsSettingsView: View {
     @ViewBuilder
     private func providerIcon(id: String) -> some View {
         switch id {
-        case "cursor", "kimi", "kiro", "grok", "copilot", "zcode", "opencodeGo", "qoder":
+        case "cursor", "kimi", "kiro", "grok", "copilot", "zcode", "opencodeGo", "qoder", "qoderCn":
             let filename: String = {
                 switch id {
                 case "cursor": return "cursor.svg"
@@ -136,6 +136,7 @@ struct LimitsSettingsView: View {
                 case "zcode": return "zcode.svg"
                 case "opencodeGo": return "opencode.svg"
                 case "qoder": return "qoder.svg"
+                case "qoderCn": return "qoder-cn.svg"
                 default: return "copilot.svg"
                 }
             }()

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -377,10 +377,10 @@ struct UsageLimitsView: View {
     private func qoderSpecs(_ q: QoderLimits) -> [LimitWindowSpec] {
         var specs: [LimitWindowSpec] = []
         if let window = q.primaryWindow {
-            specs.append(makeSpec("Plan", window.usedPercent, iso: window.resetAt))
+            specs.append(makeSpec(Strings.qoderPlanLabel, window.usedPercent, iso: window.resetAt))
         }
         if let window = q.secondaryWindow {
-            specs.append(makeSpec("Bonus", window.usedPercent, iso: window.resetAt))
+            specs.append(makeSpec(Strings.qoderBonusLabel, window.usedPercent, iso: window.resetAt))
         }
         return specs
     }

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -111,6 +111,10 @@ struct UsageLimitsView: View {
                 if let qoder = limits.qoder, qoder.configured, qoder.error == nil {
                     groups.append(AnyView(toolSection(id: id, title: planTitle("Qoder", qoder.planLabel), assetName: "QoderLogo", toolName: "Qoder", specs: qoderSpecs(qoder), updatedAtISO: qoder.cachedAt, isStale: qoder.stale ?? false)))
                 }
+            case "qoderCn":
+                if let qoderCn = limits.qoderCn, qoderCn.configured, qoderCn.error == nil {
+                    groups.append(AnyView(toolSection(id: id, title: planTitle("Qoder CN", qoderCn.planLabel), assetName: "QoderCnLogo", toolName: "Qoder CN", specs: qoderSpecs(qoderCn), updatedAtISO: qoderCn.cachedAt, isStale: qoderCn.stale ?? false)))
+                }
             default:
                 break
             }
@@ -591,7 +595,7 @@ struct UsageLimitsView: View {
     @ViewBuilder
     private func brandIcon(_ name: String) -> some View {
         switch name {
-        case "CursorLogo", "KimiLogo", "KiroLogo", "GrokLogo", "CopilotLogo", "ZcodeLogo", "OpenCodeLogo", "QoderLogo":
+        case "CursorLogo", "KimiLogo", "KiroLogo", "GrokLogo", "CopilotLogo", "ZcodeLogo", "OpenCodeLogo", "QoderLogo", "QoderCnLogo":
             let filename: String = {
                 switch name {
                 case "CursorLogo": return "cursor.svg"
@@ -601,6 +605,7 @@ struct UsageLimitsView: View {
                 case "ZcodeLogo": return "zcode.svg"
                 case "OpenCodeLogo": return "opencode.svg"
                 case "QoderLogo": return "qoder.svg"
+                case "QoderCnLogo": return "qoder-cn.svg"
                 default: return "copilot.svg"
                 }
             }()

--- a/TokenTrackerBar/TokenTrackerBarTests/LimitsSettingsStoreTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/LimitsSettingsStoreTests.swift
@@ -2,6 +2,10 @@ import XCTest
 import Combine
 
 final class LimitsSettingsStoreTests: XCTestCase {
+
+    func testQoderCnUsesItsDedicatedIcon() {
+        XCTAssertEqual(LimitsSettingsStore.iconNames["qoderCn"], "QoderCnLogo")
+    }
     private var cancellables: Set<AnyCancellable> = []
 
     override func tearDown() {

--- a/TokenTrackerBar/TokenTrackerBarTests/UsageLimitsRetentionTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/UsageLimitsRetentionTests.swift
@@ -72,6 +72,14 @@ final class UsageLimitsRetentionTests: XCTestCase {
         XCTAssertTrue(response.hasAnyProviderWithoutError)
     }
 
+    func testQoderCnCountsWhenUsable() throws {
+        let response = try decodeResponse(overrides: [
+            "qoderCn": ["configured": true],
+        ])
+
+        XCTAssertTrue(response.hasAnyProviderWithoutError)
+    }
+
     func testOptionalProviderWithErrorDoesNotCount() throws {
         let response = try decodeResponse(overrides: [
             "copilot": ["configured": true, "error": "rate limited"],

--- a/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
@@ -148,6 +148,46 @@ final class WeeklyLimitResetDetectorTests: XCTestCase {
         )
     }
 
+    func testReadingsUsePlanAndBonusLabelsForQoderAndQoderCn() throws {
+        // The menu-bar panel renders these windows as "Plan" / "Bonus"
+        // (Strings.qoderPlanLabel / qoderBonusLabel); the reset detector must
+        // use the same labels so notification copy matches the UI.
+        let json = """
+        {
+          "fetched_at": "2026-08-14T00:00:00Z",
+          "claude": { "configured": false, "error": null },
+          "codex": { "configured": false, "error": null },
+          "cursor": { "configured": false, "error": null },
+          "gemini": { "configured": false, "error": null },
+          "kiro": { "configured": false, "error": null },
+          "antigravity": { "configured": false, "error": null },
+          "qoder": {
+            "configured": true,
+            "error": null,
+            "primary_window": { "used_percent": 12, "reset_at": "2026-08-14T05:00:00Z" },
+            "secondary_window": { "used_percent": 3, "reset_at": "2026-08-20T00:00:00Z" }
+          },
+          "qoderCn": {
+            "configured": true,
+            "error": null,
+            "primary_window": { "used_percent": 40, "reset_at": "2026-08-14T05:00:00Z" },
+            "secondary_window": { "used_percent": 8, "reset_at": "2026-08-20T00:00:00Z" }
+          }
+        }
+        """
+        let response = try JSONDecoder().decode(UsageLimitsResponse.self, from: Data(json.utf8))
+        let readings = response.limitWindowReadings()
+
+        XCTAssertEqual(
+            readings.map { "\($0.provider).\($0.windowKey)" },
+            ["qoder.primary", "qoder.secondary", "qoderCn.primary", "qoderCn.secondary"]
+        )
+        XCTAssertEqual(
+            readings.map { "\($0.provider).\($0.windowLabel)" },
+            ["qoder.Plan", "qoder.Bonus", "qoderCn.Plan", "qoderCn.Bonus"]
+        )
+    }
+
     func testCelebrationProviderIconMappingsCoverAssetAndSVGProviders() {
         XCTAssertEqual(LimitResetProviderIconCatalog.assetName(for: "claude"), "ClaudeLogo")
         XCTAssertEqual(LimitResetProviderIconCatalog.assetName(for: "antigravity"), "AntigravityLogo")

--- a/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
@@ -179,7 +179,7 @@ final class WeeklyLimitResetDetectorTests: XCTestCase {
         let readings = response.limitWindowReadings()
 
         XCTAssertEqual(
-            readings.map { "\($0.provider).\($0.windowKey)" },
+            readings.map { $0.windowKey },
             ["qoder.primary", "qoder.secondary", "qoderCn.primary", "qoderCn.secondary"]
         )
         XCTAssertEqual(


### PR DESCRIPTION
## 修复内容
- macOS 限额设置和菜单栏面板为 Qoder CN 使用独立的 `qoder-cn.svg` 图标。
- 原生 macOS 客户端补齐 Qoder CN 限额的解码、展示和重置检测。
- 修复旧版 App Group 中残留的语言偏好覆盖当前应用语言的问题。

## 验证
- `git diff --check`
- 静态检查 Qoder CN 的解码、渲染和 SVG 映射。

未运行 Swift 测试：当前仓库只有 `TokenTrackerBar/project.yml`，未提交生成后的 `.xcodeproj`，本机也没有 XcodeGen。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing Qoder CN usage limits, including plan and bonus windows.
  * Added a dedicated Qoder CN icon and localized usage labels in English, Chinese, Japanese, and Korean.
  * Improved preference synchronization so localization settings remain consistent across app components.

* **Bug Fixes**
  * Corrected Qoder CN provider recognition and usability checks.
  * Improved weekly limit reset tracking for Qoder and Qoder CN usage windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->