### PR TITLE
ci: run the full test suite on macOS instead of two hand-picked files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,30 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            dashboard/package-lock.json
 
-      - name: Test OpenClaw parser on macOS
-        run: |
-          npm ci
-          node --test test/openclaw-parser.test.js
+      - name: Install root dependencies
+        run: npm ci
 
-      - name: Test macOS native pet limit reset interpolation
-        run: node --test test/native-pet-limit-reset.test.js
+      - name: Install dashboard dependencies
+        run: npm ci --prefix dashboard
+
+      # Same reason as the Linux job: the local-runtime install test asserts the
+      # bundled dashboard/dist/index.html exists, and a fresh checkout has none.
+      - name: Build dashboard
+        env:
+          VITE_INSFORGE_BASE_URL: https://srctyff5.us-east.insforge.app
+          VITE_INSFORGE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3OC0xMjM0LTU2NzgtOTBhYi1jZGVmMTIzNDU2NzgiLCJlbWFpbCI6ImFub25AaW5zZm9yZ2UuY29tIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODExNDU5NDd9.T0auta_IrVIh0uXW1bob5QSnzvsnJmN28r5XkSGEuQY
+        run: npm run dashboard:build
+
+      # The whole suite, not a hand-picked pair of files: host assumptions that
+      # only hold on GNU userland (coreutils, GNU sed, ...) are invisible to the
+      # Linux job by construction, and `npm test` is what CONTRIBUTING asks
+      # contributors to run before opening a PR.
+      - name: Test suite on macOS
+        run: npm test
 
       - name: Install xcodegen
         run: brew install xcodegen


### PR DESCRIPTION
## Summary

Run the full `npm test` suite in the macOS CI job instead of two hand-picked test files, so host assumptions that only hold on GNU userland stop shipping green.

## Why

`CONTRIBUTING.md` tells contributors that `npm test` is the gate ("Full suite, `node --test`"), and the Linux job runs exactly that. The macOS job runs **2 of the 250 files** in `test/*.test.js` (`openclaw-parser`, `native-pet-limit-reset`), so a test that quietly depends on GNU userland is green in CI and red on every Mac.

That is not hypothetical — it is what #482 fixed. `test/linux-bundle.test.js` landed on 2026-08-09 calling `sha256sum`, which macOS does not ship. `npm test` could not go green on macOS for 9 days and no CI leg could see it: the Linux job runs on `ubuntu-latest` where the command exists, and the macOS job never reached that file.

## What this does

In `macos-tests`, replaces the two named files with the same install → build → test sequence the Linux job already uses:

- `npm ci` and `npm ci --prefix dashboard`
- `npm run dashboard:build` — the local-runtime install test asserts `dashboard/dist/index.html` exists, and a fresh checkout has none
- `npm test`

Both previously named files are inside `test/*.test.js`, so coverage is a strict superset of what the job ran before. The Xcode steps are untouched.

## Cost, measured on the runner

From the CI run linked below (`macos-26`, Node 24), the three added steps:

| Step | Time |
|---|---|
| `npm ci --prefix dashboard` | 11s |
| `npm run dashboard:build` | 8s |
| `npm test` | 58s |

The suite reports `tests 2276 · pass 2274 · fail 0 · skipped 2`.

The dashboard build is not optional padding: without it the same suite fails 4 tests on macOS — `tsc validates migrated TS files`, `installLocalTrackerApp replaces stale installed runtime and writes a package marker`, and the two `Vite dev server handles …` cases.

## Verification

CI run of this exact commit with the upstream workflow, on a fork: https://github.com/vinhnguyenthanhdn/TokenTracker/actions/runs/32090693394

`macOS unit tests` green including the new `Test suite on macOS` step, plus `test + validate + build` and `Windows build`. `Linux client (Rust)` was still installing its apt dependencies on the fork runner when this was opened; that job is untouched by this change.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text) — none in this PR
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded macOS continuous integration checks to install all required dependencies, build the dashboard, and run the complete test suite.
  * Replaced targeted test execution with broader validation across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->