### PR TITLE
feat(mac): 灵动岛新增紧凑折叠模式

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandCompactPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandCompactPolicy.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Pure preference and value-selection policy for the Dynamic Island's
+/// compact collapsed layout. Keeping this independent of SwiftUI makes its
+/// fallback behaviour deterministic and directly testable.
+enum DynamicIslandCompactPolicy {
+    static let enabledDefaultsKey = "DynamicIslandCompactModeEnabled"
+
+    static func isEnabled(from defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: enabledDefaultsKey)
+    }
+
+    static func write(_ enabled: Bool, to defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: enabledDefaultsKey)
+    }
+
+    /// The first currently healthy, visible limit metric. `keepingSelected` is
+    /// deliberately empty: a stale selected slot must not become an auto-ring
+    /// candidate while its provider is unavailable.
+    static func resolveAutoRingMetric(
+        limits: UsageLimitsResponse?,
+        hiddenProviders: Set<String>
+    ) -> MenuBarDisplayMetric? {
+        MenuBarDisplayPreferences.availableItemIDs(
+            for: limits,
+            keepingSelected: [],
+            hiddenProviders: hiddenProviders
+        )
+        .compactMap(MenuBarDisplayMetric.init(rawValue:))
+        .first { $0.settingsCategory == "limits" }
+    }
+
+    /// Uses a viable Primary slot directly. A non-limit or unavailable Primary
+    /// falls back to auto, while nil preserves the user's explicit empty slot.
+    static func resolveRingMetric(
+        primarySlot: MenuBarDisplayMetric?,
+        limits: UsageLimitsResponse?,
+        hiddenProviders: Set<String>
+    ) -> MenuBarDisplayMetric? {
+        guard let primarySlot else { return nil }
+        let auto = resolveAutoRingMetric(limits: limits, hiddenProviders: hiddenProviders)
+        let available = MenuBarDisplayPreferences.availableItemIDs(
+            for: limits,
+            keepingSelected: [],
+            hiddenProviders: hiddenProviders
+        )
+        guard primarySlot.settingsCategory == "limits",
+              available.contains(primarySlot.rawValue) else {
+            return auto
+        }
+        return primarySlot
+    }
+
+    /// `trim` follows the selected display mode; `color` always tracks raw
+    /// utilization so a short remaining ring can still communicate urgency.
+    static func ringValues(
+        pct: Double?,
+        displayMode: LimitDisplayMode
+    ) -> (trim: Double, color: Double)? {
+        guard let pct else { return nil }
+        let used = min(max(pct, 0), 100) / 100
+        return (displayMode == .remaining ? 1 - used : used, used)
+    }
+
+    static func quotaColor(colorValue: Double) -> RingColorTier {
+        switch colorValue {
+        case ..<0.5: return .green
+        case ..<0.8: return .yellow
+        default: return .red
+        }
+    }
+}
+
+enum RingColorTier: Equatable {
+    case green
+    case yellow
+    case red
+}

