### PR TITLE
feat(sync): 将 Grok Build 用量记入项目用量

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2282,6 +2282,11 @@ async function cmdSync(argv, context = {}) {
           sessionId: hookSessionId,
           sessionDir:
             typeof grokHookSignal.sessionDir === "string" ? grokHookSignal.sessionDir : undefined,
+          cwd: typeof grokHookSignal.cwd === "string" ? grokHookSignal.cwd : undefined,
+          encodedCwd:
+            typeof grokHookSignal.sessionDir === "string" && grokHookSignal.sessionDir
+              ? path.basename(path.dirname(grokHookSignal.sessionDir))
+              : undefined,
           updatesPath:
             typeof grokHookSignal.updatesPath === "string" ? grokHookSignal.updatesPath : undefined,
           signalsPath:
@@ -2311,6 +2316,7 @@ async function cmdSync(argv, context = {}) {
           sessions: grokSessionInputs,
           cursors,
           queuePath,
+          projectQueuePath,
           env: process.env,
           onProgress: (p) => {
             if (!progress?.enabled) return;

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2260,7 +2260,12 @@ async function cmdSync(argv, context = {}) {
     }
 
     // ── Grok Build (xAI) ──
-    let grokResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    let grokResult = {
+      recordsProcessed: 0,
+      eventsAggregated: 0,
+      bucketsQueued: 0,
+      projectBucketsQueued: 0,
+    };
     // Full passive scan of all Grok sessions (historical + any not covered by hook)
     const grokSessions = sourceAllowed("grok") ? resolveGrokBuildSessions(process.env) : [];
     const grokSessionInputs = [...grokSessions];
@@ -2333,6 +2338,8 @@ async function cmdSync(argv, context = {}) {
         recordsProcessed: grokResult.recordsProcessed + grokScanResult.recordsProcessed,
         eventsAggregated: grokResult.eventsAggregated + grokScanResult.eventsAggregated,
         bucketsQueued: grokResult.bucketsQueued + grokScanResult.bucketsQueued,
+        projectBucketsQueued:
+          (grokResult.projectBucketsQueued || 0) + (grokScanResult.projectBucketsQueued || 0),
       };
     }
     if (isFullSourceScan && opts.repairGrok) {
@@ -2761,6 +2768,7 @@ async function cmdSync(argv, context = {}) {
       cursorStore.requiresCommit !== true &&
       totalParsed === 0 &&
       totalBuckets === 0 &&
+      !(grokResult.projectBucketsQueued > 0) &&
       !codexColdAuditDue &&
       !codexFallbackRetryRan &&
       !grokHookSignalConsumed &&

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15673,6 +15673,21 @@ async function retractStaleGrokQueueRows(queuePath, keepKeys) {
   return lines.length;
 }
 
+function pruneMissingGrokProjectUpdateOffsets(projectUpdateOffsets) {
+  if (!projectUpdateOffsets || typeof projectUpdateOffsets !== "object") return;
+  for (const updatesPath of Object.keys(projectUpdateOffsets)) {
+    if (typeof updatesPath !== "string" || !updatesPath) {
+      delete projectUpdateOffsets[updatesPath];
+      continue;
+    }
+    try {
+      if (!fssync.existsSync(updatesPath)) delete projectUpdateOffsets[updatesPath];
+    } catch {
+      delete projectUpdateOffsets[updatesPath];
+    }
+  }
+}
+
 function grokTryDecodeUriComponent(value) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -16106,6 +16121,8 @@ async function parseGrokBuildIncremental({
       onProgress({ index: index + 1, total: sessionList.length, bucketsQueued: touchedBuckets.size });
     }
   }
+
+  if (projectEnabled) pruneMissingGrokProjectUpdateOffsets(projectUpdateOffsets);
 
   let bucketsQueued = queuePath
     ? await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets })

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15673,10 +15673,46 @@ async function retractStaleGrokQueueRows(queuePath, keepKeys) {
   return lines.length;
 }
 
+function grokTryDecodeUriComponent(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const decoded = decodeURIComponent(trimmed).trim();
+    return decoded || null;
+  } catch {
+    return null;
+  }
+}
+
+function grokEncodedCwdLooksEncoded(value) {
+  return typeof value === "string" && /%[0-9A-Fa-f]{2}/.test(value);
+}
+
+// First non-empty wins: summary.info.cwd, hook sess.cwd, decode(encodedCwd),
+// then decode(basename(dirname(sessionDir))). Do not guess from updates.jsonl.
+function resolveGrokSessionCwd(sess, summary) {
+  const summaryCwd = summary?.info?.cwd;
+  if (typeof summaryCwd === "string" && summaryCwd.trim()) return summaryCwd.trim();
+  if (typeof sess?.cwd === "string" && sess.cwd.trim()) return sess.cwd.trim();
+  if (grokEncodedCwdLooksEncoded(sess?.encodedCwd)) {
+    const decoded = grokTryDecodeUriComponent(sess.encodedCwd);
+    if (decoded) return decoded;
+  }
+  const sessionDir = typeof sess?.sessionDir === "string" ? sess.sessionDir.trim() : "";
+  if (sessionDir) {
+    const decoded = grokTryDecodeUriComponent(path.basename(path.dirname(sessionDir)));
+    if (decoded) return decoded;
+  }
+  return null;
+}
+
 async function parseGrokBuildIncremental({
   sessions,
   cursors = {},
   queuePath,
+  projectQueuePath,
+  publicRepoResolver,
   onProgress,
   env = process.env
 } = {}) {
@@ -15720,6 +15756,25 @@ async function parseGrokBuildIncremental({
     typeof grokState.updateOffsets === "object"
       ? grokState.updateOffsets
       : {};
+
+  const projectEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
+  const projectState = projectEnabled ? normalizeProjectState(cursors?.projectHourly) : null;
+  const projectTouchedBuckets = projectEnabled ? new Set() : null;
+  const projectMetaCache = projectEnabled ? new Map() : null;
+  const publicRepoCache = projectEnabled ? new Map() : null;
+  // Independent of global updateOffsets so an upgrade can backfill historical
+  // turn_completed events into project.queue.jsonl without re-appending totals.
+  const projectUpdateOffsets =
+    projectEnabled &&
+    grokState.projectUpdateOffsets &&
+    typeof grokState.projectUpdateOffsets === "object"
+      ? { ...grokState.projectUpdateOffsets }
+      : {};
+  const projectSessionSnapshots = projectEnabled
+    ? normalizeGrokSessionSnapshots({
+        sessionSnapshots: grokState.projectSessionSnapshots,
+      })
+    : {};
 
   // Rebuilt from the sessions seen this scan, so entries for deleted session
   // dirs are pruned and the cursor stays bounded by the on-disk session count.
@@ -15893,6 +15948,160 @@ async function parseGrokBuildIncremental({
       };
     }
 
+    if (projectEnabled) {
+      const cwd = resolveGrokSessionCwd(sess, summary);
+      if (cwd) {
+        const projectContext = await resolveProjectContextForPath({
+          startDir: wsl.mapWslCwdToUnc(cwd, updatesPath || sess?.sessionDir || cwd),
+          projectMetaCache,
+          publicRepoCache,
+          publicRepoResolver,
+          projectState,
+        });
+        const projectRef = projectContext?.projectRef || null;
+        const projectKey = projectContext?.projectKey || null;
+        // Only advance the project cursor on successful public_verified attribution.
+        // Blocked / missing git / unverified stay unadvanced so a later sync can retry.
+        if (projectKey && projectRef) {
+          const projectPrevious = projectSessionSnapshots[sessionId] || {};
+          const projectPreviousTotal = normalizeNonNegativeNumber(projectPrevious.totalTokens);
+          const projectPreviousMessageCount = normalizeNonNegativeNumber(
+            projectPrevious.messageCount,
+          );
+          let projectSawTurnUsage = projectPrevious.source === "turn_usage";
+          let projectCumulativeTotal = projectPreviousTotal;
+          let projectTokenDelta = 0;
+          let projectFinalTouchedHourStart = null;
+          let projectSource = projectPrevious.source || null;
+          let projectLastModel = projectPrevious.model || model;
+          const projectPendingDeltas = [];
+
+          const projectUpdates = await readGrokUpdateTokenEvents(
+            updatesPath,
+            lastActive,
+            updatesPath ? projectUpdateOffsets[updatesPath] : null,
+            { fallbackModel: model },
+          );
+
+          for (const event of projectUpdates.turnEvents) {
+            projectSawTurnUsage = true;
+            const hourStartStr =
+              toUtcHalfHourStart(event.timestamp) ||
+              toUtcHalfHourStart(lastActive) ||
+              toUtcHalfHourStart(Date.now());
+            if (!hourStartStr) continue;
+            const eventModel = event.model || model;
+            const delta = {
+              input_tokens: event.input_tokens,
+              cached_input_tokens: event.cached_input_tokens,
+              cache_creation_input_tokens: event.cache_creation_input_tokens,
+              output_tokens: event.output_tokens,
+              reasoning_output_tokens: event.reasoning_output_tokens,
+              total_tokens: event.total_tokens,
+              billable_total_tokens: event.billable_total_tokens,
+              conversation_count: event.conversation_count || 1,
+            };
+            projectPendingDeltas.push({ model: eventModel, hourStartStr, delta });
+            projectCumulativeTotal += event.total_tokens;
+            projectTokenDelta += event.total_tokens;
+            projectFinalTouchedHourStart = hourStartStr;
+            projectSource = "turn_usage";
+            projectLastModel = eventModel;
+          }
+
+          // Watermark fallback uses the independent project snapshot, never
+          // global sessionSnapshots.totalTokens, and never stacks on turn usage.
+          if (!projectSawTurnUsage) {
+            let highWatermark = projectPreviousTotal;
+            for (const event of projectUpdates.contextEvents) {
+              if (event.totalTokens <= highWatermark) continue;
+              const deltaTokens = event.totalTokens - highWatermark;
+              highWatermark = event.totalTokens;
+              const hourStartStr =
+                toUtcHalfHourStart(event.timestamp) ||
+                toUtcHalfHourStart(lastActive) ||
+                toUtcHalfHourStart(Date.now());
+              if (!hourStartStr) continue;
+              const delta = estimateGrokTokenDelta(deltaTokens, 0, {
+                allowZeroConversationCount: true,
+              });
+              projectPendingDeltas.push({ model, hourStartStr, delta });
+              projectTokenDelta += deltaTokens;
+              projectFinalTouchedHourStart = hourStartStr;
+              projectSource = "updates";
+            }
+
+            const effectiveSignalTotal = grokEffectiveTotalFromSignals(safeSignals);
+            if (effectiveSignalTotal > highWatermark) {
+              const deltaTokens = effectiveSignalTotal - highWatermark;
+              highWatermark = effectiveSignalTotal;
+              const hourStartStr =
+                toUtcHalfHourStart(lastActive) || toUtcHalfHourStart(Date.now());
+              if (hourStartStr) {
+                const delta = estimateGrokTokenDelta(deltaTokens, 0, {
+                  allowZeroConversationCount: true,
+                });
+                projectPendingDeltas.push({ model, hourStartStr, delta });
+                projectTokenDelta += deltaTokens;
+                projectFinalTouchedHourStart = hourStartStr;
+                projectSource = "signals";
+              }
+            }
+            projectCumulativeTotal = Math.max(projectPreviousTotal, highWatermark);
+          }
+
+          const projectFinalTotal = Math.max(projectPreviousTotal, projectCumulativeTotal);
+
+          // legacyBaselineOnly applies only to global buckets.
+          for (const pending of projectPendingDeltas) {
+            const projectBucket = getProjectBucket(
+              projectState,
+              projectKey,
+              "grok",
+              pending.hourStartStr,
+              projectRef,
+            );
+            addTotals(projectBucket.totals, pending.delta);
+            projectTouchedBuckets.add(
+              projectBucketKey(projectKey, "grok", pending.hourStartStr),
+            );
+          }
+
+          if (!projectSawTurnUsage && projectTokenDelta > 0 && projectFinalTouchedHourStart) {
+            const deltaMessageCount =
+              messageCount > projectPreviousMessageCount
+                ? messageCount - projectPreviousMessageCount
+                : 1;
+            const projectBucket = getProjectBucket(
+              projectState,
+              projectKey,
+              "grok",
+              projectFinalTouchedHourStart,
+              projectRef,
+            );
+            addTotals(projectBucket.totals, { conversation_count: deltaMessageCount });
+            projectTouchedBuckets.add(
+              projectBucketKey(projectKey, "grok", projectFinalTouchedHourStart),
+            );
+          }
+
+          if (updatesPath && projectUpdates.offsetEntry) {
+            projectUpdateOffsets[updatesPath] = projectUpdates.offsetEntry;
+          }
+
+          if (projectFinalTotal > 0 && (projectTokenDelta > 0 || projectPreviousTotal > 0)) {
+            projectSessionSnapshots[sessionId] = {
+              totalTokens: projectFinalTotal,
+              messageCount: Math.max(projectPreviousMessageCount, messageCount),
+              model: projectLastModel || model,
+              source: projectSource || projectPrevious.source || null,
+              updatedAt: new Date().toISOString(),
+            };
+          }
+        }
+      }
+    }
+
     if (onProgress) {
       onProgress({ index: index + 1, total: sessionList.length, bucketsQueued: touchedBuckets.size });
     }
@@ -15915,8 +16124,20 @@ async function parseGrokBuildIncremental({
     bucketsQueued += retracted;
   }
 
+  const projectBucketsQueued = projectEnabled
+    ? await enqueueTouchedProjectBuckets({
+        projectQueuePath,
+        projectState,
+        projectTouchedBuckets,
+      })
+    : 0;
+
   hourlyState.updatedAt = new Date().toISOString();
   cursors.hourly = hourlyState;
+  if (projectState) {
+    projectState.updatedAt = hourlyState.updatedAt;
+    cursors.projectHourly = projectState;
+  }
   sessionSnapshots = capGrokSessionSnapshots(sessionSnapshots);
 
   const migrations = grokState.migrations && typeof grokState.migrations === "object"
@@ -15936,6 +16157,12 @@ async function parseGrokBuildIncremental({
     sessionSnapshots,
     seenSessions: Object.keys(sessionSnapshots),
     updateOffsets,
+    ...(projectEnabled
+      ? {
+          projectUpdateOffsets,
+          projectSessionSnapshots: capGrokSessionSnapshots(projectSessionSnapshots),
+        }
+      : {}),
     migrations,
     updatedAt: new Date().toISOString()
   };
@@ -15943,7 +16170,8 @@ async function parseGrokBuildIncremental({
   return {
     recordsProcessed: eventsAggregated,
     eventsAggregated,
-    bucketsQueued
+    bucketsQueued,
+    projectBucketsQueued,
   };
 }
 

--- a/test/grok-parser.test.js
+++ b/test/grok-parser.test.js
@@ -663,3 +663,65 @@ test("parseGrokBuildIncremental project backfill uses independent watermark snap
   );
 });
 
+test("parseGrokBuildIncremental drops project offsets for deleted session files", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-prune-git-"));
+  writeGitOrigin(repoDir, "https://github.com/acme/grok-project.git");
+
+  const keep = makeSession({
+    sessionId: "019f0000-keep-session",
+    cwd: repoDir,
+    summaryInfo: { cwd: repoDir },
+    turns: [grokTurnUsage()],
+  });
+  const drop = makeSession({
+    sessionId: "019f0000-drop-session",
+    cwd: repoDir,
+    summaryInfo: { cwd: repoDir },
+    turns: [grokTurnUsage({ promptId: "prompt-drop" })],
+  });
+  const keepUpdates = path.join(keep.sessionDir, "updates.jsonl");
+  const dropUpdates = path.join(drop.sessionDir, "updates.jsonl");
+  const queuePath = path.join(keep.root, "queue.jsonl");
+  const projectQueuePath = path.join(keep.root, "project.queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+
+  await parseGrokBuildIncremental({
+    sessions: [
+      { sessionDir: keep.sessionDir, sessionId: keep.sessionId, encodedCwd: keep.encodedCwd },
+      { sessionDir: drop.sessionDir, sessionId: drop.sessionId, encodedCwd: drop.encodedCwd },
+    ],
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: keep.env,
+  });
+  assert.ok(cursors.grok.projectUpdateOffsets[keepUpdates]);
+  assert.ok(cursors.grok.projectUpdateOffsets[dropUpdates]);
+
+  fs.rmSync(drop.sessionDir, { recursive: true, force: true });
+  const stalePath = path.join(keep.root, "missing-updates.jsonl");
+  cursors.grok.projectUpdateOffsets[stalePath] = { size: 12, mtimeMs: 1, ino: 1 };
+
+  await parseGrokBuildIncremental({
+    sessions: [
+      { sessionDir: keep.sessionDir, sessionId: keep.sessionId, encodedCwd: keep.encodedCwd },
+    ],
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: keep.env,
+  });
+  assert.ok(cursors.grok.projectUpdateOffsets[keepUpdates]);
+  assert.equal(cursors.grok.projectUpdateOffsets[dropUpdates], undefined);
+  assert.equal(cursors.grok.projectUpdateOffsets[stalePath], undefined);
+});
+
+test("sync.js does not skip cursor commit when Grok only queues project buckets", () => {
+  const src = fs.readFileSync(path.join(__dirname, "../src/commands/sync.js"), "utf8");
+  assert.match(src, /grokScanResult\.projectBucketsQueued/);
+  assert.match(src, /!\(grokResult\.projectBucketsQueued > 0\)/);
+});
+

--- a/test/grok-parser.test.js
+++ b/test/grok-parser.test.js
@@ -18,9 +18,11 @@ function makeSession({
   turns = [],
   contextMetas = [],
   signals = {},
+  cwd = "/tmp/project",
+  summaryInfo,
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-parser-"));
-  const encodedCwd = encodeURIComponent("/tmp/project");
+  const encodedCwd = encodeURIComponent(cwd);
   const sessionDir = path.join(root, "sessions", encodedCwd, sessionId);
   fs.mkdirSync(sessionDir, { recursive: true });
 
@@ -85,17 +87,46 @@ function makeSession({
       ...signals,
     }),
   );
-  fs.writeFileSync(
-    path.join(sessionDir, "summary.json"),
-    JSON.stringify({ updated_at: "2026-07-18T10:00:00.000Z" }),
-  );
+  const summary = { updated_at: "2026-07-18T10:00:00.000Z" };
+  if (summaryInfo && typeof summaryInfo === "object") summary.info = summaryInfo;
+  fs.writeFileSync(path.join(sessionDir, "summary.json"), JSON.stringify(summary));
 
   return {
     root,
     sessionDir,
     sessionId,
+    cwd,
+    encodedCwd,
     env: { TOKENTRACKER_GROK_HOME: root, GROK_HOME: root },
   };
+}
+
+function writeGitOrigin(repoDir, url) {
+  fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(repoDir, ".git", "config"), `[remote "origin"]\n\turl = ${url}\n`);
+}
+
+function appendGrokTurn(sessionDir, turn, { timestampMs, eventId } = {}) {
+  const sessionId = path.basename(sessionDir);
+  const line = JSON.stringify({
+    timestamp: Math.floor((timestampMs || Date.now()) / 1000),
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "turn_completed",
+        prompt_id: turn.promptId || "prompt-growth",
+        stop_reason: "end_turn",
+        usage: turn.usage,
+      },
+      _meta: {
+        totalTokens: turn.contextWindowTokens ?? 12_000,
+        eventId: eventId || `${sessionId}-growth`,
+        agentTimestampMs: timestampMs || Date.now(),
+      },
+    },
+  });
+  fs.appendFileSync(path.join(sessionDir, "updates.jsonl"), `${line}\n`);
 }
 
 function readQueue(queuePath) {
@@ -357,3 +388,278 @@ test("v3 -> v4 migration rebuilds from turn usage and does not keep old watermar
   assert.equal(row.input_tokens, 80_000);
   assert.equal(row.output_tokens, 1_000);
 });
+
+function grokTurnUsage(overrides = {}) {
+  const { modelName = "grok-4.5-build", timestampMs, promptId, ...usageOverrides } = overrides;
+  const usage = {
+    inputTokens: 1000,
+    outputTokens: 200,
+    totalTokens: 1220,
+    cachedReadTokens: 100,
+    reasoningTokens: 20,
+    ...usageOverrides,
+  };
+  return {
+    usage: {
+      ...usage,
+      modelUsage: {
+        [modelName]: {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+          cachedReadTokens: usage.cachedReadTokens,
+          reasoningTokens: usage.reasoningTokens,
+        },
+      },
+    },
+    timestampMs: timestampMs || Date.parse("2026-07-18T10:05:00.000Z"),
+    promptId,
+  };
+}
+
+test("parseGrokBuildIncremental backfills project usage from session cwd", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-git-"));
+  writeGitOrigin(repoDir, "https://github.com/acme/grok-project.git");
+
+  const fixture = makeSession({
+    cwd: repoDir,
+    summaryInfo: { cwd: repoDir },
+    turns: [grokTurnUsage()],
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const projectQueuePath = path.join(fixture.root, "project.queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+
+  await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+  const globalRowsBefore = readQueue(queuePath).length;
+  assert.ok(globalRowsBefore > 0);
+  assert.equal(cursors.grok.version, 4);
+  assert.equal(fs.existsSync(projectQueuePath), false);
+
+  const result = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(readQueue(queuePath).length, globalRowsBefore, "project backfill must not re-emit global usage");
+  assert.equal(result.projectBucketsQueued, 1);
+  assert.equal(cursors.grok.version, 4);
+
+  const projectRows = readQueue(projectQueuePath);
+  assert.equal(projectRows.length, 1);
+  assert.equal(projectRows[0].source, "grok");
+  assert.equal(projectRows[0].project_key, "acme/grok-project");
+  assert.equal(projectRows[0].project_ref, "https://github.com/acme/grok-project");
+  assert.equal(projectRows[0].total_tokens, 1220);
+  assert.equal(projectRows[0].input_tokens, 900);
+  assert.equal(projectRows[0].cached_input_tokens, 100);
+  assert.equal(projectRows[0].output_tokens, 200);
+  assert.equal(projectRows[0].reasoning_output_tokens, 20);
+
+  const unchanged = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(unchanged.bucketsQueued, 0);
+  assert.equal(unchanged.projectBucketsQueued, 0);
+  assert.equal(readQueue(queuePath).length, globalRowsBefore);
+  assert.equal(readQueue(projectQueuePath).length, 1);
+
+  appendGrokTurn(
+    fixture.sessionDir,
+    grokTurnUsage({
+      inputTokens: 500,
+      outputTokens: 80,
+      totalTokens: 590,
+      cachedReadTokens: 50,
+      reasoningTokens: 10,
+      timestampMs: Date.parse("2026-07-18T10:20:00.000Z"),
+    }),
+    {
+      timestampMs: Date.parse("2026-07-18T10:20:00.000Z"),
+      eventId: `${fixture.sessionId}-growth`,
+    },
+  );
+
+  const growth = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(growth.bucketsQueued, 1);
+  assert.equal(growth.projectBucketsQueued, 1);
+  assert.equal(readQueue(queuePath).at(-1).total_tokens, 1810);
+  assert.equal(readQueue(projectQueuePath).at(-1).total_tokens, 1810);
+  assert.equal(readQueue(projectQueuePath).at(-1).conversation_count, 2);
+});
+
+test("parseGrokBuildIncremental attributes project usage from encodedCwd only", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-encoded-cwd-"));
+  writeGitOrigin(repoDir, "https://github.com/acme/grok-project.git");
+
+  const fixture = makeSession({
+    cwd: repoDir,
+    turns: [grokTurnUsage()],
+  });
+  const summaryPath = path.join(fixture.sessionDir, "summary.json");
+  fs.writeFileSync(summaryPath, JSON.stringify({ updated_at: "2026-07-18T10:00:00.000Z" }));
+
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const projectQueuePath = path.join(fixture.root, "project.queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+
+  const sessions = resolveGrokBuildSessions(fixture.env);
+  assert.equal(sessions.length, 1);
+  assert.ok(sessions[0].encodedCwd.includes("%"));
+  delete sessions[0].cwd;
+
+  const result = await parseGrokBuildIncremental({
+    sessions,
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(result.projectBucketsQueued, 1);
+  const projectRows = readQueue(projectQueuePath);
+  assert.equal(projectRows.length, 1);
+  assert.equal(projectRows[0].project_key, "acme/grok-project");
+  assert.equal(projectRows[0].source, "grok");
+  assert.equal(projectRows[0].total_tokens, 1220);
+});
+
+test("parseGrokBuildIncremental prefers hook sess.cwd over a non-git encodedCwd", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-hook-cwd-"));
+  writeGitOrigin(repoDir, "https://github.com/acme/grok-project.git");
+  const fixture = makeSession({
+    cwd: "/tmp/not-a-git-workspace",
+    turns: [grokTurnUsage()],
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const projectQueuePath = path.join(fixture.root, "project.queue.jsonl");
+  const sessions = resolveGrokBuildSessions(fixture.env);
+  sessions[0].cwd = repoDir;
+
+  const result = await parseGrokBuildIncremental({
+    sessions,
+    cursors: {
+      hourly: { version: 3, buckets: {}, groupQueued: {} },
+      grok: { version: 4 },
+    },
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(result.projectBucketsQueued, 1);
+  assert.equal(readQueue(projectQueuePath)[0].project_key, "acme/grok-project");
+});
+
+test("parseGrokBuildIncremental skips project attribution when cwd has no git", async () => {
+  const cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-nogit-"));
+  const fixture = makeSession({
+    cwd: cwdDir,
+    summaryInfo: { cwd: cwdDir },
+    turns: [grokTurnUsage()],
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const projectQueuePath = path.join(fixture.root, "project.queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+
+  const first = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.ok(first.bucketsQueued > 0);
+  assert.equal(first.projectBucketsQueued, 0);
+  assert.equal(fs.existsSync(projectQueuePath), false);
+  assert.equal(cursors.grok.version, 4);
+  const updatesPath = path.join(fixture.sessionDir, "updates.jsonl");
+  assert.equal(cursors.grok.projectUpdateOffsets?.[updatesPath], undefined);
+
+  writeGitOrigin(cwdDir, "https://github.com/acme/grok-project.git");
+  const retry = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(retry.bucketsQueued, 0);
+  assert.equal(retry.projectBucketsQueued, 1);
+  const projectRows = readQueue(projectQueuePath);
+  assert.equal(projectRows.length, 1);
+  assert.equal(projectRows[0].project_key, "acme/grok-project");
+  assert.equal(projectRows[0].total_tokens, 1220);
+});
+
+test("parseGrokBuildIncremental project backfill uses independent watermark snapshots", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-grok-wm-"));
+  writeGitOrigin(repoDir, "https://github.com/acme/grok-project.git");
+  const fixture = makeSession({
+    cwd: repoDir,
+    summaryInfo: { cwd: repoDir },
+    turns: [],
+    contextMetas: [5_000, 12_000, 8_000, 20_000],
+    signals: { contextTokensUsed: 18_000, totalTokensBeforeCompaction: 0 },
+  });
+  const queuePath = path.join(fixture.root, "queue.jsonl");
+  const projectQueuePath = path.join(fixture.root, "project.queue.jsonl");
+  const cursors = {
+    hourly: { version: 3, buckets: {}, groupQueued: {} },
+    grok: { version: 4 },
+  };
+
+  await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    env: fixture.env,
+  });
+  const globalRowsBefore = readQueue(queuePath).length;
+
+  const result = await parseGrokBuildIncremental({
+    sessions: resolveGrokBuildSessions(fixture.env),
+    cursors,
+    queuePath,
+    projectQueuePath,
+    env: fixture.env,
+  });
+  assert.equal(readQueue(queuePath).length, globalRowsBefore);
+  assert.equal(result.projectBucketsQueued, 1);
+  const projectRows = readQueue(projectQueuePath);
+  assert.equal(projectRows.length, 1);
+  assert.equal(projectRows[0].source, "grok");
+  assert.equal(projectRows[0].project_key, "acme/grok-project");
+  assert.equal(projectRows[0].total_tokens, 20_000);
+  assert.equal(cursors.grok.sessionSnapshots[fixture.sessionId].totalTokens, 20_000);
+  assert.equal(cursors.grok.projectSessionSnapshots[fixture.sessionId].totalTokens, 20_000);
+  assert.notEqual(
+    cursors.grok.projectUpdateOffsets,
+    cursors.grok.updateOffsets,
+  );
+});
+


### PR DESCRIPTION
## Summary

仪表盘「项目用量」统计不到 Grok Build。Grok 总用量已经进 `queue.jsonl`，但解析器从未写入 `project.queue.jsonl`，所以无法挂到仓库项目上。

这次把 `parseGrokBuildIncremental` 接到现有的 Claude/Codex/Droid/Omp 项目用量链路，并用独立的项目 cursor，已同步过的安装可以回填历史，而不会把总用量再记一遍。

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `node --test test/grok-parser.test.js`（11 pass）以及原有 Grok 回归测试（15 pass）
- [x] 无新增用户文案
- [x] commit 仍为 conventional English（`feat:` / `fix:` / …）
- [x] PR 说明写了原因，不只是改了什么

## 原因

项目用量只读 `project.queue.jsonl`。Grok session 其实已有可还原的工作目录（`summary.info.cwd`、URL 编码的 session 目录、SessionEnd hook 的 `cwd`），解析器没用。会话页能看到文件夹名，项目用量面板看不到。

## 行为

- 工作目录顺序：`summary.info.cwd` → hook `cwd` → `decodeURIComponent(encodedCwd)` → session 目录名
- 仅当 `projectKey && projectRef`（`public_verified`）才入队，隐私门槛与 Claude/Codex 相同
- 没有 git / 未验证的仓库不推进项目 cursor，之后还可以重试
- `legacyBaselineOnly` 只压总用量，不压项目回填
- `GROK_CURSOR_VERSION` 保持 4（不触发总用量重建）
- auto / 增量 sync 如果只写出项目用量，也会提交 cursor，避免下一轮重复入队
- 已删除 session 的 `projectUpdateOffsets` 会裁掉；仍在磁盘上的未验证 session 保留

## 测试

- 升级回填不会重写总用量
- 重复 sync 幂等
- 增量只追加 delta
- 没有 `summary.info.cwd` 时仍可用 encodedCwd
- 无 git：不写项目行；补上 `.git` 后能回填
- 无 `turn_completed` 时用水印快照，且与总用量 cursor 独立
- 删除 session 后裁剪项目 offset
- sync.js 在仅有项目桶时不会 skip cursor 提交

<details>
<summary><strong>Codex review context</strong></summary>

- **Delta since last Codex review:** `c5c73865` 修了项目-only auto sync 丢 cursor，以及已删 session 的 offset 膨胀
- **Intended behavior / invariants:** 不改变 Grok 总用量计数；回填不得再追加 `queue.jsonl`；只存储 `public_verified` 的 git remote
- **Edge cases covered:** 升级回填、幂等、增量、encodedCwd-only、无 git 重试、watermark、offset 裁剪、project-only cursor 提交
- **Tests run (command + result):** `node --test test/grok-parser.test.js` 11 pass；`node --test --test-name-pattern "parseGrokBuildIncremental|Grok" test/rollout-parser.test.js` 14 pass
- **Known gaps / out of scope:** 仪表盘/API 未改（已按 `row.source` 聚合）；未验证 session 每次 sync 重读是故意的

### Most likely regression surface

- Grok 全局 cursor / v4 turn-usage 迁移
- 项目 cursor 若绑到 `updateOffsets` 会双计

### Verification method (choose at least one)

- 上述解析器测试

### Uncovered scope

- 未跑完整 `npm test`
- 未做仪表盘点击验证（无 UI 改动）

</details>