### PR TITLE
fix(bar): show OpenCode Go limits in menu bar

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/MenuBarDisplayPreferences.swift
@@ -34,6 +34,9 @@ enum MenuBarDisplayMetric: String, CaseIterable {
     case antigravityGemini5h
     case zcodeGlm52
     case zcodeGlm5Turbo
+    case opencodeGo5h
+    case opencodeGoWeekly
+    case opencodeGoMonthly
     case qoderQuota
     case qoderUltimate
 
@@ -74,6 +77,9 @@ enum MenuBarDisplayMetric: String, CaseIterable {
         case .antigravityGemini5h: return "Ag Gm 5h"
         case .zcodeGlm52: return "ZC Pri"
         case .zcodeGlm5Turbo: return "ZC Sec"
+        case .opencodeGo5h: return "OG 5h"
+        case .opencodeGoWeekly: return "OG Wk"
+        case .opencodeGoMonthly: return "OG Mo"
         case .qoderQuota: return "Qd Cred"
         case .qoderUltimate: return "Qd Ult"
         }
@@ -114,6 +120,9 @@ enum MenuBarDisplayMetric: String, CaseIterable {
         case .antigravityGemini5h: return "Antigravity Gemini 5h Limit"
         case .zcodeGlm52: return "ZCode Primary Limit"
         case .zcodeGlm5Turbo: return "ZCode Secondary Limit"
+        case .opencodeGo5h: return "OpenCode Go 5h Limit"
+        case .opencodeGoWeekly: return "OpenCode Go Weekly Limit"
+        case .opencodeGoMonthly: return "OpenCode Go Monthly Limit"
         case .qoderQuota: return "Qoder Credits Limit"
         case .qoderUltimate: return "Qoder Ultimate Free Calls"
         }
@@ -134,6 +143,7 @@ enum MenuBarDisplayMetric: String, CaseIterable {
              .copilotPremium, .copilotChat,
              .antigravityClaudeWeekly, .antigravityClaude5h, .antigravityGeminiWeekly, .antigravityGemini5h,
              .zcodeGlm52, .zcodeGlm5Turbo,
+             .opencodeGo5h, .opencodeGoWeekly, .opencodeGoMonthly,
              .qoderQuota, .qoderUltimate:
             return "limits"
         }
@@ -156,6 +166,7 @@ enum MenuBarDisplayMetric: String, CaseIterable {
         case .copilotPremium, .copilotChat: return "copilot"
         case .antigravityClaudeWeekly, .antigravityClaude5h, .antigravityGeminiWeekly, .antigravityGemini5h: return "antigravity"
         case .zcodeGlm52, .zcodeGlm5Turbo: return "zcode"
+        case .opencodeGo5h, .opencodeGoWeekly, .opencodeGoMonthly: return "opencodeGo"
         case .qoderQuota, .qoderUltimate: return "qoder"
         }
     }
@@ -185,6 +196,7 @@ private extension UsageLimitsResponse {
         case "copilot": return (copilot?.configured == true) && (copilot?.error == nil)
         case "antigravity": return antigravity.configured && antigravity.error == nil
         case "zcode": return (zcode?.configured == true) && (zcode?.error == nil)
+        case "opencodeGo": return (opencodeGo?.configured == true) && (opencodeGo?.error == nil)
         case "qoder": return (qoder?.configured == true) && (qoder?.error == nil)
         default: return false
         }
@@ -222,6 +234,9 @@ private extension UsageLimitsResponse {
         case .antigravityGemini5h: return antigravity.quaternaryWindow != nil
         case .zcodeGlm52: return zcode?.primaryWindow != nil
         case .zcodeGlm5Turbo: return zcode?.secondaryWindow != nil
+        case .opencodeGo5h: return opencodeGo?.primaryWindow != nil
+        case .opencodeGoWeekly: return opencodeGo?.secondaryWindow != nil
+        case .opencodeGoMonthly: return opencodeGo?.tertiaryWindow != nil
         case .qoderQuota: return qoder?.primaryWindow != nil
         case .qoderUltimate: return qoder?.secondaryWindow != nil
         }
@@ -331,6 +346,7 @@ enum MenuBarDisplayPreferences {
                  .antigravityClaudeWeekly, .antigravityClaude5h,
                  .antigravityGeminiWeekly, .antigravityGemini5h,
                  .zcodeGlm52, .zcodeGlm5Turbo,
+                 .opencodeGo5h, .opencodeGoWeekly, .opencodeGoMonthly,
                  .qoderQuota, .qoderUltimate:
                 break
             }

