### PR TITLE
feat(mac): 任意应用全屏时自动隐藏灵动岛

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -70,6 +70,65 @@ enum DynamicIslandVisibilityPolicy {
     }
 }
 
+/// Presence gate so a user-disabled island and an active full-screen app
+/// both suppress the panel without coupling those two reasons.
+enum DynamicIslandFullscreenPolicy {
+    static func shouldShowPanel(featureEnabled: Bool, fullscreenActive: Bool) -> Bool {
+        featureEnabled && !fullscreenActive
+    }
+
+    /// Native green-button full-screen sets `.fullScreen`. Legacy / video
+    /// players typically hide both the menu bar and the Dock without that
+    /// flag. System auto-hide preferences use different flags and must not
+    /// be passed in as `hides*`.
+    static func presentationLooksFullscreen(
+        containsFullScreen: Bool,
+        hidesMenuBar: Bool,
+        hidesDock: Bool
+    ) -> Bool {
+        containsFullScreen || (hidesMenuBar && hidesDock)
+    }
+
+    /// Quartz window bounds are top-left on the primary display; AppKit
+    /// screen frames are bottom-left. `primaryMaxY` is the primary screen's
+    /// `frame.maxY`.
+    static func appKitRect(fromQuartz rect: CGRect, primaryMaxY: CGFloat) -> CGRect {
+        CGRect(
+            x: rect.origin.x,
+            y: primaryMaxY - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    /// A window that covers a screen including its menu-bar strip is in
+    /// full-screen, not merely zoomed to `visibleFrame`.
+    static func windowCoversScreenIncludingMenuBar(
+        windowBounds: CGRect,
+        screenFrame: CGRect
+    ) -> Bool {
+        windowBounds.minX <= screenFrame.minX + 1
+            && windowBounds.maxX >= screenFrame.maxX - 1
+            && windowBounds.minY <= screenFrame.minY + 1
+            && windowBounds.maxY >= screenFrame.maxY - 1
+    }
+
+    /// Prefer a definite on-screen window verdict so an external-display
+    /// full-screen app does not hide the island on the notched screen.
+    /// On a single display, presentation options still catch exclusive
+    /// capture that publishes no covering window. Fall back to presentation
+    /// when the window list is unavailable.
+    static func isFullscreenAppActive(
+        windowCoversIslandScreen: Bool?,
+        presentationLooksFullscreen: Bool,
+        screenCount: Int
+    ) -> Bool {
+        if windowCoversIslandScreen == true { return true }
+        if windowCoversIslandScreen == false && screenCount > 1 { return false }
+        return presentationLooksFullscreen
+    }
+}
+
 /// Rejects stale delayed completions after rapid toggles.
 struct DynamicIslandVisibilityTransitionTracker {
     private(set) var current = 0

--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -113,18 +113,17 @@ enum DynamicIslandFullscreenPolicy {
             && windowBounds.maxY >= screenFrame.maxY - 1
     }
 
-    /// Prefer a definite on-screen window verdict so an external-display
-    /// full-screen app does not hide the island on the notched screen.
-    /// On a single display, presentation options still catch exclusive
-    /// capture that publishes no covering window. Fall back to presentation
-    /// when the window list is unavailable.
+    /// Only the island's own screen counts. A covering window on that screen
+    /// is decisive. Presentation options are system-wide, so they may only
+    /// break a tie on a single display (or when the window list is missing
+    /// there). Multiple displays never hide from presentation alone.
     static func isFullscreenAppActive(
         windowCoversIslandScreen: Bool?,
         presentationLooksFullscreen: Bool,
         screenCount: Int
     ) -> Bool {
         if windowCoversIslandScreen == true { return true }
-        if windowCoversIslandScreen == false && screenCount > 1 { return false }
+        if screenCount > 1 { return false }
         return presentationLooksFullscreen
     }
 }

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -548,10 +548,8 @@ final class DynamicIslandController: NSObject {
         applyPresence()
     }
 
-    /// On-screen window coverage of the island's screen is the source of
-    /// truth so a full-screen app on an external display does not hide the
-    /// island on the notched laptop. Presentation options are the fallback
-    /// when the window list cannot be read.
+    /// Hide only when a full-screen app occupies the island's own screen.
+    /// Presentation options are the single-display fallback.
     private func readFullscreenActive() -> Bool {
         let options = NSApp.currentSystemPresentationOptions
         let presentation = DynamicIslandFullscreenPolicy.presentationLooksFullscreen(

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -138,6 +138,9 @@ final class DynamicIslandController: NSObject {
     /// Keeps the transparent panel click-through during transitions.
     private var acceptsIslandInteraction = false
     private var observers: [NSObjectProtocol] = []
+    /// Same-space / legacy full-screen often changes presentation options
+    /// without a Space or app-activation notification.
+    private var presentationObservation: NSKeyValueObservation?
     /// While > 0 a tray menu spawned from the island is open; hover-out must
     /// not collapse the island under the menu.
     private var menuHoldCount = 0
@@ -182,10 +185,17 @@ final class DynamicIslandController: NSObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in self?.handleFullscreenEnvironmentChange() }
         })
+        presentationObservation = NSApp.observe(
+            \.currentSystemPresentationOptions,
+            options: [.new]
+        ) { [weak self] _, _ in
+            Task { @MainActor [weak self] in self?.handleFullscreenEnvironmentChange() }
+        }
     }
 
     deinit {
         visibilityWorkItem?.cancel()
+        presentationObservation?.invalidate()
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
@@ -198,6 +208,7 @@ final class DynamicIslandController: NSObject {
 
     func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Self.enabledDefaultsKey)
+        fullscreenActive = readFullscreenActive()
         applyPresence()
     }
 

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -141,6 +141,10 @@ final class DynamicIslandController: NSObject {
     /// While > 0 a tray menu spawned from the island is open; hover-out must
     /// not collapse the island under the menu.
     private var menuHoldCount = 0
+    /// True when a full-screen app occupies the island's screen. Independent
+    /// of `isEnabled` so turning the island off while full-screen does not
+    /// re-show it on exit.
+    private var fullscreenActive = false
 
     init(viewModel: DashboardViewModel) {
         self.viewModel = viewModel
@@ -151,7 +155,10 @@ final class DynamicIslandController: NSObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.repositionPanel() }
+            Task { @MainActor [weak self] in
+                self?.handleFullscreenEnvironmentChange()
+                self?.repositionPanel()
+            }
         })
         observers.append(NotificationCenter.default.addObserver(
             forName: .nativeSettingsChanged,
@@ -160,12 +167,28 @@ final class DynamicIslandController: NSObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in self?.state.settingsTick += 1 }
         })