--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandCompactPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandCompactPolicy.swift
@@ -17,9 +17,14 @@ enum DynamicIslandCompactPolicy {
     /// The first currently healthy, visible limit metric. `keepingSelected` is
     /// deliberately empty: a stale selected slot must not become an auto-ring
     /// candidate while its provider is unavailable.
+    ///
+    /// `excluding` keeps the auto-picked ring from landing on a metric the
+    /// opposite wing already renders — otherwise both wings show the same
+    /// window and the ring carries no information the user cannot already read.
     static func resolveAutoRingMetric(
         limits: UsageLimitsResponse?,
-        hiddenProviders: Set<String>
+        hiddenProviders: Set<String>,
+        excluding: MenuBarDisplayMetric? = nil
     ) -> MenuBarDisplayMetric? {
         MenuBarDisplayPreferences.availableItemIDs(
             for: limits,
@@ -27,18 +32,24 @@ enum DynamicIslandCompactPolicy {
             hiddenProviders: hiddenProviders
         )
         .compactMap(MenuBarDisplayMetric.init(rawValue:))
-        .first { $0.settingsCategory == "limits" }
+        .first { $0.settingsCategory == "limits" && $0 != excluding }
     }
 
     /// Uses a viable Primary slot directly. A non-limit or unavailable Primary
     /// falls back to auto, while nil preserves the user's explicit empty slot.
+    ///
+    /// Only the fallback path can collide with the opposite wing: slot
+    /// normalization already rejects the same metric in both slots, so an
+    /// explicitly chosen Primary is always distinct from `secondarySlot` and is
+    /// honored as-is. When the fallback has no distinct candidate left, the ring
+    /// stays empty rather than mirroring the other wing.
     static func resolveRingMetric(
         primarySlot: MenuBarDisplayMetric?,
+        secondarySlot: MenuBarDisplayMetric? = nil,
         limits: UsageLimitsResponse?,
         hiddenProviders: Set<String>
     ) -> MenuBarDisplayMetric? {
         guard let primarySlot else { return nil }
-        let auto = resolveAutoRingMetric(limits: limits, hiddenProviders: hiddenProviders)
         let available = MenuBarDisplayPreferences.availableItemIDs(
             for: limits,
             keepingSelected: [],
@@ -46,7 +57,11 @@ enum DynamicIslandCompactPolicy {
         )
         guard primarySlot.settingsCategory == "limits",
               available.contains(primarySlot.rawValue) else {
-            return auto
+            return resolveAutoRingMetric(
+                limits: limits,
+                hiddenProviders: hiddenProviders,
+                excluding: secondarySlot
+            )
         }
         return primarySlot
     }

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -984,13 +984,25 @@ final class StatusBarController: NSObject {
         // Display Metrics Submenu (affects both Dynamic Island & Menu Bar Icon)
         let displayItem = NSMenuItem(title: Strings.menuDisplayMetrics, action: nil, keyEquivalent: "")
         let displayMenu = NSMenu()
+        displayMenu.autoenablesItems = false
 
         let statsItem = NSMenuItem(title: Strings.menuShowStats, action: #selector(toggleStats), keyEquivalent: "")
         statsItem.target = self
         statsItem.state = showStats ? .on : .off
         displayMenu.addItem(statsItem)
 
-        if showStats {
+        let compactItem = NSMenuItem(title: Strings.menuDynamicIslandCompactMode, action: #selector(toggleDynamicIslandCompact), keyEquivalent: "")
+        compactItem.target = self
+        compactItem.state = DynamicIslandCompactPolicy.isEnabled() ? .on : .off
+        compactItem.isEnabled = islandEnabled
+        displayMenu.addItem(compactItem)
+
+        let remainingItem = NSMenuItem(title: Strings.menuRingShowsRemaining, action: #selector(selectRingDisplayMode(_:)), keyEquivalent: "")
+        remainingItem.target = self
+        remainingItem.state = LimitsSettingsStore.shared.displayMode == .remaining ? .on : .off
+        displayMenu.addItem(remainingItem)
+
+        if showStats || islandEnabled {
             displayMenu.addItem(.separator())
             let selectedIDs = MenuBarDisplayPreferences.read()
             let payload = MenuBarDisplayPreferences.availableItemsPayload(
@@ -1163,6 +1175,17 @@ final class StatusBarController: NSObject {
 
     @objc private func toggleStats() {
         showStats.toggle()
+    }
+
+    @objc private func toggleDynamicIslandCompact() {
+        DynamicIslandCompactPolicy.write(!DynamicIslandCompactPolicy.isEnabled())
+        NotificationCenter.default.post(name: .nativeSettingsChanged, object: nil)
+    }
+
+    @objc private func selectRingDisplayMode(_ sender: NSMenuItem) {
+        let next: LimitDisplayMode =
+            LimitsSettingsStore.shared.displayMode == .remaining ? .used : .remaining
+        LimitsSettingsStore.shared.setDisplayModeFromMenu(next)
     }
 
     @objc private func selectMenuBarSlotMetric(_ sender: NSMenuItem) {

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -234,6 +234,8 @@ enum Strings {
     static var menuStarOnGitHub: String { t("★ Star on GitHub", "★ 在 GitHub 上标星", "★ 在 GitHub 上標星", "★ GitHub でスターを付ける", "★ GitHub에서 스타하기") }
     static var menuShowStats: String { t("Show Numeric Values", "显示数值", "顯示數值", "数値の表示", "수치 표시") }
     static var menuDisplayMetrics: String { t("Display Metrics", "显示指标", "顯示指標", "表示メトリクス", "표시 메트릭") }
+    static var menuDynamicIslandCompactMode: String { t("Compact Mode (Ring)", "紧凑模式（圆环）", "緊湊模式（圓環）", "コンパクトモード（リング）", "컴팩트 모드(링)") }
+    static var menuRingShowsRemaining: String { t("Show Remaining", "显示剩余量", "顯示剩餘量", "残りを表示", "남은 양 표시") }
     static var menuPrimarySlot: String { t("Primary", "主指标", "主指標", "プライマリ", "기본") }
     static var menuSecondarySlot: String { t("Secondary", "副指标", "副指標", "セカンダリ", "보조") }
     static var menuSlotNone: String { t("None", "不显示", "不顯示", "表示しない", "표시 안 함") }

--- a/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
@@ -280,6 +280,7 @@ struct DynamicIslandView: View {
     private var ringMetric: MenuBarDisplayMetric? {
         DynamicIslandCompactPolicy.resolveRingMetric(
             primarySlot: wingMetrics.left,
+            secondarySlot: wingMetrics.right,
             limits: viewModel.usageLimits,
             hiddenProviders: LimitsSettingsStore.shared.hiddenProviders
         )

--- a/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
@@ -26,6 +26,7 @@ struct DynamicIslandView: View {
 
     @State private var menuBarIcon: NSImage? = nil
     @State private var wingMetrics = WingSelection.default
+    @State private var compactModeEnabled = false
 
     var body: some View {
         // Referenced so currency/locale changes force a re-render.
@@ -55,9 +56,11 @@ struct DynamicIslandView: View {
         .onAppear {
             self.menuBarIcon = StatusBarController.currentMenuBarIcon
             self.wingMetrics = resolveWingMetrics()
+            self.compactModeEnabled = DynamicIslandCompactPolicy.isEnabled()
         }
         .onChange(of: state.settingsTick) { _ in
             self.wingMetrics = resolveWingMetrics()
+            self.compactModeEnabled = DynamicIslandCompactPolicy.isEnabled()
         }
     }
 
@@ -156,11 +159,17 @@ struct DynamicIslandView: View {
         let geo = state.geometry
         let metrics = wingMetrics
         return HStack(spacing: 0) {
-            buildWingView(for: metrics.left)
-                .frame(width: geo.wingWidth)
+            Group {
+                if compactModeEnabled {
+                    compactRingWingView()
+                } else {
+                    buildWingView(for: metrics.left)
+                }
+            }
+            .frame(width: geo.wingWidth)
             Spacer()
                 .frame(width: geo.centerGapWidth)
-            buildWingView(for: metrics.right)
+            buildWingView(for: metrics.right, suppressValue: compactModeEnabled)
                 .frame(width: geo.wingWidth)
         }
         .frame(height: geo.collapsedHeight)
@@ -168,8 +177,12 @@ struct DynamicIslandView: View {
         // drives the shared wing width, keeping the island tight + symmetric.
         .background(
             HStack(spacing: 0) {
-                measured(buildWingView(for: metrics.left))
-                measured(buildWingView(for: metrics.right))
+                if compactModeEnabled {
+                    measured(compactRingWingView())
+                } else {
+                    measured(buildWingView(for: metrics.left))
+                }
+                measured(buildWingView(for: metrics.right, suppressValue: compactModeEnabled))
             }
             .hidden()
         )
@@ -204,13 +217,19 @@ struct DynamicIslandView: View {
     /// `.todayTokens` slot) — gates icon-frame notification re-renders.
     private var wingsShowMenuBarIcon: Bool {
         let metrics = wingMetrics
+        if compactModeEnabled {
+            return metrics.right == .todayTokens
+        }
         return metrics.left == .todayTokens || metrics.right == .todayTokens
     }
 
     @ViewBuilder
-    private func buildWingView(for metric: MenuBarDisplayMetric?) -> some View {
+    private func buildWingView(
+        for metric: MenuBarDisplayMetric?,
+        suppressValue: Bool = false
+    ) -> some View {
         if let metric {
-            buildMetricWingView(for: metric)
+            buildMetricWingView(for: metric, suppressValue: suppressValue)
         } else {
             // Explicit "none" slot: contribute nothing to the wing (the
             // shared minWingWidth floor keeps the island shape balanced).
@@ -218,7 +237,10 @@ struct DynamicIslandView: View {
         }
     }
 
-    private func buildMetricWingView(for metric: MenuBarDisplayMetric) -> some View {
+    private func buildMetricWingView(
+        for metric: MenuBarDisplayMetric,
+        suppressValue: Bool = false
+    ) -> some View {
         let content = wingContent(for: metric)
         return HStack(spacing: 4) {
             if let providerKey = metric.providerKey,
@@ -249,10 +271,67 @@ struct DynamicIslandView: View {
                     .foregroundStyle(Color.white.opacity(0.55))
             }
 
-            if !content.value.isEmpty {
+            if !content.value.isEmpty && !(metric == .todayTokens && suppressValue) {
                 wingLabel(content.value)
             }
         }
+    }
+
+    private var ringMetric: MenuBarDisplayMetric? {
+        DynamicIslandCompactPolicy.resolveRingMetric(
+            primarySlot: wingMetrics.left,
+            limits: viewModel.usageLimits,
+            hiddenProviders: LimitsSettingsStore.shared.hiddenProviders
+        )
+    }
+
+    private var ringValues: (trim: Double, color: Double)? {
+        guard let ringMetric else { return nil }
+        return DynamicIslandCompactPolicy.ringValues(
+            pct: viewModel.usageLimits?.utilizationPercent(for: ringMetric),
+            displayMode: LimitsSettingsStore.shared.displayMode
+        )
+    }
+
+    private func compactRingWingView() -> some View {
+        let metric = ringMetric
+        let values = ringValues
+        let icon = metric.flatMap(\.providerKey).flatMap { LimitsSettingsStore.iconNames[$0] }
+        let fallbackIcon = NSApp.applicationIconImage ?? NSImage(named: NSImage.applicationIconName) ?? NSImage()
+        let tier = DynamicIslandCompactPolicy.quotaColor(colorValue: values?.color ?? 0)
+        let color: Color = switch tier {
+        case .green: .green
+        case .yellow: .yellow
+        case .red: .red
+        }
+
+        return ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.15), lineWidth: 2.5)
+            if let values {
+                Circle()
+                    .trim(from: 0, to: values.trim)
+                    .stroke(color, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.easeInOut(duration: 0.35), value: values.trim)
+            }
+            if let icon {
+                Image(icon)
+                    .renderingMode(.original)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 9, height: 9)
+            } else {
+                Image(nsImage: fallbackIcon)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 9, height: 9)
+            }
+        }
+        .frame(width: 18, height: 18)
+        .id(metric?.rawValue ?? "empty")
     }
 
     private func wingContent(for metric: MenuBarDisplayMetric) -> (icon: String?, label: String?, value: String) {

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandCompactPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandCompactPolicyTests.swift
@@ -79,6 +79,68 @@ final class DynamicIslandCompactPolicyTests: XCTestCase {
         )
     }
 
+    func testResolveRingMetricFallbackSkipsTheMetricOnTheOppositeWing() throws {
+        let limits = try response(overrides: [
+            "claude": ["configured": true, "five_hour": ["utilization": 79.0]],
+            "codex": ["configured": true, "primary_window": ["used_percent": 40]],
+        ])
+
+        // Without the exclusion the ring would mirror the right wing exactly.
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .todayCost,
+                secondarySlot: .claude5h,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .codex5h
+        )
+    }
+
+    func testResolveRingMetricFallbackStaysEmptyWhenOnlyCandidateIsOnTheOtherWing() throws {
+        let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 79.0]])
+
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveRingMetric(
+            primarySlot: .todayCost,
+            secondarySlot: .claude5h,
+            limits: limits,
+            hiddenProviders: []
+        ))
+    }
+
+    func testResolveRingMetricKeepsAnExplicitPrimaryEvenIfItMatchesSecondary() throws {
+        let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 79.0]])
+
+        // Slot normalization rejects duplicate slots, so an explicit Primary is
+        // honored rather than second-guessed.
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .claude5h,
+                secondarySlot: .claude5h,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .claude5h
+        )
+    }
+
+    func testAutoRingMetricExclusionFallsThroughToTheNextWindowOfSameProvider() throws {
+        let limits = try response(claude: [
+            "configured": true,
+            "five_hour": ["utilization": 79.0],
+            "seven_day": ["utilization": 42.0],
+        ])
+
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveAutoRingMetric(
+                limits: limits,
+                hiddenProviders: [],
+                excluding: .claude5h
+            ),
+            .claude7d
+        )
+    }
+
     func testResolveRingMetricHonorsExplicitNone() throws {
         let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 30.0]])
 

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandCompactPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandCompactPolicyTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+
+final class DynamicIslandCompactPolicyTests: XCTestCase {
+    func testCompactModeDefaultsOffAndRoundTrips() throws {
+        let suiteName = "DynamicIslandCompactPolicyTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(DynamicIslandCompactPolicy.isEnabled(from: defaults))
+        DynamicIslandCompactPolicy.write(true, to: defaults)
+        XCTAssertTrue(DynamicIslandCompactPolicy.isEnabled(from: defaults))
+        DynamicIslandCompactPolicy.write(false, to: defaults)
+        XCTAssertFalse(DynamicIslandCompactPolicy.isEnabled(from: defaults))
+    }
+
+    func testResolveRingMetricUsesPrimaryLimitWhenCurrent() throws {
+        let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 30.0]])
+
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .claude5h,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .claude5h
+        )
+    }
+
+    func testResolveRingMetricFallsBackForNonLimitOrUnavailablePrimary() throws {
+        let limits = try response(overrides: [
+            "claude": ["configured": true, "five_hour": ["utilization": 30.0]],
+            "codex": ["configured": true, "primary_window": ["used_percent": 40]],
+        ])
+
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .todayTokens,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .claude5h
+        )
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .claude5h,
+                limits: limits,
+                hiddenProviders: ["claude"]
+            ),
+            .codex5h
+        )
+    }
+
+    func testResolveRingMetricFallsBackForUnconfiguredPrimaryProvider() throws {
+        let limits = try response(overrides: [
+            "claude": ["configured": false, "five_hour": ["utilization": 30.0]],
+            "codex": ["configured": true, "primary_window": ["used_percent": 40]],
+        ])
+
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .claude5h,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .codex5h
+        )
+    }
+
+    func testResolveRingMetricFallsBackWhenPrimaryWindowIsMissing() throws {
+        let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 30.0]])
+
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveRingMetric(
+                primarySlot: .claude7d,
+                limits: limits,
+                hiddenProviders: []
+            ),
+            .claude5h
+        )
+    }
+
+    func testResolveRingMetricHonorsExplicitNone() throws {
+        let limits = try response(claude: ["configured": true, "five_hour": ["utilization": 30.0]])
+
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveRingMetric(
+            primarySlot: nil,
+            limits: limits,
+            hiddenProviders: []
+        ))
+    }
+
+    func testAutoRingMetricRequiresHealthyVisibleWindow() throws {
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveAutoRingMetric(limits: nil, hiddenProviders: []))
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveAutoRingMetric(
+            limits: try response(),
+            hiddenProviders: []
+        ))
+
+        let healthy = try response(claude: ["configured": true, "five_hour": ["utilization": 30.0]])
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveAutoRingMetric(limits: healthy, hiddenProviders: []),
+            .claude5h
+        )
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveAutoRingMetric(
+            limits: healthy,
+            hiddenProviders: ["claude"]
+        ))
+
+        let windowless = try response(claude: ["configured": true])
+        XCTAssertNil(DynamicIslandCompactPolicy.resolveAutoRingMetric(limits: windowless, hiddenProviders: []))
+
+        let errored = try response(overrides: [
+            "claude": ["configured": true, "error": "429", "five_hour": ["utilization": 30.0]],
+            "codex": ["configured": true, "primary_window": ["used_percent": 40]],
+        ])
+        XCTAssertEqual(
+            DynamicIslandCompactPolicy.resolveAutoRingMetric(limits: errored, hiddenProviders: []),
+            .codex5h
+        )
+    }
+
+    func testRingValuesSeparateDisplayTrimFromRawUsageColor() {
+        XCTAssertNil(DynamicIslandCompactPolicy.ringValues(pct: nil, displayMode: .used))
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 30, displayMode: .used), trim: 0.30, color: 0.30)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 30, displayMode: .remaining), trim: 0.70, color: 0.30)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 85, displayMode: .remaining), trim: 0.15, color: 0.85)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 0, displayMode: .used), trim: 0, color: 0)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 100, displayMode: .used), trim: 1, color: 1)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 120, displayMode: .used), trim: 1, color: 1)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 0, displayMode: .remaining), trim: 1, color: 0)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 100, displayMode: .remaining), trim: 0, color: 1)
+        XCTAssertEqualValues(DynamicIslandCompactPolicy.ringValues(pct: 120, displayMode: .remaining), trim: 0, color: 1)
+    }
+
+    func testQuotaColorBoundaries() {
+        XCTAssertEqual(DynamicIslandCompactPolicy.quotaColor(colorValue: 0.499), .green)
+        XCTAssertEqual(DynamicIslandCompactPolicy.quotaColor(colorValue: 0.5), .yellow)
+        XCTAssertEqual(DynamicIslandCompactPolicy.quotaColor(colorValue: 0.799), .yellow)
+        XCTAssertEqual(DynamicIslandCompactPolicy.quotaColor(colorValue: 0.8), .red)
+    }
+
+    private func XCTAssertEqualValues(
+        _ actual: (trim: Double, color: Double)?,
+        trim: Double,
+        color: Double,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual else {
+            XCTFail("Expected ring values", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual.trim, trim, accuracy: 0.000_001, file: file, line: line)
+        XCTAssertEqual(actual.color, color, accuracy: 0.000_001, file: file, line: line)
+    }
+
+    private func response(
+        claude: [String: Any] = ["configured": false],
+        overrides: [String: Any] = [:]
+    ) throws -> UsageLimitsResponse {
+        var payload: [String: Any] = [
+            "fetched_at": "2026-08-17T00:00:00Z",
+            "claude": claude,
+            "codex": ["configured": false],
+            "cursor": ["configured": false],
+            "gemini": ["configured": false],
+            "kiro": ["configured": false],
+            "antigravity": ["configured": false],
+        ]
+        for (key, value) in overrides {
+            payload[key] = value
+        }
+        return try JSONDecoder().decode(
+            UsageLimitsResponse.self,
+            from: JSONSerialization.data(withJSONObject: payload)
+        )
+    }
+}

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -122,6 +122,7 @@ targets:
       - path: TokenTrackerBar/Models/LimitsSettingsStore.swift
       - path: TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
       - path: TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+      - path: TokenTrackerBar/Models/DynamicIslandCompactPolicy.swift
       - path: TokenTrackerBar/Models/MenuBarIconStyle.swift
       - path: TokenTrackerBar/Models/UsageLimits.swift
       - path: TokenTrackerBar/Models/LimitPace.swift


