### PR TITLE
test: stub sha256sum so the Linux bundle test runs off GNU coreutils

### DIFF
--- a/test/linux-bundle.test.js
+++ b/test/linux-bundle.test.js
@@ -35,6 +35,24 @@ test("Linux bundle rebuilds an isolated runtime and synchronizes an isolated Tau
     fs.mkdirSync(dashboardDist, { recursive: true });
     fs.writeFileSync(path.join(dashboardDist, "index.html"), "<main>dashboard fixture</main>");
 
+    // The bundle script verifies the downloaded Node tarball with `sha256sum`,
+    // and so does the stubbed curl below. That binary is GNU coreutils and does
+    // not exist on macOS, so stubbing curl/tar/npm but not the checksum tool is
+    // what kept this test Linux-only. The shim is a real SHA-256 in sha256sum's
+    // output format, so the checksum gate is still exercised, not bypassed.
+    fs.writeFileSync(path.join(toolsDir, "sha256sum.cjs"), `const { createHash } = require("node:crypto");
+const fs = require("node:fs");
+const digest = (buffer) => createHash("sha256").update(buffer).digest("hex");
+const files = process.argv.slice(2);
+const targets = files.length > 0 ? files : ["-"];
+for (const target of targets) {
+  process.stdout.write(\`\${digest(fs.readFileSync(target === "-" ? 0 : target))}  \${target}\\n\`);
+}
+`);
+    writeExecutable(path.join(toolsDir, "sha256sum"), `#!/usr/bin/env bash
+set -euo pipefail
+exec "\${TOKENTRACKER_TEST_NODE:-node}" "$(dirname "$0")/sha256sum.cjs" "$@"
+`);
     writeExecutable(path.join(toolsDir, "curl"), `#!/usr/bin/env bash
 set -euo pipefail
 output=""
@@ -63,6 +81,7 @@ chmod +x "$destination/node-v22.22.2-linux-x64/bin/node"
       env: {
         ...process.env,
         PATH: `${toolsDir}:${process.env.PATH}`,
+        TOKENTRACKER_TEST_NODE: process.execPath,
         TOKENTRACKER_LINUX_EMBED_DIR: embeddedServer,
         TOKENTRACKER_DASHBOARD_DIST: dashboardDist,
         TOKENTRACKER_TAURI_ICON: tauriIcon,


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` names `npm test` as the gate for a pull request. On macOS it cannot pass, on a clean checkout, after following the documented setup exactly:

```
✖ Linux bundle rebuilds an isolated runtime and synchronizes an isolated Tauri icon
  AssertionError: bundle script failed:
    /var/folders/.../tokentracker-linux-bundle-XXXX/tools/curl: line 9: sha256sum: command not found
    TokenTrackerLinux/scripts/bundle-node-linux.sh: line 40: sha256sum: command not found
```

`sha256sum` is GNU coreutils. macOS ships `shasum` instead, so the binary does not exist there.

The test already stubs `curl`, `tar` and `npm` into a temporary `tools/` directory precisely so the bundle script runs the same way on any host — that is what "isolated runtime" in the test name means. The checksum tool is the one host dependency that was left out, and it is reached from both sides: the script verifies the tarball at `bundle-node-linux.sh:40`, and the stubbed `curl` computes the digest it advertises in `SHASUMS256.txt`.

CI does not surface this. The `ci` job runs the full suite on `ubuntu-latest`, where `sha256sum` exists; the `macos-tests` job runs `test/openclaw-parser.test.js` and `test/native-pet-limit-reset.test.js` plus the Xcode tests, never `npm test`. So the failure is only visible to a person on a Mac — on a repository that ships a macOS menu bar app.

## What

One more stub in the same `tools/` directory: a `sha256sum` that computes a real SHA-256 and prints it in `sha256sum`'s output format, handling both a file argument and stdin. It is a Node script behind a small bash shim, so it needs nothing beyond the Node the suite already runs on.

The checksum gate stays live rather than being bypassed — the digest is genuinely computed on the bytes the stubbed `curl` produced. Because `tools/` is first on `PATH`, the shim shadows the host binary on Linux too, so the test stops depending on which checksum tool the developer happens to have.

`TokenTrackerLinux/scripts/bundle-node-linux.sh` is untouched. On the release runner it is Linux and `sha256sum` is correct there.

## Verification

macOS 26, Node 24, clean clone, following `CONTRIBUTING.md` setup:

| | result |
|---|---|
| `npm test` before | `tests 2272 · pass 2269 · fail 1` — the Linux bundle test |
| `npm test` after | `tests 2272 · pass 2270 · fail 0` |

The gate is still enforced. Making the stubbed `curl` write bytes that do not match the digest it advertises turns the test red for the right reason:

```
AssertionError: bundle script failed: Node.js checksum mismatch for node-v22.22.2-linux-x64.tar.gz
```

Also run locally, all clean: `validate:copy`, `validate:locale`, `validate:ui-hardcode`, `validate:guardrails`, `validate:versions`, and `test/architecture-guardrails.test.js`.

Linux is unaffected. A first pull request sits at `action_required` until a maintainer approves it, so I ran your CI workflow against this exact commit on my fork: [run 32054803079](https://github.com/vinhnguyenthanhdn/TokenTracker/actions/runs/32054803079) — `test + validate + build`, `macOS unit tests`, `Windows build` and `Linux client (Rust)` all green.

## Checklist

- [x] Tests pass (`npm test`)
- [x] No user-facing strings added
- [x] No Swift changed
- [x] Conventional commit style
- [x] Description explains why
