### PR TITLE
fix: allow scrolling trend tooltip model list

### DIFF
--- a/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
+++ b/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
@@ -485,6 +485,17 @@ export function TrendMonitor({
     }, 150);
   }, []);
 
+  const handleTooltipMouseEnter = React.useCallback(() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  }, []);
+
+  const handleTooltipMouseLeave = React.useCallback(() => {
+    handleBarMouseLeave();
+  }, [handleBarMouseLeave]);
+
   return (
     <div
       ref={containerRef}
@@ -610,7 +621,10 @@ export function TrendMonitor({
       {/* 2D 精致 Hover Tooltip */}
       {hoveredBar && (
         <div
-          className="absolute z-[9999] w-0 h-0 transition-all duration-100 ease-out pointer-events-none"
+          data-trend-tooltip="true"
+          onMouseEnter={handleTooltipMouseEnter}
+          onMouseLeave={handleTooltipMouseLeave}
+          className="absolute z-[9999] w-0 h-0 transition-all duration-100 ease-out"
           style={{
             left: `${tooltipPos.x}px`,
             top: `${tooltipPos.y}px`,

--- a/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // The zoom modal pulls in use-trend-data (a .ts hook imported with a .js
 // specifier) which vitest's resolver can't follow the way the Vite build does.
@@ -25,6 +25,10 @@ describe("getTrendMonitorScale", () => {
 });
 
 describe("TrendMonitor", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps normal bars visible when a single day is an outlier", () => {
     const rows = [80, 90, 95, 110, 120, 140, 10000].map((value) => ({
       billable_total_tokens: value,
@@ -113,6 +117,33 @@ describe("TrendMonitor", () => {
       <TrendMonitor rows={rows} zoomConfig={{ baseUrl: "http://localhost" }} showTimeZoneLabel={false} />,
     );
     expect(withCfg.queryByRole("button")).not.toBeNull();
+  });
+
+  it("keeps the scrollable tooltip open while the pointer moves from a bar into it", () => {
+    vi.useFakeTimers();
+    const models = Object.fromEntries(
+      Array.from({ length: 8 }, (_, index) => [`model-${index + 1}`, 100 - index]),
+    );
+    const { container } = render(
+      <TrendMonitor
+        rows={[{ billable_total_tokens: 772, models }]}
+        showTimeZoneLabel={false}
+      />,
+    );
+
+    const bar = container.querySelector('[data-trend-bar="true"]');
+    fireEvent.mouseEnter(bar);
+    const tooltip = container.querySelector('[data-trend-tooltip="true"]');
+    expect(tooltip).not.toBeNull();
+
+    fireEvent.mouseLeave(bar);
+    fireEvent.mouseEnter(tooltip);
+    act(() => vi.advanceTimersByTime(200));
+    expect(container.querySelector('[data-trend-tooltip="true"]')).not.toBeNull();
+
+    fireEvent.mouseLeave(tooltip);
+    act(() => vi.advanceTimersByTime(200));
+    expect(container.querySelector('[data-trend-tooltip="true"]')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- let the trend tooltip receive pointer and wheel events
- keep it open while moving from a bar into the tooltip
- close it after the pointer leaves the tooltip
- add a regression test for the delayed hover handoff

## Validation

- `npm test -- --run src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx`
- `npm run typecheck`
- dashboard lint, full test suite, and production build
- real in-app-browser mouse/wheel validation with 8 models in both normal and enlarged charts

Fixes #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trend chart tooltips so they remain visible when moving the pointer from a chart bar into the tooltip.
  * Tooltips now close reliably after the pointer leaves and the hide delay completes.

* **Tests**
  * Added regression coverage for tooltip hover and delayed-dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->