### PR TITLE
fix(mac): 退出全屏后恢复灵动岛

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -129,19 +129,20 @@ enum DynamicIslandFullscreenPolicy {
     }
 }
 
-/// Persistent retry schedule for re-reading the full-screen window list.
-/// Extracted so the interval is unit-testable and the controller never
-/// hardcodes it.
+/// Coalesced settle schedule for re-reading the full-screen window list after
+/// an environment signal (space change, activation, presentation-options
+/// change). Extracted so the schedule is unit-testable and the controller
+/// never hardcodes it.
 enum DynamicIslandFullscreenRetryPolicy {
-    /// Low-frequency re-read interval while `isEnabled && fullscreenActive`.
+    /// Delays for a bounded re-read burst fired after an environment signal.
     /// A space-change notification can fire before the covering window is
-    /// dropped from the window list, so the first read can be stale; this
-    /// interval gives the window server time to settle. The retry keeps
-    /// running until restored, disabled, or deinit'd — it is not a bounded
-    /// burst, because the user may exit full-screen long after the last
-    /// notification fired (a 3-attempt burst would have exhausted during the
-    /// full-screen session itself).
-    static let retryInterval: TimeInterval = 1.0
+    /// dropped from the window list, so the first read (and often the second)
+    /// can still be stale; these delays give the window server time to
+    /// settle. Bounded, not a heartbeat: native full-screen enter/exit both
+    /// fire an observer, so a retry never has to survive an arbitrary gap
+    /// with no signal — it only has to outlast the window list's own catch-up
+    /// window after one has already fired.
+    static let settleDelays: [TimeInterval] = [0.15, 0.45, 1.0]
 }
 
 /// Restore-path decision during a mid-flight hide. When the island should

--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 
 /// Pure layout policy shared by the Dynamic Island controller and view.
 ///
@@ -126,6 +127,27 @@ enum DynamicIslandFullscreenPolicy {
         if screenCount > 1 { return false }
         return presentationLooksFullscreen
     }
+}
+
+/// Retry schedule for re-reading the full-screen window list after an
+/// environment change. Extracted so the intervals are unit-testable and the
+/// controller never hardcodes them.
+enum DynamicIslandFullscreenRetryPolicy {
+    /// Delayed re-reads after a space/presentation change. A space-change
+    /// notification can fire before `CGWindowListCopyWindowInfo` drops the
+    /// covering window, so the first read can be stale; these intervals give
+    /// the window server time to settle before we give up.
+    static let intervals: [TimeInterval] = [0.15, 0.5, 1.0]
+
+    /// Returns the next retry interval for the given zero-based attempt, or
+    /// nil when the schedule is exhausted.
+    static func nextInterval(attempt: Int) -> TimeInterval? {
+        guard attempt < intervals.count else { return nil }
+        return intervals[attempt]
+    }
+
+    /// Total number of retries the policy will schedule.
+    static let maxAttempts = intervals.count
 }
 
 /// Rejects stale delayed completions after rapid toggles.

--- a/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/DynamicIslandLayoutPolicy.swift
@@ -129,25 +129,34 @@ enum DynamicIslandFullscreenPolicy {
     }
 }
 
-/// Retry schedule for re-reading the full-screen window list after an
-/// environment change. Extracted so the intervals are unit-testable and the
-/// controller never hardcodes them.
+/// Persistent retry schedule for re-reading the full-screen window list.
+/// Extracted so the interval is unit-testable and the controller never
+/// hardcodes it.
 enum DynamicIslandFullscreenRetryPolicy {
-    /// Delayed re-reads after a space/presentation change. A space-change
-    /// notification can fire before `CGWindowListCopyWindowInfo` drops the
-    /// covering window, so the first read can be stale; these intervals give
-    /// the window server time to settle before we give up.
-    static let intervals: [TimeInterval] = [0.15, 0.5, 1.0]
+    /// Low-frequency re-read interval while `isEnabled && fullscreenActive`.
+    /// A space-change notification can fire before the covering window is
+    /// dropped from the window list, so the first read can be stale; this
+    /// interval gives the window server time to settle. The retry keeps
+    /// running until restored, disabled, or deinit'd — it is not a bounded
+    /// burst, because the user may exit full-screen long after the last
+    /// notification fired (a 3-attempt burst would have exhausted during the
+    /// full-screen session itself).
+    static let retryInterval: TimeInterval = 1.0
+}
 
