### PR TITLE
fix: 修复 landing 页 JSON-LD 无法解析

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -195,7 +195,7 @@
               { "@type": "ListItem", "position": 29, "name": "Qoder" },
               { "@type": "ListItem", "position": 30, "name": "AnythingLLM Desktop" },
               { "@type": "ListItem", "position": 31, "name": "Claude Science" },
-              { "@type": "ListItem", "position": 32, "name": "DeepSeek Harness" }
+              { "@type": "ListItem", "position": 32, "name": "DeepSeek Harness" },
               { "@type": "ListItem", "position": 33, "name": "TRAE Work CN" }
             ]
           },
@@ -211,7 +211,8 @@
                 }
               },
               {
-                "@type": "Quest                "name": "Which AI coding CLIs does Token Tracker support?",
+                "@type": "Question",
+                "name": "Which AI coding CLIs does Token Tracker support?",
                 "acceptedAnswer": {
                   "@type": "Answer",
                   "text": "Token Tracker supports 33 AI coding tools, including Claude Code, Codex CLI, Cursor, Gemini CLI, Antigravity, Kiro, OpenCode, OpenClaw, Every Code, Hermes Agent, GitHub Copilot, Kimi Code, CodeBuddy, WorkBuddy, Grok Build, oh-my-pi, pi, Prime Agent, Craft Agents, Reasonix, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose, Droid, Mimo Code, ZCode, Qoder, AnythingLLM Desktop, Claude Science, DeepSeek Harness, and TRAE Work CN."

--- a/test/discovery-metadata.test.js
+++ b/test/discovery-metadata.test.js
@@ -83,3 +83,32 @@ test("npm metadata carries the current product hook", () => {
   assert.ok(pkg.keywords.includes("desktop-widget"));
   assert.ok(pkg.keywords.includes("ai-coding-tools"));
 });
+
+test("dashboard JSON-LD scripts parse as valid JSON", () => {
+  const index = read("dashboard/index.html");
+  const blocks = [...index.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((match) => match[1]);
+  assert.ok(blocks.length > 0, "dashboard/index.html includes JSON-LD");
+
+  const parsed = blocks.map((block, i) => {
+    try {
+      return JSON.parse(block);
+    } catch (err) {
+      assert.fail(`JSON-LD block ${i} failed to parse: ${err.message}`);
+    }
+  });
+
+  const graph = parsed.flatMap((doc) => (Array.isArray(doc["@graph"]) ? doc["@graph"] : [doc]));
+
+  const faq = graph.find((node) => node["@type"] === "FAQPage");
+  assert.ok(faq, "JSON-LD includes an FAQPage");
+  const supportedClis = (faq.mainEntity || []).find((entity) =>
+    entity.name === "Which AI coding CLIs does Token Tracker support?",
+  );
+  assert.ok(supportedClis, "FAQ includes the supported-CLIs question");
+  assert.equal(supportedClis["@type"], "Question");
+
+  const tools = graph.find((node) => node["@type"] === "ItemList" && node.name === "Supported AI coding agent CLIs");
+  assert.ok(tools, "JSON-LD includes the coding-tools ItemList");
+  assert.ok(Array.isArray(tools.itemListElement), "coding-tools ItemList is an array");
+});


### PR DESCRIPTION
## Summary

Fixes #495

`dashboard/index.html` 里的 JSON-LD 在 main 上就解析不了，搜索引擎读不到支持的工具列表和 FAQ。

两处语法错误：

1. ItemList 里 DeepSeek Harness 和 TRAE Work CN 之间缺逗号
2. 「Which AI coding CLIs does Token Tracker support?」那条 FAQ 的 `@type` 被截成 `"Quest`，和后面的 `"name"` 粘在一起

只修这两处，不改工具计数和其它文案。`test/discovery-metadata.test.js` 对每段 `application/ld+json` 做 `JSON.parse`，并断言该 FAQ 解析后是 `"Question"`。

## Scope

- [x] Dashboard (`dashboard/index.html`)
- [x] Docs / CI / config（`test/discovery-metadata.test.js`）

## Checklist

- [x] `node --test test/discovery-metadata.test.js`（5 pass）
- [x] 去掉逗号或还原 `"Quest` 截断后，新测试会失败
- [x] 无新增用户文案
- [x] conventional commit
- [x] 版本未 bump


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected structured FAQ metadata so search engines can interpret the FAQ content properly.
  * Preserved the DeepSeek Harness entry in the supported coding-tools list.

* **Tests**
  * Added validation to confirm dashboard structured data is valid and includes the expected FAQ and coding-tools information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->