### PR TITLE
fix(linux): default to the WebKitGTK compatibility renderer

### DIFF
--- a/TokenTrackerLinux/README.md
+++ b/TokenTrackerLinux/README.md
@@ -91,6 +91,37 @@ Until the extension is installed, closing the window hides the app with no way t
 get it back from the tray — quit it from the launcher or with `pkill
 tokentracker-linux`.
 
+### The window is blank, or the app exits immediately
+
+WebKitGTK renders through DMA-BUF by default. On some Wayland setups — most
+reliably NVIDIA's proprietary driver — that path either paints a permanently
+blank webview or loses the Wayland connection outright, exiting non-zero with:
+
+```
+Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
+```
+
+The client therefore sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` before starting
+GTK. To retry the accelerated renderer, set it explicitly — an explicit value is
+never overridden:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=0 tokentracker-linux
+```
+
+WebKitGTK treats the variable as "set and not `0`", so `=0` genuinely restores
+the accelerated path while any other value (including an empty string) disables
+it.
+
+Note that when the webview aborts this way the app never reaches its shutdown
+path, so the bundled Node server is left running and keeps port 17680. Since
+OAuth sign-in requires that exact port, a later launch will fall back to a
+random port and browser sign-in will fail until the orphan is stopped:
+
+```bash
+pkill -f 'tokentracker/bin/tracker.js serve'
+```
+
 ## Sign-in
 
 The app prefers a **fixed loopback port, 17680**, because OAuth redirect URLs

--- a/TokenTrackerLinux/src-tauri/src/main.rs
+++ b/TokenTrackerLinux/src-tauri/src/main.rs
@@ -9,6 +9,8 @@ use tauri::{AppHandle, Manager, WebviewWindow, WindowEvent};
 
 static SERVER: Lazy<Mutex<Option<TokenTrackerServer>>> = Lazy::new(|| Mutex::new(None));
 
+const WEBKIT_DMABUF_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
 const NATIVE_OAUTH_BRIDGE: &str = r#"
 (() => {
   if (window.location.hostname !== '127.0.0.1') return;
@@ -21,6 +23,24 @@ const NATIVE_OAUTH_BRIDGE: &str = r#"
   };
 })();
 "#;
