### PR TITLE
[codex] Windows 排行榜显示横向滚动条

### DIFF
--- a/TokenTrackerWin/DashboardWindow.cs
+++ b/TokenTrackerWin/DashboardWindow.cs
@@ -467,6 +467,45 @@ internal sealed class DashboardWindow : Window
         // the window's DWM acrylic shows through. Solid cards keep their own bg.
         const string css = """
             ::-webkit-scrollbar{display:none!important}
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar{
+              display:block!important;
+              height:15px!important;
+              width:15px!important;
+              background:var(--oai-gray-100)!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll{
+              scrollbar-color:var(--oai-gray-400) var(--oai-gray-100)!important;
+              scrollbar-width:auto!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-track{
+              background:var(--oai-gray-100)!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-thumb{
+              background:var(--oai-gray-400)!important;
+              border:0!important;
+              border-radius:0!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-thumb:hover{
+              background:var(--oai-gray-500)!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-button{
+              display:block!important;
+              width:15px!important;
+              height:15px!important;
+              background-color:var(--oai-gray-100)!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-button:horizontal:decrement{
+              background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9 4 5 8l4 4' fill='none' stroke='%236f726f' stroke-width='1.5'/%3E%3C/svg%3E")!important;
+              background-position:center!important;
+              background-repeat:no-repeat!important;
+              background-size:12px 12px!important;
+            }
+            html.native-windows-app .tt-leaderboard-scroll::-webkit-scrollbar-button:horizontal:increment{
+              background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7 4 11 8l-4 4' fill='none' stroke='%236f726f' stroke-width='1.5'/%3E%3C/svg%3E")!important;
+              background-position:center!important;
+              background-repeat:no-repeat!important;
+              background-size:12px 12px!important;
+            }
             *{-webkit-user-select:none;user-select:none}
             input,textarea{-webkit-user-select:text;user-select:text}
 

--- a/dashboard/src/components/LeaderboardSkeleton.jsx
+++ b/dashboard/src/components/LeaderboardSkeleton.jsx
@@ -99,7 +99,7 @@ function MobileSkeletonRow({ index }) {
 export function LeaderboardSkeleton({ rows = 10 }) {
   return (
     <>
-    <div className="hidden w-full overflow-x-auto sm:block">
+    <div className="tt-leaderboard-scroll hidden w-full overflow-x-auto sm:block">
       <table className="min-w-max w-full text-left text-sm">
         <thead className="border-b border-oai-gray-200 dark:border-oai-gray-800">
           <tr>

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -797,7 +797,7 @@ export function LeaderboardPage({
         modifiers={[restrictToHorizontalAxis]}
         onDragEnd={handleDragEnd}
       >
-      <div className="hidden w-full overflow-x-auto sm:block">
+      <div className="tt-leaderboard-scroll hidden w-full overflow-x-auto sm:block">
         <table className="min-w-full w-full text-left text-sm sm:min-w-max">
           <thead className="border-b border-oai-gray-200 dark:border-oai-gray-800">
             <tr>

--- a/dashboard/src/pages/LeaderboardPage.test.jsx
+++ b/dashboard/src/pages/LeaderboardPage.test.jsx
@@ -144,6 +144,21 @@ describe("LeaderboardPage window-session cache reuse", () => {
     expect(tokenCell.className).not.toContain("dark:group-hover:bg-oai-gray-900/60");
   });
 
+  it("marks the desktop table as the native horizontal-scroll exception", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    const { container } = renderLeaderboard();
+
+    expect(container.querySelector(".tt-leaderboard-scroll")).not.toBeNull();
+  });
+
   it("renders snapshot freshness as a readable localized date instead of raw ISO", () => {
     const generatedAt = "2026-07-20T01:20:43.517Z";
     const contextKey = getLeaderboardPreloadContextKey({


### PR DESCRIPTION
## 概要

这个 PR 为 Windows 客户端的排行榜表格增加与网页版视觉接近的、明确可见的横向滚动条，方便用户查看右侧的统计列。

## 问题说明

在 Windows 客户端中，页面当前会统一隐藏 WebView2 的滚动条。排行榜表格虽然仍然可以通过 `Shift` + 鼠标滚轮进行横向滚动，但界面没有明显的滚动提示，用户看到被截断的列时容易下意识地认为表格无法横向滚动。

## 修改内容

- 为排行榜桌面表格及加载骨架增加独立的横向滚动容器标识。
- 仅针对 Windows 客户端的排行榜区域恢复可见的横向滚动条。
- 使用较厚的灰色滑块和轨道，并显示左右箭头按钮，使滚动条外观和网页版截图中的效果保持一致。
- 保持其他页面、普通网页访问和 macOS 客户端现有的滚动条行为不变。
- 增加前端回归测试，确认排行榜桌面表格使用该例外容器。

## 影响范围

- [ ] CLI (`src/`)
- [x] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [x] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## 验证情况

- `npm test -- LeaderboardPage.test.jsx`（17 项通过）
- `npm run build`（通过）
- `dotnet build TokenTrackerWin/TokenTrackerWin.csproj -c Debug`（通过）
- `dotnet test TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj -c Release`（8 项通过）
- 已重新生成安装包并覆盖安装 Windows 客户端进行验证。

希望这个改动能够让 Windows 用户更容易发现排行榜还可以横向查看，也请维护者帮忙确认这种局部恢复可见滚动条的方式是否符合项目的界面设计。
