### PR TITLE
[codex] 修复 Windows 发行包缺失 zstd 原生模块

### DIFF
--- a/TokenTrackerWin/scripts/bundle-node.ps1
+++ b/TokenTrackerWin/scripts/bundle-node.ps1
@@ -143,6 +143,12 @@ Write-Host 'Installing production dependencies...'
 Push-Location $ttDir
 try {
     & npm install --omit=dev --no-optional --ignore-scripts | Out-Null
+    & npm rebuild '@mongodb-js/zstd' | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Error 'Failed to build @mongodb-js/zstd' }
+
+    $zstdModule = Join-Path $ttDir 'node_modules\@mongodb-js\zstd'
+    & (Join-Path $EmbedDir 'node.exe') -e 'require(process.argv[1])' $zstdModule
+    if ($LASTEXITCODE -ne 0) { Write-Error 'Bundled @mongodb-js/zstd failed to load' }
 } finally {
     Pop-Location
 }

--- a/test/release-windows-workflow.test.js
+++ b/test/release-windows-workflow.test.js
@@ -15,6 +15,14 @@ function loadWorkflow() {
   return fs.readFileSync(WORKFLOW_PATH, "utf8");
 }
 
+const BUNDLE_SCRIPT_PATH = path.join(
+  __dirname,
+  "..",
+  "TokenTrackerWin",
+  "scripts",
+  "bundle-node.ps1"
+);
+
 test("release-windows workflow file exists", () => {
   assert.ok(fs.existsSync(WORKFLOW_PATH));
 });
@@ -64,6 +72,13 @@ test("workflow builds dashboard before bundling EmbeddedServer", () => {
 test("workflow bundles EmbeddedServer via bundle-node.ps1", () => {
   const content = loadWorkflow();
   assert.ok(content.includes("bundle-node.ps1"));
+});
+
+test("Windows bundle rebuilds and loads the zstd native dependency", () => {
+  const content = fs.readFileSync(BUNDLE_SCRIPT_PATH, "utf8");
+  assert.ok(content.includes("npm rebuild '@mongodb-js/zstd'"));
+  assert.ok(content.includes("require(process.argv[1])"));
+  assert.ok(content.includes("Bundled @mongodb-js/zstd failed to load"));
 });
 
 test("workflow publishes a self-contained win-x64 build", () => {


### PR DESCRIPTION
## Summary

修复 Windows 发行包因禁用 npm 生命周期脚本而缺失 `@mongodb-js/zstd` 原生模块的问题，使 DeepSeek Harness 的 `.jsonl.zstd` 会话日志能够被正常统计。

Fixes #465。Follow-up to #463。

## Root cause

`TokenTrackerWin/scripts/bundle-node.ps1` 使用 `npm install --ignore-scripts`，而 `@mongodb-js/zstd` 的 `zstd.node` 只能由安装脚本下载或编译。官方 v0.88.8 Windows 包因此只有 JavaScript 加载器和 C++ 源码，运行时无法加载原生模块，DSH 解析器随后跳过压缩会话。

## Changes

- 保留全局 `--ignore-scripts`，只对 `@mongodb-js/zstd` 执行定向 `npm rebuild`。
- 构建后使用随包 Node 加载 zstd；缺失或 ABI/架构不兼容时让打包直接失败。
- 增加 Windows 发布契约测试，锁定 rebuild 和运行时加载检查。

## Scope

仅修改 Windows app 的打包脚本和相应发布契约测试；不修改 CLI、Dashboard、macOS app 或文档配置。

## Validation

- `node --test test/release-windows-workflow.test.js test/deepseek-harness.test.js`：40/40 通过。
- `npm run validate:guardrails`、`npm run validate:versions`、`npm run dashboard:build`：通过。
- Windows bundler：生成 611,840 字节的 `build/Release/zstd.node`，随包 Node 22.22.2 加载成功。
- `dotnet publish --self-contained true` 与 Inno Setup：通过；本机构建并覆盖安装成功。
- 真实 DSH 数据：识别 18 个会话文件并生成 20 条 DSH 队列记录；重复同步新增 0 条。
- GitHub Actions：CI、CodeQL、Windows build、Linux client、macOS unit tests 全部通过。

完整 `npm test` 在本机 Windows 运行超过 6 分钟仍未退出，已停止；GitHub Actions 已完成全量复核。

## Invariants / risk

- 其他生产依赖继续禁用生命周期脚本，只放行已知的 zstd 原生依赖。
- Windows 发行物必须包含可由随包 Node 22.22.2 加载的 zstd 原生模块。
- 原生模块构建或加载失败时必须终止打包，不能生成降级但不可用的安装包。
- 最可能的回归面是 Windows runner 获取 zstd 预构建二进制的网络可用性。

macOS 与 Linux 打包路径未在本 PR 中修改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Windows bundled Node setup by rebuilding the native compression component after production dependencies are installed.
  - Added validation to ensure the rebuilt component loads successfully, with clear failure reporting when it does not.

- **Tests**
  - Added coverage verifying successful rebuild and loading behavior, as well as the associated failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->