+
+/// WebKitGTK renders through DMA-BUF by default. On a number of otherwise
+/// supported Wayland setups — most reliably NVIDIA's proprietary driver — that
+/// path either paints a permanently blank webview or loses the Wayland
+/// connection outright, aborting with `Error 71 (Protocol error)` before the
+/// dashboard is ever shown. The abort skips `stop_server`, so the bundled Node
+/// server is orphaned on port 17680 and later launches lose OAuth sign-in.
+///
+/// Defaults to the compatibility renderer while treating an explicit user value
+/// as authoritative, so `WEBKIT_DISABLE_DMABUF_RENDERER=0` can still opt back
+/// into the accelerated path. Called as the first statement in `main` because
+/// the variable is only read when GTK/WebKit initializes, and `set_var` is
+/// sound only while the process is still single-threaded.
+fn configure_webkit_runtime() {
+    if std::env::var_os(WEBKIT_DMABUF_ENV).is_none() {
+        std::env::set_var(WEBKIT_DMABUF_ENV, "1");
+    }
+}
 
 fn stop_server() {
     if let Ok(mut guard) = SERVER.lock() {
@@ -220,6 +240,8 @@ fn start_health_monitor() {
 }
 
 fn main() {
+    configure_webkit_runtime();
+
     let initial_args: Vec<String> = std::env::args().collect();
 
     tauri::Builder::default()

--- a/test/linux-health-monitor.test.js
+++ b/test/linux-health-monitor.test.js
@@ -120,6 +120,24 @@ test('Linux tray does not ship a click handler that cannot fire', () => {
   assert.match(tray, /Linux/, 'the platform limitation should be documented in place');
 });
 
+test('Linux configures the WebKitGTK DMA-BUF fallback before Tauri starts', () => {
+  const main = read('TokenTrackerLinux/src-tauri/src/main.rs');
+
+  // WebKitGTK's DMA-BUF renderer paints a blank webview on some Wayland/NVIDIA
+  // setups. The override only takes effect if it is set before GTK/WebKit is
+  // initialized, so it has to be the first thing main() does.
+  assert.match(
+    main,
+    /fn main\(\) \{\s*configure_webkit_runtime\(\);/,
+    'configure_webkit_runtime() must run before tauri::Builder',
+  );
+
+  // An explicit user value stays authoritative, so WEBKIT_DISABLE_DMABUF_RENDERER=0
+  // can still opt back into the accelerated renderer.
+  assert.match(main, /var_os\(WEBKIT_DMABUF_ENV\)\.is_none\(\)/);
+  assert.match(main, /const WEBKIT_DMABUF_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";/);
+});
+
 test('GitHub CI validates synchronized platform versions', () => {
   const workflow = read('.github/workflows/ci.yml');
   assert.match(workflow, /npm run validate:versions/);

--- a/test/linux-health-monitor.test.js
+++ b/test/linux-health-monitor.test.js
@@ -136,6 +136,11 @@ test('Linux configures the WebKitGTK DMA-BUF fallback before Tauri starts', () =
   // can still opt back into the accelerated renderer.
   assert.match(main, /var_os\(WEBKIT_DMABUF_ENV\)\.is_none\(\)/);
   assert.match(main, /const WEBKIT_DMABUF_ENV: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";/);
+
+  // The assigned value matters: WebKitGTK reads the variable as "set and not
+  // 0", so defaulting it to "0" would silently re-enable the DMA-BUF renderer
+  // this guards against while every other assertion here still passed.
+  assert.match(main, /set_var\(WEBKIT_DMABUF_ENV, "1"\)/);
 });
 
 test('GitHub CI validates synchronized platform versions', () => {


### PR DESCRIPTION
## Problem

WebKitGTK renders through DMA-BUF by default. On some Wayland setups — most reliably NVIDIA's proprietary driver — that path either paints a permanently blank webview or loses the Wayland connection outright, aborting before the dashboard is ever shown:

```
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

The process exits non-zero, so on a desktop launch there is no window and no error the user ever sees. Everything else looks healthy on the way down — the bundled Node server starts and answers its readiness probe, and nothing lands in `server.log`.

## Evidence

Tested against an **unmodified** build of current `main` (`b7ce3aec`), so the variable is isolated as the cause independently of this patch. Fedora 44 / GNOME (Wayland), GeForce GTX 1070 on NVIDIA 580.173.02, WebKitGTK 4.1:

| `WEBKIT_DISABLE_DMABUF_RENDERER` | Result |
| --- | --- |
| unset — upstream's current default | `exit 1`, `Error 71 (Protocol error)` |
| `1` | runs normally |
| `0` | `exit 1`, `Error 71 (Protocol error)` |
| empty string | runs normally |

The last two rows confirm WebKitGTK reads the variable as *set and not `0`*.

## Fix

Set the variable to `1` before GTK initializes, and leave any user-supplied value untouched — which, given the semantics above, means `WEBKIT_DISABLE_DMABUF_RENDERER=0` still genuinely opts back into the accelerated renderer:

```bash
WEBKIT_DISABLE_DMABUF_RENDERER=0 tokentracker-linux
```

`configure_webkit_runtime()` is the first statement in `main` for two reasons: the variable is only read when GTK/WebKit initializes, and `std::env::set_var` is sound only while the process is still single-threaded.

## Separate bug found while testing (not fixed here)

The abort never reaches `stop_server()`, so each crashed launch **orphans the bundled Node server**. I accumulated four of them across test runs, holding ports 17680, 45859, 40603 and 40555. Because the orphan keeps 17680, the next launch hits the `pick_available_port` fallback and lands on a random port — and per `server.rs`'s own comment, OAuth sign-in then silently fails until the orphan is killed. Documented in the README here; happy to file it separately if you want it fixed.

## Scope

- Linux-only. No `src/` or `dashboard/` changes, so the npm CLI, macOS and Windows are untouched.
- No version bump — `scripts/version-files.cjs` drives nine files off `package.json`, so that's yours to make on the next release.
- README gains a troubleshooting section, since the symptom is invisible in the logs and users have nothing to search for otherwise.
- Test in `test/linux-health-monitor.test.js` asserts the call is the first thing `main` does and that an explicit value stays authoritative.

## Verification

- `cargo check --locked --all-targets` — clean, no new warnings
- `cargo test --locked` — 12 + 14 passing
- `node --test test/linux-health-monitor.test.js test/linux-bundle.test.js test/linux-test-safety.test.js test/linux-client-workflow.test.js` — 21 passing
- `npm run validate:guardrails`, `npm run validate:versions`, `node --test test/architecture-guardrails.test.js` — clean
- Both binaries built from this tree and installed side by side; the running process was confirmed via `/proc/<pid>/exe` hashes so the before/after runs could not be mixed up

`cargo fmt --check` and `clippy` could not be run locally (this box has cargo without the rustfmt/clippy components), so CI is the authority on those two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux startup reliability by disabling problematic WebKitGTK DMA-BUF rendering by default on affected Wayland setups.
  - Preserved explicit user configuration for re-enabling hardware acceleration.
  - Added guidance for resolving blank or immediately closing Linux windows and cleaning up stalled processes.

- **Tests**
  - Added coverage to verify renderer configuration is applied before application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->