### PR DESCRIPTION
## 做了什么

灵动岛折叠态新增「紧凑模式」：左翼收敛为单个 18pt 额度圆环，岛宽恒定压在最小值上，不再随文案长度和数字位数变化。默认关闭，旧用户升级后视觉零变化。

- **圆环取值**：弧长跟随全局的「已用/剩余」口径，颜色**恒定**跟随原始已用比例（<50% 绿 / <80% 黄 / 否则红）。这样在剩余量模式下「还剩 15%」仍然是红色，不会因为环画得短就变绿。
- **圆环来源**：复用现有 Primary 槽，不新增偏好。槽位是非额度项、provider 已隐藏/未配置、或该窗口缺失时，回落到第一个当前真有值的额度 metric；用户显式选 None 则保持空轨迹、不回落。
- **右侧内容**：复用现有 Secondary 槽，用户可选。仅对 today-tokens 抑制数字，让动画图标单独呈现；其余 metric 照常显示数值。
- **设置落点**：两个勾选框都插进现有 `Display Metrics` 子菜单，顶层菜单结构零改动。

## 顺带修掉的两个既有缺陷

1. **槽位选择器不可达**：Primary/Secondary 被 `if showStats` 门禁着，但灵动岛的 `resolveWingMetrics()` 根本不看 `showStats`。关掉「显示数值」后，岛照常按这两个槽渲染，用户却在菜单里再也找不到它们。条件改为 `showStats || islandEnabled`。
2. **手动 isEnabled 被静默覆盖**：`NSMenu.autoenablesItems` 默认为 true，AppKit 会按「target 是否响应 action」重算并覆盖手动设置的值，仓库内既没关掉它也没实现 `validateMenuItem`。现已在该子菜单上显式关闭。

