### PR TITLE
fix(dashboard): replace hand-drawn Pi placeholder with official pi.dev logo

### DIFF
--- a/dashboard/public/brand-logos/pi.svg
+++ b/dashboard/public/brand-logos/pi.svg
@@ -1,16 +1,9 @@
-<svg width="56" height="56" viewBox="0 0 120 90" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Pi">
-  <title>Pi</title>
-  <defs>
-    <linearGradient id="piBar" x1="10" y1="14" x2="110" y2="14" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#818CF8"/>
-      <stop offset="100%" stop-color="#4F46E5"/>
-    </linearGradient>
-    <linearGradient id="piLeg" x1="0" y1="20" x2="0" y2="82" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#6366F1"/>
-      <stop offset="100%" stop-color="#4338CA"/>
-    </linearGradient>
-  </defs>
-  <rect x="10" y="8" width="100" height="12" rx="3" fill="url(#piBar)"/>
-  <rect x="25" y="20" width="12" height="62" rx="3" fill="url(#piLeg)"/>
-  <rect x="83" y="20" width="12" height="62" rx="3" fill="url(#piLeg)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <!-- Official Pi mark from https://pi.dev/logo.svg (pi coding agent).
+       Published in white only; luminance is switched at the <img> boundary
+       via PROVIDER_LOGO_CLASS_MAP so both themes keep contrast. -->
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/>
+  <!-- i dot -->
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
 </svg>

--- a/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
+++ b/dashboard/src/ui/dashboard/components/ProviderIcon.jsx
@@ -388,7 +388,9 @@ const PROVIDER_LOGO_MAP = {
   "KILO-CLI": "/brand-logos/kilo.svg",
   "KILO-CODE": "/brand-logos/kilo.svg",
   MIMO: "/brand-logos/mimo.svg",
-  // oh-my-pi / pi: multi-color brand marks (pi letterform + plugin connector).
+  // oh-my-pi: multi-color brand mark (pi letterform + plugin connector). pi
+  // itself publishes a white-only mark (pi.dev/logo.svg), so it gets the same
+  // <img> luminance treatment as AnythingLLM in PROVIDER_LOGO_CLASS_MAP.
   OMP: "/brand-logos/omp.svg",
   OPENCLAW: "/brand-logos/openclaw.svg",
   OPENCODE: "/brand-logos/opencode.svg",
@@ -413,6 +415,14 @@ const PROVIDER_LOGO_MAP = {
 // (which may differ from the OS preference) always has sufficient contrast.
 const PROVIDER_LOGO_CLASS_MAP = {
   ANYTHINGLLM: "brightness-0 dark:brightness-100",
+  // pi publishes its mark in white only (pi.dev/logo.svg) — same treatment
+  // as AnythingLLM: black on light backgrounds, native white on dark.
+  PI: "brightness-0 dark:brightness-100",
+  "PI-ANTHROPIC": "brightness-0 dark:brightness-100",
+  "PI-DEEPSEEK": "brightness-0 dark:brightness-100",
+  "PI-GITHUB-COPILOT": "brightness-0 dark:brightness-100",
+  "PI-COPILOT": "brightness-0 dark:brightness-100",
+  "PI-OPENAI-CODEX": "brightness-0 dark:brightness-100",
   QODER: "dark:invert",
 };
 

--- a/dashboard/src/ui/dashboard/components/ProviderIcon.test.jsx
+++ b/dashboard/src/ui/dashboard/components/ProviderIcon.test.jsx
@@ -49,11 +49,13 @@ describe("ProviderIcon", () => {
     expect(icon).toHaveAttribute("height", "20");
   });
 
-  it("renders the multi-color Pi brand logo", () => {
+  it("renders the official white Pi mark with explicit light and dark treatment", () => {
     const { container } = render(<ProviderIcon provider="pi" size={18} />);
     const icon = container.querySelector('img[src="/brand-logos/pi.svg"]');
     expect(icon).not.toBeNull();
     expect(icon).toHaveAttribute("width", "18");
+    // Official pi.dev/logo.svg is white-only: black on light, white on dark.
+    expect(icon).toHaveClass("brightness-0", "dark:brightness-100");
   });
 
   it("renders the Reasonix brand icon", () => {
@@ -109,5 +111,6 @@ describe("ProviderIcon", () => {
       const { container } = render(<ProviderIcon provider={provider} size={16} />);
       const icon = container.querySelector('img[src="/brand-logos/pi.svg"]');
       expect(icon, `${provider} maps to pi.svg`).not.toBeNull();
+      expect(icon, `${provider} switches luminance`).toHaveClass("brightness-0", "dark:brightness-100");
     }
   });


### PR DESCRIPTION
## Summary
- The `pi` provider icon (`dashboard/public/brand-logos/pi.svg`) was a generic hand-drawn gradient π placeholder, not the actual brand mark of the pi coding agent.
- Replaced it with the official mark served from `https://pi.dev/logo.svg` (same asset the project's npm README links), geometry kept verbatim (viewBox `0 0 800 800`).
- The official SVG is white-only, so all six pi entries (`PI`, `PI-ANTHROPIC`, `PI-DEEPSEEK`, `PI-GITHUB-COPILOT`, `PI-COPILOT`, `PI-OPENAI-CODEX`) now get the same `<img>` luminance treatment already used for AnythingLLM: `brightness-0 dark:brightness-100` — black on light backgrounds, native white on dark.

## Test plan
- [x] `dashboard`: `npx vitest run src/ui/dashboard/components/ProviderIcon.test.jsx` — 11 passed (updated assertions cover the new luminance classes)
- [x] Verified rendering side-by-side on light/dark backgrounds before submitting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated Pi provider icons to display consistently across light and dark themes.
  - Pi logos now appear black in light mode and retain their native white appearance in dark mode.
  - Standardized the visual treatment for Pi, Pi DeepSeek, and Pi OpenAI Codex provider variants.
  - Clarified the OMP logo presentation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->