### PR TITLE
fix: reset responsive drawer and manage modal focus

### DIFF
--- a/dashboard/src/ui/components/Sidebar.jsx
+++ b/dashboard/src/ui/components/Sidebar.jsx
@@ -436,9 +436,9 @@ function Sidebar({ collapsed, onToggleCollapsed }) {
 
   return (
     <aside
+      data-native-sidebar
       id="app-sidebar"
       data-sidebar-state={collapsed ? "collapsed" : "expanded"}
-      data-native-sidebar
       aria-label={copy("nav.aside_label")}
       className={cn(
         "hidden lg:flex flex-col shrink-0 h-full min-h-0 transition-[width] duration-200",
@@ -453,7 +453,7 @@ function Sidebar({ collapsed, onToggleCollapsed }) {
 /**
  * Mobile drawer — slides in from the left, full-height overlay.
  */
-function MobileDrawer({ open, onClose }) {
+function MobileDrawer({ open, onClose, onDesktopBreakpointClose }) {
   const drawerRef = useRef(null);
   const closeButtonRef = useRef(null);
 
@@ -497,10 +497,10 @@ function MobileDrawer({ open, onClose }) {
     if (!open || typeof window === "undefined" || typeof window.matchMedia !== "function") return;
     const desktopQuery = window.matchMedia("(min-width: 1024px)");
     const onBreakpointChange = (event) => {
-      if (event.matches) onClose();
+      if (event.matches) onDesktopBreakpointClose();
     };
     if (desktopQuery.matches) {
-      onClose();
+      onDesktopBreakpointClose();
       return;
     }
     if (desktopQuery.addEventListener) {
@@ -509,7 +509,7 @@ function MobileDrawer({ open, onClose }) {
     }
     desktopQuery.addListener?.(onBreakpointChange);
     return () => desktopQuery.removeListener?.(onBreakpointChange);
-  }, [open, onClose]);
+  }, [open, onDesktopBreakpointClose]);
 
   // Lock body scroll when open
   useEffect(() => {
@@ -590,12 +590,22 @@ export function AppLayout({ children }) {
   const { collapsed, toggle } = useSidebarCollapsed();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const menuButtonRef = useRef(null);
+  const mainContentRef = useRef(null);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
   const closeDrawer = useCallback(() => {
     setDrawerOpen(false);
     // Restore focus to the control that opened the drawer for keyboard and
     // assistive-technology users.
     menuButtonRef.current?.focus();
+  }, []);
+  const closeDrawerForDesktop = useCallback(() => {
+    setDrawerOpen(false);
+    const focusMainContent = () => mainContentRef.current?.focus();
+    if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(focusMainContent);
+    } else {
+      focusMainContent();
+    }
   }, []);
 
   /** macOS WKWebView：底层由 NSVisualEffectView 提供模糊，Web 根布局透明，侧栏浮在背景上；浏览器仍用灰色底。 */
@@ -621,7 +631,11 @@ export function AppLayout({ children }) {
       )}
       <div className="flex-1 min-h-0 flex">
         <Sidebar collapsed={collapsed} onToggleCollapsed={toggle} />
-        <MobileDrawer open={drawerOpen} onClose={closeDrawer} />
+        <MobileDrawer
+          open={drawerOpen}
+          onClose={closeDrawer}
+          onDesktopBreakpointClose={closeDrawerForDesktop}
+        />
         {/* lg：与侧栏内容区对齐 — 侧栏底部按钮区为 px-2 py-3；主卡右侧/底侧用 pr-3 pb-3 与 py-3 视觉一致，避免仅靠 p-2 显得贴边 */}
         {/* Mac App：`lg:pr-3 lg:pb-3` (12pt) 须与 Swift `DashboardChromeMetrics.mainGutterPoints` 一致，主卡圆角由 `--tt-main-card-radius` 注入 */}
         <div className="flex-1 min-w-0 min-h-0 p-2 lg:pl-0 lg:pr-3 lg:pb-3 flex flex-col">
@@ -633,7 +647,12 @@ export function AppLayout({ children }) {
             )}
           >
             <MobileTopBar open={drawerOpen} onOpenDrawer={openDrawer} menuButtonRef={menuButtonRef} />
-            <div className="flex-1 min-h-0 overflow-y-auto">
+            <div
+              ref={mainContentRef}
+              id="app-main-content"
+              tabIndex={-1}
+              className="flex-1 min-h-0 overflow-y-auto"
+            >
               {children}
             </div>
           </div>

--- a/dashboard/src/ui/components/Sidebar.jsx
+++ b/dashboard/src/ui/components/Sidebar.jsx
@@ -140,6 +140,7 @@ function NavItem({ item, collapsed, active, onClick }) {
       to={item.to}
       onClick={onClick}
       title={collapsed ? item.label : undefined}
+      aria-label={collapsed ? item.label : undefined}
       aria-current={active ? "page" : undefined}
       className={cn(
         "flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px] no-underline transition-colors",
@@ -160,7 +161,7 @@ function NavItem({ item, collapsed, active, onClick }) {
 /**
  * Tertiary icon button — uniform 40×40 (meets WCAG 2.5.5 close enough; AAA prefers 44).
  */
-function IconButton({ as = "button", title, onClick, href, children, className: extraClassName, ...rest }) {
+function IconButton({ as = "button", buttonRef, title, onClick, href, children, className: extraClassName, ...rest }) {
   const className = cn(
     "flex h-10 w-10 items-center justify-center rounded-lg text-oai-gray-600 dark:text-oai-gray-400 hover:bg-oai-gray-200/60 dark:hover:bg-oai-gray-800 hover:text-oai-black dark:hover:text-white transition-colors no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-brand-500",
     extraClassName,
@@ -173,7 +174,7 @@ function IconButton({ as = "button", title, onClick, href, children, className: 
     );
   }
   return (
-    <button type="button" title={title} aria-label={title} onClick={onClick} className={className} {...rest}>
+    <button ref={buttonRef} type="button" title={title} aria-label={title} onClick={onClick} className={className} {...rest}>
       {children}
     </button>
   );
@@ -311,8 +312,17 @@ function ThemePill({ theme, resolvedTheme, onSetTheme, glassChrome = false }) {
  * @param {() => void} onItemClick - called after a nav item is clicked (used by drawer to close)
  * @param {boolean} showCloseButton - show X close button instead of collapse toggle (mobile)
  * @param {() => void} onClose - close handler for mobile drawer
+ * @param {React.RefObject<HTMLButtonElement>} closeButtonRef - mobile close button focus target
  */
-function SidebarBody({ collapsed, onToggleCollapsed, onItemClick, showCloseButton = false, onClose, glassChrome = false }) {
+function SidebarBody({
+  collapsed,
+  onToggleCollapsed,
+  onItemClick,
+  showCloseButton = false,
+  onClose,
+  closeButtonRef,
+  glassChrome = false,
+}) {
   const location = useLocation();
   const pathname = location?.pathname || "/";
   const { theme, resolvedTheme, setTheme } = useTheme();
@@ -335,6 +345,7 @@ function SidebarBody({ collapsed, onToggleCollapsed, onItemClick, showCloseButto
               />
             </div>
             <button
+              ref={closeButtonRef}
               type="button"
               onClick={onClose}
               aria-label={copy("nav.close_menu")}
@@ -390,13 +401,14 @@ function SidebarBody({ collapsed, onToggleCollapsed, onItemClick, showCloseButto
         <ThemePill theme={theme} resolvedTheme={resolvedTheme} onSetTheme={setTheme} glassChrome={glassChrome} />
         <div className="flex items-center gap-1.5">
           {!collapsed && <StarPill glassChrome={glassChrome} />}
-          {/* TEMP: collapse button hidden — restore when ready
           {!showCloseButton && (
             <button
               type="button"
               onClick={onToggleCollapsed}
               aria-label={collapsed ? copy("nav.expand") : copy("nav.collapse")}
               title={collapsed ? copy("nav.expand") : copy("nav.collapse")}
+              aria-expanded={!collapsed}
+              aria-controls="app-sidebar"
               className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-oai-gray-500 dark:text-oai-gray-500 hover:bg-oai-gray-200/60 dark:hover:bg-oai-gray-800 hover:text-oai-gray-900 dark:hover:text-oai-gray-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-brand-500"
             >
               {collapsed ? (
@@ -406,7 +418,6 @@ function SidebarBody({ collapsed, onToggleCollapsed, onItemClick, showCloseButto
               )}
             </button>
           )}
-          */}
         </div>
       </div>
     </>
@@ -425,6 +436,8 @@ function Sidebar({ collapsed, onToggleCollapsed }) {
 
   return (
     <aside
+      id="app-sidebar"
+      data-sidebar-state={collapsed ? "collapsed" : "expanded"}
       data-native-sidebar
       aria-label={copy("nav.aside_label")}
       className={cn(
@@ -441,14 +454,61 @@ function Sidebar({ collapsed, onToggleCollapsed }) {
  * Mobile drawer — slides in from the left, full-height overlay.
  */
 function MobileDrawer({ open, onClose }) {
+  const drawerRef = useRef(null);
+  const closeButtonRef = useRef(null);
+
+  // Put focus on the close action when the drawer opens and keep keyboard focus
+  // inside the modal drawer until it closes.
+  useEffect(() => {
+    if (!open) return;
+    closeButtonRef.current?.focus();
+  }, [open]);
+
   // Close on Escape
   useEffect(() => {
     if (!open) return;
     const onKey = (e) => {
       if (e.key === "Escape") onClose();
+      if (e.key !== "Tab") return;
+
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+      const focusable = drawer.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // An open mobile drawer must be reset when the viewport crosses the desktop
+  // breakpoint, otherwise it can reappear on the next narrow-window visit.
+  useEffect(() => {
+    if (!open || typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const desktopQuery = window.matchMedia("(min-width: 1024px)");
+    const onBreakpointChange = (event) => {
+      if (event.matches) onClose();
+    };
+    if (desktopQuery.matches) {
+      onClose();
+      return;
+    }
+    if (desktopQuery.addEventListener) {
+      desktopQuery.addEventListener("change", onBreakpointChange);
+      return () => desktopQuery.removeEventListener("change", onBreakpointChange);
+    }
+    desktopQuery.addListener?.(onBreakpointChange);
+    return () => desktopQuery.removeListener?.(onBreakpointChange);
   }, [open, onClose]);
 
   // Lock body scroll when open
@@ -470,6 +530,10 @@ function MobileDrawer({ open, onClose }) {
         aria-hidden
       />
       <aside
+        ref={drawerRef}
+        id="mobile-navigation-drawer"
+        role="dialog"
+        aria-modal="true"
         aria-label={copy("nav.aside_label")}
         className="relative w-[260px] max-w-[80vw] flex flex-col bg-oai-white dark:bg-oai-gray-900 border-r border-oai-gray-200 dark:border-oai-gray-800 shadow-2xl"
       >
@@ -477,6 +541,7 @@ function MobileDrawer({ open, onClose }) {
           collapsed={false}
           showCloseButton
           onClose={onClose}
+          closeButtonRef={closeButtonRef}
           onItemClick={onClose}
         />
       </aside>
@@ -487,10 +552,16 @@ function MobileDrawer({ open, onClose }) {
 /**
  * Mobile top bar — shows hamburger + brand on screens < lg.
  */
-function MobileTopBar({ onOpenDrawer }) {
+function MobileTopBar({ open, onOpenDrawer, menuButtonRef }) {
   return (
     <div className="lg:hidden flex items-center justify-between gap-2 px-3 h-14 border-b border-oai-gray-200 dark:border-oai-gray-800">
-      <IconButton title={copy("nav.menu")} onClick={onOpenDrawer}>
+      <IconButton
+        buttonRef={menuButtonRef}
+        title={copy("nav.menu")}
+        onClick={onOpenDrawer}
+        aria-expanded={open}
+        aria-controls="mobile-navigation-drawer"
+      >
         <Menu className="h-5 w-5" aria-hidden />
       </IconButton>
       <Link
@@ -518,8 +589,14 @@ function MobileTopBar({ onOpenDrawer }) {
 export function AppLayout({ children }) {
   const { collapsed, toggle } = useSidebarCollapsed();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const menuButtonRef = useRef(null);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
-  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false);
+    // Restore focus to the control that opened the drawer for keyboard and
+    // assistive-technology users.
+    menuButtonRef.current?.focus();
+  }, []);
 
   /** macOS WKWebView：底层由 NSVisualEffectView 提供模糊，Web 根布局透明，侧栏浮在背景上；浏览器仍用灰色底。 */
   const nativeEmbed = useMemo(() => {
@@ -555,7 +632,7 @@ export function AppLayout({ children }) {
               !nativeEmbed && "shadow-sm",
             )}
           >
-            <MobileTopBar onOpenDrawer={openDrawer} />
+            <MobileTopBar open={drawerOpen} onOpenDrawer={openDrawer} menuButtonRef={menuButtonRef} />
             <div className="flex-1 min-h-0 overflow-y-auto">
               {children}
             </div>

--- a/dashboard/src/ui/components/Sidebar.test.jsx
+++ b/dashboard/src/ui/components/Sidebar.test.jsx
@@ -1,0 +1,180 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppLayout } from "./Sidebar.jsx";
+
+const LABELS = {
+  "nav.group.general": "General",
+  "nav.group.tools": "Tools",
+  "nav.group.account": "Account",
+  "nav.usage": "Usage",
+  "nav.sessions": "Sessions",
+  "nav.limits": "Limits",
+  "nav.leaderboard": "Leaderboard",
+  "nav.achievements": "Achievements",
+  "nav.widgets": "Widgets",
+  "nav.pet": "Desktop pet",
+  "nav.skills": "Skills",
+  "nav.ip_check": "IP check",
+  "nav.service_status": "Service status",
+  "nav.settings": "Settings",
+  "nav.expand": "Expand sidebar",
+  "nav.collapse": "Collapse sidebar",
+  "nav.menu": "Open navigation menu",
+  "nav.close_menu": "Close navigation menu",
+  "nav.aside_label": "Main navigation",
+  "nav.nav_label": "Primary navigation",
+  "shared.github.star": "Star",
+};
+
+vi.mock("../../lib/copy", () => ({
+  copy: (key) => LABELS[key] || key,
+}));
+
+vi.mock("../../hooks/useTheme.js", () => ({
+  useTheme: () => ({ theme: "system", resolvedTheme: "light", setTheme: vi.fn() }),
+}));
+
+vi.mock("../../hooks/useLocale.js", () => ({
+  useLocale: () => ({ resolvedLocale: "en" }),
+}));
+
+vi.mock("../../lib/native-bridge.js", () => ({
+  isNativeApp: () => false,
+  isNativeEmbed: () => false,
+  isNativeWindowsApp: () => false,
+}));
+
+vi.mock("../dashboard/util/should-fetch-github-stars.js", () => ({
+  shouldFetchGithubStars: () => false,
+}));
+
+vi.mock("../../components/InsforgeUserHeaderControls.jsx", () => ({
+  InsforgeUserHeaderControls: () => <button type="button" aria-label="Account control" />,
+}));
+
+let desktopMatches = false;
+let mediaListeners;
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <AppLayout>
+        <main />
+      </AppLayout>
+    </MemoryRouter>,
+  );
+}
+
+describe("AppLayout sidebar controls", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    desktopMatches = false;
+    mediaListeners = new Set();
+    window.matchMedia = vi.fn((query) => ({
+      matches: query === "(min-width: 1024px)" ? desktopMatches : false,
+      media: query,
+      onchange: null,
+      addEventListener: (_type, listener) => mediaListeners.add(listener),
+      removeEventListener: (_type, listener) => mediaListeners.delete(listener),
+      addListener: (_listener) => {},
+      removeListener: (_listener) => {},
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("collapses and expands the desktop sidebar and persists the preference", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    const sidebar = screen.getByRole("complementary", { name: "Main navigation" });
+    const collapseButton = screen.getByRole("button", { name: "Collapse sidebar" });
+    expect(sidebar).toHaveAttribute("data-sidebar-state", "expanded");
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+
+    await act(async () => user.click(collapseButton));
+
+    expect(sidebar).toHaveAttribute("data-sidebar-state", "collapsed");
+    expect(window.localStorage.getItem("tt.sidebarCollapsed")).toBe("1");
+    expect(screen.getByRole("link", { name: "Usage" })).toHaveAttribute("aria-label", "Usage");
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toHaveAttribute("aria-expanded", "false");
+
+    await act(async () => user.click(screen.getByRole("button", { name: "Expand sidebar" })));
+
+    expect(sidebar).toHaveAttribute("data-sidebar-state", "expanded");
+    expect(window.localStorage.getItem("tt.sidebarCollapsed")).toBe("0");
+  });
+
+  it("moves focus into the mobile drawer and closes it with the dedicated button", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    const openButton = screen.getByRole("button", { name: "Open navigation menu" });
+    await act(async () => user.click(openButton));
+
+    const drawer = screen.getByRole("dialog", { name: "Main navigation" });
+    const closeButton = screen.getByRole("button", { name: "Close navigation menu" });
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+    expect(openButton).toHaveAttribute("aria-expanded", "true");
+    expect(document.activeElement).toBe(closeButton);
+
+    await act(async () => user.click(closeButton));
+
+    expect(screen.queryByRole("dialog", { name: "Main navigation" })).not.toBeInTheDocument();
+    expect(openButton).toHaveAttribute("aria-expanded", "false");
+    expect(document.activeElement).toBe(openButton);
+  });
+
+  it("closes the mobile drawer with Escape and backdrop clicks", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+    const openButton = screen.getByRole("button", { name: "Open navigation menu" });
+
+    await act(async () => user.click(openButton));
+    await act(async () => user.keyboard("{Escape}"));
+    expect(screen.queryByRole("dialog", { name: "Main navigation" })).not.toBeInTheDocument();
+
+    await act(async () => user.click(openButton));
+    const backdrop = document.querySelector(".bg-black\\/40");
+    expect(backdrop).toBeInTheDocument();
+    await act(async () => user.click(backdrop));
+    expect(screen.queryByRole("dialog", { name: "Main navigation" })).not.toBeInTheDocument();
+  });
+
+  it("keeps Tab focus within the mobile drawer", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+    await act(async () => user.click(screen.getByRole("button", { name: "Open navigation menu" })));
+
+    const drawer = screen.getByRole("dialog", { name: "Main navigation" });
+    const focusable = drawer.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    last.focus();
+    await act(async () => user.tab());
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    await act(async () => user.tab({ shift: true }));
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("closes an open drawer when the viewport crosses the desktop breakpoint", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+    await act(async () => user.click(screen.getByRole("button", { name: "Open navigation menu" })));
+    expect(screen.getByRole("dialog", { name: "Main navigation" })).toBeInTheDocument();
+
+    await act(async () => {
+      desktopMatches = true;
+      mediaListeners.forEach((listener) => listener({ matches: true }));
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Main navigation" })).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/ui/components/Sidebar.test.jsx
+++ b/dashboard/src/ui/components/Sidebar.test.jsx
@@ -167,14 +167,21 @@ describe("AppLayout sidebar controls", () => {
   it("closes an open drawer when the viewport crosses the desktop breakpoint", async () => {
     const user = userEvent.setup();
     renderLayout();
-    await act(async () => user.click(screen.getByRole("button", { name: "Open navigation menu" })));
+    const openButton = screen.getByRole("button", { name: "Open navigation menu" });
+    const mainContent = document.getElementById("app-main-content");
+    await act(async () => user.click(openButton));
     expect(screen.getByRole("dialog", { name: "Main navigation" })).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe("hidden");
 
     await act(async () => {
       desktopMatches = true;
       mediaListeners.forEach((listener) => listener({ matches: true }));
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
     });
 
     expect(screen.queryByRole("dialog", { name: "Main navigation" })).not.toBeInTheDocument();
+    expect(document.body.style.overflow).toBe("");
+    expect(document.activeElement).toBe(mainContent);
+    expect(document.activeElement).not.toBe(openButton);
   });
 });


### PR DESCRIPTION
## Summary

- Reset an open mobile drawer when the viewport enters the desktop breakpoint so the hidden drawer unmounts and the body scroll lock is released.
- Add modal dialog semantics, move focus into the drawer, trap Tab focus, and restore focus to the mobile menu button after normal user dismissals.
- Use a separate breakpoint-close path that moves focus to the visible main-content region instead of the now-hidden mobile menu button.
- Preserve data-native-sidebar as the desktop aside's first attribute so the native Windows selector guard remains intact.

## Validation

- node --test test/windows-native-glass-selector.test.js
- npm --prefix dashboard test -- src/ui/components/Sidebar.test.jsx --minWorkers=1 --maxWorkers=1
- npm --prefix dashboard run lint
- npm --prefix dashboard run typecheck
- npm --prefix dashboard run build
- npm run validate:copy
- npm run validate:ui-hardcode
- npm run validate:guardrails
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved sidebar navigation labels and keyboard focus handling.
  - Added focus trapping for the mobile drawer and restored focus when it closes.
  - Added dialog semantics and expanded/collapsed state indicators.

- **User Experience**
  - Mobile navigation now closes with Escape, backdrop clicks, or when switching to desktop view.
  - Sidebar collapse preferences persist between sessions.

- **Tests**
  - Added coverage for desktop, mobile, focus, keyboard, persistence, and breakpoint behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->