### PR TITLE
fix(auth): restore native sessions after WebView restart

### DIFF
--- a/dashboard/src/contexts/InsforgeAuthContext.jsx
+++ b/dashboard/src/contexts/InsforgeAuthContext.jsx
@@ -5,6 +5,7 @@ import { isLikelyExpiredAccessToken } from "../lib/auth-token";
 import { getPublicVisibility } from "../lib/api";
 import { clearLocalApiAuthToken, getLocalApiAuthHeaders } from "../lib/local-api-auth";
 import { isNativeWindowsApp } from "../lib/native-bridge.js";
+import { restoreInsforgeUser } from "../lib/insforge-session-recovery.mjs";
 
 const InsforgeAuthContext = createContext(null);
 
@@ -85,16 +86,8 @@ export function InsforgeAuthProvider({ children }) {
     setLoading(true);
     (async () => {
       try {
-        let { data, error } = await client.auth.getCurrentUser();
+        const { data, error } = await restoreInsforgeUser(client.auth, { isActive: () => active });
         if (!active) return;
-        // OAuth 回调与首次 getCurrentUser 偶发竞态：无 error 但 user 仍为空时再试一次
-        if (!error && !data?.user) {
-          await new Promise((r) => setTimeout(r, 150));
-          if (!active) return;
-          const again = await client.auth.getCurrentUser();
-          data = again.data;
-          error = again.error;
-        }
         if (error) {
           setUser(null);
           return;

--- a/dashboard/src/lib/insforge-session-recovery.mjs
+++ b/dashboard/src/lib/insforge-session-recovery.mjs
@@ -1,0 +1,44 @@
+const OAUTH_CALLBACK_SETTLE_MS = 150;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function canRecoverSession(error) {
+  if (!error) return true;
+  const status = Number(error.statusCode ?? error.status);
+  return status === 401 || status === 403;
+}
+
+/**
+ * Restore a session after a fresh embedded-browser launch.
+ *
+ * InsForge normally restores a valid httpOnly session cookie from
+ * getCurrentUser(). On macOS, the dashboard WebView is intentionally released
+ * when its window closes, so a restart can begin with no WebView cookies even
+ * though the local API still holds its persisted refresh token. In that narrow
+ * recovery path, explicitly call refreshSession() once so the local API can
+ * mint and relay a new browser session.
+ */
+export async function restoreInsforgeUser(auth, options = {}) {
+  const settleDelayMs = Math.max(0, Number(options.settleDelayMs ?? OAUTH_CALLBACK_SETTLE_MS) || 0);
+  const wait = options.wait ?? delay;
+  const isActive = options.isActive ?? (() => true);
+
+  let current = await auth.getCurrentUser();
+  if (current?.data?.user || !canRecoverSession(current?.error)) return current;
+  if (!isActive()) return current;
+
+  // Preserve the OAuth callback race workaround before attempting recovery.
+  if (!current?.error && settleDelayMs > 0) {
+    await wait(settleDelayMs);
+    if (!isActive()) return current;
+    current = await auth.getCurrentUser();
+    if (current?.data?.user || !canRecoverSession(current?.error)) return current;
+  }
+
+  if (!isActive()) return current;
+  if (typeof auth.refreshSession !== "function") return current;
+  const refreshed = await auth.refreshSession();
+  if (refreshed?.error) return current;
+
+  return auth.getCurrentUser();
+}

--- a/test/insforge-session-recovery.test.js
+++ b/test/insforge-session-recovery.test.js
@@ -1,0 +1,112 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const test = require("node:test");
+
+async function loadRecovery() {
+  const url = pathToFileURL(
+    path.join(process.cwd(), "dashboard/src/lib/insforge-session-recovery.mjs"),
+  ).href;
+  return import(url);
+}
+
+test("uses the existing user without refreshing", async () => {
+  const { restoreInsforgeUser } = await loadRecovery();
+  const user = { id: "existing-user" };
+  const auth = {
+    getCurrentUser: async () => ({ data: { user }, error: null }),
+    refreshSession: async () => assert.fail("should not refresh an existing session"),
+  };
+
+  const result = await restoreInsforgeUser(auth, { settleDelayMs: 0 });
+  assert.equal(result.data.user, user);
+});
+
+test("refreshes once when a new WebView has no session cookie", async () => {
+  const { restoreInsforgeUser } = await loadRecovery();
+  const user = { id: "restored-user" };
+  let getCurrentUserCalls = 0;
+  let refreshCalls = 0;
+  const auth = {
+    getCurrentUser: async () => {
+      getCurrentUserCalls += 1;
+      return getCurrentUserCalls === 3
+        ? { data: { user }, error: null }
+        : { data: { user: null }, error: null };
+    },
+    refreshSession: async () => {
+      refreshCalls += 1;
+      return { data: { accessToken: "restored-token" }, error: null };
+    },
+  };
+
+  const result = await restoreInsforgeUser(auth, { settleDelayMs: 1, wait: async () => {} });
+  assert.equal(result.data.user, user);
+  assert.equal(getCurrentUserCalls, 3);
+  assert.equal(refreshCalls, 1);
+});
+
+test("refreshes a recoverable unauthorized response without waiting", async () => {
+  const { restoreInsforgeUser } = await loadRecovery();
+  const user = { id: "renewed-user" };
+  let getCurrentUserCalls = 0;
+  let refreshCalls = 0;
+  const auth = {
+    getCurrentUser: async () => {
+      getCurrentUserCalls += 1;
+      return getCurrentUserCalls === 1
+        ? { data: { user: null }, error: { statusCode: 401 } }
+        : { data: { user }, error: null };
+    },
+    refreshSession: async () => {
+      refreshCalls += 1;
+      return { data: {}, error: null };
+    },
+  };
+
+  const result = await restoreInsforgeUser(auth, {
+    settleDelayMs: 150,
+    wait: async () => assert.fail("should not wait before recovering a 401"),
+  });
+  assert.equal(result.data.user, user);
+  assert.equal(getCurrentUserCalls, 2);
+  assert.equal(refreshCalls, 1);
+});
+
+test("does not turn a network failure into a refresh request", async () => {
+  const { restoreInsforgeUser } = await loadRecovery();
+  let refreshCalls = 0;
+  const failure = { statusCode: 502, message: "upstream unavailable" };
+  const auth = {
+    getCurrentUser: async () => ({ data: { user: null }, error: failure }),
+    refreshSession: async () => {
+      refreshCalls += 1;
+      return { data: {}, error: null };
+    },
+  };
+
+  const result = await restoreInsforgeUser(auth, { settleDelayMs: 0 });
+  assert.equal(result.error, failure);
+  assert.equal(refreshCalls, 0);
+});
+
+test("does not refresh after the auth provider has been disposed", async () => {
+  const { restoreInsforgeUser } = await loadRecovery();
+  let refreshCalls = 0;
+  const current = { data: { user: null }, error: null };
+  const auth = {
+    getCurrentUser: async () => current,
+    refreshSession: async () => {
+      refreshCalls += 1;
+      return { data: {}, error: null };
+    },
+  };
+
+  const result = await restoreInsforgeUser(auth, {
+    settleDelayMs: 1,
+    wait: async () => assert.fail("should not wait after disposal"),
+    isActive: () => false,
+  });
+  assert.equal(result, current);
+  assert.equal(refreshCalls, 0);
+});


### PR DESCRIPTION
## Summary

Restore a native dashboard session after a fresh WKWebView launch by performing one bounded refresh through the local auth relay when persisted refresh credentials exist.

## Scope

- [ ] CLI (`src/`)
- [x] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no new user-facing strings)
- [x] Commits follow conventional style (`fix:`)
- [x] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

### Rules / invariants

- An already valid session must not trigger a refresh request.
- A fresh native WebView may recover once through the local auth relay’s persisted refresh-token fallback.
- Only an empty user state or 401/403 is recoverable; network/server failures must not become refresh loops.
- An unmounted auth provider must not issue a delayed refresh.

### Boundary matrix (list at least 3)

| Boundary | Expected behavior |
| --- | --- |
| Existing valid user | Return user immediately; no refresh |
| Empty initial WebView session | Preserve the OAuth callback retry, then refresh once and re-read user |
| 401 / 403 response | Refresh immediately once, then re-read user |
| 5xx / network failure | Preserve failure; do not refresh |
| Provider disposed during startup | Stop before retry/refresh |

### Public exposure checklist (if applicable)

- [x] Not applicable

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** Added bounded native session recovery helper and five regression cases.
- **Intended behavior / invariants:** Restore a persisted native session after a new WebView starts without broadening refresh behavior or creating retry loops.
- **Edge cases covered:** Existing session, empty WebView session, 401 recovery, network failure, disposed provider.
- **Tests run (command + result):**
  - `npm test` — 2,432 passed, 0 failed, 2 skipped
  - `npm --prefix dashboard exec vitest run src/contexts/__tests__/InsforgeAuthContext.test.jsx` — 6 passed
  - Dashboard lint and production build — passed
  - Xcode-beta Debug build, signing, and launch verification — passed

### Most likely regression surface

Native OAuth callback timing and signed-out dashboard startup behavior.

### Verification method (choose at least one)

- [x] Automated regression tests
- [x] Dashboard production build
- [x] Native Xcode-beta build and launch verification

### Uncovered scope

No automated real-Google-account reboot test; this still needs one manual verification on macOS 27 after merging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration when reopening the app in an embedded browser.
  * Users are less likely to be signed out when session cookies are temporarily unavailable.
  * Added recovery for expired authentication sessions while preserving genuine network errors.
  * Prevented session recovery from continuing after the authentication provider is closed.
* **Tests**
  * Added coverage for session reuse, recovery, authentication errors, network failures, and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->