### PR TITLE
fix(opencode-go): handle live API shape {usage:{rolling:{percent,resetsAt}}}

### DIFF
--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -560,7 +560,11 @@ async function fetchOpencodeGoApiLimits({ apiKey, fetchImpl, nowMs, timeoutMs })
           }
           return undefined;
         })();
-        return buildWindow({ usagePercent: pct, resetInSec, nowMs });
+        const modernWindow = buildWindow({ usagePercent: pct, resetInSec, nowMs });
+        // Only prefer the modern window when it actually parsed; an incomplete
+        // modern object (e.g. percent without reset info) must fall through to
+        // a valid legacy window instead of losing it.
+        if (modernWindow) return modernWindow;
       }
     }
     if (legacy && typeof legacy === "object") {

--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -543,21 +543,35 @@ async function fetchOpencodeGoApiLimits({ apiKey, fetchImpl, nowMs, timeoutMs })
     };
   }
 
-  const rolling = buildWindow({
-    usagePercent: payload?.rollingUsage?.usagePercent,
-    resetInSec: payload?.rollingUsage?.resetInSec,
-    nowMs,
-  });
-  const weekly = buildWindow({
-    usagePercent: payload?.weeklyUsage?.usagePercent,
-    resetInSec: payload?.weeklyUsage?.resetInSec,
-    nowMs,
-  });
-  const monthly = buildWindow({
-    usagePercent: payload?.monthlyUsage?.usagePercent,
-    resetInSec: payload?.monthlyUsage?.resetInSec,
-    nowMs,
-  });
+  // Upstream has shipped two shapes:
+  // - Early spec (anomalyco/opencode#16513): { rollingUsage: { usagePercent, resetInSec } ... }
+  // - Live API (2026-08): { usage: { rolling: { percent, resetsAt }, weekly: {}, monthly: {} } }
+  const resolveApiWindow = (legacy, modern) => {
+    if (modern && typeof modern === "object") {
+      const pct = modern.percent ?? modern.usagePercent ?? modern.usage_percent;
+      const resetsAt = modern.resetsAt ?? modern.resets_at ?? modern.resetAt ?? modern.reset_at;
+      if (pct != null || resetsAt != null) {
+        const resetInSec = (() => {
+          if (typeof modern.resetInSec === "number" || typeof modern.resetInSec === "string") return Number(modern.resetInSec);
+          if (typeof modern.reset_in_sec === "number" || typeof modern.reset_in_sec === "string") return Number(modern.reset_in_sec);
+          if (typeof resetsAt === "string" && resetsAt) {
+            const ts = Date.parse(resetsAt);
+            if (Number.isFinite(ts)) return Math.max(0, Math.floor((ts - nowMs) / 1000));
+          }
+          return undefined;
+        })();
+        return buildWindow({ usagePercent: pct, resetInSec, nowMs });
+      }
+    }
+    if (legacy && typeof legacy === "object") {
+      return buildWindow({ usagePercent: legacy.usagePercent ?? legacy.percent, resetInSec: legacy.resetInSec ?? legacy.reset_in_sec, nowMs });
+    }
+    return null;
+  };
+
+  const rolling = resolveApiWindow(payload?.rollingUsage, payload?.usage?.rolling ?? payload?.rolling);
+  const weekly = resolveApiWindow(payload?.weeklyUsage, payload?.usage?.weekly ?? payload?.weekly);
+  const monthly = resolveApiWindow(payload?.monthlyUsage, payload?.usage?.monthly ?? payload?.monthly);
 
   if (!rolling && !weekly && !monthly) {
     return {

--- a/test/opencode-go-limits.test.js
+++ b/test/opencode-go-limits.test.js
@@ -283,6 +283,52 @@ describe("fetchOpencodeGoLimits", () => {
     assert.equal(out.primary_window?.used_percent, 42);
   });
 
+  it("parses the live API shape {usage:{rolling:{percent,resetsAt}}}", async () => {
+    const out = await fetchOpencodeGoLimits({
+      env: apiCfg,
+      fetchImpl: async () =>
+        jsonResponse(200, {
+          useBalance: false,
+          usage: {
+            rolling: { percent: 42, resetsAt: "2026-08-21T18:00:00.000Z" },
+            weekly: { percent: 18, resetsAt: "2026-08-24T00:00:00.000Z" },
+            monthly: { percent: 7, resetsAt: "2026-09-01T00:00:00.000Z" },
+          },
+        }),
+      nowMs: Date.parse("2026-08-21T14:45:35.000Z"),
+    });
+
+    assert.equal(out.error, null);
+    assert.equal(out.source, "api");
+    assert.equal(out.primary_window?.used_percent, 42);
+    assert.equal(out.primary_window?.reset_at, "2026-08-21T18:00:00.000Z");
+    assert.equal(out.secondary_window?.used_percent, 18);
+    assert.equal(out.tertiary_window?.used_percent, 7);
+  });
+
+  it("falls back to a valid legacy window when the modern window is incomplete", async () => {
+    const out = await fetchOpencodeGoLimits({
+      env: apiCfg,
+      fetchImpl: async () =>
+        jsonResponse(200, {
+          useBalance: false,
+          // Modern rolling present but unusable on its own (percent without
+          // any reset info) -> buildWindow() returns null; the resolver must
+          // fall through to the legacy window instead of dropping it.
+          usage: { rolling: { percent: 99 } },
+          rollingUsage: { status: "ok", usagePercent: 42, resetInSec: 12345 },
+        }),
+      nowMs: 1_700_000_000_000,
+    });
+
+    assert.equal(out.error, null);
+    assert.equal(out.primary_window?.used_percent, 42, "legacy rolling must survive");
+    assert.equal(
+      out.primary_window?.reset_at,
+      new Date(1_700_000_000_000 + 12345_000).toISOString(),
+    );
+  });
+
   it("returns actionable authentication errors from the official API", async () => {
     const unauthorized = await fetchOpencodeGoLimits({
       env: apiCfg,


### PR DESCRIPTION
从已关闭的 #497 中拆出的独立修复。#497 因「TokenTracker 不保管用户 API key」的凭据口径（#201）整体关闭，本 PR 只保留其中与凭据存储完全无关的解析修复，基于 upstream/main 重新整理。

## 问题

#457 让后端走官方 API（`OPENCODE_GO_API_KEY -> GET /zen/go/v1/usage`），但线上接口实际返回的是新结构：

```json
{ "usage": { "rolling": { "percent": 12.3, "resetsAt": "2026-08-21T18:00:00Z" }, "weekly": {}, "monthly": {} } }
```

而当前解析只认早期 spec 的 `rollingUsage/weeklyUsage/monthlyUsage` + `usagePercent/resetInSec`，真实 key 请求成功却报 `did not include any known usage windows`。

## 修改

- `src/lib/opencode-go-limits.js` 的 `fetchOpencodeGoApiLimits`：同时支持两种结构，modern `{usage:{rolling:{percent,resetsAt}}}` 优先，legacy `rollingUsage.usagePercent/resetInSec` 兜底
- `resetsAt`（ISO 时间）换算为 `resetInSec`
- 兼容字段别名：`percent/usagePercent/usage_percent`、`resetsAt/resets_at/resetAt/reset_at`

## 验证

- `npm run test`：2395 pass / 0 fail
- 不涉及凭据读写，`src/lib/opencode-go-limits.js` 之外的文件零改动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage-limit reporting to support both legacy and newer API response formats.
  - Usage percentages are now interpreted consistently across supported field formats.
  - Reset times are now calculated correctly from timestamps or duration values.
  - Added support for nested usage windows and alternate reset fields.
  - Incomplete modern responses now fall back to valid legacy data.
  - Existing legacy response handling remains supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->