+        let workspace = NSWorkspace.shared.notificationCenter
+        observers.append(workspace.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.handleFullscreenEnvironmentChange() }
+        })
+        observers.append(workspace.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.handleFullscreenEnvironmentChange() }
+        })
     }
 
     deinit {
         visibilityWorkItem?.cancel()
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
         }
     }
 
@@ -175,15 +198,17 @@ final class DynamicIslandController: NSObject {
 
     func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Self.enabledDefaultsKey)
-        if enabled { show() } else { hide() }
+        applyPresence()
     }
 
     /// Re-show the island on launch if it was enabled when the app last quit.
     func restoreIfNeeded() {
-        if isEnabled { show() }
+        fullscreenActive = readFullscreenActive()
+        applyPresence()
     }
 
     func show() {
+        guard shouldShowPanel else { return }
         let panel = panel ?? makePanel()
         self.panel = panel
         let wasVisible = state.isPanelVisible && panel.isVisible
@@ -216,7 +241,7 @@ final class DynamicIslandController: NSObject {
         DispatchQueue.main.async { [weak self, weak panel] in
             guard let self, let panel,
                   self.visibilityTransitions.owns(transition),
-                  self.isEnabled
+                  self.shouldShowPanel
             else { return }
             panel.alphaValue = 1
             withAnimation(.timingCurve(0.16, 1, 0.3, 1, duration: DynamicIslandVisibilityPolicy.showDuration)) {
@@ -226,7 +251,7 @@ final class DynamicIslandController: NSObject {
                 after: DynamicIslandVisibilityPolicy.showDuration,
                 transition: transition
             ) { controller in
-                guard controller.isEnabled else { return }
+                guard controller.shouldShowPanel else { return }
                 controller.acceptsIslandInteraction = true
                 controller.panel?.updateHitRegion()
             }
@@ -265,7 +290,7 @@ final class DynamicIslandController: NSObject {
             after: DynamicIslandVisibilityPolicy.hideCompletionDelay,
             transition: transition
         ) { controller in
-            guard !controller.isEnabled else { return }
+            guard !controller.shouldShowPanel else { return }
             controller.state.isPanelVisible = false
             controller.panel?.orderOut(nil)
         }
@@ -489,6 +514,97 @@ final class DynamicIslandController: NSObject {
         return NSRect(x: x, y: y, width: width, height: height)
     }
 
+    // MARK: - Full-screen presence
+
+    private var shouldShowPanel: Bool {
+        DynamicIslandFullscreenPolicy.shouldShowPanel(
+            featureEnabled: isEnabled,
+            fullscreenActive: fullscreenActive
+        )
+    }
+
+    private func applyPresence() {
+        if shouldShowPanel {
+            guard !(state.isPanelVisible && panel?.isVisible == true) else { return }
+            show()
+        } else {
+            hide()
+        }
+    }
+
+    private func handleFullscreenEnvironmentChange() {
+        fullscreenActive = readFullscreenActive()
+        applyPresence()
+    }
+
+    /// On-screen window coverage of the island's screen is the source of
+    /// truth so a full-screen app on an external display does not hide the
+    /// island on the notched laptop. Presentation options are the fallback
+    /// when the window list cannot be read.
+    private func readFullscreenActive() -> Bool {
+        let options = NSApp.currentSystemPresentationOptions
+        let presentation = DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+            containsFullScreen: options.contains(.fullScreen),
+            hidesMenuBar: options.contains(.hideMenuBar),
+            hidesDock: options.contains(.hideDock)
+        )
+        return DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+            windowCoversIslandScreen: islandScreenHasFullscreenWindow(),
+            presentationLooksFullscreen: presentation,
+            screenCount: NSScreen.screens.count
+        )
+    }
+
+    private static let fullscreenIgnoredWindowOwners: Set<String> = [
+        "Dock", "Window Server", "WindowServer", "SystemUIServer",
+        "Control Center", "Notification Centre", "Notification Center",
+    ]
+
+    /// `nil` when the window list is unavailable so the caller can fall back.
+    private func islandScreenHasFullscreenWindow() -> Bool? {
+        guard let screen = targetScreen(),
+              let primary = NSScreen.screens.first
+        else { return false }
+        let cgOptions = CGWindowListOption(arrayLiteral: .optionOnScreenOnly, .excludeDesktopElements)
+        guard let infoList = CGWindowListCopyWindowInfo(cgOptions, kCGNullWindowID) as? [[String: Any]] else {
+            return nil
+        }
+
+        let screenFrame = screen.frame
+        let primaryMaxY = primary.frame.maxY
+
+        for info in infoList {
+            if let alpha = info[kCGWindowAlpha as String] as? NSNumber, alpha.doubleValue <= 0 {
+                continue
+            }
+            // Dock (20) / menu bar (24) can report screen-sized frames.
+            // Screensaver (1000) should still hide the island.
+            let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            if layer >= 20 && layer < 1000 { continue }
+            if let owner = info[kCGWindowOwnerName as String] as? String,
+               Self.fullscreenIgnoredWindowOwners.contains(owner) {
+                continue
+            }
+            // kCGWindowBounds is a CFDictionary of NSNumbers; a Swift
+            // `[String: CGFloat]` cast drops every real window.
+            guard let boundsDict = info[kCGWindowBounds as String] as? NSDictionary else { continue }
+            var quartzRect = CGRect.zero
+            guard CGRectMakeWithDictionaryRepresentation(boundsDict, &quartzRect) else { continue }
+
+            let windowBounds = DynamicIslandFullscreenPolicy.appKitRect(
+                fromQuartz: quartzRect,
+                primaryMaxY: primaryMaxY
+            )
+            if DynamicIslandFullscreenPolicy.windowCoversScreenIncludingMenuBar(
+                windowBounds: windowBounds,
+                screenFrame: screenFrame
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
     /// Recompute geometry and re-pin to the current target screen (display
     /// plug/unplug, lid close, resolution change).
     private func repositionPanel() {
@@ -564,9 +680,10 @@ final class DynamicIslandController: NSObject {
         // shadow would trace the transparent frame rect instead.
         panel.hasShadow = false
         // Sit above the menu bar so the island hugs the notch, ride along to
-        // every Space / full-screen app, stay out of Cmd-Tab.
+        // every regular Space, stay out of Cmd-Tab. Omit .fullScreenAuxiliary
+        // so the island does not overlay another app's full-screen Space.
         panel.level = .statusBar
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
         panel.acceptsMouseMovedEvents = true

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -147,4 +147,142 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
         XCTAssertFalse(tracker.owns(closing))
         XCTAssertTrue(tracker.owns(reopening))
     }
+
+    func testPanelStaysHiddenWhileFeatureOffOrFullscreen() {
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.shouldShowPanel(
+                featureEnabled: true,
+                fullscreenActive: false
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.shouldShowPanel(
+                featureEnabled: true,
+                fullscreenActive: true
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.shouldShowPanel(
+                featureEnabled: false,
+                fullscreenActive: false
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.shouldShowPanel(
+                featureEnabled: false,
+                fullscreenActive: true
+            )
+        )
+    }
+
+    func testPresentationFullscreenIgnoresPartialMenuBarOrDockHide() {
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+                containsFullScreen: true,
+                hidesMenuBar: false,
+                hidesDock: false
+            )
+        )
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+                containsFullScreen: false,
+                hidesMenuBar: true,
+                hidesDock: true
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+                containsFullScreen: false,
+                hidesMenuBar: true,
+                hidesDock: false
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+                containsFullScreen: false,
+                hidesMenuBar: false,
+                hidesDock: true
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.presentationLooksFullscreen(
+                containsFullScreen: false,
+                hidesMenuBar: false,
+                hidesDock: false
+            )
+        )
+    }
+
+    func testWindowCoverageTreatsMenuBarOverlapAsFullscreenNotZoom() {
+        let screen = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let fullscreen = screen
+        let zoomed = CGRect(x: 0, y: 0, width: 1_440, height: 875)
+        let splitHalf = CGRect(x: 0, y: 0, width: 720, height: 900)
+
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.windowCoversScreenIncludingMenuBar(
+                windowBounds: fullscreen,
+                screenFrame: screen
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.windowCoversScreenIncludingMenuBar(
+                windowBounds: zoomed,
+                screenFrame: screen
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.windowCoversScreenIncludingMenuBar(
+                windowBounds: splitHalf,
+                screenFrame: screen
+            )
+        )
+    }
+
+    func testQuartzBoundsConvertAgainstPrimaryDisplayTop() {
+        let converted = DynamicIslandFullscreenPolicy.appKitRect(
+            fromQuartz: CGRect(x: 100, y: 0, width: 200, height: 50),
+            primaryMaxY: 900
+        )
+
+        XCTAssertEqual(converted, CGRect(x: 100, y: 850, width: 200, height: 50))
+    }
+
+    func testFullscreenVerdictPrefersWindowCoverageOverPresentation() {
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+                windowCoversIslandScreen: false,
+                presentationLooksFullscreen: true,
+                screenCount: 2
+            )
+        )
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+                windowCoversIslandScreen: false,
+                presentationLooksFullscreen: true,
+                screenCount: 1
+            )
+        )
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+                windowCoversIslandScreen: true,
+                presentationLooksFullscreen: false,
+                screenCount: 2
+            )
+        )
+        XCTAssertTrue(
+            DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+                windowCoversIslandScreen: nil,
+                presentationLooksFullscreen: true,
+                screenCount: 2
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandFullscreenPolicy.isFullscreenAppActive(
+                windowCoversIslandScreen: nil,
+                presentationLooksFullscreen: false,
+                screenCount: 1
+            )
+        )
+    }
 }

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -270,7 +270,7 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
                 screenCount: 2
             )
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             DynamicIslandFullscreenPolicy.isFullscreenAppActive(
                 windowCoversIslandScreen: nil,
                 presentationLooksFullscreen: true,

--- a/test/dynamic-island-fullscreen-guardrails.test.js
+++ b/test/dynamic-island-fullscreen-guardrails.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const controllerSource = fs.readFileSync(
+  path.join(
+    __dirname,
+    "../TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift",
+  ),
+  "utf8",
+);
+
+const policySource = fs.readFileSync(
+  path.join(
+    __dirname,
+    "../TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift",
+  ),
+  "utf8",
+);
+
+test("the island leaves another app's full-screen Space instead of overlaying it", () => {
+  const behaviorMatch = controllerSource.match(
+    /panel\.collectionBehavior\s*=\s*\[([^\]]+)\]/,
+  );
+  assert.ok(behaviorMatch, "island panel must set an explicit collectionBehavior");
+  assert.match(behaviorMatch[1], /\.canJoinAllSpaces\b/);
+  assert.doesNotMatch(
+    behaviorMatch[1],
+    /\.fullScreenAuxiliary\b/,
+    "fullScreenAuxiliary would keep the island on top of native full-screen Spaces",
+  );
+});
+
+test("island presence is gated on a testable full-screen policy", () => {
+  assert.match(
+    policySource,
+    /enum\s+DynamicIslandFullscreenPolicy/,
+    "full-screen decisions must live in a pure policy, not only AppKit glue",
+  );
+  assert.match(
+    policySource,
+    /static\s+func\s+shouldShowPanel\(featureEnabled:\s*Bool,\s*fullscreenActive:\s*Bool\)/,
+  );
+  assert.match(
+    controllerSource,
+    /DynamicIslandFullscreenPolicy\.shouldShowPanel\(/,
+    "the controller must consult the policy before showing the panel",
+  );
+  assert.match(
+    controllerSource,
+    /NSWorkspace\.activeSpaceDidChangeNotification/,
+    "space changes (native full-screen enter/exit) must refresh presence",
+  );
+  assert.match(
+    controllerSource,
+    /NSWorkspace\.didActivateApplicationNotification/,
+    "app switches must refresh presence so a newly focused full-screen app hides the island",
+  );
+  assert.match(
+    controllerSource,
+    /CGRectMakeWithDictionaryRepresentation/,
+    "window bounds must come from the CFDictionary helper; a [String: CGFloat] cast drops real window lists",
+  );
+});

--- a/test/dynamic-island-fullscreen-guardrails.test.js
+++ b/test/dynamic-island-fullscreen-guardrails.test.js
@@ -59,6 +59,16 @@ test("island presence is gated on a testable full-screen policy", () => {
   );
   assert.match(
     controllerSource,
+    /NSApp\.observe\(\s*\\\.currentSystemPresentationOptions/,
+    "same-space full-screen changes presentation options without a Space or app switch",
+  );
+  assert.match(
+    controllerSource,
+    /func setEnabled\([\s\S]*?fullscreenActive = readFullscreenActive\(\)[\s\S]*?applyPresence\(\)/,
+    "enabling the island must re-read full-screen state so it does not appear over an already full-screen app",
+  );
+  assert.match(
+    controllerSource,
     /CGRectMakeWithDictionaryRepresentation/,
     "window bounds must come from the CFDictionary helper; a [String: CGFloat] cast drops real window lists",
   );


### PR DESCRIPTION
## Summary

灵动岛所在屏幕有应用全屏时自动隐藏，退出后恢复。不改用户开关。

外接屏全屏不影响；最大化或系统自动隐藏菜单栏/Dock 不触发。

## Scope

- [x] macOS app (`TokenTrackerBar/`)

## Checklist

- [x] 相关 JS guardrail 通过
- [x] 无新增用户文案
- [x] conventional commit
- [ ] 本机无 Xcode.app，XCTest 未跑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Dynamic Island panel now automatically hides while an app or window is in full-screen mode.
  * Panel visibility updates correctly when switching apps, entering or leaving full-screen Spaces, or changing display configurations.
  * The panel no longer appears over full-screen content, including windows covering an entire display.
  * Visibility continues to respect the Dynamic Island feature setting.
  * Full-screen detection now accounts for system presentation settings and display changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->