### PR TITLE
fix(zcode): resolve ZCode usage DB under HOME on Windows, APPDATA fallback

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -85,7 +85,7 @@ const {
 } = require("../lib/rollout");
 const wsl = require("../lib/wsl-probe");
 const { getWslMode, isInvalidWslMode, shouldProbeWsl, discoverWslHome } = wsl;
-const { resolveInstallPaths } = require("../lib/install-resolver");
+const { resolveInstallPaths, resolveZcodeNativeDbPath } = require("../lib/install-resolver");
 const { probeGrokHookState, resolveGrokHome } = require("../lib/grok-hook");
 const { probeOmpHookState } = require("../lib/omp-hook");
 
@@ -456,10 +456,7 @@ async function cmdStatus(argv = []) {
   const mimoDbPath = mimoActive.join(" | ");
 
   // ZCode (Z.ai's coding agent — OpenCode-fork SQLite) — passive scan of db.sqlite.
-  const zcodeHome = process.env.ZCODE_HOME || path.join(home, ".zcode");
-  const zcodeNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
-    ? path.join(process.env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")
-    : path.join(zcodeHome, "cli", "db", "db.sqlite");
+  const zcodeNativeValue = resolveZcodeNativeDbPath({ home });
   const wslZcodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
     ? wsl.discoverWslHome(".zcode")
     : null;

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -5,7 +5,7 @@ const fssync = require("node:fs");
 const cp = require("node:child_process");
 const readline = require("node:readline");
 
-const { resolveInstallPaths, ensureFlatCursor } = require("../lib/install-resolver");
+const { resolveInstallPaths, resolveZcodeNativeDbPath, ensureFlatCursor } = require("../lib/install-resolver");
 const { multiInstallParse, mergeBothFileSources } = require("../lib/multi-install-parser");
 const wsl = require("../lib/wsl-probe");
 const {
@@ -576,7 +576,6 @@ async function cmdSync(argv, context = {}) {
     const xdgDataHome = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
     const kiloHome = process.env.KILO_HOME || path.join(xdgDataHome, "kilo");
     const mimoHome = process.env.MIMO_HOME || path.join(xdgDataHome, "mimocode");
-    const zcodeHome = process.env.ZCODE_HOME || path.join(home, ".zcode");
 
     // OpenClaw session plugin integration: lifecycle hooks request an
     // OpenClaw-only auto sync so unrelated providers do not get walked.
@@ -1369,9 +1368,7 @@ async function cmdSync(argv, context = {}) {
     // ── ZCode (Z.ai's coding agent — OpenCode-fork SQLite) ──
     let zcodeResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (sourceAllowed("zcode")) {
-      const zcodeNativeValue = process.platform === "win32" && typeof process.env.APPDATA === "string"
-        ? path.join(process.env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")
-        : path.join(zcodeHome, "cli", "db", "db.sqlite");
+      const zcodeNativeValue = resolveZcodeNativeDbPath({ home });
       const wslZcodeDir = process.platform === "win32" && wsl.shouldProbeWsl(process.env)
         ? wsl.discoverWslHome(".zcode")
         : null;

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -62,13 +62,20 @@ function resolveZcodeNativeDbPath({
   deps = {},
 } = {}) {
   const existsSync = deps.existsSync || fssync.existsSync;
-  const zcodeHome =
-    typeof env.ZCODE_HOME === "string" && env.ZCODE_HOME.trim()
-      ? path.resolve(env.ZCODE_HOME.trim())
-      : path.join(home, ".zcode");
+  const zcodeHomeOverride =
+    typeof env.ZCODE_HOME === "string" ? env.ZCODE_HOME.trim() : "";
+  const zcodeHome = zcodeHomeOverride
+    ? path.resolve(zcodeHomeOverride)
+    : path.join(home, ".zcode");
+  // An explicit ZCODE_HOME pins the install: when its database is missing we
+  // must not fall back to an APPDATA database, or sync could read a different
+  // ZCode installation than the one the user pointed at.
   const candidates = [
     path.join(zcodeHome, "cli", "db", "db.sqlite"),
-    ...(platform === "win32" && typeof env.APPDATA === "string"
+    ...(!zcodeHomeOverride &&
+    platform === "win32" &&
+    typeof env.APPDATA === "string" &&
+    env.APPDATA.trim()
       ? [path.join(env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")]
       : []),
   ];

--- a/src/lib/install-resolver.js
+++ b/src/lib/install-resolver.js
@@ -1,4 +1,5 @@
 const fssync = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const wsl = require("./wsl-probe");
 
@@ -46,6 +47,32 @@ function resolveInstallPaths({ nativeValue, wslDir, wslValue, requireAnyChild, u
 function pathExists(p, existsSync) {
   if (typeof p !== "string" || !p) return null;
   try { return (existsSync || fssync.existsSync)(p) ? p : null; } catch (_e) { return null; }
+}
+
+// ZCode stores its CLI DB under the user's home dir on every platform
+// (~/.zcode/cli/db/db.sqlite), Windows included. The win32 APPDATA guess
+// (introduced with the WSL dual-install work) silently missed the native
+// install, so probe home first and keep APPDATA only as a fallback for
+// installs that do live under Roaming. Falls back to the home path when
+// neither exists so resolveInstallPaths can null it uniformly.
+function resolveZcodeNativeDbPath({
+  home = os.homedir(),
+  env = process.env,
+  platform = process.platform,
+  deps = {},
+} = {}) {
+  const existsSync = deps.existsSync || fssync.existsSync;
+  const zcodeHome =
+    typeof env.ZCODE_HOME === "string" && env.ZCODE_HOME.trim()
+      ? path.resolve(env.ZCODE_HOME.trim())
+      : path.join(home, ".zcode");
+  const candidates = [
+    path.join(zcodeHome, "cli", "db", "db.sqlite"),
+    ...(platform === "win32" && typeof env.APPDATA === "string"
+      ? [path.join(env.APPDATA.trim(), ".zcode", "cli", "db", "db.sqlite")]
+      : []),
+  ];
+  return candidates.find((p) => existsSync(p)) || candidates[0];
 }
 
 function hasAnyChild(p, children, existsSync) {
@@ -99,6 +126,7 @@ function ensureFlatCursor(cursors, providerName, env, preferredKey) {
 
 module.exports = {
   resolveInstallPaths,
+  resolveZcodeNativeDbPath,
   ensureNamespacedCursors,
   ensureFlatCursor,
 };

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -252,6 +252,26 @@ test("resolveZcodeNativeDbPath honors ZCODE_HOME override", (t) => {
   assert.equal(r, path.join(path.resolve("/custom/zcode"), "cli", "db", "db.sqlite"));
 });
 
+test("resolveZcodeNativeDbPath does not fall back to APPDATA when ZCODE_HOME DB is missing", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-zcode-override-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const zcodeHome = path.join(tmpDir, "custom");
+  const appData = path.join(tmpDir, "roaming");
+  // APPDATA holds a real DB, but ZCODE_HOME explicitly points elsewhere (missing DB).
+  const appDataDb = path.join(appData, ".zcode", "cli", "db", "db.sqlite");
+  fs.mkdirSync(path.dirname(appDataDb), { recursive: true });
+  fs.writeFileSync(appDataDb, "");
+
+  const r = resolveZcodeNativeDbPath({
+    home: path.join(tmpDir, "home"),
+    env: { ZCODE_HOME: zcodeHome, APPDATA: appData },
+    platform: "win32",
+  });
+  // The override pins the install: APPDATA must NOT be picked.
+  assert.equal(r, path.join(zcodeHome, "cli", "db", "db.sqlite"));
+});
+
 // ── ensureNamespacedCursors ───────────────────────────────────────────────────
 
 test("ensureNamespacedCursors transparent for already-namespaced cursors", () => {

--- a/test/install-resolver.test.js
+++ b/test/install-resolver.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const fs = require("node:fs");
 const os = require("node:os");
 
-const { resolveInstallPaths, ensureNamespacedCursors } = require("../src/lib/install-resolver");
+const { resolveInstallPaths, resolveZcodeNativeDbPath, ensureNamespacedCursors } = require("../src/lib/install-resolver");
 const wsl = require("../src/lib/wsl-probe");
 
 // ── resolveInstallPaths ───────────────────────────────────────────────────────
@@ -197,6 +197,59 @@ test("zcode WSL path resolves on Windows both mode", (t) => {
   );
   assert.equal(r.native, nativeDir);
   assert.equal(r.wsl, wslDir);
+});
+
+// ── resolveZcodeNativeDbPath ──────────────────────────────────────────────────
+
+test("resolveZcodeNativeDbPath prefers HOME over APPDATA on Windows", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-zcode-native-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const home = path.join(tmpDir, "home");
+  const appData = path.join(tmpDir, "roaming");
+  const dbPath = path.join(home, ".zcode", "cli", "db", "db.sqlite");
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  fs.writeFileSync(dbPath, "");
+  // Both exist: home wins (ZCode stores under ~/.zcode on Windows too).
+  fs.mkdirSync(path.dirname(path.join(appData, ".zcode", "cli", "db", "db.sqlite")), { recursive: true });
+  fs.writeFileSync(path.join(appData, ".zcode", "cli", "db", "db.sqlite"), "");
+
+  const r = resolveZcodeNativeDbPath({ home, env: { APPDATA: appData }, platform: "win32" });
+  assert.equal(r, dbPath);
+});
+
+test("resolveZcodeNativeDbPath falls back to APPDATA when HOME db is missing on Windows", (t) => {
+  mockPlatform(t, "win32");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ir-zcode-appdata-"));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  const home = path.join(tmpDir, "home");
+  const appData = path.join(tmpDir, "roaming");
+  const dbPath = path.join(appData, ".zcode", "cli", "db", "db.sqlite");
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  fs.writeFileSync(dbPath, "");
+
+  const r = resolveZcodeNativeDbPath({ home, env: { APPDATA: appData }, platform: "win32" });
+  assert.equal(r, dbPath);
+});
+
+test("resolveZcodeNativeDbPath uses HOME on non-Windows", (t) => {
+  mockPlatform(t, "linux");
+  const r = resolveZcodeNativeDbPath({
+    home: "/home/user",
+    env: { APPDATA: "/roaming" },
+    platform: "linux",
+  });
+  assert.equal(r, path.join("/home/user", ".zcode", "cli", "db", "db.sqlite"));
+});
+
+test("resolveZcodeNativeDbPath honors ZCODE_HOME override", (t) => {
+  mockPlatform(t, "win32");
+  const r = resolveZcodeNativeDbPath({
+    home: "/home/user",
+    env: { ZCODE_HOME: "/custom/zcode", APPDATA: "/roaming" },
+    platform: "win32",
+  });
+  assert.equal(r, path.join(path.resolve("/custom/zcode"), "cli", "db", "db.sqlite"));
 });
 
 // ── ensureNamespacedCursors ───────────────────────────────────────────────────


### PR DESCRIPTION
ZCode stores its CLI DB under the user's home dir on every platform (~/.zcode/cli/db/db.sqlite), Windows included, but sync/status only probed %APPDATA%\.zcode\cli\db\db.sqlite on win32, silently skipping ZCode token-usage sync and reporting ZCode as not installed. The APPDATA guess came from the WSL dual-install rework (PR #295) and contradicts the documented ~/.zcode/cli/db/db.sqlite path.

Add install-resolver.resolveZcodeNativeDbPath(): probe HOME first, keep APPDATA as fallback; sync.js and status.js now use it. Add 4 regression tests covering home-first / APPDATA fallback / non-Windows / ZCODE_HOME override.

## Summary

Fix ZCode token-usage sync on Windows: the usage DB is resolved from the user's home dir (~/.zcode, matching the README-documented path) with APPDATA kept only as a fallback, so ZCode usage is no longer silently skipped and status no longer misreports ZCode as not installed.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

-  ZCode native DB resolution prefers ~/.zcode (HOME) on every platform; APPDATA is only a win32 fallback — matches the README-documented path.
-  Non-Windows resolution is byte-for-byte unchanged (HOME only).
-  WSL dual-install probing is unchanged (resolveInstallPaths with wslValue); no union mode → a single native pick, so both-locations-exist cannot double-count.
-  ZCODE_HOME env override keeps priority over both defaults.

### Boundary matrix (list at least 3)
-  win32, HOME DB exists → HOME wins (regression test)
-  win32, HOME missing, APPDATA exists → APPDATA fallback (regression test)
-  win32 / non-win32, neither exists → HOME candidate returned, resolveInstallPaths nulls it → ZCode   skipped, same as before
-  non-win32 → HOME only (regression test)
-  ZCODE_HOME set → overrides both (regression test)

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

### Most likely regression surface

-

### Verification method (choose at least one)

-

### Uncovered scope

-

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the ZCode native database across operating systems.
  - Added support for custom installation locations and Windows fallback paths.
  - Status and sync commands now consistently use the resolved database location.

- **Tests**
  - Added coverage for Windows, non-Windows, custom home directories, and installation overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->