### PR TITLE
fix(mac): isolate menu bar popover from app-wide activation

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -27,6 +27,7 @@ final class StatusBarController: NSObject {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let popover = NSPopover()
     private var popoverAnchorWindow: NSWindow?
+    private var popoverDismissMonitor: Any?
     private let viewModel: DashboardViewModel
     private let serverManager: ServerManager
     private let launchAtLoginManager: LaunchAtLoginManager
@@ -776,6 +777,10 @@ final class StatusBarController: NSObject {
     }
 
     private func handlePopoverDidClose() {
+        if let popoverDismissMonitor {
+            NSEvent.removeMonitor(popoverDismissMonitor)
+            self.popoverDismissMonitor = nil
+        }
         viewModel.setPopoverVisible(false)
         popoverAnchorWindow?.orderOut(nil)
         updateStatsDisplay()
@@ -816,8 +821,13 @@ final class StatusBarController: NSObject {
             // while the Dashboard window is frontmost). .fullScreenAuxiliary matches
             // the anchor window so the popover also shows over full-screen Spaces.
             window.collectionBehavior.insert([.canJoinAllSpaces, .fullScreenAuxiliary])
-            NSApp.activate(ignoringOtherApps: true)
             window.makeKey()
+        }
+
+        popoverDismissMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            Task { @MainActor in self?.closePopoverIfShown() }
         }
 
         // Opportunistically sync stale local data before refreshing the popover.

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -50,6 +50,9 @@ test("menu-bar popover does not activate the app", () => {
   const toggleStart = source.indexOf("private func togglePopover()");
   const toggleEnd = source.indexOf("private func makePopoverAnchorWindow()");
   const togglePopover = source.slice(toggleStart, toggleEnd);
+  const didCloseStart = source.indexOf("private func handlePopoverDidClose()");
+  const didCloseEnd = source.indexOf("// MARK: - Click Handling");
+  const handlePopoverDidClose = source.slice(didCloseStart, didCloseEnd);
 
   assert.doesNotMatch(
     togglePopover,
@@ -67,9 +70,14 @@ test("menu-bar popover does not activate the app", () => {
     "An inactive app needs a global mouse monitor so clicks in other apps still close the transient popover.",
   );
   assert.match(
-    source,
-    /private\s+func\s+handlePopoverDidClose\(\)[\s\S]*NSEvent\.removeMonitor\(popoverDismissMonitor\)/,
-    "Closing the popover should remove its global mouse monitor.",
+    togglePopover,
+    /popoverDismissMonitor\s*=\s*NSEvent\.addGlobalMonitorForEvents[\s\S]*?closePopoverIfShown\(\)/,
+    "The stored global monitor must close the popover.",
+  );
+  assert.match(
+    handlePopoverDidClose,
+    /NSEvent\.removeMonitor\(popoverDismissMonitor\)[\s\S]*self\.popoverDismissMonitor\s*=\s*nil/,
+    "Popover cleanup must remove and clear the global mouse monitor.",
   );
 });
 

--- a/test/macos-popover-anchor-window.test.js
+++ b/test/macos-popover-anchor-window.test.js
@@ -45,6 +45,34 @@ test("menu-bar popover keeps cached dashboard content visible during background 
   );
 });
 
+test("menu-bar popover does not activate the app", () => {
+  const source = readStatusBarController();
+  const toggleStart = source.indexOf("private func togglePopover()");
+  const toggleEnd = source.indexOf("private func makePopoverAnchorWindow()");
+  const togglePopover = source.slice(toggleStart, toggleEnd);
+
+  assert.doesNotMatch(
+    togglePopover,
+    /NSApp\.activate/,
+    "Opening the menu-bar popover must not activate the app and reorder an existing Dashboard window.",
+  );
+  assert.match(
+    togglePopover,
+    /window\.makeKey\(\)/,
+    "The popover window should remain key for keyboard and VoiceOver interaction.",
+  );
+  assert.match(
+    togglePopover,
+    /NSEvent\.addGlobalMonitorForEvents\(\s*matching:\s*\[[^\]]*\.leftMouseDown[^\]]*\.rightMouseDown[^\]]*\]/,
+    "An inactive app needs a global mouse monitor so clicks in other apps still close the transient popover.",
+  );
+  assert.match(
+    source,
+    /private\s+func\s+handlePopoverDidClose\(\)[\s\S]*NSEvent\.removeMonitor\(popoverDismissMonitor\)/,
+    "Closing the popover should remove its global mouse monitor.",
+  );
+});
+
 test("menu-bar popover is anchored to an app-owned positioning window", () => {
   const source = readStatusBarController();
   const didCloseStart = source.indexOf("forName: NSPopover.didCloseNotification");


### PR DESCRIPTION
## Summary

Keep menu-bar popover presentation window-scoped: opening it no longer activates the entire app. This preserves the presentation state of an existing Dashboard window and keeps the popover on the display/Space containing the clicked status item, while retaining click-outside dismissal, keyboard interaction, and VoiceOver support.

## Why

`StatusBarController.togglePopover()` called `NSApp.activate(ignoringOtherApps: true)` every time it opened the popover. That process-wide activation caused two user-visible failures:

- It could restore a minimized Dashboard or raise a Dashboard that was intentionally behind another app.
- On a two-display setup with another app full-screen, it could reactivate TokenTracker's previously associated Space and show the popover on the other display instead of under the clicked menu-bar icon.

The second behavior regressed the display/Space anchoring established by #193. A path-limited bisect identified #443 as the first bad revision: after Dashboard close stopped globally hiding TokenTracker so the Dynamic Island and desktop pet could remain visible, the later `NSApp.activate` call could reuse the app's stale Space association. Temporarily restoring `NSApp.hide(nil)` confirmed that causal chain, but reverting to global hiding is not an acceptable fix because it would hide those independent floating surfaces.

Both failures share the same boundary violation: a menu-bar popover should not activate the entire application. Explicit Dashboard actions continue to own Dashboard activation and restoration.

Removing app activation also exposed an AppKit edge case: while TokenTracker remains inactive, a transient popover does not reliably observe mouse events delivered to another app. The fix therefore installs a global mouse-down monitor only while the popover is open and removes it immediately when the popover closes.

## Changes

- Remove app-wide activation from the shared popover-opening path used by the status item and the right-click **Today Summary** action.
- Keep the popover window key so keyboard and VoiceOver interaction continue to work.
- Close the popover when a left or right mouse-down is delivered to another app, without activating TokenTracker.
- Preserve the app-owned anchor window and its full-screen Space collection behavior.
- Add regression coverage that rejects `NSApp.activate` in `togglePopover()` and verifies the complete monitor lifecycle.

## User impact

Opening the menu-bar popover now:

- Appears under the clicked status item on the same display, including when that display contains a full-screen app.
- Leaves the Dashboard exactly as it was: frontmost, covered by another app, minimized, or closed.
- Leaves Dynamic Island and desktop-pet visibility unchanged.

Explicit Dashboard actions such as **Open Dashboard** and Settings retain their existing behavior.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Validation

- `npm test` — 2,173 passed, 0 failed, 2 skipped.
- `node --test test/macos-popover-anchor-window.test.js test/macos-dashboard-window-space.test.js` — 8 passed.
- `xcodebuild -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBarTests -configuration Debug -derivedDataPath DerivedData -only-testing:TokenTrackerBarTests/DashboardPresentationPolicyTests test` — 4 passed.
- Full Debug build with the embedded server completed and passed ad-hoc code-sign verification.
- Manual Dashboard-state validation covered both popover entry points with the Dashboard frontmost, covered by another app, minimized with Stage Manager on and off, and closed. Click, scroll, keyboard, VoiceOver, click-outside dismissal, **Open Dashboard**, and Settings all passed.
- PR #443 preservation check with the complete Debug app passed: after closing the Dashboard, the TokenTracker Dock icon disappeared while both Dynamic Island and the desktop pet remained visible.
- Real two-display validation with Chrome full-screen:
  - `main@0f48136d` reproduced the popover on the other display.
  - The #193 merge commit `16719dad` remained good in the same environment.
  - `git bisect` identified #443 commit `6fdeabf1` as the first bad revision.
  - A diagnostic-only restoration of `NSApp.hide(nil)` made `6fdeabf1` good, confirming the activation/Space causal chain.
  - This PR at `bc2fde6e` kept single and repeated opens on the clicked display with the full-screen menu bar both auto-hidden and always visible; switching back to the desktop revealed no orphaned popover.

## Out of scope

- Update alerts, About panels, and other non-popover activation paths.

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (not applicable; no strings added)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu-bar popovers now close when users click elsewhere with either the left or right mouse button.
  * Opening the popover no longer unnecessarily activates the application, while keeping it ready for interaction.

* **Tests**
  * Added coverage for popover focus, dismissal, and mouse-monitor cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->