--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -94,6 +94,12 @@ extension UsageLimitsResponse {
             return guarded(zcode?.configured, zcode?.error, zcode?.primaryWindow?.usedPercent)
         case .zcodeGlm5Turbo:
             return guarded(zcode?.configured, zcode?.error, zcode?.secondaryWindow?.usedPercent)
+        case .opencodeGo5h:
+            return guarded(opencodeGo?.configured, opencodeGo?.error, opencodeGo?.primaryWindow?.usedPercent)
+        case .opencodeGoWeekly:
+            return guarded(opencodeGo?.configured, opencodeGo?.error, opencodeGo?.secondaryWindow?.usedPercent)
+        case .opencodeGoMonthly:
+            return guarded(opencodeGo?.configured, opencodeGo?.error, opencodeGo?.tertiaryWindow?.usedPercent)
         case .qoderQuota:
             return guarded(qoder?.configured, qoder?.error, qoder?.primaryWindow?.usedPercent)
         case .qoderUltimate:

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -1297,6 +1297,7 @@ final class StatusBarController: NSObject {
     // MARK: - Menu Actions
 
     @objc private func openPopover() {
+        popoverReshowAttempted = false
         // Small delay to let the menu dismiss before showing popover
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             self?.togglePopover()

--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -526,6 +526,12 @@ final class StatusBarController: NSObject {
                 return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.zcode?.configured, error: viewModel.usageLimits?.zcode?.error, window: viewModel.usageLimits?.zcode?.primaryWindow)
             case .zcodeGlm5Turbo:
                 return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.zcode?.configured, error: viewModel.usageLimits?.zcode?.error, window: viewModel.usageLimits?.zcode?.secondaryWindow)
+            case .opencodeGo5h:
+                return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.opencodeGo?.configured, error: viewModel.usageLimits?.opencodeGo?.error, window: viewModel.usageLimits?.opencodeGo?.primaryWindow)
+            case .opencodeGoWeekly:
+                return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.opencodeGo?.configured, error: viewModel.usageLimits?.opencodeGo?.error, window: viewModel.usageLimits?.opencodeGo?.secondaryWindow)
+            case .opencodeGoMonthly:
+                return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.opencodeGo?.configured, error: viewModel.usageLimits?.opencodeGo?.error, window: viewModel.usageLimits?.opencodeGo?.tertiaryWindow)
             case .qoderQuota:
                 return genericLimitValue(id: id, metric: metric, configured: viewModel.usageLimits?.qoder?.configured, error: viewModel.usageLimits?.qoder?.error, window: viewModel.usageLimits?.qoder?.primaryWindow)
             case .qoderUltimate:

--- a/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/WidgetSnapshotWriter.swift
@@ -421,6 +421,25 @@ enum WidgetSnapshotWriter {
             }
         }
 
+        // OpenCode Go
+        if let opencodeGo = limits.opencodeGo, opencodeGo.configured {
+            if let w = opencodeGo.primaryWindow {
+                out.append(LimitProvider(source: "opencodeGo", label: "OpenCode Go",
+                                         fraction: w.usedPercent / 100.0,
+                                         resetsAt: parseISO(w.resetAt)))
+            }
+            if let w = opencodeGo.secondaryWindow {
+                out.append(LimitProvider(source: "opencodeGo", label: "OpenCode Go · Weekly",
+                                         fraction: w.usedPercent / 100.0,
+                                         resetsAt: parseISO(w.resetAt)))
+            }
+            if let w = opencodeGo.tertiaryWindow {
+                out.append(LimitProvider(source: "opencodeGo", label: "OpenCode Go · Monthly",
+                                         fraction: w.usedPercent / 100.0,
+                                         resetsAt: parseISO(w.resetAt)))
+            }
+        }
+
         // GitHub Copilot
         if let copilot = limits.copilot, copilot.configured {
             if let w = copilot.primaryWindow {


### PR DESCRIPTION
### 问题

菜单栏额度显示的下拉列表（`MenuBarDisplayMetric`）未接入 `opencodeGo`，导致即便 `OPENCODE_GO_API_KEY` 已配置、本机 `/functions/tokentracker-usage-limits` 已返回 `opencodeGo: {configured:true, primary 12%/secondary 7%/tertiary 6%, source:api}`，用户在菜单栏设置里也无法选择 OpenCode Go 的三项额度。

Dashboard 弹窗内正常（`PROVIDER_LIMIT_SPECS.opencodeGo` 已接入），说明后端链路完整，问题仅在 Swift 展示层。

### 根因

* `Models/MenuBarDisplayPreferences.swift` 无 `opencodeGo` 三个 case，且 `providerKey`/`isProviderAvailable`/`hasWindow` 未处理
* `Models/UsageLimits.swift` `utilizationPercent(for:)` 无分支
* `Services/StatusBarController.swift` `buildMenuBarDisplayValues()` 无分支
* `Services/WidgetSnapshotWriter.swift` 的 widget 快照也未包含 Go

### 修复

* 新增 `opencodeGo5h` / `opencodeGoWeekly` / `opencodeGoMonthly`（`OG 5h` / `OG Wk` / `OG Mo`，`providerKey=opencodeGo`），对齐 `LimitsSettingsStore.allProviders` 的顺序（zcode 之后、qoder 之前）
* 补齐 `utilizationPercent`、`hasWindow`、`isProviderAvailable`、`StatusBarController` 渲染、widget snapshot 的 3 个窗口
* 验证：`xcodebuild test -scheme TokenTrackerBarTests` 155 tests, 154 passed（1 个既有的中文 locale 导致的 `qoder.Plan` vs `套餐` 用例在英文 CI 下通过）

Closes the reported '菜单栏额度显示指标无法显示opencodeGo套餐的额度'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode Go usage tracking for 5-hour, weekly, and monthly limits.
  * Added OpenCode Go metrics to menu-bar displays and widgets.
  * Added availability checks, labels, settings, and reset-time information for each metric.

* **Bug Fixes**
  * Improved popover reopening behavior after display interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->