-    /// Returns the next retry interval for the given zero-based attempt, or
-    /// nil when the schedule is exhausted.
-    static func nextInterval(attempt: Int) -> TimeInterval? {
-        guard attempt < intervals.count else { return nil }
-        return intervals[attempt]
+/// Restore-path decision during a mid-flight hide. When the island should
+/// show but a hide animation is still settling, the controller must force
+/// show() rather than letting the `isPanelVisible && panel.isVisible` guard
+/// skip it — the panel is still on screen mid-collapse and would otherwise
+/// stay hidden until the next environment change.
+enum DynamicIslandRestorePolicy {
+    /// Whether the restore path must force-show through a mid-flight hide.
+    static func mustForceShowDuringDismissal(
+        shouldShowPanel: Bool,
+        isVisibilityDismissing: Bool
+    ) -> Bool {
+        shouldShowPanel && isVisibilityDismissing
     }
-
-    /// Total number of retries the policy will schedule.
-    static let maxAttempts = intervals.count
 }
 
 /// Rejects stale delayed completions after rapid toggles.

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -570,7 +570,10 @@ final class DynamicIslandController: NSObject {
             // and reverse it. The panel is still on screen mid-collapse, so
             // we must call show() directly — the isPanelVisible guard below
             // would skip it and the island would stay hidden.
-            if state.isVisibilityDismissing {
+            if DynamicIslandRestorePolicy.mustForceShowDuringDismissal(
+                shouldShowPanel: shouldShowPanel,
+                isVisibilityDismissing: state.isVisibilityDismissing
+            ) {
                 beginVisibilityTransition()
                 show()
                 cancelFullscreenRetry()

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -148,14 +148,16 @@ final class DynamicIslandController: NSObject {
     /// of `isEnabled` so turning the island off while full-screen does not
     /// re-show it on exit.
     private var fullscreenActive = false
-    /// Pending retry that re-reads the window list after an environment
-    /// change. Non-nil while a retry is scheduled.
-    private var fullscreenRetryWorkItem: DispatchWorkItem?
+    /// Pending settle tick that re-reads the window list after an environment
+    /// change. Non-nil while a settle burst is running.
+    private var fullscreenSettleWorkItem: DispatchWorkItem?
+    /// Index into `fullscreenSettleDelays` for the next scheduled tick.
+    private var fullscreenSettleAttempt = 0
 
-    /// Persistent retry interval — read from the policy so unit tests that
-    /// change the policy also change the rate.
-    private static let retryInterval: TimeInterval =
-        DynamicIslandFullscreenRetryPolicy.retryInterval
+    /// Bounded settle-burst delays — read from the policy so unit tests that
+    /// change the policy also change the schedule.
+    private static let fullscreenSettleDelays: [TimeInterval] =
+        DynamicIslandFullscreenRetryPolicy.settleDelays
 
     init(viewModel: DashboardViewModel) {
         self.viewModel = viewModel
@@ -213,7 +215,7 @@ final class DynamicIslandController: NSObject {
 
     deinit {
         visibilityWorkItem?.cancel()
-        fullscreenRetryWorkItem?.cancel()
+        fullscreenSettleWorkItem?.cancel()
         presentationObservation?.invalidate()
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
@@ -227,15 +229,15 @@ final class DynamicIslandController: NSObject {
 
     func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Self.enabledDefaultsKey)
-        cancelFullscreenRetry()
+        cancelFullscreenSettleRetries()
         fullscreenActive = readFullscreenActive()
         applyPresence()
-        // Only keep the persistent retry running when the feature is both
-        // enabled and currently suppressed by full-screen. Disabling while
-        // full-screen must not leave a timer ticking to re-read the window
-        // list for no reason.
+        // Only arm a settle burst when the feature is both enabled and
+        // currently suppressed by full-screen. Disabling while full-screen
+        // must not leave a tick scheduled to re-read the window list for no
+        // reason.
         if enabled && fullscreenActive {
-            scheduleFullscreenRetry()
+            armFullscreenSettleRetries()
         }
     }
 
@@ -244,7 +246,7 @@ final class DynamicIslandController: NSObject {
         fullscreenActive = readFullscreenActive()
         applyPresence()
         if fullscreenActive {
-            scheduleFullscreenRetry()
+            armFullscreenSettleRetries()
         }
     }
 
@@ -576,14 +578,14 @@ final class DynamicIslandController: NSObject {
             ) {
                 beginVisibilityTransition()
                 show()
-                cancelFullscreenRetry()
+                cancelFullscreenSettleRetries()
                 return
             }
             guard !(state.isPanelVisible && panel?.isVisible == true) else { return }
             show()
             // A successful show means the island is restored; no need to keep
-            // retrying.
-            cancelFullscreenRetry()
+            // settling.
+            cancelFullscreenSettleRetries()
         } else {
             hide()
         }
@@ -592,44 +594,57 @@ final class DynamicIslandController: NSObject {
     private func handleFullscreenEnvironmentChange() {
         fullscreenActive = readFullscreenActive()
         applyPresence()
-        // A space-change notification can fire before the covering window is
-        // dropped from the window list, so the first read can still report
-        // fullscreen. While suppressed *because of fullscreen* (not because
-        // the user disabled the island), keep a low-rate retry running so a
-        // stale window list does not stick `fullscreenActive == true` forever.
-        // This is the persistent mechanism — it survives gaps where no
-        // notification fires (user exits full-screen while the app is in the
-        // background), unlike a fixed 3-attempt burst that exhausts before
-        // the user returns.
+        // A space-change / activation / presentation-options notification can
+        // fire before the covering window is dropped from the window list, so
+        // the first read can still report fullscreen. Arm a short, bounded
+        // settle burst to catch up — native full-screen enter/exit both fire
+        // an observer, so restore never has to survive a silent gap; it only
+        // has to outlast the window list's own catch-up delay after a signal
+        // already fired.
         if fullscreenActive {
-            scheduleFullscreenRetry()
+            armFullscreenSettleRetries()
         } else {
-            cancelFullscreenRetry()
+            cancelFullscreenSettleRetries()
         }
     }
 
-    /// Schedules a persistent low-frequency re-read of the full-screen window
-    /// list. Reschedules itself every ~1s while `isEnabled && fullscreenActive`.
-    /// Stops once restored, disabled, or deinit'd.
-    private func scheduleFullscreenRetry() {
-        fullscreenRetryWorkItem?.cancel()
+    /// Arms a bounded, coalesced settle burst after an environment signal.
+    /// Cancels any burst already in flight and restarts the delay sequence
+    /// from the top — a new signal supersedes a stale one rather than
+    /// stacking with it.
+    private func armFullscreenSettleRetries() {
+        fullscreenSettleWorkItem?.cancel()
+        fullscreenSettleWorkItem = nil
+        fullscreenSettleAttempt = 0
+        scheduleNextFullscreenSettle()
+    }
+
+    /// Schedules the next `DynamicIslandFullscreenRetryPolicy.settleDelays`
+    /// tick. Each tick re-reads the window list and calls `applyPresence()`;
+    /// if still full-screen and delays remain it schedules the next one, and
+    /// after the last delay it simply stops — this is a bounded burst, not a
+    /// loop.
+    private func scheduleNextFullscreenSettle() {
+        guard fullscreenSettleAttempt < Self.fullscreenSettleDelays.count else { return }
+        let delay = Self.fullscreenSettleDelays[fullscreenSettleAttempt]
+        fullscreenSettleAttempt += 1
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            self.fullscreenRetryWorkItem = nil
+            self.fullscreenSettleWorkItem = nil
             guard self.isEnabled else { return }
             self.fullscreenActive = self.readFullscreenActive()
             self.applyPresence()
-            if self.fullscreenActive {
-                self.scheduleFullscreenRetry()
-            }
+            guard self.fullscreenActive else { return }
+            self.scheduleNextFullscreenSettle()
         }
-        fullscreenRetryWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval, execute: workItem)
+        fullscreenSettleWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
-    private func cancelFullscreenRetry() {
-        fullscreenRetryWorkItem?.cancel()
-        fullscreenRetryWorkItem = nil
+    private func cancelFullscreenSettleRetries() {
+        fullscreenSettleWorkItem?.cancel()
+        fullscreenSettleWorkItem = nil
+        fullscreenSettleAttempt = 0
     }
 
     /// Hide only when a full-screen app occupies the island's own screen.

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -152,10 +152,10 @@ final class DynamicIslandController: NSObject {
     /// change. Non-nil while a retry is scheduled.
     private var fullscreenRetryWorkItem: DispatchWorkItem?
 
-    /// Persistent retry interval — the last (longest) entry in the retry
-    /// policy, so unit tests that change the policy also change the rate.
+    /// Persistent retry interval — read from the policy so unit tests that
+    /// change the policy also change the rate.
     private static let retryInterval: TimeInterval =
-        DynamicIslandFullscreenRetryPolicy.intervals.last ?? 1.0
+        DynamicIslandFullscreenRetryPolicy.retryInterval
 
     init(viewModel: DashboardViewModel) {
         self.viewModel = viewModel
@@ -230,7 +230,11 @@ final class DynamicIslandController: NSObject {
         cancelFullscreenRetry()
         fullscreenActive = readFullscreenActive()
         applyPresence()
-        if fullscreenActive {
+        // Only keep the persistent retry running when the feature is both
+        // enabled and currently suppressed by full-screen. Disabling while
+        // full-screen must not leave a timer ticking to re-read the window
+        // list for no reason.
+        if enabled && fullscreenActive {
             scheduleFullscreenRetry()
         }
     }

--- a/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DynamicIslandController.swift
@@ -148,6 +148,14 @@ final class DynamicIslandController: NSObject {
     /// of `isEnabled` so turning the island off while full-screen does not
     /// re-show it on exit.
     private var fullscreenActive = false
+    /// Pending retry that re-reads the window list after an environment
+    /// change. Non-nil while a retry is scheduled.
+    private var fullscreenRetryWorkItem: DispatchWorkItem?
+
+    /// Persistent retry interval — the last (longest) entry in the retry
+    /// policy, so unit tests that change the policy also change the rate.
+    private static let retryInterval: TimeInterval =
+        DynamicIslandFullscreenRetryPolicy.intervals.last ?? 1.0
 
     init(viewModel: DashboardViewModel) {
         self.viewModel = viewModel
@@ -162,6 +170,16 @@ final class DynamicIslandController: NSObject {
                 self?.handleFullscreenEnvironmentChange()
                 self?.repositionPanel()
             }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Necessary but not sufficient: activation settles the window list
+            // and presentation options, so it catches the case where the other
+            // notifications never fired while the app was in the background.
+            Task { @MainActor [weak self] in self?.handleFullscreenEnvironmentChange() }
         })
         observers.append(NotificationCenter.default.addObserver(
             forName: .nativeSettingsChanged,
@@ -195,6 +213,7 @@ final class DynamicIslandController: NSObject {
 
     deinit {
         visibilityWorkItem?.cancel()
+        fullscreenRetryWorkItem?.cancel()
         presentationObservation?.invalidate()
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
@@ -208,14 +227,21 @@ final class DynamicIslandController: NSObject {
 
     func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Self.enabledDefaultsKey)
+        cancelFullscreenRetry()
         fullscreenActive = readFullscreenActive()
         applyPresence()
+        if fullscreenActive {
+            scheduleFullscreenRetry()
+        }
     }
 
     /// Re-show the island on launch if it was enabled when the app last quit.
     func restoreIfNeeded() {
         fullscreenActive = readFullscreenActive()
         applyPresence()
+        if fullscreenActive {
+            scheduleFullscreenRetry()
+        }
     }
 
     func show() {
@@ -536,8 +562,21 @@ final class DynamicIslandController: NSObject {
 
     private func applyPresence() {
         if shouldShowPanel {
+            // If a hide animation is mid-flight, cancel the pending completion
+            // and reverse it. The panel is still on screen mid-collapse, so
+            // we must call show() directly — the isPanelVisible guard below
+            // would skip it and the island would stay hidden.
+            if state.isVisibilityDismissing {
+                beginVisibilityTransition()
+                show()
+                cancelFullscreenRetry()
+                return
+            }
             guard !(state.isPanelVisible && panel?.isVisible == true) else { return }
             show()
+            // A successful show means the island is restored; no need to keep
+            // retrying.
+            cancelFullscreenRetry()
         } else {
             hide()
         }
@@ -546,6 +585,44 @@ final class DynamicIslandController: NSObject {
     private func handleFullscreenEnvironmentChange() {
         fullscreenActive = readFullscreenActive()
         applyPresence()
+        // A space-change notification can fire before the covering window is
+        // dropped from the window list, so the first read can still report
+        // fullscreen. While suppressed *because of fullscreen* (not because
+        // the user disabled the island), keep a low-rate retry running so a
+        // stale window list does not stick `fullscreenActive == true` forever.
+        // This is the persistent mechanism — it survives gaps where no
+        // notification fires (user exits full-screen while the app is in the
+        // background), unlike a fixed 3-attempt burst that exhausts before
+        // the user returns.
+        if fullscreenActive {
+            scheduleFullscreenRetry()
+        } else {
+            cancelFullscreenRetry()
+        }
+    }
+
+    /// Schedules a persistent low-frequency re-read of the full-screen window
+    /// list. Reschedules itself every ~1s while `isEnabled && fullscreenActive`.
+    /// Stops once restored, disabled, or deinit'd.
+    private func scheduleFullscreenRetry() {
+        fullscreenRetryWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.fullscreenRetryWorkItem = nil
+            guard self.isEnabled else { return }
+            self.fullscreenActive = self.readFullscreenActive()
+            self.applyPresence()
+            if self.fullscreenActive {
+                self.scheduleFullscreenRetry()
+            }
+        }
+        fullscreenRetryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval, execute: workItem)
+    }
+
+    private func cancelFullscreenRetry() {
+        fullscreenRetryWorkItem?.cancel()
+        fullscreenRetryWorkItem = nil
     }
 
     /// Hide only when a full-screen app occupies the island's own screen.

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -130,6 +130,39 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
         )
     }
 
+    func testFullscreenRetryPolicyIntervalsArePositiveAndEscalating() {
+        let intervals = DynamicIslandFullscreenRetryPolicy.intervals
+
+        XCTAssertEqual(intervals.count, 3)
+        XCTAssertGreaterThan(intervals[0], 0)
+        XCTAssertGreaterThan(intervals[1], intervals[0])
+        XCTAssertGreaterThan(intervals[2], intervals[1])
+    }
+
+    func testFullscreenRetryPolicyExhaustsAfterMaxAttempts() {
+        XCTAssertEqual(
+            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 0),
+            DynamicIslandFullscreenRetryPolicy.intervals[0]
+        )
+        XCTAssertEqual(
+            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 1),
+            DynamicIslandFullscreenRetryPolicy.intervals[1]
+        )
+        XCTAssertEqual(
+            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 2),
+            DynamicIslandFullscreenRetryPolicy.intervals[2]
+        )
+        XCTAssertNil(DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 3))
+        XCTAssertNil(DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 100))
+    }
+
+    func testFullscreenRetryPolicyMaxAttemptsMatchesIntervalCount() {
+        XCTAssertEqual(
+            DynamicIslandFullscreenRetryPolicy.maxAttempts,
+            DynamicIslandFullscreenRetryPolicy.intervals.count
+        )
+    }
+
     func testHideCompletionIncludesCompositorSettleDelay() {
         XCTAssertEqual(
             DynamicIslandVisibilityPolicy.hideCompletionDelay,

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -130,13 +130,17 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
         )
     }
 
-    func testFullscreenRetryIntervalIsPositiveAndLowFrequency() {
-        let interval = DynamicIslandFullscreenRetryPolicy.retryInterval
+    func testFullscreenSettleDelaysAreShortBoundedAndIncreasing() {
+        let delays = DynamicIslandFullscreenRetryPolicy.settleDelays
 
-        XCTAssertGreaterThan(interval, 0)
-        // Low-frequency: ~1s, not a tight burst.
-        XCTAssertGreaterThanOrEqual(interval, 0.5)
-        XCTAssertLessThanOrEqual(interval, 2.0)
+        // Bounded burst, not a heartbeat: 2-4 delays, each short.
+        XCTAssertGreaterThanOrEqual(delays.count, 2)
+        XCTAssertLessThanOrEqual(delays.count, 4)
+        for delay in delays {
+            XCTAssertGreaterThan(delay, 0)
+            XCTAssertLessThanOrEqual(delay, 1.5)
+        }
+        XCTAssertEqual(delays, delays.sorted(), "delays should back off, not tick at a fixed rate")
     }
 
     func testForceShowWhenRestoringDuringMidHide() {

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -130,36 +130,50 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
         )
     }
 
-    func testFullscreenRetryPolicyIntervalsArePositiveAndEscalating() {
-        let intervals = DynamicIslandFullscreenRetryPolicy.intervals
+    func testFullscreenRetryIntervalIsPositiveAndLowFrequency() {
+        let interval = DynamicIslandFullscreenRetryPolicy.retryInterval
 
-        XCTAssertEqual(intervals.count, 3)
-        XCTAssertGreaterThan(intervals[0], 0)
-        XCTAssertGreaterThan(intervals[1], intervals[0])
-        XCTAssertGreaterThan(intervals[2], intervals[1])
+        XCTAssertGreaterThan(interval, 0)
+        // Low-frequency: ~1s, not a tight burst.
+        XCTAssertGreaterThanOrEqual(interval, 0.5)
+        XCTAssertLessThanOrEqual(interval, 2.0)
     }
 
-    func testFullscreenRetryPolicyExhaustsAfterMaxAttempts() {
-        XCTAssertEqual(
-            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 0),
-            DynamicIslandFullscreenRetryPolicy.intervals[0]
-        )
-        XCTAssertEqual(
-            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 1),
-            DynamicIslandFullscreenRetryPolicy.intervals[1]
-        )
-        XCTAssertEqual(
-            DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 2),
-            DynamicIslandFullscreenRetryPolicy.intervals[2]
-        )
-        XCTAssertNil(DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 3))
-        XCTAssertNil(DynamicIslandFullscreenRetryPolicy.nextInterval(attempt: 100))
+    func testFullscreenRetryIsPersistentNotBounded() {
+        // The retry is not a bounded burst: there is no maxAttempts counter
+        // and no nextInterval(attempt:) that returns nil. The policy exposes
+        // a single interval that the controller reschedules itself with
+        // while `isEnabled && fullscreenActive`.
+        XCTAssertNoThrow(DynamicIslandFullscreenRetryPolicy.retryInterval)
     }
 
-    func testFullscreenRetryPolicyMaxAttemptsMatchesIntervalCount() {
-        XCTAssertEqual(
-            DynamicIslandFullscreenRetryPolicy.maxAttempts,
-            DynamicIslandFullscreenRetryPolicy.intervals.count
+    func testForceShowWhenRestoringDuringMidHide() {
+        // The user exits full-screen during a hide animation: the panel is
+        // still on screen mid-collapse, so the restore path must force-show
+        // through the `isPanelVisible && panel.isVisible` guard.
+        XCTAssertTrue(
+            DynamicIslandRestorePolicy.mustForceShowDuringDismissal(
+                shouldShowPanel: true,
+                isVisibilityDismissing: true
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandRestorePolicy.mustForceShowDuringDismissal(
+                shouldShowPanel: true,
+                isVisibilityDismissing: false
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandRestorePolicy.mustForceShowDuringDismissal(
+                shouldShowPanel: false,
+                isVisibilityDismissing: true
+            )
+        )
+        XCTAssertFalse(
+            DynamicIslandRestorePolicy.mustForceShowDuringDismissal(
+                shouldShowPanel: false,
+                isVisibilityDismissing: false
+            )
         )
     }
 

--- a/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/DynamicIslandLayoutPolicyTests.swift
@@ -139,14 +139,6 @@ final class DynamicIslandLayoutPolicyTests: XCTestCase {
         XCTAssertLessThanOrEqual(interval, 2.0)
     }
 
-    func testFullscreenRetryIsPersistentNotBounded() {
-        // The retry is not a bounded burst: there is no maxAttempts counter
-        // and no nextInterval(attempt:) that returns nil. The policy exposes
-        // a single interval that the controller reschedules itself with
-        // while `isEnabled && fullscreenActive`.
-        XCTAssertNoThrow(DynamicIslandFullscreenRetryPolicy.retryInterval)
-    }
-
     func testForceShowWhenRestoringDuringMidHide() {
         // The user exits full-screen during a hide animation: the panel is
         // still on screen mid-collapse, so the restore path must force-show

--- a/test/dynamic-island-fullscreen-guardrails.test.js
+++ b/test/dynamic-island-fullscreen-guardrails.test.js
@@ -73,3 +73,36 @@ test("island presence is gated on a testable full-screen policy", () => {
     "window bounds must come from the CFDictionary helper; a [String: CGFloat] cast drops real window lists",
   );
 });
+
+test("Dynamic Island restore after full-screen exit survives with no exit notification", () => {
+  assert.match(
+    controllerSource,
+    /func scheduleFullscreenRetry\(\)[\s\S]*?if self\.fullscreenActive \{\s*\n\s*self\.scheduleFullscreenRetry\(\)/,
+    "the retry work item must reschedule itself while fullscreenActive — an unbounded loop, not a bounded burst",
+  );
+  assert.match(
+    controllerSource,
+    /deinit[\s\S]*?fullscreenRetryWorkItem\?\.cancel\(\)/,
+    "deinit must cancel the pending retry work item",
+  );
+  assert.match(
+    controllerSource,
+    /func setEnabled\([\s\S]*?(?:fullscreenRetryWorkItem\?\.cancel\(\)|cancelFullscreenRetry\(\))/,
+    "setEnabled must cancel the pending retry work item",
+  );
+  assert.match(
+    controllerSource,
+    /func setEnabled\([\s\S]*?if enabled && fullscreenActive \{\s*\n\s*scheduleFullscreenRetry\(\)/,
+    "setEnabled must only reschedule the retry when enabled && fullscreenActive",
+  );
+  assert.match(
+    controllerSource,
+    /DynamicIslandRestorePolicy\.mustForceShowDuringDismissal\(/,
+    "applyPresence must consult the testable restore policy, not an inlined isVisibilityDismissing check",
+  );
+  assert.match(
+    controllerSource,
+    /NSApplication\.didBecomeActiveNotification/,
+    "app activation must remain a restore signal even though it alone cannot cover a background exit",
+  );
+});

--- a/test/dynamic-island-fullscreen-guardrails.test.js
+++ b/test/dynamic-island-fullscreen-guardrails.test.js
@@ -74,27 +74,76 @@ test("island presence is gated on a testable full-screen policy", () => {
   );
 });
 
-test("Dynamic Island restore after full-screen exit survives with no exit notification", () => {
+test("Dynamic Island restore settles on fullscreen events with a bounded burst, not a poll", () => {
+  const settleFunctionMatch = controllerSource.match(
+    /private func scheduleNextFullscreenSettle\(\) \{([\s\S]*?)\n    private func cancelFullscreenSettleRetries/,
+  );
+  assert.ok(
+    settleFunctionMatch,
+    "scheduleNextFullscreenSettle must exist as its own function, bounded above cancelFullscreenSettleRetries",
+  );
+  const settleBody = settleFunctionMatch[1];
+
+  assert.match(
+    settleBody,
+    /guard\s+fullscreenSettleAttempt\s*<\s*Self\.fullscreenSettleDelays\.count\s+else\s*\{\s*return\s*\}/,
+    "each tick must check a bounded attempt index against the delay list before scheduling another",
+  );
+  assert.match(
+    settleBody,
+    /fullscreenSettleAttempt\s*\+=\s*1/,
+    "each tick must advance the attempt index — a reschedule with no advancing counter is the old unbounded loop",
+  );
+  assert.match(
+    settleBody,
+    /guard self\.fullscreenActive else \{ return \}\s*\n\s*self\.scheduleNextFullscreenSettle\(\)/,
+    "a tick may only schedule the next one while still full-screen, and must call the bounded scheduler",
+  );
+
+  assert.doesNotMatch(
+    controllerSource,
+    /if self\.fullscreenActive \{\s*\n\s*self\.scheduleFullscreenRetry\(\)/,
+    "the old unbounded retry loop (reschedule on fullscreenActive alone, no attempt bound) must not come back",
+  );
+  assert.doesNotMatch(
+    controllerSource,
+    /Self\.retryInterval/,
+    "a single fixed retryInterval heartbeat must not come back — settling now uses a bounded delay list",
+  );
+
+  assert.match(
+    policySource,
+    /static\s+let\s+settleDelays:\s*\[TimeInterval\]\s*=\s*\[[^\]]+\]/,
+    "the settle schedule must be a finite array of delays, not a single repeating interval",
+  );
+  assert.doesNotMatch(
+    policySource,
+    /static\s+let\s+retryInterval/,
+    "the old single-interval retry constant must be gone",
+  );
+
   assert.match(
     controllerSource,
-    /func scheduleFullscreenRetry\(\)[\s\S]*?if self\.fullscreenActive \{\s*\n\s*self\.scheduleFullscreenRetry\(\)/,
-    "the retry work item must reschedule itself while fullscreenActive — an unbounded loop, not a bounded burst",
+    /func armFullscreenSettleRetries\(\)\s*\{[^}]*fullscreenSettleAttempt = 0/,
+    "arming a burst must reset the attempt index so a new signal restarts the schedule from the top",
+  );
+
+  assert.match(
+    controllerSource,
+    /deinit\s*\{[^}]*fullscreenSettleWorkItem\?\.cancel\(\)/,
+    "deinit must cancel the pending settle work item",
   );
   assert.match(
     controllerSource,
-    /deinit\s*\{[^}]*fullscreenRetryWorkItem\?\.cancel\(\)/,
-    "deinit must cancel the pending retry work item",
+    /func setEnabled\([^)]*\)\s*\{[^}]*cancelFullscreenSettleRetries\(\)/,
+    "setEnabled must cancel any in-flight settle burst before re-reading",
   );
   assert.match(
     controllerSource,
-    /func setEnabled\([^)]*\)\s*\{[^}]*(?:fullscreenRetryWorkItem\?\.cancel\(\)|cancelFullscreenRetry\(\))/,
-    "setEnabled must cancel the pending retry work item",
+    /func setEnabled\([^)]*\)\s*\{[^}]*if enabled && fullscreenActive \{\s*\n\s*armFullscreenSettleRetries\(\)/,
+    "setEnabled may only arm a new settle burst when enabled && fullscreenActive",
   );
-  assert.match(
-    controllerSource,
-    /func setEnabled\([\s\S]*?if enabled && fullscreenActive \{\s*\n\s*scheduleFullscreenRetry\(\)/,
-    "setEnabled must only reschedule the retry when enabled && fullscreenActive",
-  );
+
   assert.match(
     controllerSource,
     /DynamicIslandRestorePolicy\.mustForceShowDuringDismissal\(/,

--- a/test/dynamic-island-fullscreen-guardrails.test.js
+++ b/test/dynamic-island-fullscreen-guardrails.test.js
@@ -82,12 +82,12 @@ test("Dynamic Island restore after full-screen exit survives with no exit notifi
   );
   assert.match(
     controllerSource,
-    /deinit[\s\S]*?fullscreenRetryWorkItem\?\.cancel\(\)/,
+    /deinit\s*\{[^}]*fullscreenRetryWorkItem\?\.cancel\(\)/,
     "deinit must cancel the pending retry work item",
   );
   assert.match(
     controllerSource,
-    /func setEnabled\([\s\S]*?(?:fullscreenRetryWorkItem\?\.cancel\(\)|cancelFullscreenRetry\(\))/,
+    /func setEnabled\([^)]*\)\s*\{[^}]*(?:fullscreenRetryWorkItem\?\.cancel\(\)|cancelFullscreenRetry\(\))/,
     "setEnabled must cancel the pending retry work item",
   );
   assert.match(


### PR DESCRIPTION
## Summary

灵动岛在其它应用进入全屏时会隐藏，但退出全屏后不会自动回来，要点一下 TokenTracker 才恢复。

根因有两处：

1. 隐藏动画还没结束时，`applyPresence()` 会因为面板仍可见而跳过 `show()`。
2. 绿钮退出全屏会发 Space 通知，但第一次读 `CGWindowList` 往往还看得到盖着菜单栏的窗口，于是仍判全屏。

这次在 mid-hide 恢复时强制 `show()`，并在环境信号（切 Space、切前台应用、自己变成前台、presentation options、屏幕参数）之后按 `0.15s / 0.45s / 1.0s` 再读几次窗口列表。读到已经不是全屏就立刻显示并取消剩余 tick；最后一次之后停止。全屏期间不再每秒轮询。

点菜单栏图标恢复的路径仍走 `didBecomeActiveNotification`。

## Scope

- [x] macOS app (`TokenTrackerBar/`)
- [x] Docs / CI / config（`test/dynamic-island-fullscreen-guardrails.test.js`）

## Checklist

- [x] `node --test test/dynamic-island-fullscreen-guardrails.test.js`（3 pass）
- [x] `swiftc -parse` 两个 Swift 文件干净
- [x] 无新增用户文案
- [x] conventional commit
- [ ] 本机无 Xcode.app，XCTest 未跑

## 行为

- 进入全屏：现有 observer 隐藏岛（不变）
- 退出原生全屏：Space 通知 + 短延迟重读，覆盖窗口列表滞后
- 隐藏动画中途退出：`mustForceShowDuringDismissal` 打断 hide completion，避免面板被 `orderOut` 后卡住
- `setEnabled(false)` / `deinit` 取消在途 settle tick

## 已知取舍

同空间、不改 presentation、也不切应用的「假全屏」如果缩小过程中一个通知都不发，岛仍要等用户点一下 TokenTracker。这是拿掉 1Hz 轮询后的预期缺口，不是这次漏修的路径。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel restoration when returning from full-screen mode.
  * Prevented the panel from disappearing unexpectedly while visibility changes are still in progress.
  * Improved reliability when the app is activated, enabled, or restored after environmental changes.
  * Added bounded recovery behavior to avoid repeated or indefinite restoration attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->