### PR TITLE
[codex] 修复本地云端同步撞锁后误报成功

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -363,7 +363,7 @@ async function acquireSyncLock(
     priorityPollMs = PRIORITY_LOCK_POLL_MS,
   } = {},
 ) {
-  const waitsForPriority = Boolean(!opts.auto || opts.drain || opts.publishAccount);
+  const waitsForPriority = Boolean(opts.waitForLock || opts.drain || opts.publishAccount);
   let lock = await openLock(lockPath, {
     quietIfLocked: opts.auto || waitsForPriority,
   });
@@ -2835,6 +2835,7 @@ function parseArgs(argv) {
     fromOpenclaw: false,
     source: null,
     drain: false,
+    waitForLock: false,
     background: false,
     publishAccount: false,
     allLocalSources: false,
@@ -2852,6 +2853,7 @@ function parseArgs(argv) {
     }
     else if (a.startsWith("--source=")) out.source = normalizeSyncSource(a.slice("--source=".length));
     else if (a === "--drain") out.drain = true;
+    else if (a === "--wait-for-lock") out.waitForLock = true;
     else if (a === "--background" || a === "--lightweight") out.background = true;
     else if (a === "--publish-account") out.publishAccount = true;
     else if (a === "--all-local-sources") out.allLocalSources = true;

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -363,7 +363,7 @@ async function acquireSyncLock(
     priorityPollMs = PRIORITY_LOCK_POLL_MS,
   } = {},
 ) {
-  const waitsForPriority = Boolean(opts.drain || opts.publishAccount);
+  const waitsForPriority = Boolean(!opts.auto || opts.drain || opts.publishAccount);
   let lock = await openLock(lockPath, {
     quietIfLocked: opts.auto || waitsForPriority,
   });

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -880,6 +880,7 @@ function runSyncCommand(extraEnv = {}, opts = {}) {
     if (opts.publishAccount === true) args.push("--publish-account");
     if (opts.allLocalSources === true) args.push("--all-local-sources");
     if (opts.drain === true) args.push("--drain");
+    if (opts.waitForLock === true) args.push("--wait-for-lock");
     const child = spawn(process.execPath, args, {
       env: { ...process.env, ...extraEnv },
       stdio: ["ignore", "pipe", "pipe"],
@@ -1971,6 +1972,8 @@ function createLocalApiHandler({ queuePath }) {
           background,
           publishAccount,
           allLocalSources,
+          waitForLock:
+            !drain && !background && Boolean(extraEnv.TOKENTRACKER_DEVICE_TOKEN),
         });
         try {
           const { resetUsageLimitsCache } = require("./usage-limits");

--- a/test/local-api-background.test.js
+++ b/test/local-api-background.test.js
@@ -210,7 +210,12 @@ test("local-api background and lightweight require boolean true", async () => {
   for (const body of cases) {
     const call = await runLocalSync({ auto: true, ...body });
     const args = call.args;
-    assert.deepEqual(args.slice(-3), [path.join(process.cwd(), "bin/tracker.js"), "sync", "--auto"]);
+    assert.deepEqual(args.slice(-4), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--auto",
+      "--wait-for-lock",
+    ]);
   }
 });
 
@@ -356,7 +361,11 @@ test("local-api manual and drain sync still issue relayed cloud device tokens", 
   const savedBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
   const savedFetch = global.fetch;
   const cases = [
-    { prefix: "tokentracker-local-api-manual-cloud-", body: {}, expectedArgs: ["sync"] },
+    {
+      prefix: "tokentracker-local-api-manual-cloud-",
+      body: {},
+      expectedArgs: ["sync", "--wait-for-lock"],
+    },
     { prefix: "tokentracker-local-api-drain-cloud-", body: { drain: true }, expectedArgs: ["sync", "--drain"] },
   ];
 

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -492,7 +492,12 @@ test("local sync only treats boolean true as background or lightweight", async (
       assert.equal(handled, true);
       assert.equal(res.statusCode, 200);
       assert.equal(calls.length, 1);
-      assert.deepEqual(calls[0].args.slice(-3), [path.join(process.cwd(), "bin/tracker.js"), "sync", "--auto"]);
+      assert.deepEqual(calls[0].args.slice(-4), [
+        path.join(process.cwd(), "bin/tracker.js"),
+        "sync",
+        "--auto",
+        "--wait-for-lock",
+      ]);
     } finally {
       restore();
     }
@@ -533,7 +538,11 @@ test("local sync only treats boolean true as drain", async () => {
       assert.equal(handled, true);
       assert.equal(res.statusCode, 200);
       assert.equal(calls.length, 1);
-      assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+      assert.deepEqual(calls[0].args.slice(-3), [
+        path.join(process.cwd(), "bin/tracker.js"),
+        "sync",
+        "--wait-for-lock",
+      ]);
     } finally {
       restore();
     }
@@ -587,7 +596,11 @@ test("local sync non-drain request mints a device token from relayed login when 
     assert.equal(handled, true);
     assert.equal(res.statusCode, 200);
     assert.equal(calls.length, 1);
-    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.deepEqual(calls[0].args.slice(-3), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--wait-for-lock",
+    ]);
     assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
     assert.ok(fetchCalls.some((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")));
     assert.ok(fetchCalls.some((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")));
@@ -1022,7 +1035,11 @@ test("local sync non-drain request keeps explicit device token without relayed m
     assert.equal(handled, true);
     assert.equal(res.statusCode, 200);
     assert.equal(calls.length, 1);
-    assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    assert.deepEqual(calls[0].args.slice(-3), [
+      path.join(process.cwd(), "bin/tracker.js"),
+      "sync",
+      "--wait-for-lock",
+    ]);
     assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "explicit-device-token");
   } finally {
     restore();

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -4,7 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { acquireSyncLock, cmdSync } = require("../src/commands/sync");
+const { cmdSync } = require("../src/commands/sync");
 const { openLock } = require("../src/lib/fs");
 
 function tokenCountLine({ ts, totalTokens }) {
@@ -265,7 +265,7 @@ test("native account publication waits for an overlapping sync instead of report
   });
 });
 
-test("manual sync waits for an overlapping background sync instead of reporting success", async () => {
+test("explicit wait-for-lock fails instead of reporting success when the lock stays busy", async () => {
   await withTempSyncEnv(async (home) => {
     const trackerDir = path.join(home, ".tokentracker", "tracker");
     await fs.mkdir(trackerDir, { recursive: true });
@@ -275,16 +275,17 @@ test("manual sync waits for an overlapping background sync instead of reporting 
     });
     assert.ok(active);
 
-    const waitingLock = acquireSyncLock(
-      lockPath,
-      { auto: false, drain: false, publishAccount: false },
-      { priorityWaitMs: 500, priorityPollMs: 10 },
-    );
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    await active.release();
-    const acquired = await waitingLock;
-    assert.ok(acquired);
-    await acquired.release();
+    try {
+      await assert.rejects(
+        cmdSync(
+          ["--wait-for-lock"],
+          { lockWaitOptions: { priorityWaitMs: 40, priorityPollMs: 5 } },
+        ),
+        (error) => error.code === "SYNC_BUSY",
+      );
+    } finally {
+      await active.release();
+    }
   });
 });
 

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -4,7 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { cmdSync } = require("../src/commands/sync");
+const { acquireSyncLock, cmdSync } = require("../src/commands/sync");
 const { openLock } = require("../src/lib/fs");
 
 function tokenCountLine({ ts, totalTokens }) {
@@ -262,6 +262,29 @@ test("native account publication waits for an overlapping sync instead of report
     const queue = await readQueue(home);
     assert.match(queue, /"source":"codex"/);
     assert.match(queue, /"total_tokens":79/);
+  });
+});
+
+test("manual sync waits for an overlapping background sync instead of reporting success", async () => {
+  await withTempSyncEnv(async (home) => {
+    const trackerDir = path.join(home, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    const lockPath = path.join(trackerDir, "sync.lock");
+    const active = await openLock(lockPath, {
+      quietIfLocked: true,
+    });
+    assert.ok(active);
+
+    const waitingLock = acquireSyncLock(
+      lockPath,
+      { auto: false, drain: false, publishAccount: false },
+      { priorityWaitMs: 500, priorityPollMs: 10 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await active.release();
+    const acquired = await waitingLock;
+    assert.ok(acquired);
+    await acquired.release();
   });
 });
 


### PR DESCRIPTION
## Summary

修复 Dashboard/本地云端同步与后台同步撞锁时静默退出 0、导致调用方误报成功的问题，同时保留普通 CLI `sync` 既有的快速诊断行为。

本修复从 #466 拆出，独立于 Windows zstd 打包修复。

## Root cause

桌面端启动后可能正在运行后台同步，Dashboard 云端同步又会通过本地 API 启动普通 `sync`。普通 CLI 的既有语义是：拿不到 `sync.lock` 时记录 `lock_busy`/`lock_debris` 诊断标记并正常退出。对交互式 CLI 这是有意保留的诊断行为，但本地 API 会把退出码 0 转成 HTTP 200 / `{ ok: true }`，使 Dashboard 在实际未上传时推进“同步完成”状态。

## Changes

- 新增明确的内部 CLI 选项 `--wait-for-lock`，复用现有 90 秒等待、250 毫秒轮询和 `SYNC_BUSY` 超时错误。
- 只有本地同步 API 发起的非后台、非 `drain` 云端同步在确实拥有 device token 时注入该选项。
- `--drain` 和 `--publish-account` 继续沿用原本已有的优先等待语义，不重复改变。
- 普通 CLI `sync` 不使用该选项，继续快速退出并保留原有锁诊断标记。
- 增加显式等待锁、本地 API 参数边界和普通 CLI 锁残留诊断的回归覆盖。

## Scope

修改通用 CLI 的显式锁选项、本地云端同步 API 及相应测试；Dashboard 调用协议、各桌面端打包逻辑和普通 CLI 默认行为均不改变。

## Validation

- 锁语义专项测试：3/3 通过。
- 本地 API、安全边界和锁残留诊断测试：41/41 通过。
- `npm run validate:guardrails`、`npm run validate:copy`：通过。
- GitHub Actions：`test + validate + build`、CodeQL、Windows build、Linux client、macOS unit tests 全部通过。
- 本机 Windows 的完整 `npm test` 在 10 分钟上限内未退出，未把本地超时记作通过；GitHub Actions 已在干净环境完成全量复核。

## Behavior / risk

- Dashboard/本地云端同步：锁忙时等待，锁释放后继续；90 秒仍未释放则显式返回 `SYNC_BUSY`，不能再误报成功。
- 普通 CLI `sync`：锁忙时仍按原逻辑快速退出并写入可查询诊断标记。
- 后台同步：锁忙时仍快速跳过。
- `--drain`/账户发布：保持原有优先等待行为。

数据不会因本问题丢失；旧行为的问题是上传未发生但就绪状态被错误推进。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for sync operations to wait for an active sync to finish instead of immediately skipping.
  * Manual, non-background sync requests now wait for the sync lock when a device token is available.

* **Bug Fixes**
  * Sync requests now correctly report `SYNC_BUSY` when the lock remains unavailable beyond the configured wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->