## 影响面

只动 `TokenTrackerBar/`。`dashboard/`、`src/`、Windows、Linux 均零改动，未触发发版路径。

刻意**没有**新增 `MenuBarDisplayMetric` case（曾考虑用它承载「宠物」选项）：该枚举会经 NativeBridge 整包推给 dashboard，新 case 会在设置页下拉框里冒出一个绕过 `copy.csv` 的裸文案选项，预览值还会显示无意义的数字。改用渲染层特化规避，标准模式行为一字未变。

## 验证状态

- 全量类型检查 0 error、零新增警告（69 个源文件；`ScreenConfettiOverlayController.swift` 因 `Vortex` SPM 依赖无法解析而打桩排除）。
- 新增 10 个单测，覆盖回落矩阵、trim/color 分离、0/100/越界在 used 与 remaining 两条路径的 clamp、颜色分档边界。
- **测试未运行**：开发机只有 Command Line Tools，无 Xcode.app，`xcodebuild` 与 XCTest 均不可用。测试能否编译通过、能否跑绿，需要 CI 或有 Xcode 的环境确认。
- 未做真机视觉核对：折叠态圆环在真实刘海高度下的余量（仅按模拟值 30pt 计算），以及 metric 切换时 `.id()` 隔离是否真的阻断了 trim 插值。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compact Dynamic Island mode with an animated quota ring.
  - Supports displaying used or remaining usage.
  - Added automatic metric selection with fallback behavior.
  - Added menu controls for compact mode and ring display settings.
  - Ring colors indicate usage levels with green, yellow, and red tiers.

- **Bug Fixes**
  - Improved handling of unavailable, stale, hidden, or invalid metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->