### PR TITLE
fix(pricing): bill whole Beijing weekends off-peak for DeepSeek V4

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -394,6 +394,16 @@ function getRowPricing(row: { model?: string; hour_start?: string; pricing_tier?
     if (Number.isFinite(timestamp)) {
       const hour = new Date(timestamp).getUTCHours();
       offPeak = !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
+      // From 00:00 Beijing time on 2026-08-23 (2026-08-22T16:00Z) DeepSeek bills
+      // whole Beijing weekends off-peak, peak hours included. That weekend runs
+      // 16:00Z Friday to 16:00Z Sunday, so the +08:00 shift before getUTCDay()
+      // is what puts both edges in the right place; reading the weekday off the
+      // raw instant marks a different 48 hours. China has had no daylight saving
+      // since 1991. https://api-docs.deepseek.com/quick_start/pricing/
+      if (timestamp >= Date.UTC(2026, 7, 22, 16, 0, 0)) {
+        const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+        if (beijingDay === 0 || beijingDay === 6) offPeak = true;
+      }
     }
   }
   if (!offPeak) return pricing;

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -370,6 +370,16 @@ function getRowPricing(row: { model?: string; hour_start?: string; pricing_tier?
     if (Number.isFinite(timestamp)) {
       const hour = new Date(timestamp).getUTCHours();
       offPeak = !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
+      // From 00:00 Beijing time on 2026-08-23 (2026-08-22T16:00Z) DeepSeek bills
+      // whole Beijing weekends off-peak, peak hours included. That weekend runs
+      // 16:00Z Friday to 16:00Z Sunday, so the +08:00 shift before getUTCDay()
+      // is what puts both edges in the right place; reading the weekday off the
+      // raw instant marks a different 48 hours. China has had no daylight saving
+      // since 1991. https://api-docs.deepseek.com/quick_start/pricing/
+      if (timestamp >= Date.UTC(2026, 7, 22, 16, 0, 0)) {
+        const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+        if (beijingDay === 0 || beijingDay === 6) offPeak = true;
+      }
     }
   }
   if (!offPeak) return pricing;

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -395,6 +395,16 @@ function getRowPricing(row: { model?: string; hour_start?: string; pricing_tier?
     if (Number.isFinite(timestamp)) {
       const hour = new Date(timestamp).getUTCHours();
       offPeak = !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
+      // From 00:00 Beijing time on 2026-08-23 (2026-08-22T16:00Z) DeepSeek bills
+      // whole Beijing weekends off-peak, peak hours included. That weekend runs
+      // 16:00Z Friday to 16:00Z Sunday, so the +08:00 shift before getUTCDay()
+      // is what puts both edges in the right place; reading the weekday off the
+      // raw instant marks a different 48 hours. China has had no daylight saving
+      // since 1991. https://api-docs.deepseek.com/quick_start/pricing/
+      if (timestamp >= Date.UTC(2026, 7, 22, 16, 0, 0)) {
+        const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+        if (beijingDay === 0 || beijingDay === 6) offPeak = true;
+      }
     }
   }
   if (!offPeak) return pricing;

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -367,6 +367,16 @@ function getRowPricing(row: { model?: string; hour_start?: string; pricing_tier?
     if (Number.isFinite(timestamp)) {
       const hour = new Date(timestamp).getUTCHours();
       offPeak = !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
+      // From 00:00 Beijing time on 2026-08-23 (2026-08-22T16:00Z) DeepSeek bills
+      // whole Beijing weekends off-peak, peak hours included. That weekend runs
+      // 16:00Z Friday to 16:00Z Sunday, so the +08:00 shift before getUTCDay()
+      // is what puts both edges in the right place; reading the weekday off the
+      // raw instant marks a different 48 hours. China has had no daylight saving
+      // since 1991. https://api-docs.deepseek.com/quick_start/pricing/
+      if (timestamp >= Date.UTC(2026, 7, 22, 16, 0, 0)) {
+        const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+        if (beijingDay === 0 || beijingDay === 6) offPeak = true;
+      }
     }
   }
   if (!offPeak) return pricing;

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -390,6 +390,16 @@ function getRowPricing(row: { model?: string; hour_start?: string; pricing_tier?
     if (Number.isFinite(timestamp)) {
       const hour = new Date(timestamp).getUTCHours();
       offPeak = !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
+      // From 00:00 Beijing time on 2026-08-23 (2026-08-22T16:00Z) DeepSeek bills
+      // whole Beijing weekends off-peak, peak hours included. That weekend runs
+      // 16:00Z Friday to 16:00Z Sunday, so the +08:00 shift before getUTCDay()
+      // is what puts both edges in the right place; reading the weekday off the
+      // raw instant marks a different 48 hours. China has had no daylight saving
+      // since 1991. https://api-docs.deepseek.com/quick_start/pricing/
+      if (timestamp >= Date.UTC(2026, 7, 22, 16, 0, 0)) {
+        const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+        if (beijingDay === 0 || beijingDay === 6) offPeak = true;
+      }
     }
   }
   if (!offPeak) return pricing;

--- a/src/lib/pricing/index.js
+++ b/src/lib/pricing/index.js
@@ -126,11 +126,28 @@ function isDeepSeekTimePricedModel(model) {
   return DEEPSEEK_TIME_PRICED_MODELS.some((name) => lower.includes(name));
 }
 
+// From 00:00 Beijing time on 2026-08-23 — this instant — DeepSeek bills whole
+// Beijing weekends off-peak, peak hours included.
+// https://api-docs.deepseek.com/quick_start/pricing/
+const DEEPSEEK_WEEKEND_OFF_PEAK_FROM_MS = Date.UTC(2026, 7, 22, 16, 0, 0);
+
+// The weekend is bounded in Beijing time, so it runs 16:00Z Friday to 16:00Z
+// Sunday. Shifting the instant by +08:00 before reading the weekday is what puts
+// both of those edges in the right place; getUTCDay() on the raw instant marks a
+// different 48 hours. China has had no daylight saving since 1991, so the fixed
+// offset is exact.
+function isBeijingWeekendOffPeak(timestamp) {
+  if (timestamp < DEEPSEEK_WEEKEND_OFF_PEAK_FROM_MS) return false;
+  const beijingDay = new Date(timestamp + 8 * 60 * 60 * 1000).getUTCDay();
+  return beijingDay === 0 || beijingDay === 6;
+}
+
 function isDeepSeekOffPeak(row) {
   if (row?.pricing_tier === "off_peak") return true;
   if (row?.pricing_tier === "peak") return false;
   const timestamp = Date.parse(String(row?.hour_start || ""));
   if (!Number.isFinite(timestamp)) return false;
+  if (isBeijingWeekendOffPeak(timestamp)) return true;
   const hour = new Date(timestamp).getUTCHours();
   return !((hour >= 1 && hour < 4) || (hour >= 6 && hour < 10));
 }

--- a/test/edge-pricing-parity.test.js
+++ b/test/edge-pricing-parity.test.js
@@ -40,6 +40,14 @@ function extractBlock(name) {
   return m[0];
 }
 
+const ROW_PRICING_RE = /\nfunction getRowPricing\([\s\S]*?\n\}/;
+
+function extractRowPricing(name) {
+  const m = readEdge(name).match(ROW_PRICING_RE);
+  assert.ok(m, `${name}: getRowPricing not found`);
+  return m[0];
+}
+
 test("MODEL_PRICING + getModelPricing are byte-identical across all 5 edge files", () => {
   const canonical = extractBlock(CANONICAL);
   for (const name of MIRRORS) {
@@ -124,6 +132,25 @@ test("all cloud cost paths retain DeepSeek V4 peak/off-peak pricing tiers", () =
     assert.ok(source.includes('pricing_tier === "off_peak"'), `${name}: off-peak tier missing`);
     assert.ok(source.includes('hour >= 1 && hour < 4'), `${name}: first peak window missing`);
     assert.ok(source.includes('hour >= 6 && hour < 10'), `${name}: second peak window missing`);
+    assert.ok(
+      source.includes("Date.UTC(2026, 7, 22, 16, 0, 0)"),
+      `${name}: Beijing weekend off-peak rule missing`,
+    );
+    assert.ok(
+      source.includes("timestamp + 8 * 60 * 60 * 1000).getUTCDay()"),
+      `${name}: weekend must be read in Beijing time, not on the raw UTC instant`,
+    );
+  }
+  // getRowPricing carries the tier logic and is copied by hand like the pricing
+  // block above, so hold it to the same byte-identical rule. Substring checks
+  // alone let one file's window drift while every assertion still passes.
+  const canonicalRow = extractRowPricing(CANONICAL);
+  for (const name of MIRRORS) {
+    assert.strictEqual(
+      extractRowPricing(name),
+      canonicalRow,
+      `${name} getRowPricing drifted from ${CANONICAL} — copy the canonical function over verbatim`,
+    );
   }
   const breakdown = readEdge("tokentracker-account-model-breakdown.ts");
   assert.match(

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -757,6 +757,47 @@ test("index: DeepSeek V4 pricing follows official UTC peak and off-peak windows 
     "missing/invalid timestamps fail closed to peak pricing",
   );
 
+  // From 00:00 Beijing time on 2026-08-23 — 2026-08-22T16:00Z — whole Beijing
+  // weekends bill off-peak, peak hours included.
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-pro", "2026-08-22T06:00:00Z")),
+    6.644,
+    "Beijing Saturday before the rule takes effect is still peak",
+  );
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-pro", "2026-08-23T01:00:00Z")),
+    3.322,
+    "Beijing Sunday 09:00 is the first peak window the weekend rule flips",
+  );
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-flash", "2026-08-23T09:59:00Z")),
+    1.107,
+    "Beijing Sunday 17:59 is still inside the weekend",
+  );
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-pro", "2026-08-24T01:00:00Z")),
+    6.644,
+    "Beijing Monday 09:00 is a weekday again",
+  );
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-pro", "2026-08-28T06:00:00Z")),
+    6.644,
+    "Beijing Friday 14:00 is a weekday",
+  );
+  assert.equal(
+    pricing.computeRowCost(row("deepseek-v4-pro", "2026-08-29T06:00:00Z")),
+    3.322,
+    "Beijing Saturday 14:00 is off-peak",
+  );
+  assert.equal(
+    pricing.computeRowCost({
+      ...row("deepseek-v4-pro", "2026-08-23T01:00:00Z"),
+      pricing_tier: "peak",
+    }),
+    6.644,
+    "an explicit stored tier still wins over the derived weekend rule",
+  );
+
   assert.deepEqual(
     pricing.getModelPricing("deepseek-chat"),
     { input: 0.14, output: 0.28, cache_read: 0.0028, cache_write: 0.14 },


### PR DESCRIPTION
## What's wrong

The derived DeepSeek tier — `isDeepSeekOffPeak` in `src/lib/pricing/index.js`,
and the hand-copied `getRowPricing` in all five edge patches — decides from the
UTC hour alone. DeepSeek's pricing page now says:

> Effective 00:00 (Beijing Time) on Sunday, August 23, 2026, we will adjust our
> peak/off-peak billing rules … with off-peak rates applying throughout the day
> on weekends (Saturdays and Sundays, Beijing Time)

That instant is **2026-08-22T16:00Z — already past.** So rows whose `hour_start`
falls in `01:00–04:00` or `06:00–10:00` UTC on a Beijing Saturday or Sunday are
still priced at peak, while DeepSeek bills off-peak. Off-peak is exactly half, so
those hours read **2×** — in account daily, summary, model breakdown, leaderboard
list and leaderboard profile alike.

The first window this gets wrong is **2026-08-23 01:00–04:00 UTC** (Beijing
Sunday 09:00–12:00).

An explicitly stored `pricing_tier` still wins, unchanged — this only touches the
derived path.

## The part that is easy to get subtly wrong

The weekend is bounded in **Beijing** time, not UTC: `16:00Z Friday` to
`16:00Z Sunday`. `new Date(timestamp).getUTCDay()` marks a different 48 hours, so
the instant is shifted by `+08:00` first. China has had no daylight saving since
1991, so the fixed offset is exact and needs no tz database.

To be straight about how much that costs today: nothing. The two peak windows sit
entirely outside the 16 hours where the two spellings disagree, so both currently
return the same tier. It is not a live bug — it is a trap that arms itself if the
windows ever move. I did it the right way round anyway and said so in the comment.

## Changes

- `src/lib/pricing/index.js` — `isBeijingWeekendOffPeak`, consulted by
  `isDeepSeekOffPeak` before the hour check.
- The five `dashboard/edge-patches/*.ts` — the same block, byte-identical, per
  the copy discipline in `test/edge-pricing-parity.test.js`.
- `test/pricing.test.js` — seven assertions on `computeRowCost` inside the
  existing `#491` test: a Beijing Saturday **before** the rule takes effect that
  must still be peak, the first Sunday window it flips, a Beijing Monday, a
  Friday, a later Saturday, and an explicit `pricing_tier: "peak"` that must
  still override.
- `test/edge-pricing-parity.test.js` — asserts all five files carry the effective
  instant and the `+08:00` shift, **and** adds a real byte-identical parity check
  on `getRowPricing`. That function was only substring-checked before, so one
  file's window could drift while every assertion still passed — the same failure
  mode the `MODEL_PRICING` parity test exists to catch.

## Verification

```
node --test test/pricing.test.js test/edge-pricing-parity.test.js
# 54 pass, 0 fail
```

Full `npm test` is **2328 tests / 2290 pass / 32 fail — identical with and
without this patch** (I checked by stashing). Those 32 are `MODULE_NOT_FOUND` and
`TS2307` from an environment without `npm install` run; none are in the pricing
or edge-parity files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DeepSeek V4 pricing now recognizes Beijing-local Saturdays and Sundays as off-peak starting August 23, 2026.
  * Weekend usage receives the existing 50% off-peak rate across dashboards, summaries, leaderboards, and account breakdowns.
  * Pricing correctly handles the UTC-to-Beijing time boundary while preserving explicit pricing tiers and weekday peak rules.

* **Tests**
  * Added coverage for weekend pricing, boundary times, weekday peak periods, and pricing-tier precedence.
  * Added consistency checks to ensure pricing behavior matches across dashboard views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->