### PR TITLE
feat(opencode): 支持 OpenCode v2（opencode2）的用量统计

### DIFF
--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -414,7 +414,18 @@ function buildLocalWindow({ used, limit, resetMs }) {
 // so we sum in SQLite and return a single row rather than streaming every
 // opencode-go turn into JS — keeps the limits poll cheap, cf. the spawnSync
 // freeze lesson).
-function buildGoAggregateSql({ sessionStart, weekStart, weekEnd, monthStart, monthEnd }) {
+//
+// Two schema generations share the same file (see src/lib/rollout.js):
+//   v1 keeps the `message` table with `$.role`/flat `$.providerID`.
+//   v2 (`opencode2`) moved messages to `session_message` (role is now the
+//     `type` column) and nests the provider under `$.model.providerID`.
+function buildGoAggregateSql({ sessionStart, weekStart, weekEnd, monthStart, monthEnd }, variant = "v1") {
+  const isV2 = variant === "v2";
+  const table = isV2 ? "session_message" : "message";
+  const rolePredicate = isV2 ? "type = 'assistant'" : "json_extract(data,'$.role') = 'assistant'";
+  const providerPredicate = isV2
+    ? "json_extract(data,'$.model.providerID') = 'opencode-go'"
+    : "json_extract(data,'$.providerID') = 'opencode-go'";
   return (
     "SELECT " +
     `COALESCE(SUM(CASE WHEN createdMs >= ${sessionStart} THEN cost ELSE 0 END), 0) AS sessionCost, ` +
@@ -425,13 +436,38 @@ function buildGoAggregateSql({ sessionStart, weekStart, weekEnd, monthStart, mon
     "FROM (" +
     "SELECT CAST(COALESCE(json_extract(data,'$.time.created'), time_created) AS INTEGER) AS createdMs, " +
     "CAST(json_extract(data,'$.cost') AS REAL) AS cost " +
-    "FROM message " +
+    `FROM ${table} ` +
     "WHERE json_valid(data) " +
-    "AND json_extract(data,'$.providerID') = 'opencode-go' " +
-    "AND json_extract(data,'$.role') = 'assistant' " +
+    `AND ${providerPredicate} ` +
+    `AND ${rolePredicate} ` +
     "AND json_type(data,'$.cost') IN ('integer','real')" +
     ")"
   );
+}
+
+// Detect which message-table generation a database carries ("v1" / "v2" /
+// null when sqlite_master cannot be read, e.g. mocked readers in tests).
+// A database carrying BOTH tables resolves to "v1" on purpose: unlike the
+// message parser (which dedups rows by sessionID|messageID), this aggregate is
+// a blind SUM with no key to dedup on, so unioning two generations could
+// double-count cost if the tables overlap. Undercounting an opt-in estimate is
+// the safe side of that trade.
+async function detectOpencodeDbGeneration(dbPath, sqliteOptions = {}) {
+  let rows;
+  try {
+    rows = await readSqliteJsonRowsAsync(
+      dbPath,
+      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('message','session_message')`,
+      { label: "OpenCode Go", timeout: 5_000, ...sqliteOptions },
+    );
+  } catch (_e) {
+    return null;
+  }
+  if (!Array.isArray(rows)) return null;
+  const names = new Set(rows.map((r) => String(r?.name || "").trim()).filter(Boolean));
+  if (names.size === 0) return null;
+  if (!names.has("message") && names.has("session_message")) return "v2";
+  return "v1";
 }
 
 // Returns { source:'local', primary/secondary/tertiary_window } or null when no
@@ -445,32 +481,42 @@ async function collectOpencodeGoLocal({ home, env = process.env, nowMs = Date.no
   const weekStart = weekStartMs(nowMs);
   const weekEnd = weekStart + WEEK_MS;
   const { startMs: monthStart, endMs: monthEnd } = monthBoundsMs(nowMs);
-  const sql = buildGoAggregateSql({ sessionStart, weekStart, weekEnd, monthStart, monthEnd });
+  const windowArgs = { sessionStart, weekStart, weekEnd, monthStart, monthEnd };
 
   let agg = null;
   for (const dbPath of paths) {
-    let rows;
-    try {
-      rows = await readSqliteJsonRowsAsync(dbPath, sql, {
-        label: "OpenCode Go",
-        timeout: 5_000,
-        ...sqliteOptions,
-      });
-    } catch (_e) {
-      continue;
-    }
-    const row = rows && rows[0];
-    if (!row) continue;
-    const rowCount = Number(row.rowCount) || 0;
-    if (rowCount <= 0) continue;
-    if (!agg) agg = { sessionCost: 0, weeklyCost: 0, monthlyCost: 0, sessionOldest: null, rowCount: 0 };
-    agg.sessionCost += Number(row.sessionCost) || 0;
-    agg.weeklyCost += Number(row.weeklyCost) || 0;
-    agg.monthlyCost += Number(row.monthlyCost) || 0;
-    agg.rowCount += rowCount;
-    const oldest = row.sessionOldest == null ? null : Number(row.sessionOldest);
-    if (oldest != null && Number.isFinite(oldest)) {
-      agg.sessionOldest = agg.sessionOldest == null ? oldest : Math.min(agg.sessionOldest, oldest);
+    // Each database can be a different OpenCode generation. When sqlite_master
+    // is unreadable, fall back to v1-then-v2 so the legacy query runs first.
+    const generation = await detectOpencodeDbGeneration(dbPath, sqliteOptions);
+    const variants = generation === "v2" ? ["v2"] : generation === "v1" ? ["v1"] : ["v1", "v2"];
+
+    for (const variant of variants) {
+      const sql = buildGoAggregateSql(windowArgs, variant);
+      let rows;
+      try {
+        rows = await readSqliteJsonRowsAsync(dbPath, sql, {
+          label: "OpenCode Go",
+          timeout: 5_000,
+          throwOnReadFailure: true,
+          ...sqliteOptions,
+        });
+      } catch (_e) {
+        continue;
+      }
+      const row = rows && rows[0];
+      if (!row) continue;
+      const rowCount = Number(row.rowCount) || 0;
+      if (rowCount <= 0) continue;
+      if (!agg) agg = { sessionCost: 0, weeklyCost: 0, monthlyCost: 0, sessionOldest: null, rowCount: 0 };
+      agg.sessionCost += Number(row.sessionCost) || 0;
+      agg.weeklyCost += Number(row.weeklyCost) || 0;
+      agg.monthlyCost += Number(row.monthlyCost) || 0;
+      agg.rowCount += rowCount;
+      const oldest = row.sessionOldest == null ? null : Number(row.sessionOldest);
+      if (oldest != null && Number.isFinite(oldest)) {
+        agg.sessionOldest = agg.sessionOldest == null ? oldest : Math.min(agg.sessionOldest, oldest);
+      }
+      break; // this database answered — don't re-run the other schema on it
     }
   }
   if (!agg || agg.rowCount <= 0) return null;

--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -445,29 +445,30 @@ function buildGoAggregateSql({ sessionStart, weekStart, weekEnd, monthStart, mon
   );
 }
 
-// Detect which message-table generation a database carries ("v1" / "v2" /
-// null when sqlite_master cannot be read, e.g. mocked readers in tests).
-// A database carrying BOTH tables resolves to "v1" on purpose: unlike the
+// Detect whether the database has any rows in session_message. This is the
+// shared opencode2 probe (see src/lib/rollout.js): a pure v1 database has an
+// empty session_message table, and blindly running the v2 aggregate against it
+// is harmless here (no JOIN, no directory lookup) — but the probe result still
+// drives variant ordering so v2 is preferred when data exists.
+//
+// A database carrying BOTH tables resolves to "v1 first" on purpose: unlike the
 // message parser (which dedups rows by sessionID|messageID), this aggregate is
 // a blind SUM with no key to dedup on, so unioning two generations could
 // double-count cost if the tables overlap. Undercounting an opt-in estimate is
 // the safe side of that trade.
-async function detectOpencodeDbGeneration(dbPath, sqliteOptions = {}) {
+async function detectOpencodeGoHasSessionMessages(dbPath, sqliteOptions = {}) {
   let rows;
   try {
     rows = await readSqliteJsonRowsAsync(
       dbPath,
-      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('message','session_message')`,
+      `SELECT (SELECT 1 FROM session_message LIMIT 1) AS hasRows`,
       { label: "OpenCode Go", timeout: 5_000, ...sqliteOptions },
     );
   } catch (_e) {
     return null;
   }
-  if (!Array.isArray(rows)) return null;
-  const names = new Set(rows.map((r) => String(r?.name || "").trim()).filter(Boolean));
-  if (names.size === 0) return null;
-  if (!names.has("message") && names.has("session_message")) return "v2";
-  return "v1";
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  return Boolean(rows[0]?.hasRows);
 }
 
 // Returns { source:'local', primary/secondary/tertiary_window } or null when no
@@ -487,8 +488,8 @@ async function collectOpencodeGoLocal({ home, env = process.env, nowMs = Date.no
   for (const dbPath of paths) {
     // Each database can be a different OpenCode generation. When sqlite_master
     // is unreadable, fall back to v1-then-v2 so the legacy query runs first.
-    const generation = await detectOpencodeDbGeneration(dbPath, sqliteOptions);
-    const variants = generation === "v2" ? ["v2"] : generation === "v1" ? ["v1"] : ["v1", "v2"];
+    const hasRows = await detectOpencodeGoHasSessionMessages(dbPath, sqliteOptions);
+    const variants = hasRows === true ? ["v2", "v1"] : hasRows === false ? ["v1", "v2"] : ["v1", "v2"];
 
     for (const variant of variants) {
       const sql = buildGoAggregateSql(windowArgs, variant);
@@ -497,8 +498,8 @@ async function collectOpencodeGoLocal({ home, env = process.env, nowMs = Date.no
         rows = await readSqliteJsonRowsAsync(dbPath, sql, {
           label: "OpenCode Go",
           timeout: 5_000,
-          throwOnReadFailure: true,
           ...sqliteOptions,
+          throwOnReadFailure: true,
         });
       } catch (_e) {
         continue;

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2698,7 +2698,8 @@ async function parseOpencodeMessageFile({
     };
   }
 
-  const model = normalizeModelInput(msg?.modelID || msg?.model || msg?.modelId) || DEFAULT_MODEL;
+  const { modelId: fileModelId } = normalizeOpencodeModelFields(msg);
+  const model = fileModelId || DEFAULT_MODEL;
   const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
   addTotals(bucket.totals, delta);
   touchedBuckets.add(bucketKey(source, model, bucketStart));
@@ -3289,8 +3290,11 @@ function deriveOpencodeMessageFingerprint({ msg, totals, source }) {
   const created = coerceEpochMs(msg?.time?.created) || 0;
   const completed = coerceEpochMs(msg?.time?.completed) || 0;
   if (!created && !completed) return null;
-  const model = normalizeModelInput(msg?.modelID || msg?.model || msg?.modelId) || DEFAULT_MODEL;
-  const provider = normalizeMessageKeyPart(msg?.providerID || msg?.provider || msg?.providerId);
+  // v1 keeps flat modelID/providerID strings; v2 nests them in
+  // `model: { id, providerID }` — normalize both (see normalizeOpencodeModelFields).
+  const { modelId, providerId } = normalizeOpencodeModelFields(msg);
+  const model = modelId || DEFAULT_MODEL;
+  const provider = providerId;
   const raw = [
     normalizeSourceInput(source) || "opencode",
     created,
@@ -3402,7 +3406,8 @@ function repairCountedOpencodeForkCopy({
   if (!timestampMs) return false;
   const bucketStart = toUtcHalfHourStart(new Date(timestampMs).toISOString());
   if (!bucketStart) return false;
-  const model = normalizeModelInput(msg?.modelID || msg?.model || msg?.modelId) || DEFAULT_MODEL;
+  const { modelId: repairModelId } = normalizeOpencodeModelFields(msg);
+  const model = repairModelId || DEFAULT_MODEL;
   const counted = { ...totals, conversation_count: 1 };
   const bucket = getHourlyBucket(hourlyState, source, model, bucketStart);
   subtractTotals(bucket.totals, counted);
@@ -3633,6 +3638,33 @@ function normalizeModelInput(value) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+// OpenCode v1 stores the model as flat strings on every assistant message
+// (`modelID`, `providerID`), while OpenCode v2 (the `opencode2` beta, which
+// moved messages into the `session_message` table) nests them inside a single
+// object: `model: { id, providerID, variant }`. Some forks also wrote a plain
+// string into `model`. Resolve both shapes to { modelId, providerId } so
+// bucket keys and fork fingerprints stay identical across versions.
+function normalizeOpencodeModelFields(msg) {
+  const directModel =
+    normalizeModelInput(msg?.modelID) ||
+    normalizeModelInput(typeof msg?.model === "string" ? msg.model : null) ||
+    normalizeModelInput(msg?.modelId);
+  if (directModel) {
+    return {
+      modelId: directModel,
+      providerId: normalizeMessageKeyPart(msg?.providerID || msg?.provider || msg?.providerId),
+    };
+  }
+  const nested = msg?.model;
+  if (nested && typeof nested === "object") {
+    return {
+      modelId: normalizeModelInput(nested.id),
+      providerId: normalizeMessageKeyPart(nested.providerID),
+    };
+  }
+  return { modelId: null, providerId: "" };
 }
 
 async function resolveProjectMetaForPath(startDir, cache) {
@@ -4298,12 +4330,49 @@ async function walkOpencodeMessages(dir, out) {
 }
 
 // ---------------------------------------------------------------------------
-// OpenCode SQLite DB reader (v1.2+ stores messages in opencode.db)
+// OpenCode SQLite DB reader
+//
+// Two storage generations share the same file (~/.local/share/opencode/opencode.db):
+//   v1 (`opencode` ≤1.x): messages in the `message` table, role inside the JSON
+//     blob (`$.role`), flat `modelID`/`providerID` strings.
+//   v2 (`opencode2` beta): messages moved to `session_message` (role is now the
+//     `type` column), model nested as `model: { id, providerID }`, and the
+//     project directory lives on `session_v2.directory`.
+// Detect the generation via sqlite_master and fall back to trying both so
+// exotic setups (or partial mocks in tests) still read something sensible.
 // ---------------------------------------------------------------------------
+
+const OPENCODE_DB_V1_MESSAGE_SQL =
+  `SELECT id, session_id, time_updated, data FROM message ` +
+  `WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created ASC`;
+
+// LEFT JOIN keeps orphaned rows readable; `directory` feeds project attribution
+// (injected into msg.path.cwd below so downstream resolution stays unchanged).
+const OPENCODE_DB_V2_MESSAGE_SQL =
+  `SELECT sm.id AS id, sm.session_id AS session_id, sm.time_updated AS time_updated, ` +
+  `s.directory AS directory, sm.data AS data ` +
+  `FROM session_message sm LEFT JOIN session_v2 s ON s.id = sm.session_id ` +
+  `WHERE sm.type = 'assistant' ORDER BY sm.time_created ASC`;
+
+function detectOpencodeDbGeneration(dbPath, sqliteOptions = {}) {
+  let rows;
+  try {
+    rows = readSqliteJsonRows(
+      dbPath,
+      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('message','session_message')`,
+      { label: "OpenCode", timeout: 10_000, maxBuffer: 1024 * 1024, ...sqliteOptions },
+    );
+  } catch (_e) {
+    return null;
+  }
+  if (!Array.isArray(rows)) return null;
+  const names = new Set(rows.map((r) => String(r?.name || "").trim()).filter(Boolean));
+  if (names.size === 0) return null;
+  return { hasV1MessageTable: names.has("message"), hasV2SessionMessageTable: names.has("session_message") };
+}
 
 function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
-  const sql = `SELECT id, session_id, time_updated, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created ASC`;
 
   let snapshot = null;
   let effectiveDbPath = dbPath;
@@ -4314,13 +4383,10 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
     } catch (_e) { }
   }
 
-  try {
-    const rows = readSqliteJsonRows(effectiveDbPath, sql, {
-      label: "OpenCode",
-      maxBuffer: 50 * 1024 * 1024,
-      timeout: 30_000,
-      ...sqliteOptions,
-    });
+  // Parse raw SQL rows into the shared { id, sessionID, timeUpdated, data }
+  // shape; optionally restore v2's session-level project directory as the
+  // per-message `path.cwd` the rest of the pipeline expects.
+  const collectRows = (rows, isV2) => {
     const out = [];
     for (const row of rows) {
       if (!row || typeof row.data !== "string") continue;
@@ -4338,6 +4404,9 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
         toNonNegativeInt(tokens.output) > 0 ||
         toNonNegativeInt(tokens.reasoning) > 0;
       if (!hasTokens) continue;
+      if (isV2 && typeof row.directory === "string" && row.directory.trim()) {
+        data.path = { ...(typeof data.path === "object" && data.path ? data.path : {}), cwd: row.directory };
+      }
       out.push({
         id: row.id || data.id,
         sessionID: row.session_id || data.sessionID,
@@ -4346,6 +4415,50 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
       });
     }
     return out;
+  };
+
+  const readGeneration = (sql, isV2) => {
+    try {
+      const rows = readSqliteJsonRows(effectiveDbPath, sql, {
+        label: "OpenCode",
+        maxBuffer: 50 * 1024 * 1024,
+        timeout: 30_000,
+        throwOnReadFailure: true,
+        ...sqliteOptions,
+      });
+      return Array.isArray(rows) ? rows : [];
+    } catch (_e) {
+      return null; // query-level failure (e.g. wrong generation's table)
+    }
+  };
+
+  try {
+    // Prefer the detected generation. When detection is inconclusive (legacy
+    // forks with odd sqlite setups, mocked readers in tests), try v1 first and
+    // fall through to v2 only if v1 errored or came up empty — a real database
+    // carries exactly one generation, so the first non-empty read wins.
+    const generation = detectOpencodeDbGeneration(effectiveDbPath, sqliteOptions);
+    if (generation) {
+      let out = [];
+      if (generation.hasV1MessageTable) {
+        out = out.concat(collectRows(readGeneration(OPENCODE_DB_V1_MESSAGE_SQL, false) || [], false));
+      }
+      if (generation.hasV2SessionMessageTable) {
+        out = out.concat(collectRows(readGeneration(OPENCODE_DB_V2_MESSAGE_SQL, true) || [], true));
+      }
+      return out;
+    }
+
+    for (const [sql, isV2] of [
+      [OPENCODE_DB_V1_MESSAGE_SQL, false],
+      [OPENCODE_DB_V2_MESSAGE_SQL, true],
+    ]) {
+      const rows = readGeneration(sql, isV2);
+      if (!rows) continue;
+      const out = collectRows(rows, isV2);
+      if (out.length > 0) return out;
+    }
+    return [];
   } finally {
     if (snapshot) snapshot.cleanup();
   }
@@ -4562,7 +4675,8 @@ async function parseOpencodeDbIncremental({
       continue;
     }
 
-    const model = normalizeModelInput(msg?.modelID || msg?.model || msg?.modelId) || DEFAULT_MODEL;
+    const { modelId: dbModelId } = normalizeOpencodeModelFields(msg);
+    const model = dbModelId || DEFAULT_MODEL;
     const bucket = getHourlyBucket(hourlyState, defaultSource, model, bucketStart);
     addTotals(bucket.totals, delta);
     touchedBuckets.add(bucketKey(defaultSource, model, bucketStart));

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -4332,43 +4332,73 @@ async function walkOpencodeMessages(dir, out) {
 // ---------------------------------------------------------------------------
 // OpenCode SQLite DB reader
 //
-// Two storage generations share the same file (~/.local/share/opencode/opencode.db):
-//   v1 (`opencode` ≤1.x): messages in the `message` table, role inside the JSON
-//     blob (`$.role`), flat `modelID`/`providerID` strings.
-//   v2 (`opencode2` beta): messages moved to `session_message` (role is now the
-//     `type` column), model nested as `model: { id, providerID }`, and the
-//     project directory lives on `session_v2.directory`.
-// Detect the generation via sqlite_master and fall back to trying both so
-// exotic setups (or partial mocks in tests) still read something sensible.
+// Four real database shapes exist in the wild (see PR #501 / opencode2):
+//   A  pure v1:        `message`(data) + `session_message`(empty) [+ `session`]
+//   B  beta-17887:     `session_message`(data) + `session_v2`
+//   C  upstream v2:    `session_message`(data) + `session`
+//   D  transitional:   `message`(old data) + `session_message`(new data)
+//
+// The reader must serve all four without firing a doomed SQL at type A (an
+// empty `session_message` table still EXISTS — querying it with a JOIN against
+// `session_v2` that does not exist throws "no such table" every sync, and the
+// old code silently swallowed that error). The combined probe below answers
+// both "is there v2 data?" and "which session table exists?" in one round-trip.
 // ---------------------------------------------------------------------------
 
 const OPENCODE_DB_V1_MESSAGE_SQL =
   `SELECT id, session_id, time_updated, data FROM message ` +
   `WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created ASC`;
 
-// LEFT JOIN keeps orphaned rows readable; `directory` feeds project attribution
-// (injected into msg.path.cwd below so downstream resolution stays unchanged).
-const OPENCODE_DB_V2_MESSAGE_SQL =
-  `SELECT sm.id AS id, sm.session_id AS session_id, sm.time_updated AS time_updated, ` +
-  `s.directory AS directory, sm.data AS data ` +
-  `FROM session_message sm LEFT JOIN session_v2 s ON s.id = sm.session_id ` +
-  `WHERE sm.type = 'assistant' ORDER BY sm.time_created ASC`;
+// Build the v2 query. When a session table exists the LEFT JOIN restores the
+// project directory for downstream attribution; when it does not (type B
+// without session_v2, or an exotic fork) the join and directory column are
+// omitted and tokens are counted as-is.
+function buildV2Sql(sessionTable) {
+  const joinClause = sessionTable
+    ? `LEFT JOIN ${sessionTable} s ON s.id = sm.session_id `
+    : "";
+  const directorySelect = sessionTable
+    ? `s.directory AS directory, `
+    : "";
+  return (
+    `SELECT sm.id AS id, sm.session_id AS session_id, sm.time_updated AS time_updated, ` +
+    `${directorySelect}sm.data AS data ` +
+    `FROM session_message sm ${joinClause}` +
+    `WHERE sm.type = 'assistant' ORDER BY sm.time_created ASC`
+  );
+}
 
-function detectOpencodeDbGeneration(dbPath, sqliteOptions = {}) {
+// One combined probe: hasRows (is there any data in session_message?) plus
+// sessionTable (which session table exists, session_v2 preferred over session
+// via DESC). Returns null when the probe itself fails — callers treat that as
+// v1-only, matching the pre-existing silent-degradation contract.
+function detectOpencodeMessageLayout(dbPath, sqliteOptions = {}) {
   let rows;
   try {
     rows = readSqliteJsonRows(
       dbPath,
-      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('message','session_message')`,
+      `SELECT (SELECT 1 FROM session_message LIMIT 1) AS hasRows,
+              (SELECT name FROM sqlite_master WHERE name IN ('session','session_v2') ORDER BY name DESC LIMIT 1) AS sessionTable`,
       { label: "OpenCode", timeout: 10_000, maxBuffer: 1024 * 1024, ...sqliteOptions },
     );
   } catch (_e) {
     return null;
   }
-  if (!Array.isArray(rows)) return null;
-  const names = new Set(rows.map((r) => String(r?.name || "").trim()).filter(Boolean));
-  if (names.size === 0) return null;
-  return { hasV1MessageTable: names.has("message"), hasV2SessionMessageTable: names.has("session_message") };
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const row = rows[0];
+  return {
+    hasRows: Boolean(row?.hasRows),
+    sessionTable: typeof row?.sessionTable === "string" && row.sessionTable.trim()
+      ? row.sessionTable.trim()
+      : null,
+  };
+}
+
+// Shared provider resolver: v1 rows carry a top-level providerID, v2 rows nest
+// it under model.providerID. Used by the mimo/zcode discriminators so they work
+// against both generations without duplicating the resolution logic.
+function opencodeMessageProvider(data) {
+  return data?.providerID || data?.model?.providerID || "";
 }
 
 function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
@@ -4386,6 +4416,12 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   // Parse raw SQL rows into the shared { id, sessionID, timeUpdated, data }
   // shape; optionally restore v2's session-level project directory as the
   // per-message `path.cwd` the rest of the pipeline expects.
+  //
+  // D-state (transitional) union: both the legacy `message` table and the new
+  // `session_message` table may carry rows. Cross-table duplicates are caught
+  // by the existing cursor-key + #426 fingerprint dedup in
+  // parseOpencodeDbIncremental, so unioning here is safe — the downstream
+  // parser collapses identical sessionID|messageID pairs before bucketing.
   const collectRows = (rows, isV2) => {
     const out = [];
     for (const row of rows) {
@@ -4417,14 +4453,14 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
     return out;
   };
 
-  const readGeneration = (sql, isV2) => {
+  const readGeneration = (sql) => {
     try {
       const rows = readSqliteJsonRows(effectiveDbPath, sql, {
         label: "OpenCode",
         maxBuffer: 50 * 1024 * 1024,
         timeout: 30_000,
-        throwOnReadFailure: true,
         ...sqliteOptions,
+        throwOnReadFailure: true,
       });
       return Array.isArray(rows) ? rows : [];
     } catch (_e) {
@@ -4433,32 +4469,22 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   };
 
   try {
-    // Prefer the detected generation. When detection is inconclusive (legacy
-    // forks with odd sqlite setups, mocked readers in tests), try v1 first and
-    // fall through to v2 only if v1 errored or came up empty — a real database
-    // carries exactly one generation, so the first non-empty read wins.
-    const generation = detectOpencodeDbGeneration(effectiveDbPath, sqliteOptions);
-    if (generation) {
-      let out = [];
-      if (generation.hasV1MessageTable) {
-        out = out.concat(collectRows(readGeneration(OPENCODE_DB_V1_MESSAGE_SQL, false) || [], false));
-      }
-      if (generation.hasV2SessionMessageTable) {
-        out = out.concat(collectRows(readGeneration(OPENCODE_DB_V2_MESSAGE_SQL, true) || [], true));
-      }
-      return out;
+    // Combined probe drives the orchestration: v1 always runs (it is the
+    // baseline every database carries or degrades to), v2 runs only when the
+    // probe confirms session_message has rows — this avoids firing a JOIN
+    // against a non-existent session table on type-A databases.
+    const probe = detectOpencodeMessageLayout(effectiveDbPath, sqliteOptions);
+    const out = [];
+
+    const rows1 = readGeneration(OPENCODE_DB_V1_MESSAGE_SQL);
+    if (rows1) out.push(...collectRows(rows1, false));
+
+    if (probe?.hasRows) {
+      const rows2 = readGeneration(buildV2Sql(probe.sessionTable));
+      if (rows2) out.push(...collectRows(rows2, true));
     }
 
-    for (const [sql, isV2] of [
-      [OPENCODE_DB_V1_MESSAGE_SQL, false],
-      [OPENCODE_DB_V2_MESSAGE_SQL, true],
-    ]) {
-      const rows = readGeneration(sql, isV2);
-      if (!rows) continue;
-      const out = collectRows(rows, isV2);
-      if (out.length > 0) return out;
-    }
-    return [];
+    return out;
   } finally {
     if (snapshot) snapshot.cleanup();
   }
@@ -4482,7 +4508,7 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
 // subsumes it.
 function isMimoNativeMessage(data) {
   if (!data) return false;
-  const provider = String(data.providerID || "").toLowerCase();
+  const provider = String(opencodeMessageProvider(data)).toLowerCase();
   return provider === "mimo" || provider === "xiaomi";
 }
 
@@ -4516,7 +4542,7 @@ function readMimoDbMessages(dbPath, sqliteOptions = {}) {
 // re-count it. Mirrors the Mimo discipline.
 function isZcodeNativeMessage(data) {
   if (!data) return false;
-  const provider = String(data.providerID || "").toLowerCase();
+  const provider = String(opencodeMessageProvider(data)).toLowerCase();
   if (!provider) return false;
   return !(
     provider.includes("anthropic") ||

--- a/test/opencode-go-local-limits.test.js
+++ b/test/opencode-go-local-limits.test.js
@@ -197,6 +197,72 @@ describe("collectOpencodeGoLocal (real fixture DB)", { skip: !sqlite }, () => {
   });
 });
 
+// opencode2 (OpenCode v2 beta) rewrote the storage layer: the `message` table
+// became `session_message` (role is now a `type` column) and the provider
+// moved under `$.model.providerID`. The local cost estimate must keep working
+// against both generations sharing the same file.
+describe("collectOpencodeGoLocal (opencode2 session_message fixture)", { skip: !sqlite }, () => {
+  let tmpDir;
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-go-v2-test-"));
+    buildV2FixtureDb(tmpDir);
+  });
+  after(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (_e) {
+      /* best effort */
+    }
+  });
+
+  function makeSessionMessageRow(db, { id, providerID, type, cost, createdMs }) {
+    const data = JSON.stringify({
+      model: { id: "x-preview-f-free", providerID },
+      type,
+      cost,
+      time: { created: createdMs },
+    });
+    db.prepare(
+      "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES (?, ?, ?, 0, ?, ?, ?)",
+    ).run(id, "sess_v2_1", type, createdMs, createdMs, data);
+  }
+
+  function buildV2FixtureDb(dir) {
+    const dbPath = path.join(dir, "opencode.db");
+    const db = new sqlite.DatabaseSync(dbPath);
+    db.exec(
+      "CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, seq INTEGER NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
+    );
+    const weekStart = weekStartMs(NOW_MS);
+    const monthStart = Date.UTC(2026, 5, 1);
+
+    const rows = [
+      // Mirrors the v1 fixture layout so window math stays comparable.
+      { id: "A", providerID: "opencode-go", type: "assistant", cost: 6.0, createdMs: NOW_MS - 1 * HOUR },
+      { id: "B", providerID: "opencode-go", type: "assistant", cost: 3.0, createdMs: NOW_MS - 6 * HOUR },
+      { id: "C", providerID: "opencode-go", type: "assistant", cost: 12.0, createdMs: monthStart + 1 * HOUR },
+      { id: "D", providerID: "opencode-go", type: "assistant", cost: 100.0, createdMs: monthStart - 1 * HOUR },
+      // Nested provider filter must exclude non-Go providers…
+      { id: "E", providerID: "opencode", type: "assistant", cost: 50.0, createdMs: NOW_MS - 1 * HOUR },
+      // …and the `type` column replaces the old role filter.
+      { id: "F", providerID: "opencode-go", type: "user", cost: 50.0, createdMs: NOW_MS - 1 * HOUR },
+    ];
+    for (const r of rows) makeSessionMessageRow(db, r);
+    db.close();
+    assert.ok(monthStart + 1 * HOUR < weekStart, "fixture: C must precede the week start");
+  }
+
+  it("sums opencode-go cost per window from the session_message table", async () => {
+    const out = await collectOpencodeGoLocal({ env: { OPENCODE_HOME: tmpDir }, nowMs: NOW_MS });
+    assert.ok(out, "expected a local result");
+    assert.equal(out.source, "local");
+    // Same expectations as the v1 fixture: A / A+B / A+B+C.
+    assert.equal(out.primary_window.used_percent, 50);
+    assert.equal(out.secondary_window.used_percent, 30);
+    assert.equal(out.tertiary_window.used_percent, 35);
+  });
+});
+
 describe("fetchOpencodeGoLimits source selection (real fixture DB)", { skip: !sqlite }, () => {
   let tmpDir;
   before(() => {

--- a/test/opencode-go-local-limits.test.js
+++ b/test/opencode-go-local-limits.test.js
@@ -230,8 +230,12 @@ describe("collectOpencodeGoLocal (opencode2 session_message fixture)", { skip: !
   function buildV2FixtureDb(dir) {
     const dbPath = path.join(dir, "opencode.db");
     const db = new sqlite.DatabaseSync(dbPath);
+    // C-type (upstream v2): session_message carries data, session table exists
+    // for the FK target. go-limits does not JOIN, but the table presence keeps
+    // the fixture aligned with the real upstream schema.
     db.exec(
-      "CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, seq INTEGER NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
+      "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL)" +
+      ";CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, seq INTEGER NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
     );
     const weekStart = weekStartMs(NOW_MS);
     const monthStart = Date.UTC(2026, 5, 1);
@@ -257,6 +261,69 @@ describe("collectOpencodeGoLocal (opencode2 session_message fixture)", { skip: !
     assert.ok(out, "expected a local result");
     assert.equal(out.source, "local");
     // Same expectations as the v1 fixture: A / A+B / A+B+C.
+    assert.equal(out.primary_window.used_percent, 50);
+    assert.equal(out.secondary_window.used_percent, 30);
+    assert.equal(out.tertiary_window.used_percent, 35);
+  });
+});
+
+// Type A (pure v1): the session_message table exists but is empty. The probe
+// reports hasRows=false, so the v1 variant runs first and the v2 aggregate is
+// never fired (it would find no rows anyway, but the ordering proves the probe
+// drives variant selection correctly).
+describe("collectOpencodeGoLocal (type A: empty session_message → v1 path)", { skip: !sqlite }, () => {
+  let tmpDir;
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-go-v1-test-"));
+    buildTypeAFixtureDb(tmpDir);
+  });
+  after(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (_e) {
+      /* best effort */
+    }
+  });
+
+  function makeMessageRow(db, { id, providerID, role, cost, createdMs }) {
+    const data = JSON.stringify({
+      providerID,
+      role,
+      cost,
+      time: { created: createdMs },
+    });
+    db.prepare(
+      "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+    ).run(id, "sess_1", createdMs, createdMs, data);
+  }
+
+  function buildTypeAFixtureDb(dir) {
+    const dbPath = path.join(dir, "opencode.db");
+    const db = new sqlite.DatabaseSync(dbPath);
+    // Type A: message table has data, session_message exists but is empty.
+    db.exec(
+      "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)" +
+      ";CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, seq INTEGER NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
+    );
+    const weekStart = weekStartMs(NOW_MS);
+    const monthStart = Date.UTC(2026, 5, 1);
+    const rows = [
+      { id: "A", providerID: "opencode-go", role: "assistant", cost: 6.0, createdMs: NOW_MS - 1 * HOUR },
+      { id: "B", providerID: "opencode-go", role: "assistant", cost: 3.0, createdMs: NOW_MS - 6 * HOUR },
+      { id: "C", providerID: "opencode-go", role: "assistant", cost: 12.0, createdMs: monthStart + 1 * HOUR },
+      { id: "D", providerID: "opencode-go", role: "assistant", cost: 100.0, createdMs: monthStart - 1 * HOUR },
+      { id: "E", providerID: "opencode", role: "assistant", cost: 50.0, createdMs: NOW_MS - 1 * HOUR },
+      { id: "F", providerID: "opencode-go", role: "user", cost: 50.0, createdMs: NOW_MS - 1 * HOUR },
+    ];
+    for (const r of rows) makeMessageRow(db, r);
+    db.close();
+    assert.ok(monthStart + 1 * HOUR < weekStart, "fixture: C must precede the week start");
+  }
+
+  it("reads v1 message rows when session_message is empty", async () => {
+    const out = await collectOpencodeGoLocal({ env: { OPENCODE_HOME: tmpDir }, nowMs: NOW_MS });
+    assert.ok(out, "expected a local result from the v1 message table");
+    assert.equal(out.source, "local");
     assert.equal(out.primary_window.used_percent, 50);
     assert.equal(out.secondary_window.used_percent, 30);
     assert.equal(out.tertiary_window.used_percent, 35);

--- a/test/opencode2-parser.test.js
+++ b/test/opencode2-parser.test.js
@@ -1,0 +1,358 @@
+"use strict";
+
+// OpenCode v2 (the `opencode2` beta) keeps the same data directory but rewrote
+// the storage layer: assistant messages moved from the `message` table to
+// `session_message` (role is now a `type` column), the model became a nested
+// `model: { id, providerID }` object, and the project directory lives on
+// `session_v2.directory` instead of the message's own `path.cwd`. These tests
+// pin the reader/parser contract for BOTH generations sharing one parser, all
+// aggregating under source="opencode".
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { runSql } = require("./helpers/sqlite-write");
+const {
+  readOpencodeDbMessages,
+  parseOpencodeDbIncremental,
+} = require("../src/lib/rollout");
+
+let sqlite = null;
+try {
+  sqlite = require("node:sqlite");
+} catch (_e) {
+  sqlite = null;
+}
+
+function buildV2FixtureDb(dbPath, { messages = [], sessions = [] } = {}) {
+  runSql(
+    dbPath,
+    [
+      // Minimal stand-ins for the real opencode2 tables — only the columns the
+      // reader touches are present.
+      "CREATE TABLE session_v2 (id TEXT PRIMARY KEY, directory TEXT NOT NULL)",
+      `CREATE TABLE session_message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      )`,
+    ].join(";\n") + ";",
+  );
+  const db = new sqlite.DatabaseSync(dbPath);
+  try {
+    for (const s of sessions) {
+      db.prepare("INSERT INTO session_v2 (id, directory) VALUES (?, ?)").run(s.id, s.directory);
+    }
+    for (const m of messages) {
+      const createdMs = m.time?.created ?? 0;
+      const updatedMs = m.time?.completed ?? createdMs;
+      db.prepare(
+        "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(m.id, m.sessionID, m.type || "assistant", m.seq ?? 0, createdMs, updatedMs, JSON.stringify(m));
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function buildV1FixtureDb(dbPath, messages) {
+  runSql(
+    dbPath,
+    "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
+  );
+  const db = new sqlite.DatabaseSync(dbPath);
+  try {
+    for (const m of messages) {
+      const createdMs = m.time?.created ?? 0;
+      const updatedMs = m.time?.completed ?? createdMs;
+      db.prepare(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+      ).run(m.id, m.sessionID, createdMs, updatedMs, JSON.stringify(m));
+    }
+  } finally {
+    db.close();
+  }
+}
+
+// An opencode2-shaped assistant message: nested model object, no top-level
+// modelID/providerID, tokens/cache identical to v1.
+function v2AssistantMessage({ id, sessionID, modelId = "x-preview-f-free", providerID = "opencode", input = 100, output = 20, cached = 0, cacheWrite = 0, reasoning = 0 }) {
+  return {
+    id,
+    sessionID,
+    type: "assistant",
+    agent: "build",
+    model: { id: modelId, providerID },
+    time: { created: Date.parse("2026-08-01T10:00:00.000Z"), completed: Date.parse("2026-08-01T10:00:05.000Z") },
+    tokens: { input, output, reasoning, cache: { read: cached, write: cacheWrite } },
+  };
+}
+
+// A v1-shaped assistant message: flat modelID/providerID strings + role key.
+function v1AssistantMessage({ id, sessionID, modelID = "claude-sonnet-4", providerID = "anthropic", input = 100, output = 20, cached = 0, cacheWrite = 0 }) {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    modelID,
+    providerID,
+    time: { created: Date.parse("2026-08-01T10:00:00.000Z"), completed: Date.parse("2026-08-01T10:00:05.000Z") },
+    tokens: { input, output, reasoning: 0, cache: { read: cached, write: cacheWrite } },
+  };
+}
+
+async function withTmp(fn) {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-opencode2-"));
+  try {
+    return await fn(tmp);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+}
+
+async function readQueue(queuePath) {
+  const text = await fs.readFile(queuePath, "utf8").catch(() => "");
+  if (!text.trim()) return [];
+  return text.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function queueTotals(queuePath) {
+  const rows = await readQueue(queuePath);
+  const latest = new Map();
+  for (const row of rows) latest.set(`${row.source}|${row.model}|${row.hour_start}`, row);
+  const totals = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: 0,
+  };
+  for (const row of latest.values()) {
+    for (const key of Object.keys(totals)) totals[key] += row[key] || 0;
+  }
+  return { rows, totals };
+}
+
+test("readOpencodeDbMessages reads the opencode2 session_message schema", async () => {
+  await withTmp(async (tmp) => {
+    const dbPath = path.join(tmp, "opencode.db");
+    buildV2FixtureDb(dbPath, {
+      sessions: [{ id: "ses_v2_1", directory: "/Users/alice/dev/widgets" }],
+      messages: [
+        v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1" }),
+        // Some OpenCode forks wrote a plain string into `model` — the reader
+        // must not care; model resolution happens downstream either way.
+        { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_1" }), model: "string-form-model" },
+        // user turns and token-less assistants never carry usage
+        { ...v2AssistantMessage({ id: "msg_u", sessionID: "ses_v2_1" }), type: "user" },
+        { ...v2AssistantMessage({ id: "msg_e", sessionID: "ses_v2_1" }), tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+      ],
+    });
+
+    const rows = readOpencodeDbMessages(dbPath);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].id, "msg_a");
+    assert.equal(rows[0].sessionID, "ses_v2_1");
+    // Nested model object survives untouched…
+    assert.deepEqual(rows[0].data.model, { id: "x-preview-f-free", providerID: "opencode" });
+    // …and the session's directory is restored as the per-message path.cwd so
+    // project attribution works without any downstream change.
+    assert.equal(rows[0].data.path.cwd, "/Users/alice/dev/widgets");
+  });
+});
+
+test("readOpencodeDbMessages still reads the v1 message table unchanged", async () => {
+  await withTmp(async (tmp) => {
+    const dbPath = path.join(tmp, "opencode.db");
+    buildV1FixtureDb(dbPath, [v1AssistantMessage({ id: "msg_v1", sessionID: "ses_v1" })]);
+
+    const rows = readOpencodeDbMessages(dbPath);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, "msg_v1");
+    assert.equal(rows[0].data.modelID, "claude-sonnet-4");
+    assert.equal(rows[0].data.providerID, "anthropic");
+  });
+});
+
+test("readOpencodeDbMessages falls back to session_message when sqlite_master probing is inconclusive", async () => {
+  await withTmp(async (tmp) => {
+    // Simulate a reader stack that answers only real table queries (the probe
+    // comes back empty), so the code must try v1 → fail ("no such table") → v2.
+    const calls = [];
+    const dbPath = path.join(tmp, "opencode.db");
+    await fs.writeFile(dbPath, "", "utf8");
+    const sqliteOptions = {
+      execFileSync() {
+        throw new Error("spawn sqlite3 ENOENT");
+      },
+      requireFn(name) {
+        assert.equal(name, "node:sqlite");
+        return {
+          DatabaseSync: class FakeDatabaseSync {
+            prepare(sql) {
+              calls.push(sql);
+              if (sql.includes("sqlite_master")) return { all: () => [] };
+              if (/FROM message /.test(sql)) {
+                throw new Error("no such table: message");
+              }
+              if (sql.includes("FROM session_message")) {
+                return {
+                  all: () => [
+                    {
+                      id: "msg_fb",
+                      session_id: "ses_fb",
+                      time_updated: Date.parse("2026-08-01T10:00:05.000Z"),
+                      directory: "/Users/alice/dev/widgets",
+                      data: JSON.stringify(v2AssistantMessage({ id: "msg_fb", sessionID: "ses_fb" })),
+                    },
+                  ],
+                };
+              }
+              throw new Error(`unexpected sql: ${sql}`);
+            }
+            close() {}
+          },
+        };
+      },
+      stderr: { write() {} },
+    };
+
+    const rows = readOpencodeDbMessages(dbPath, sqliteOptions);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, "msg_fb");
+    assert.equal(rows[0].sessionID, "ses_fb");
+    assert.ok(calls.some((sql) => sql.includes("FROM session_message")));
+  });
+});
+
+test("parseOpencodeDbIncremental buckets opencode2 messages under source=opencode with the nested model id", async () => {
+  await withTmp(async (tmp) => {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const res = await parseOpencodeDbIncremental({
+      dbMessages: [
+        {
+          id: "msg_a",
+          sessionID: "ses_v2_1",
+          data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
+        },
+        // String-form `model` (fork variant) must resolve through the same helper.
+        {
+          id: "msg_s",
+          sessionID: "ses_v2_2",
+          data: { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_2", input: 10, output: 5 }), model: "string-form-model" },
+        },
+      ],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+
+    assert.equal(res.eventsAggregated, 2);
+    const { rows, totals } = await queueTotals(queuePath);
+    assert.equal(rows.length, 2);
+    assert.ok(rows.every((r) => r.source === "opencode"));
+    assert.ok(rows.some((r) => r.model === "x-preview-f-free"));
+    assert.ok(rows.some((r) => r.model === "string-form-model"));
+    assert.equal(totals.input_tokens, 5654);
+    assert.equal(totals.output_tokens, 66);
+    assert.equal(totals.cached_input_tokens, 3136);
+    assert.equal(totals.reasoning_output_tokens, 8);
+
+    // Idempotent: replaying the same snapshot aggregates nothing new.
+    const again = await parseOpencodeDbIncremental({
+      dbMessages: [
+        {
+          id: "msg_a",
+          sessionID: "ses_v2_1",
+          data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
+        },
+      ],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+    assert.equal(again.eventsAggregated, 0);
+  });
+});
+
+test("opencode2 fork copies are deduped via the fingerprint built from the nested model", async () => {
+  await withTmp(async (tmp) => {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    // Session.fork re-materialises the parent turn under a new id/session with
+    // an identical payload — exactly the #426 shape, now in v2 clothing.
+    const wrap = (m) => ({ id: m.id, sessionID: m.sessionID, data: m });
+    const parent = v2AssistantMessage({ id: "msg_p", sessionID: "ses_parent", input: 5000, output: 100 });
+    const forkCopy = v2AssistantMessage({ id: "msg_f", sessionID: "ses_fork", input: 5000, output: 100 });
+    const genuineContinuation = v2AssistantMessage({ id: "msg_g", sessionID: "ses_fork", input: 42, output: 7 });
+
+    const res = await parseOpencodeDbIncremental({
+      dbMessages: [wrap(parent), wrap(forkCopy), wrap(genuineContinuation)],
+      cursors,
+      queuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+    assert.equal(res.eventsAggregated, 2); // parent + continuation; copy suppressed
+
+    const { totals } = await queueTotals(queuePath);
+    assert.equal(totals.input_tokens, 5042);
+    assert.equal(totals.output_tokens, 107);
+  });
+});
+
+test("end to end: opencode2 fixture DB flows through reader + parser with project attribution", async () => {
+  await withTmp(async (tmp) => {
+    // Minimal git repo the project resolver can walk into from the session's
+    // recorded directory.
+    const repoRoot = path.join(tmp, "widgets");
+    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, ".git", "config"),
+      '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n',
+      "utf8",
+    );
+
+    const dbPath = path.join(tmp, "opencode.db");
+    buildV2FixtureDb(dbPath, {
+      sessions: [{ id: "ses_repo", directory: repoRoot }],
+      messages: [v2AssistantMessage({ id: "msg_repo", sessionID: "ses_repo", input: 44322, output: 9905 })],
+    });
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const dbMessages = readOpencodeDbMessages(dbPath);
+    const res = await parseOpencodeDbIncremental({
+      dbMessages,
+      dbPath,
+      cursors,
+      queuePath,
+      projectQueuePath,
+      source: "opencode",
+      cursorKey: "opencode",
+    });
+
+    assert.equal(res.eventsAggregated, 1);
+    const { rows } = await queueTotals(queuePath);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].model, "x-preview-f-free");
+
+    const projectRows = await readQueue(projectQueuePath);
+    assert.equal(projectRows.length, 1);
+    assert.equal(projectRows[0].project_key, "acme/widgets");
+  });
+});

--- a/test/opencode2-parser.test.js
+++ b/test/opencode2-parser.test.js
@@ -7,18 +7,21 @@
 // `session_v2.directory` instead of the message's own `path.cwd`. These tests
 // pin the reader/parser contract for BOTH generations sharing one parser, all
 // aggregating under source="opencode".
+//
+// Four real database shapes are covered:
+//   A  pure v1:        `message`(data) + `session_message`(empty) [+ `session`]
+//   B  beta-17887:     `session_message`(data) + `session_v2`
+//   C  upstream v2:    `session_message`(data) + `session`
+//   D  transitional:   `message`(old data) + `session_message`(new data)
 const assert = require("node:assert/strict");
 const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
-const { runSql } = require("./helpers/sqlite-write");
-const {
-  readOpencodeDbMessages,
-  parseOpencodeDbIncremental,
-} = require("../src/lib/rollout");
-
+// Probe node:sqlite availability first; only lazy-load the write helper when
+// the runtime supports it (fixes the skip-logic bypass where an unconditional
+// top-level require threw before the skip could take effect).
 let sqlite = null;
 try {
   sqlite = require("node:sqlite");
@@ -26,54 +29,84 @@ try {
   sqlite = null;
 }
 
-function buildV2FixtureDb(dbPath, { messages = [], sessions = [] } = {}) {
-  runSql(
-    dbPath,
-    [
-      // Minimal stand-ins for the real opencode2 tables — only the columns the
-      // reader touches are present.
-      "CREATE TABLE session_v2 (id TEXT PRIMARY KEY, directory TEXT NOT NULL)",
-      `CREATE TABLE session_message (
-        id TEXT PRIMARY KEY,
-        session_id TEXT NOT NULL,
-        type TEXT NOT NULL,
-        seq INTEGER NOT NULL,
-        time_created INTEGER NOT NULL,
-        time_updated INTEGER NOT NULL,
-        data TEXT NOT NULL
-      )`,
-    ].join(";\n") + ";",
+const { runSql } = sqlite ? require("./helpers/sqlite-write") : { runSql: null };
+const {
+  readOpencodeDbMessages,
+  parseOpencodeDbIncremental,
+} = require("../src/lib/rollout");
+
+// --- fixture helpers --------------------------------------------------------
+
+function buildMessageTableSql() {
+  return (
+    "CREATE TABLE message (" +
+    " id TEXT PRIMARY KEY," +
+    " session_id TEXT NOT NULL," +
+    " time_created INTEGER NOT NULL," +
+    " time_updated INTEGER NOT NULL," +
+    " data TEXT NOT NULL" +
+    ")"
   );
+}
+
+function buildSessionMessageTableSql() {
+  return (
+    "CREATE TABLE session_message (" +
+    " id TEXT PRIMARY KEY," +
+    " session_id TEXT NOT NULL," +
+    " type TEXT NOT NULL," +
+    " seq INTEGER NOT NULL," +
+    " time_created INTEGER NOT NULL," +
+    " time_updated INTEGER NOT NULL," +
+    " data TEXT NOT NULL" +
+    ")"
+  );
+}
+
+function buildSessionV2TableSql() {
+  return "CREATE TABLE session_v2 (id TEXT PRIMARY KEY, directory TEXT NOT NULL)";
+}
+
+function buildSessionTableSql() {
+  return "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL)";
+}
+
+// Build a fixture DB of the given type. `messages` always carries v1-shaped
+// rows (flat providerID/role); `v2Messages` carries v2-shaped rows (nested
+// model/type). The FK target for session_message must be real:
+//   A/C → session(id),  B → session_v2(id).
+function buildFixtureDb(dbPath, { type, messages = [], v2Messages = [], sessions = [] } = {}) {
+  const statements = [];
+  const hasMessageTable = type === "A" || type === "D";
+  const hasSessionMessageTable = type === "B" || type === "C" || type === "D";
+  const sessionTableName = type === "B" ? "session_v2" : "session";
+
+  if (hasMessageTable) statements.push(buildMessageTableSql());
+  if (hasSessionMessageTable) statements.push(buildSessionMessageTableSql());
+  if (sessions.length > 0) {
+    if (sessionTableName === "session_v2") statements.push(buildSessionV2TableSql());
+    else statements.push(buildSessionTableSql());
+  }
+  runSql(dbPath, statements.join(";\n") + ";");
+
   const db = new sqlite.DatabaseSync(dbPath);
   try {
     for (const s of sessions) {
-      db.prepare("INSERT INTO session_v2 (id, directory) VALUES (?, ?)").run(s.id, s.directory);
+      db.prepare(`INSERT INTO ${sessionTableName} (id, directory) VALUES (?, ?)`).run(s.id, s.directory);
     }
-    for (const m of messages) {
-      const createdMs = m.time?.created ?? 0;
-      const updatedMs = m.time?.completed ?? createdMs;
-      db.prepare(
-        "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      ).run(m.id, m.sessionID, m.type || "assistant", m.seq ?? 0, createdMs, updatedMs, JSON.stringify(m));
-    }
-  } finally {
-    db.close();
-  }
-}
-
-function buildV1FixtureDb(dbPath, messages) {
-  runSql(
-    dbPath,
-    "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL)",
-  );
-  const db = new sqlite.DatabaseSync(dbPath);
-  try {
     for (const m of messages) {
       const createdMs = m.time?.created ?? 0;
       const updatedMs = m.time?.completed ?? createdMs;
       db.prepare(
         "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
       ).run(m.id, m.sessionID, createdMs, updatedMs, JSON.stringify(m));
+    }
+    for (const m of v2Messages) {
+      const createdMs = m.time?.created ?? 0;
+      const updatedMs = m.time?.completed ?? createdMs;
+      db.prepare(
+        "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(m.id, m.sessionID, m.type || "assistant", m.seq ?? 0, createdMs, updatedMs, JSON.stringify(m));
     }
   } finally {
     db.close();
@@ -140,219 +173,403 @@ async function queueTotals(queuePath) {
   return { rows, totals };
 }
 
-test("readOpencodeDbMessages reads the opencode2 session_message schema", async () => {
-  await withTmp(async (tmp) => {
-    const dbPath = path.join(tmp, "opencode.db");
-    buildV2FixtureDb(dbPath, {
-      sessions: [{ id: "ses_v2_1", directory: "/Users/alice/dev/widgets" }],
-      messages: [
-        v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1" }),
-        // Some OpenCode forks wrote a plain string into `model` — the reader
-        // must not care; model resolution happens downstream either way.
-        { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_1" }), model: "string-form-model" },
-        // user turns and token-less assistants never carry usage
-        { ...v2AssistantMessage({ id: "msg_u", sessionID: "ses_v2_1" }), type: "user" },
-        { ...v2AssistantMessage({ id: "msg_e", sessionID: "ses_v2_1" }), tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
-      ],
+// --- tests ------------------------------------------------------------------
+
+const skipTests = !sqlite
+  ? () => {
+      console.log("SKIP: node:sqlite unavailable — all opencode2-parser tests skipped");
+    }
+  : null;
+
+// When sqlite is unavailable, the describe blocks still need to register
+// without throwing. node:test allows a conditional describe via function
+// evaluation, but the simplest approach is to guard the test() calls.
+
+if (sqlite) {
+  test("readOpencodeDbMessages reads the opencode2 session_message schema (type B: session_v2)", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "B",
+        sessions: [{ id: "ses_v2_1", directory: "/Users/alice/dev/widgets" }],
+        v2Messages: [
+          v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1" }),
+          // Some OpenCode forks wrote a plain string into `model` — the reader
+          // must not care; model resolution happens downstream either way.
+          { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_1" }), model: "string-form-model" },
+          // user turns and token-less assistants never carry usage
+          { ...v2AssistantMessage({ id: "msg_u", sessionID: "ses_v2_1" }), type: "user" },
+          { ...v2AssistantMessage({ id: "msg_e", sessionID: "ses_v2_1" }), tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ],
+      });
+
+      const rows = readOpencodeDbMessages(dbPath);
+      assert.equal(rows.length, 2);
+      assert.equal(rows[0].id, "msg_a");
+      assert.equal(rows[0].sessionID, "ses_v2_1");
+      // Nested model object survives untouched…
+      assert.deepEqual(rows[0].data.model, { id: "x-preview-f-free", providerID: "opencode" });
+      // …and the session's directory is restored as the per-message path.cwd so
+      // project attribution works without any downstream change.
+      assert.equal(rows[0].data.path.cwd, "/Users/alice/dev/widgets");
     });
-
-    const rows = readOpencodeDbMessages(dbPath);
-    assert.equal(rows.length, 2);
-    assert.equal(rows[0].id, "msg_a");
-    assert.equal(rows[0].sessionID, "ses_v2_1");
-    // Nested model object survives untouched…
-    assert.deepEqual(rows[0].data.model, { id: "x-preview-f-free", providerID: "opencode" });
-    // …and the session's directory is restored as the per-message path.cwd so
-    // project attribution works without any downstream change.
-    assert.equal(rows[0].data.path.cwd, "/Users/alice/dev/widgets");
   });
-});
 
-test("readOpencodeDbMessages still reads the v1 message table unchanged", async () => {
-  await withTmp(async (tmp) => {
-    const dbPath = path.join(tmp, "opencode.db");
-    buildV1FixtureDb(dbPath, [v1AssistantMessage({ id: "msg_v1", sessionID: "ses_v1" })]);
+  test("readOpencodeDbMessages still reads the v1 message table unchanged (type A)", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "A",
+        messages: [v1AssistantMessage({ id: "msg_v1", sessionID: "ses_v1" })],
+      });
 
-    const rows = readOpencodeDbMessages(dbPath);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].id, "msg_v1");
-    assert.equal(rows[0].data.modelID, "claude-sonnet-4");
-    assert.equal(rows[0].data.providerID, "anthropic");
+      const rows = readOpencodeDbMessages(dbPath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].id, "msg_v1");
+      assert.equal(rows[0].data.modelID, "claude-sonnet-4");
+      assert.equal(rows[0].data.providerID, "anthropic");
+    });
   });
-});
 
-test("readOpencodeDbMessages falls back to session_message when sqlite_master probing is inconclusive", async () => {
-  await withTmp(async (tmp) => {
-    // Simulate a reader stack that answers only real table queries (the probe
-    // comes back empty), so the code must try v1 → fail ("no such table") → v2.
-    const calls = [];
-    const dbPath = path.join(tmp, "opencode.db");
-    await fs.writeFile(dbPath, "", "utf8");
-    const sqliteOptions = {
-      execFileSync() {
-        throw new Error("spawn sqlite3 ENOENT");
-      },
-      requireFn(name) {
-        assert.equal(name, "node:sqlite");
-        return {
-          DatabaseSync: class FakeDatabaseSync {
-            prepare(sql) {
-              calls.push(sql);
-              if (sql.includes("sqlite_master")) return { all: () => [] };
-              if (/FROM message /.test(sql)) {
-                throw new Error("no such table: message");
+  test("type C (upstream v2 with session table): directory injected from session.directory", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "C",
+        sessions: [{ id: "ses_c", directory: "/Users/bob/dev/phones" }],
+        v2Messages: [v2AssistantMessage({ id: "msg_c", sessionID: "ses_c" })],
+      });
+
+      const rows = readOpencodeDbMessages(dbPath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].data.path.cwd, "/Users/bob/dev/phones");
+    });
+  });
+
+  test("type A: no v2 data SQL is issued (empty session_message → probe.hasRows=false)", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      // Type A: message table has data, session_message is empty (table exists
+      // but has no rows). The probe must report hasRows=false, so the v2 query
+      // (which would JOIN against a non-existent session table) is never fired.
+      buildFixtureDb(dbPath, {
+        type: "A",
+        messages: [v1AssistantMessage({ id: "msg_a1", sessionID: "ses_a1" })],
+      });
+
+      // Count SQL calls by wrapping readSqliteJsonRows via sqliteOptions.
+      const sqlCalls = [];
+      const sqliteOptions = {
+        requireFn(name) {
+          assert.equal(name, "node:sqlite");
+          return {
+            DatabaseSync: class FakeDatabaseSync {
+              prepare(sql) {
+                sqlCalls.push(sql);
+                if (sql.includes("sqlite_master")) {
+                  // The combined probe: hasRows=0 (empty), sessionTable='session'
+                  return { all: () => [{ hasRows: 0, sessionTable: "session" }] };
+                }
+                if (/FROM message /.test(sql)) {
+                  return {
+                    all: () => [
+                      {
+                        id: "msg_a1",
+                        session_id: "ses_a1",
+                        time_updated: Date.parse("2026-08-01T10:00:05.000Z"),
+                        data: JSON.stringify(v1AssistantMessage({ id: "msg_a1", sessionID: "ses_a1" })),
+                      },
+                    ],
+                  };
+                }
+                throw new Error(`unexpected sql: ${sql}`);
               }
-              if (sql.includes("FROM session_message")) {
-                return {
-                  all: () => [
-                    {
-                      id: "msg_fb",
-                      session_id: "ses_fb",
-                      time_updated: Date.parse("2026-08-01T10:00:05.000Z"),
-                      directory: "/Users/alice/dev/widgets",
-                      data: JSON.stringify(v2AssistantMessage({ id: "msg_fb", sessionID: "ses_fb" })),
-                    },
-                  ],
-                };
+              close() {}
+            },
+          };
+        },
+        execFileSync() {
+          throw new Error("spawn sqlite3 ENOENT");
+        },
+        stderr: { write() {} },
+      };
+
+      const rows = readOpencodeDbMessages(dbPath, sqliteOptions);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].id, "msg_a1");
+      // The v2 data query (which aliases session_message as sm) must NOT have
+      // been issued. The probe itself references session_message in a subquery
+      // — that is allowed and counted separately.
+      const v2DataQueries = sqlCalls.filter((sql) => sql.includes("FROM session_message sm"));
+      assert.equal(v2DataQueries.length, 0, "type A must not fire any v2 data query");
+    });
+  });
+
+  test("type D (transitional): union of v1 + v2 rows, cross-table dedup via parseOpencodeDbIncremental", async () => {
+    await withTmp(async (tmp) => {
+      const queuePath = path.join(tmp, "queue.jsonl");
+      const cursors = { version: 1, files: {}, updatedAt: null };
+
+      // Two tables each carry data. Two rows share sessionID|messageID across
+      // tables — the parser must dedup them (cursor key + #426 fingerprint).
+      const v1Msg = v1AssistantMessage({ id: "msg_dup", sessionID: "ses_dup", input: 100, output: 20 });
+      const v2Msg = v2AssistantMessage({ id: "msg_dup", sessionID: "ses_dup", input: 100, output: 20 });
+      const v1Only = v1AssistantMessage({ id: "msg_v1only", sessionID: "ses_v1only", input: 50, output: 10 });
+      const v2Only = v2AssistantMessage({ id: "msg_v2only", sessionID: "ses_v2only", input: 60, output: 15 });
+
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "D",
+        messages: [v1Msg, v1Only],
+        v2Messages: [v2Msg, v2Only],
+      });
+
+      const dbMessages = readOpencodeDbMessages(dbPath);
+      // 4 raw rows: 2 v1 + 2 v2 (the duplicate pair is still present at the
+      // reader level — dedup happens downstream in parseOpencodeDbIncremental).
+      assert.equal(dbMessages.length, 4);
+
+      const res = await parseOpencodeDbIncremental({
+        dbMessages,
+        cursors,
+        queuePath,
+        source: "opencode",
+        cursorKey: "opencode",
+      });
+      // 3 unique messages after dedup: msg_dup (deduped to 1), msg_v1only, msg_v2only
+      assert.equal(res.eventsAggregated, 3);
+
+      const { totals } = await queueTotals(queuePath);
+      assert.equal(totals.input_tokens, 210); // 100 + 50 + 60
+      assert.equal(totals.output_tokens, 45);  // 20 + 10 + 15
+    });
+  });
+
+  test("probe failure degrades to v1-only", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      await fs.writeFile(dbPath, "", "utf8");
+      // Fake reader where the probe itself throws (simulating no session_message
+      // table at all). The code must treat this as v1-only and still try the
+      // v1 query.
+      const sqliteOptions = {
+        execFileSync() {
+          throw new Error("spawn sqlite3 ENOENT");
+        },
+        requireFn(name) {
+          assert.equal(name, "node:sqlite");
+          return {
+            DatabaseSync: class FakeDatabaseSync {
+              prepare(sql) {
+                if (sql.includes("sqlite_master")) {
+                  throw new Error("no such table: session_message");
+                }
+                if (/FROM message /.test(sql)) {
+                  return {
+                    all: () => [
+                      {
+                        id: "msg_v1",
+                        session_id: "ses_v1",
+                        time_updated: Date.parse("2026-08-01T10:00:05.000Z"),
+                        data: JSON.stringify(v1AssistantMessage({ id: "msg_v1", sessionID: "ses_v1" })),
+                      },
+                    ],
+                  };
+                }
+                throw new Error(`unexpected sql: ${sql}`);
               }
-              throw new Error(`unexpected sql: ${sql}`);
-            }
-            close() {}
+              close() {}
+            },
+          };
+        },
+        stderr: { write() {} },
+      };
+
+      const rows = readOpencodeDbMessages(dbPath, sqliteOptions);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].id, "msg_v1");
+    });
+  });
+
+  test("parseOpencodeDbIncremental buckets opencode2 messages under source=opencode with the nested model id", async () => {
+    await withTmp(async (tmp) => {
+      const queuePath = path.join(tmp, "queue.jsonl");
+      const cursors = { version: 1, files: {}, updatedAt: null };
+
+      const res = await parseOpencodeDbIncremental({
+        dbMessages: [
+          {
+            id: "msg_a",
+            sessionID: "ses_v2_1",
+            data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
           },
-        };
-      },
-      stderr: { write() {} },
-    };
+          // String-form `model` (fork variant) must resolve through the same helper.
+          {
+            id: "msg_s",
+            sessionID: "ses_v2_2",
+            data: { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_2", input: 10, output: 5 }), model: "string-form-model" },
+          },
+        ],
+        cursors,
+        queuePath,
+        source: "opencode",
+        cursorKey: "opencode",
+      });
 
-    const rows = readOpencodeDbMessages(dbPath, sqliteOptions);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].id, "msg_fb");
-    assert.equal(rows[0].sessionID, "ses_fb");
-    assert.ok(calls.some((sql) => sql.includes("FROM session_message")));
+      assert.equal(res.eventsAggregated, 2);
+      const { rows, totals } = await queueTotals(queuePath);
+      assert.equal(rows.length, 2);
+      assert.ok(rows.every((r) => r.source === "opencode"));
+      assert.ok(rows.some((r) => r.model === "x-preview-f-free"));
+      assert.ok(rows.some((r) => r.model === "string-form-model"));
+      assert.equal(totals.input_tokens, 5654);
+      assert.equal(totals.output_tokens, 66);
+      assert.equal(totals.cached_input_tokens, 3136);
+      assert.equal(totals.reasoning_output_tokens, 8);
+
+      // Idempotent: replaying the same snapshot aggregates nothing new.
+      const again = await parseOpencodeDbIncremental({
+        dbMessages: [
+          {
+            id: "msg_a",
+            sessionID: "ses_v2_1",
+            data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
+          },
+        ],
+        cursors,
+        queuePath,
+        source: "opencode",
+        cursorKey: "opencode",
+      });
+      assert.equal(again.eventsAggregated, 0);
+    });
   });
-});
 
-test("parseOpencodeDbIncremental buckets opencode2 messages under source=opencode with the nested model id", async () => {
-  await withTmp(async (tmp) => {
-    const queuePath = path.join(tmp, "queue.jsonl");
-    const cursors = { version: 1, files: {}, updatedAt: null };
+  test("opencode2 fork copies are deduped via the fingerprint built from the nested model", async () => {
+    await withTmp(async (tmp) => {
+      const queuePath = path.join(tmp, "queue.jsonl");
+      const cursors = { version: 1, files: {}, updatedAt: null };
 
-    const res = await parseOpencodeDbIncremental({
-      dbMessages: [
-        {
-          id: "msg_a",
-          sessionID: "ses_v2_1",
-          data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
-        },
-        // String-form `model` (fork variant) must resolve through the same helper.
-        {
-          id: "msg_s",
-          sessionID: "ses_v2_2",
-          data: { ...v2AssistantMessage({ id: "msg_s", sessionID: "ses_v2_2", input: 10, output: 5 }), model: "string-form-model" },
-        },
-      ],
-      cursors,
-      queuePath,
-      source: "opencode",
-      cursorKey: "opencode",
+      // Session.fork re-materialises the parent turn under a new id/session with
+      // an identical payload — exactly the #426 shape, now in v2 clothing.
+      const wrap = (m) => ({ id: m.id, sessionID: m.sessionID, data: m });
+      const parent = v2AssistantMessage({ id: "msg_p", sessionID: "ses_parent", input: 5000, output: 100 });
+      const forkCopy = v2AssistantMessage({ id: "msg_f", sessionID: "ses_fork", input: 5000, output: 100 });
+      const genuineContinuation = v2AssistantMessage({ id: "msg_g", sessionID: "ses_fork", input: 42, output: 7 });
+
+      const res = await parseOpencodeDbIncremental({
+        dbMessages: [wrap(parent), wrap(forkCopy), wrap(genuineContinuation)],
+        cursors,
+        queuePath,
+        source: "opencode",
+        cursorKey: "opencode",
+      });
+      assert.equal(res.eventsAggregated, 2); // parent + continuation; copy suppressed
+
+      const { totals } = await queueTotals(queuePath);
+      assert.equal(totals.input_tokens, 5042);
+      assert.equal(totals.output_tokens, 107);
     });
-
-    assert.equal(res.eventsAggregated, 2);
-    const { rows, totals } = await queueTotals(queuePath);
-    assert.equal(rows.length, 2);
-    assert.ok(rows.every((r) => r.source === "opencode"));
-    assert.ok(rows.some((r) => r.model === "x-preview-f-free"));
-    assert.ok(rows.some((r) => r.model === "string-form-model"));
-    assert.equal(totals.input_tokens, 5654);
-    assert.equal(totals.output_tokens, 66);
-    assert.equal(totals.cached_input_tokens, 3136);
-    assert.equal(totals.reasoning_output_tokens, 8);
-
-    // Idempotent: replaying the same snapshot aggregates nothing new.
-    const again = await parseOpencodeDbIncremental({
-      dbMessages: [
-        {
-          id: "msg_a",
-          sessionID: "ses_v2_1",
-          data: v2AssistantMessage({ id: "msg_a", sessionID: "ses_v2_1", input: 5644, output: 61, reasoning: 8, cached: 3136 }),
-        },
-      ],
-      cursors,
-      queuePath,
-      source: "opencode",
-      cursorKey: "opencode",
-    });
-    assert.equal(again.eventsAggregated, 0);
   });
-});
 
-test("opencode2 fork copies are deduped via the fingerprint built from the nested model", async () => {
-  await withTmp(async (tmp) => {
-    const queuePath = path.join(tmp, "queue.jsonl");
-    const cursors = { version: 1, files: {}, updatedAt: null };
+  test("end to end: opencode2 fixture DB flows through reader + parser with project attribution (type C)", async () => {
+    await withTmp(async (tmp) => {
+      // Minimal git repo the project resolver can walk into from the session's
+      // recorded directory.
+      const repoRoot = path.join(tmp, "widgets");
+      await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+      await fs.writeFile(
+        path.join(repoRoot, ".git", "config"),
+        '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n',
+        "utf8",
+      );
 
-    // Session.fork re-materialises the parent turn under a new id/session with
-    // an identical payload — exactly the #426 shape, now in v2 clothing.
-    const wrap = (m) => ({ id: m.id, sessionID: m.sessionID, data: m });
-    const parent = v2AssistantMessage({ id: "msg_p", sessionID: "ses_parent", input: 5000, output: 100 });
-    const forkCopy = v2AssistantMessage({ id: "msg_f", sessionID: "ses_fork", input: 5000, output: 100 });
-    const genuineContinuation = v2AssistantMessage({ id: "msg_g", sessionID: "ses_fork", input: 42, output: 7 });
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "C",
+        sessions: [{ id: "ses_repo", directory: repoRoot }],
+        v2Messages: [v2AssistantMessage({ id: "msg_repo", sessionID: "ses_repo", input: 44322, output: 9905 })],
+      });
 
-    const res = await parseOpencodeDbIncremental({
-      dbMessages: [wrap(parent), wrap(forkCopy), wrap(genuineContinuation)],
-      cursors,
-      queuePath,
-      source: "opencode",
-      cursorKey: "opencode",
+      const queuePath = path.join(tmp, "queue.jsonl");
+      const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+      const cursors = { version: 1, files: {}, updatedAt: null };
+
+      const dbMessages = readOpencodeDbMessages(dbPath);
+      const res = await parseOpencodeDbIncremental({
+        dbMessages,
+        dbPath,
+        cursors,
+        queuePath,
+        projectQueuePath,
+        source: "opencode",
+        cursorKey: "opencode",
+      });
+
+      assert.equal(res.eventsAggregated, 1);
+      const { rows } = await queueTotals(queuePath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].model, "x-preview-f-free");
+
+      const projectRows = await readQueue(projectQueuePath);
+      assert.equal(projectRows.length, 1);
+      assert.equal(projectRows[0].project_key, "acme/widgets");
     });
-    assert.equal(res.eventsAggregated, 2); // parent + continuation; copy suppressed
-
-    const { totals } = await queueTotals(queuePath);
-    assert.equal(totals.input_tokens, 5042);
-    assert.equal(totals.output_tokens, 107);
   });
-});
 
-test("end to end: opencode2 fixture DB flows through reader + parser with project attribution", async () => {
-  await withTmp(async (tmp) => {
-    // Minimal git repo the project resolver can walk into from the session's
-    // recorded directory.
-    const repoRoot = path.join(tmp, "widgets");
-    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
-    await fs.writeFile(
-      path.join(repoRoot, ".git", "config"),
-      '[remote "origin"]\n\turl = https://github.com/acme/widgets.git\n',
-      "utf8",
-    );
+  test("string-form model in v1 message table resolves correctly", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "A",
+        messages: [
+          { ...v1AssistantMessage({ id: "msg_str", sessionID: "ses_str" }), modelID: "string-form-model" },
+        ],
+      });
 
-    const dbPath = path.join(tmp, "opencode.db");
-    buildV2FixtureDb(dbPath, {
-      sessions: [{ id: "ses_repo", directory: repoRoot }],
-      messages: [v2AssistantMessage({ id: "msg_repo", sessionID: "ses_repo", input: 44322, output: 9905 })],
+      const rows = readOpencodeDbMessages(dbPath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].data.modelID, "string-form-model");
     });
-
-    const queuePath = path.join(tmp, "queue.jsonl");
-    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
-    const cursors = { version: 1, files: {}, updatedAt: null };
-
-    const dbMessages = readOpencodeDbMessages(dbPath);
-    const res = await parseOpencodeDbIncremental({
-      dbMessages,
-      dbPath,
-      cursors,
-      queuePath,
-      projectQueuePath,
-      source: "opencode",
-      cursorKey: "opencode",
-    });
-
-    assert.equal(res.eventsAggregated, 1);
-    const { rows } = await queueTotals(queuePath);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].model, "x-preview-f-free");
-
-    const projectRows = await readQueue(projectQueuePath);
-    assert.equal(projectRows.length, 1);
-    assert.equal(projectRows[0].project_key, "acme/widgets");
   });
-});
+
+  // The mimo/zcode discriminators resolve the provider via
+  // opencodeMessageProvider(): flat providerID on v1 rows, model.providerID on
+  // v2 rows. Pin the nested branch so a future fork upgrade cannot silently
+  // zero out these sources (zcode's empty-provider guard drops everything).
+  test("mimo/zcode discriminators resolve nested model.providerID on v2 rows", async () => {
+    await withTmp(async (tmp) => {
+      const dbPath = path.join(tmp, "opencode.db");
+      buildFixtureDb(dbPath, {
+        type: "B",
+        sessions: [{ id: "ses_m", directory: "/tmp/x" }],
+        v2Messages: [
+          { ...v2AssistantMessage({ id: "msg_m", sessionID: "ses_m", input: 10, output: 5 }), model: { id: "mimo-v2", providerID: "mimo" } },
+          { ...v2AssistantMessage({ id: "msg_c", sessionID: "ses_m", input: 7, output: 3 }), model: { id: "claude-x", providerID: "anthropic" } },
+        ],
+      });
+      const { readMimoDbMessages } = require("../src/lib/rollout");
+      const mimoRows = readMimoDbMessages(dbPath);
+      assert.equal(mimoRows.length, 1);
+      assert.equal(mimoRows[0].data.model.providerID, "mimo");
+
+      buildFixtureDb(path.join(tmp, "zcode.db"), {
+        type: "B",
+        sessions: [{ id: "ses_z", directory: "/tmp/x" }],
+        v2Messages: [
+          { ...v2AssistantMessage({ id: "msg_z", sessionID: "ses_z", input: 9, output: 2 }), model: { id: "glm-5", providerID: "builtin:zai" } },
+          { ...v2AssistantMessage({ id: "msg_o", sessionID: "ses_z", input: 6, output: 4 }), model: { id: "gpt-x", providerID: "openai" } },
+        ],
+      });
+      const { readZcodeDbMessages } = require("../src/lib/rollout");
+      const zcodeRows = readZcodeDbMessages(path.join(tmp, "zcode.db"));
+      assert.equal(zcodeRows.length, 1);
+      assert.equal(zcodeRows[0].data.model.providerID, "builtin:zai");
+    });
+  });
+} else {
+  // node:sqlite unavailable — skip with a visible message.
+  test("SKIP: node:sqlite unavailable", () => {
+    console.log("SKIP: node:sqlite unavailable — all opencode2-parser tests skipped");
+  });
+}


### PR DESCRIPTION
## 问题

opencode2（OpenCode v2 beta）与 v1 共用 `~/.local/share/opencode/opencode.db`，但存储层重写：

- 消息表 `message` → `session_message`（角色从 JSON $.role 移到 `type` 列）
- 模型由顶层字符串 `modelID`/`providerID` 改为嵌套对象 `model:{id, providerID}`
- 项目目录从消息内 `path.cwd` 移到 `session_v2.directory`

旧读取 SQL 报 "no such table: message" 且被静默吞掉，v2 用户用量显示为空。

## 方案

- `readOpencodeDbMessages`：sqlite_master 探测代际，v1/v2 各走对应 SQL；探测不可用时 v1→v2 回退。v2 行经 LEFT JOIN 还原 session 目录（注入 path.cwd），项目归因链路零改动
- 新增 `normalizeOpencodeModelFields`：统一扁平/嵌套/字符串三种模型形态，bucket 键与 #426 fork 去重指纹共用
- go-limits opt-in 本地成本估算同步适配双 schema；额度主链路为云端 API，不受影响
- 归类不变：仍聚合为 source=opencode

## 验证

- 全量 `npm test`：2401 pass / 0 fail（与基线一致）；新增 `test/opencode2-parser.test.js` 与 go-limits v2 fixture，变异验证 ×3 均被捕获
- 真机 opencode2 库实测：133 条消息 / 5.7M tokens 正确读出

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode usage tracking across legacy, beta, transitional, and newer database formats.
  * Fixed model and provider detection for nested and legacy model information.
  * Improved project attribution using session directory data.
  * Prevented duplicate usage and cost counting across overlapping or forked messages.
  * Added resilient fallback handling when database format detection is inconclusive or tables are empty.
* **Tests**
  * Expanded coverage for compatibility, session attribution, provider filtering, deduplication, and cost calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->