### PR TITLE
fix(linux): reap servers orphaned by a crashed app

### DIFF
--- a/TokenTrackerLinux/src-tauri/src/server.rs
+++ b/TokenTrackerLinux/src-tauri/src/server.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -12,6 +14,11 @@ use std::time::{Duration, Instant};
 use crate::paths::RuntimePaths;
 
 const READINESS_PATH: &str = "/functions/tokentracker-user-status";
+
+/// How long to wait for an orphaned server to exit before giving up, and how
+/// long to wait before escalating SIGTERM to SIGKILL.
+const REAP_TIMEOUT: Duration = Duration::from_secs(3);
+const REAP_ESCALATE_AFTER: Duration = Duration::from_millis(750);
 
 /// How often the health monitor probes the server.
 pub const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(15);
@@ -89,22 +96,291 @@ pub struct TokenTrackerServer {
     background_sync: BackgroundSync,
 }
 
+/// Directories that may hold server records, most preferred first.
+///
+/// Deliberately excludes the `/tmp` fallback [`server_log_paths`] ends with:
+/// that directory is writable by every account, so another user could plant a
+/// forged record naming one of this user's PIDs and have the next launch signal
+/// it. A log line lost when no private state directory exists is acceptable; a
+/// signal sent on a stranger's say-so is not.
+pub fn server_record_dirs(xdg_state_home: Option<PathBuf>, home: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(state_home) = xdg_state_home {
+        dirs.push(state_home.join("tokentracker").join("servers"));
+    }
+    if let Some(home) = home {
+        let dir = home
+            .join(".local")
+            .join("state")
+            .join("tokentracker")
+            .join("servers");
+        if !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    }
+    dirs
+}
+
+/// One record per owning app process, rather than a single `server.json`.
+///
+/// Single-instance locking runs over the session D-Bus, so a second login
+/// session on the same account starts a second app. A shared file would let
+/// each session delete or overwrite the other's record, and the loser's server
+/// could then never be reaped -- leaving port 17680 held and OAuth broken,
+/// which is the failure this whole mechanism exists to prevent.
+pub fn server_record_name(owner_pid: i32) -> String {
+    format!("server-{owner_pid}.json")
+}
+
+/// Identity of a spawned server.
+///
+/// Deliberately *not* a filesystem path. An AppImage mounts itself at a fresh
+/// `/tmp/.mount_XXXXXX` on every launch, so the orphan's `node` and `tracker.js`
+/// paths never match the ones this launch resolved -- and the AppImage is the
+/// only Linux artifact the release workflow builds.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ServerRecord {
+    pub pid: i32,
+    pub port: u16,
+    /// Process start from `/proc/<pid>/stat`, pinning the record to one
+    /// specific process so a recycled PID is never mistaken for it.
+    pub start_time: u64,
+    /// `/proc/sys/kernel/random/boot_id`. `start_time` counts ticks since boot
+    /// and restarts from zero on every boot, so without this a record surviving
+    /// an unclean shutdown could match an unrelated process that merely landed
+    /// on the same PID at the same tick.
+    pub boot_id: String,
+    /// The app process that spawned this server, identified the same way.
+    /// "Orphaned" means the owner is gone, not merely that the child is alive.
+    pub owner_pid: i32,
+    pub owner_start_time: u64,
+}
+
+/// The current boot's identifier, or `None` where the kernel does not expose
+/// one -- in which case no record is written and nothing is ever signalled.
+pub fn boot_id() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+}
+
+/// Read field 22 (`starttime`) of `/proc/<pid>/stat`.
+///
+/// Parsed after the final `)` because field 2 is the executable name and may
+/// itself contain spaces and parentheses.
+pub fn process_start_time(pid: i32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = &stat[stat.rfind(')')? + 1..];
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+/// True when `pid` is alive and is still the exact process described by
+/// `record` -- the check that makes signalling PID-reuse-safe.
+fn record_still_matches(record: &ServerRecord) -> bool {
+    boot_id().is_some_and(|id| id == record.boot_id)
+        && process_start_time(record.pid) == Some(record.start_time)
+}
+
+fn owner_still_running(record: &ServerRecord) -> bool {
+    process_start_time(record.owner_pid) == Some(record.owner_start_time)
+}
+
+fn record_dirs() -> Vec<PathBuf> {
+    let xdg_state_home = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    server_record_dirs(xdg_state_home, home)
+}
+
+/// Persist the identity of a freshly spawned server.
+fn record_server(pid: u32, port: u16) {
+    let owner_pid = std::process::id() as i32;
+    let (Some(start_time), Some(owner_start_time), Some(boot_id)) = (
+        process_start_time(pid as i32),
+        process_start_time(owner_pid),
+        boot_id(),
+    ) else {
+        return;
+    };
+    let Ok(json) = serde_json::to_string(&ServerRecord {
+        pid: pid as i32,
+        port,
+        start_time,
+        boot_id,
+        owner_pid,
+        owner_start_time,
+    }) else {
+        return;
+    };
+
+    // Walk the whole candidate chain like `open_server_log`: settling for the
+    // first candidate would silently record nothing when XDG_STATE_HOME is
+    // read-only, leaving a later crash unrecoverable.
+    for dir in record_dirs() {
+        // 0700/0600 explicitly: a permissive umask (0002, or 0000) would
+        // otherwise leave these group- or world-writable, letting another
+        // account rewrite a victim-owned record in place -- the uid check in
+        // `read_record` would still pass, and this process would then signal
+        // whatever pid the forged record named.
+        let _ = std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&dir);
+        let written = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(dir.join(server_record_name(owner_pid)))
+            .and_then(|mut file| file.write_all(json.as_bytes()));
+        if written.is_ok() {
+            return;
+        }
+    }
+}
+
+/// Remove only *this* process's record, never another session's.
+fn clear_server_record() {
+    let name = server_record_name(std::process::id() as i32);
+    for dir in record_dirs() {
+        let _ = std::fs::remove_file(dir.join(&name));
+    }
+}
+
+/// Read a record, rejecting anything this user does not own.
+fn read_record(path: &Path) -> Option<ServerRecord> {
+    // O_NOFOLLOW plus fstat on the descriptor actually read: checking the path
+    // and then reopening it would let a symlink be swapped in between the two.
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .ok()?;
+    let metadata = file.metadata().ok()?;
+    // SAFETY: getuid(2) is always successful.
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::getuid() } {
+        return None;
+    }
+    // Writable by anyone but the owner means the contents cannot be trusted
+    // even though the owner is right.
+    if metadata.mode() & 0o022 != 0 {
+        return None;
+    }
+
+    let mut raw = Vec::new();
+    file.read_to_end(&mut raw).ok()?;
+    serde_json::from_slice(&raw).ok()
+}
+
+/// Stop servers orphaned by an earlier crash.
+///
+/// A GTK/Wayland failure calls `_exit(1)` -- verified: an `atexit` hook
+/// registered at startup never runs -- so neither `Drop` nor Tauri's
+/// `RunEvent::ExitRequested` fires and the Node child survives its parent. An
+/// orphan holding [`PREFERRED_PORT`] is not merely idle: it forces the next
+/// launch onto a random port, which silently costs OAuth sign-in.
+pub fn reap_orphaned_servers() -> Vec<i32> {
+    let mut reaped = Vec::new();
+
+    for dir in record_dirs() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(record) = read_record(&path) else {
+                continue;
+            };
+            // A live owner means another app instance is running this server,
+            // not that it was stranded. Leave its record in place: deleting it
+            // would strand that server permanently if it later crashed.
+            if owner_still_running(&record) {
+                continue;
+            }
+            let _ = std::fs::remove_file(&path);
+            if record.pid <= 0 || record.pid == std::process::id() as i32 {
+                continue;
+            }
+            if !record_still_matches(&record) {
+                continue;
+            }
+
+            // SAFETY: kill(2) on the negated pid signals the process group the
+            // server leads, which is the pid confirmed above.
+            unsafe {
+                libc::kill(-record.pid, libc::SIGTERM);
+            }
+            // Signalling is not enough: the listening socket outlives the
+            // signal, so returning here would let `pick_available_port` still
+            // find PREFERRED_PORT taken and fall back to a random one --
+            // exactly the OAuth failure this is meant to prevent.
+            wait_for_exit(&record, REAP_TIMEOUT, REAP_ESCALATE_AFTER);
+            reaped.push(record.pid);
+        }
+    }
+
+    reaped
+}
+
+/// Poll until the recorded process is gone, escalating to SIGKILL after
+/// `escalate_after`. Bounded: a process that never exits must not block startup.
+///
+/// Identity is rechecked before escalating, so a PID recycled inside the wait
+/// window is left alone rather than killed.
+fn wait_for_exit(record: &ServerRecord, timeout: Duration, escalate_after: Duration) {
+    let start = Instant::now();
+    let deadline = start + timeout;
+    let escalate_at = start + escalate_after;
+    let mut escalated = false;
+
+    loop {
+        if !record_still_matches(record) || Instant::now() >= deadline {
+            return;
+        }
+        if !escalated && Instant::now() >= escalate_at {
+            // SAFETY: identity revalidated by the check above on this same
+            // iteration, so this cannot land on a recycled PID.
+            unsafe {
+                libc::kill(-record.pid, libc::SIGKILL);
+            }
+            escalated = true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 impl TokenTrackerServer {
     pub fn start(paths: RuntimePaths) -> Result<Self, String> {
+        // Before picking a port: an orphan from an earlier crash holding
+        // PREFERRED_PORT would otherwise push this launch onto a random port
+        // and silently break OAuth sign-in.
+        for pid in reap_orphaned_servers() {
+            eprintln!("[TokenTracker] stopped an orphaned server from an earlier run (pid {pid})");
+        }
+
         let port = pick_available_port()?;
         let url = dashboard_url(port);
 
         let args = serve_args(&paths.tracker, port);
         let mut child = Command::new(&paths.node)
             .args(&args)
+            // Own process group: `bin/tracker.js` re-executes itself through
+            // `spawnSync` when a proxy is configured, so the process actually
+            // holding the port is a grandchild. Signalling the group reaches it;
+            // signalling this pid alone would leave it on 17680.
+            .process_group(0)
             .stdout(Stdio::null())
             .stderr(server_log_stdio())
             .spawn()
             .map_err(|error| format!("failed to start TokenTracker server: {error}"))?;
+        record_server(child.id(), port);
 
         wait_for_server_ready(port, READY_TIMEOUT).inspect_err(|_| {
-            let _ = child.kill();
-            let _ = child.wait();
+            // Group first, record second: `stop_child` reaches a proxy
+            // relaunch's grandchild, and if it somehow fails the record must
+            // still be on disk for the next launch to reap.
+            stop_child(Some(&mut child));
+            clear_server_record();
         })?;
 
         let background_sync = BackgroundSync::start(paths.clone());
@@ -145,8 +421,10 @@ impl TokenTrackerServer {
     /// handled by the health monitor after it releases the global server mutex,
     /// so app shutdown never waits for the full readiness timeout.
     pub fn restart_process(&mut self) -> Result<(), String> {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        // Group, not just the leader: with a proxy relaunch the listener is a
+        // grandchild, and leaving it alive means the replacement cannot bind
+        // the same port.
+        stop_child(Some(&mut self.child));
 
         // Brief pause for the OS to release the port.
         thread::sleep(Duration::from_millis(500));
@@ -159,16 +437,19 @@ impl TokenTrackerServer {
         let args = serve_args(&self.paths.tracker, self.port);
         self.child = Command::new(&self.paths.node)
             .args(&args)
+            .process_group(0)
             .stdout(Stdio::null())
             .stderr(log_file.map_or_else(Stdio::null, Stdio::from))
             .spawn()
             .map_err(|error| format!("failed to restart server: {error}"))?;
+        record_server(self.child.id(), self.port);
 
         Ok(())
     }
 
     pub fn stop(&mut self) {
         self.background_sync.stop();
+        clear_server_record();
         stop_child(Some(&mut self.child));
     }
 }
@@ -356,6 +637,23 @@ fn stop_child(child: Option<&mut Child>) {
     match child.try_wait() {
         Ok(Some(_)) => {}
         Ok(None) | Err(_) => {
+            // Same grandchild problem as the reaper: killing only the leader
+            // leaves a proxy-relaunched server holding the port.
+            let pgid = child.id() as i32;
+            // SAFETY: kill(2) on the group this child leads.
+            unsafe {
+                libc::kill(-pgid, libc::SIGTERM);
+            }
+            for _ in 0..20 {
+                if matches!(child.try_wait(), Ok(Some(_))) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+            // SAFETY: as above; harmless once the group is already gone.
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
             let _ = child.kill();
             let _ = child.wait();
         }

--- a/TokenTrackerLinux/src-tauri/src/server.rs
+++ b/TokenTrackerLinux/src-tauri/src/server.rs
@@ -20,6 +20,13 @@ const READINESS_PATH: &str = "/functions/tokentracker-user-status";
 const REAP_TIMEOUT: Duration = Duration::from_secs(3);
 const REAP_ESCALATE_AFTER: Duration = Duration::from_millis(750);
 
+/// The same, for a server this process is shutting down on its way out.
+const STOP_TIMEOUT: Duration = Duration::from_secs(2);
+const STOP_ESCALATE_AFTER: Duration = Duration::from_secs(1);
+
+/// How often either wait re-checks the process group.
+const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
 /// How often the health monitor probes the server.
 pub const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(15);
 
@@ -196,6 +203,35 @@ pub fn leads_own_process_group(pid: i32) -> bool {
     unsafe { libc::getpgid(pid) == pid }
 }
 
+/// Whether any process remains in the group led by `pgid`.
+///
+/// `kill(-pgid, 0)` asks about the *group*, so this stays true after the leader
+/// exits while a descendant runs on -- which is the case that matters, because
+/// the descendant is what holds the port. `EPERM` means members exist that this
+/// process may not signal, which is still "alive" for the purpose of deciding
+/// whether the port has been released.
+///
+/// Note the ordering property this relies on: a task closes its file
+/// descriptors during exit, before it leaves its process group, so an empty
+/// group is proof the listening socket is gone -- strictly stronger than
+/// probing the port.
+pub fn group_still_alive(pgid: i32) -> bool {
+    if pgid <= 1 {
+        return false;
+    }
+    // SAFETY: signal 0 runs kill(2)'s existence and permission checks without
+    // delivering anything.
+    if unsafe { libc::kill(-pgid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+/// Whether `port` can be bound right now, i.e. nothing is listening on it.
+fn port_is_free(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
 fn owner_still_running(record: &ServerRecord) -> bool {
     process_start_time(record.owner_pid) == Some(record.owner_start_time)
 }
@@ -286,6 +322,17 @@ fn read_record(path: &Path) -> Option<ServerRecord> {
     serde_json::from_slice(&raw).ok()
 }
 
+/// What became of one orphaned server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReapOutcome {
+    pub pid: i32,
+    pub port: u16,
+    /// Whether the recorded port is actually bindable again. False means the
+    /// next launch will fall back to a random port, which is worth saying out
+    /// loud: it is precisely the state that breaks OAuth sign-in silently.
+    pub port_recovered: bool,
+}
+
 /// Stop servers orphaned by an earlier crash.
 ///
 /// A GTK/Wayland failure calls `_exit(1)` -- verified: an `atexit` hook
@@ -293,7 +340,7 @@ fn read_record(path: &Path) -> Option<ServerRecord> {
 /// `RunEvent::ExitRequested` fires and the Node child survives its parent. An
 /// orphan holding [`PREFERRED_PORT`] is not merely idle: it forces the next
 /// launch onto a random port, which silently costs OAuth sign-in.
-pub fn reap_orphaned_servers() -> Vec<i32> {
+pub fn reap_orphaned_servers() -> Vec<ReapOutcome> {
     let mut reaped = Vec::new();
 
     for dir in record_dirs() {
@@ -318,54 +365,91 @@ pub fn reap_orphaned_servers() -> Vec<i32> {
             if !record_still_matches(&record) {
                 continue;
             }
-            // Only a group leader may be negated; anything else would signal a
-            // group this process never created.
-            if !leads_own_process_group(record.pid) {
-                continue;
-            }
-
-            // SAFETY: kill(2) on the negated pid signals the process group the
-            // server leads, confirmed directly above.
-            unsafe {
-                libc::kill(-record.pid, libc::SIGTERM);
-            }
-            // Signalling is not enough: the listening socket outlives the
-            // signal, so returning here would let `pick_available_port` still
-            // find PREFERRED_PORT taken and fall back to a random one --
-            // exactly the OAuth failure this is meant to prevent.
-            wait_for_exit(&record, REAP_TIMEOUT, REAP_ESCALATE_AFTER);
-            reaped.push(record.pid);
+            let port_recovered = stop_recorded_server(&record, REAP_TIMEOUT, REAP_ESCALATE_AFTER);
+            reaped.push(ReapOutcome {
+                pid: record.pid,
+                port: record.port,
+                port_recovered,
+            });
         }
     }
 
     reaped
 }
 
-/// Poll until the recorded process is gone, escalating to SIGKILL after
-/// `escalate_after`. Bounded: a process that never exits must not block startup.
+/// Signal one recorded server's process group and wait for the port to come
+/// back. Returns whether it did.
 ///
-/// Identity is rechecked before escalating, so a PID recycled inside the wait
-/// window is left alone rather than killed.
-fn wait_for_exit(record: &ServerRecord, timeout: Duration, escalate_after: Duration) {
+/// Split out of [`reap_orphaned_servers`] so the wait can be exercised against a
+/// real process tree without going through the on-disk records.
+pub fn stop_recorded_server(
+    record: &ServerRecord,
+    timeout: Duration,
+    escalate_after: Duration,
+) -> bool {
+    // Only a group leader may be negated; anything else would signal a group
+    // this process never created.
+    if !leads_own_process_group(record.pid) {
+        return port_is_free(record.port);
+    }
+
+    // SAFETY: kill(2) on the negated pid signals the process group the server
+    // leads, confirmed directly above.
+    unsafe {
+        libc::kill(-record.pid, libc::SIGTERM);
+    }
+    // Signalling is not enough: the listening socket outlives the signal, so
+    // returning here would let `pick_available_port` still find PREFERRED_PORT
+    // taken and fall back to a random one -- exactly the OAuth failure this is
+    // meant to prevent.
+    if !wait_for_exit(record, timeout, escalate_after) {
+        return false;
+    }
+    // The group is gone, which normally means the socket is closed with it. A
+    // descendant that called setsid() would have left the group and survived the
+    // signal, so the port is checked rather than assumed: reporting a recovery
+    // that did not happen is how this failure stayed invisible before.
+    port_is_free(record.port)
+}
+
+/// Poll until the recorded server's process *group* is empty, escalating to
+/// SIGKILL after `escalate_after`. Returns whether it emptied within `timeout`;
+/// bounded, because a process that never exits must not block startup.
+///
+/// Waiting on the group rather than on `record.pid` is the point. `bin/tracker.js`
+/// re-executes itself through `spawnSync` when a proxy is configured, so the
+/// process holding the port is a grandchild, and it can outlive the leader that
+/// SIGTERM kills. Returning when the leader died would report the port recovered
+/// while a descendant still listens on it.
+fn wait_for_exit(record: &ServerRecord, timeout: Duration, escalate_after: Duration) -> bool {
     let start = Instant::now();
     let deadline = start + timeout;
     let escalate_at = start + escalate_after;
     let mut escalated = false;
 
     loop {
-        if !record_still_matches(record) || Instant::now() >= deadline {
-            return;
+        if !group_still_alive(record.pid) {
+            return true;
         }
-        if !escalated && Instant::now() >= escalate_at && leads_own_process_group(record.pid) {
-            // SAFETY: identity and group leadership revalidated on this same
-            // iteration, so this cannot land on a recycled PID or a foreign
-            // group.
+        if Instant::now() >= deadline {
+            return false;
+        }
+        if !escalated && Instant::now() >= escalate_at {
+            // SAFETY: the group has been observed alive on every iteration since
+            // the SIGTERM that opened this wait -- the loop returns the instant
+            // it is not -- and the kernel keeps a pid number reserved while it
+            // is still some group's pgid. So `-record.pid` cannot have been
+            // freed and recycled into a stranger's group underneath us.
+            //
+            // `leads_own_process_group` is deliberately not rechecked here: once
+            // the leader exits it can never hold again, and requiring it is what
+            // let a surviving descendant keep the port.
             unsafe {
                 libc::kill(-record.pid, libc::SIGKILL);
             }
             escalated = true;
         }
-        thread::sleep(Duration::from_millis(50));
+        thread::sleep(EXIT_POLL_INTERVAL);
     }
 }
 
@@ -374,8 +458,23 @@ impl TokenTrackerServer {
         // Before picking a port: an orphan from an earlier crash holding
         // PREFERRED_PORT would otherwise push this launch onto a random port
         // and silently break OAuth sign-in.
-        for pid in reap_orphaned_servers() {
-            eprintln!("[TokenTracker] stopped an orphaned server from an earlier run (pid {pid})");
+        for outcome in reap_orphaned_servers() {
+            let ReapOutcome {
+                pid,
+                port,
+                port_recovered,
+            } = outcome;
+            if port_recovered {
+                eprintln!(
+                    "[TokenTracker] stopped an orphaned server from an earlier run \
+                     (pid {pid}, port {port} released)"
+                );
+            } else {
+                eprintln!(
+                    "[TokenTracker] an orphaned server (pid {pid}) still holds port {port}; \
+                     this launch will fall back to a random port and OAuth sign-in may fail"
+                );
+            }
         }
 
         let port = pick_available_port()?;
@@ -657,45 +756,49 @@ fn stop_child(child: Option<&mut Child>) {
     let Some(child) = child else {
         return;
     };
-    match child.try_wait() {
-        Ok(Some(_)) => {}
-        Ok(None) | Err(_) => {
-            // Same grandchild problem as the reaper: killing only the leader
-            // leaves a proxy-relaunched server holding the port. Every child
-            // spawned here uses `process_group(0)`, but check rather than
-            // assume -- negating a pid that leads no group would signal one
-            // this process never created.
-            let pgid = child.id() as i32;
-            let group = leads_own_process_group(pgid);
-            if group {
-                // SAFETY: kill(2) on the group this child leads.
-                unsafe {
-                    libc::kill(-pgid, libc::SIGTERM);
-                }
-            }
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
 
-            let mut exited = false;
-            for _ in 0..20 {
-                if matches!(child.try_wait(), Ok(Some(_))) {
-                    exited = true;
-                    break;
-                }
-                thread::sleep(Duration::from_millis(50));
-            }
+    // Same grandchild problem as the reaper: killing only the leader leaves a
+    // proxy-relaunched server holding the port. Every child spawned here uses
+    // `process_group(0)`, but check rather than assume -- negating a pid that
+    // leads no group would signal one this process never created.
+    let pgid = child.id() as i32;
+    if leads_own_process_group(pgid) {
+        // SAFETY: kill(2) on the group this child leads.
+        unsafe {
+            libc::kill(-pgid, libc::SIGTERM);
+        }
 
-            // Escalate only while the leader is still unreaped. Once `try_wait`
-            // reaps it the pid is free to be recycled, and `-pgid` could then
-            // name a stranger's group.
-            if !exited && group && leads_own_process_group(pgid) {
-                // SAFETY: leadership revalidated immediately above.
+        // Wait on the group, not on the leader. Waiting for `try_wait` alone
+        // returns as soon as the leader dies, and a descendant that shuts down
+        // more slowly then survives with the port. The leader is reaped inside
+        // the loop because a zombie is still a group member, so leaving it
+        // unreaped would make the group look alive until the deadline.
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        let escalate_at = Instant::now() + STOP_ESCALATE_AFTER;
+        let mut escalated = false;
+        loop {
+            let _ = child.try_wait();
+            if !group_still_alive(pgid) || Instant::now() >= deadline {
+                break;
+            }
+            if !escalated && Instant::now() >= escalate_at {
+                // SAFETY: the group has been alive on every iteration since the
+                // SIGTERM above, and a pid stays reserved while it is still some
+                // group's pgid, so this cannot reach a recycled pid's group.
                 unsafe {
                     libc::kill(-pgid, libc::SIGKILL);
                 }
+                escalated = true;
             }
-            let _ = child.kill();
-            let _ = child.wait();
+            thread::sleep(EXIT_POLL_INTERVAL);
         }
     }
+
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 pub fn wait_for_server_ready(port: u16, timeout: Duration) -> Result<(), String> {

--- a/TokenTrackerLinux/src-tauri/src/server.rs
+++ b/TokenTrackerLinux/src-tauri/src/server.rs
@@ -182,6 +182,20 @@ fn record_still_matches(record: &ServerRecord) -> bool {
         && process_start_time(record.pid) == Some(record.start_time)
 }
 
+/// Whether `pid` leads its own process group, so `kill(-pid, ..)` targets
+/// exactly that group and nothing else.
+///
+/// Rejects pid <= 1 before anything else: `kill(-1, sig)` is POSIX's broadcast
+/// to *every* process the caller may signal, so a record naming pid 1 would
+/// tear down the whole login session instead of one server.
+pub fn leads_own_process_group(pid: i32) -> bool {
+    if pid <= 1 {
+        return false;
+    }
+    // SAFETY: getpgid(2) on a plain pid; returns -1 when the pid is gone.
+    unsafe { libc::getpgid(pid) == pid }
+}
+
 fn owner_still_running(record: &ServerRecord) -> bool {
     process_start_time(record.owner_pid) == Some(record.owner_start_time)
 }
@@ -298,15 +312,20 @@ pub fn reap_orphaned_servers() -> Vec<i32> {
                 continue;
             }
             let _ = std::fs::remove_file(&path);
-            if record.pid <= 0 || record.pid == std::process::id() as i32 {
+            if record.pid <= 1 || record.pid == std::process::id() as i32 {
                 continue;
             }
             if !record_still_matches(&record) {
                 continue;
             }
+            // Only a group leader may be negated; anything else would signal a
+            // group this process never created.
+            if !leads_own_process_group(record.pid) {
+                continue;
+            }
 
             // SAFETY: kill(2) on the negated pid signals the process group the
-            // server leads, which is the pid confirmed above.
+            // server leads, confirmed directly above.
             unsafe {
                 libc::kill(-record.pid, libc::SIGTERM);
             }
@@ -337,9 +356,10 @@ fn wait_for_exit(record: &ServerRecord, timeout: Duration, escalate_after: Durat
         if !record_still_matches(record) || Instant::now() >= deadline {
             return;
         }
-        if !escalated && Instant::now() >= escalate_at {
-            // SAFETY: identity revalidated by the check above on this same
-            // iteration, so this cannot land on a recycled PID.
+        if !escalated && Instant::now() >= escalate_at && leads_own_process_group(record.pid) {
+            // SAFETY: identity and group leadership revalidated on this same
+            // iteration, so this cannot land on a recycled PID or a foreign
+            // group.
             unsafe {
                 libc::kill(-record.pid, libc::SIGKILL);
             }
@@ -621,6 +641,9 @@ fn run_background_sync(paths: &RuntimePaths, child_slot: &Mutex<Option<Child>>) 
     let args = sync_args(&paths.tracker);
     match Command::new(&paths.node)
         .args(args)
+        // Own group, like the server spawns: `stop_child` signals by group, and
+        // a plain pid there would name a group this process never created.
+        .process_group(0)
         .stdout(Stdio::null())
         .stderr(server_log_stdio())
         .spawn()
@@ -638,21 +661,36 @@ fn stop_child(child: Option<&mut Child>) {
         Ok(Some(_)) => {}
         Ok(None) | Err(_) => {
             // Same grandchild problem as the reaper: killing only the leader
-            // leaves a proxy-relaunched server holding the port.
+            // leaves a proxy-relaunched server holding the port. Every child
+            // spawned here uses `process_group(0)`, but check rather than
+            // assume -- negating a pid that leads no group would signal one
+            // this process never created.
             let pgid = child.id() as i32;
-            // SAFETY: kill(2) on the group this child leads.
-            unsafe {
-                libc::kill(-pgid, libc::SIGTERM);
+            let group = leads_own_process_group(pgid);
+            if group {
+                // SAFETY: kill(2) on the group this child leads.
+                unsafe {
+                    libc::kill(-pgid, libc::SIGTERM);
+                }
             }
+
+            let mut exited = false;
             for _ in 0..20 {
                 if matches!(child.try_wait(), Ok(Some(_))) {
+                    exited = true;
                     break;
                 }
                 thread::sleep(Duration::from_millis(50));
             }
-            // SAFETY: as above; harmless once the group is already gone.
-            unsafe {
-                libc::kill(-pgid, libc::SIGKILL);
+
+            // Escalate only while the leader is still unreaped. Once `try_wait`
+            // reaps it the pid is free to be recycled, and `-pgid` could then
+            // name a stranger's group.
+            if !exited && group && leads_own_process_group(pgid) {
+                // SAFETY: leadership revalidated immediately above.
+                unsafe {
+                    libc::kill(-pgid, libc::SIGKILL);
+                }
             }
             let _ = child.kill();
             let _ = child.wait();

--- a/TokenTrackerLinux/src-tauri/tests/server.rs
+++ b/TokenTrackerLinux/src-tauri/tests/server.rs
@@ -47,17 +47,17 @@ impl Drop for TempDir {
 
 const PREFERRED_PORT: u16 = 17680;
 
-// Held by every test here that binds a port, because cargo runs them in
-// parallel. Two distinct races, both of which have actually fired:
+// Held by every test here that binds a port *or forks*, because cargo runs them
+// in parallel. Two races, both of which have actually fired:
 //
 //   - Both port tests bind PREFERRED_PORT. The free-port case drops its probe
 //     before calling pick_available_port(), which is exactly the window the
 //     fallback case spends holding that same port, so unserialized the
 //     free-port case gets handed a fallback port.
-//   - pick_available_port() reports a port it has already released, so any
-//     concurrent bind of port 0 can be handed that same number before the
-//     fallback case re-binds it -- which is how the orphan tests below, which
-//     take ephemeral ports of their own, broke that assertion on CI.
+//   - `fork` duplicates every open descriptor, and CLOEXEC only closes them at
+//     `exec`, so a process spawned by one test holds a copy of whatever socket
+//     another test has open in between. Both port tests re-bind a port they
+//     just released, and that copy makes the re-bind EADDRINUSE.
 //
 // Poisoning is recovered from rather than propagated: one test panicking must
 // not turn the others into further, misleading failures.
@@ -357,16 +357,18 @@ fn a_descendant_still_holding_the_port_outlives_the_leader() {
     // The subshell ignores SIGTERM and keeps listening; the leader takes the
     // default disposition and dies, exactly like a server whose child shuts down
     // slower than its parent.
-    let Some(tree) =
-        OrphanTree::spawn("( trap '' TERM; : > {ready}; while :; do sleep 1; done ) &")
-    else {
+    let Some(tree) = OrphanTree::spawn(
+        "( trap ': > {signalled}' TERM; : > {ready}; while :; do sleep 1; done ) &",
+    ) else {
         return;
     };
 
+    // A full second before escalation: `kill` only queues SIGTERM, so a shorter
+    // window lets SIGKILL beat the descendant's trap to the marker below.
     let recovered = stop_recorded_server(
         &tree.record(),
         Duration::from_secs(5),
-        Duration::from_millis(250),
+        Duration::from_secs(1),
     );
 
     assert!(
@@ -374,10 +376,57 @@ fn a_descendant_still_holding_the_port_outlives_the_leader() {
         "the reap must report the port recovered only once nothing holds it"
     );
     assert!(
+        tree.was_signalled(),
+        "the descendant should have seen the group's SIGTERM before being killed"
+    );
+    assert!(
         port_is_bindable(tree.port),
         "the descendant kept port {}; reaping must wait for the whole process group, \
          not just the recorded leader, or startup silently falls back to a random port",
         tree.port
+    );
+}
+
+/// A leader that has already exited leaves nothing that can identify its group:
+/// its pgid is reusable once the group empties, and the recorded port is a fixed
+/// number another instance may hold. Neither authorizes a signal. Pinned because
+/// the tempting fix is to signal it anyway.
+#[test]
+fn a_leaderless_group_is_never_signalled() {
+    let Some(tree) = OrphanTree::spawn(
+        "( trap ': > {signalled}' TERM; : > {ready}; while :; do sleep 1; done ) &",
+    ) else {
+        return;
+    };
+    // Captured while the leader lives, like a record written before the crash.
+    let record = tree.record();
+
+    // SAFETY: a plain pid, not a group: only the leader dies, and the descendant
+    // it spawned stays behind holding the port.
+    unsafe {
+        libc::kill(record.pid, libc::SIGKILL);
+    }
+    wait_for(Duration::from_secs(5), || {
+        process_start_time(record.pid).is_none().then_some(())
+    })
+    .expect("the leader should be gone and reaped by init");
+
+    let recovered =
+        stop_recorded_server(&record, Duration::from_secs(2), Duration::from_millis(250));
+
+    assert!(
+        !recovered,
+        "the port is still held, so nothing was recovered"
+    );
+    // The descendant survives SIGTERM by design, so survival proves nothing and
+    // delivery itself is asserted on. Polled, not sampled once: a trap and a
+    // SIGKILL teardown both land after `kill` has already returned.
+    let breach = wait_for(Duration::from_millis(300), || {
+        (tree.was_signalled() || port_is_bindable(tree.port)).then_some(())
+    });
+    assert!(
+        breach.is_none(),
+        "a group with no identifiable leader was signalled"
     );
 }
 
@@ -428,6 +477,7 @@ fn a_group_signal_is_never_aimed_at_the_whole_session() {
 struct OrphanTree {
     pid: i32,
     port: u16,
+    signalled: PathBuf,
     _scratch: TempDir,
     /// Held for as long as the tree owns its port, so the ephemeral port it
     /// takes cannot land on one `pick_available_port` has just released.
@@ -446,15 +496,17 @@ impl OrphanTree {
     /// Returns `None` where the tree cannot be built, which is a skip rather than
     /// a failure: `setsid` is util-linux, not POSIX.
     fn spawn(descendant: &str) -> Option<Self> {
+        // Taken before the first fork, not just the first bind: see PORT_GUARD.
+        let serial = port_guard();
         if !command_exists("setsid") {
             eprintln!("setsid is unavailable on this machine; skipping");
             return None;
         }
 
-        let serial = port_guard();
         let scratch = TempDir::new("orphan");
         let pidfile = scratch.path().join("leader.pid");
         let ready = scratch.path().join("descendant.ready");
+        let signalled = scratch.path().join("descendant.sigterm");
         let listener =
             TcpListener::bind(("127.0.0.1", 0)).expect("a scratch port should be bindable");
         let port = listener
@@ -470,7 +522,9 @@ impl OrphanTree {
         let leader = format!(
             "exec 3<&0; echo $$ > {pidfile}; {descendant} while :; do sleep 1; done",
             pidfile = pidfile.display(),
-            descendant = descendant.replace("{ready}", &ready.display().to_string())
+            descendant = descendant
+                .replace("{ready}", &ready.display().to_string())
+                .replace("{signalled}", &signalled.display().to_string())
         );
         // `setsid` is invoked directly rather than through a shell: the script
         // has to reach the inner `sh` unexpanded, and `$$` inside a nested quoted
@@ -498,6 +552,7 @@ impl OrphanTree {
         let tree = Self {
             pid,
             port,
+            signalled,
             _scratch: scratch,
             _serial: serial,
         };
@@ -507,6 +562,12 @@ impl OrphanTree {
         })
         .expect("the descendant should exist, and the tree lead its own group and hold the port");
         Some(tree)
+    }
+
+    /// Whether the descendant has seen a SIGTERM -- which surviving one does not
+    /// tell you.
+    fn was_signalled(&self) -> bool {
+        self.signalled.exists()
     }
 
     fn record(&self) -> ServerRecord {

--- a/TokenTrackerLinux/src-tauri/tests/server.rs
+++ b/TokenTrackerLinux/src-tauri/tests/server.rs
@@ -47,23 +47,29 @@ impl Drop for TempDir {
 
 const PREFERRED_PORT: u16 = 17680;
 
-// Both port tests bind PREFERRED_PORT, and cargo runs tests in parallel. The
-// free-port case drops its probe before calling pick_available_port() — which
-// is exactly the window the fallback case spends holding that same port — so
-// unserialized they race and the free-port case gets handed a fallback port.
+// Held by every test here that binds a port, because cargo runs them in
+// parallel. Two distinct races, both of which have actually fired:
+//
+//   - Both port tests bind PREFERRED_PORT. The free-port case drops its probe
+//     before calling pick_available_port(), which is exactly the window the
+//     fallback case spends holding that same port, so unserialized the
+//     free-port case gets handed a fallback port.
+//   - pick_available_port() reports a port it has already released, so any
+//     concurrent bind of port 0 can be handed that same number before the
+//     fallback case re-binds it -- which is how the orphan tests below, which
+//     take ephemeral ports of their own, broke that assertion on CI.
+//
 // Poisoning is recovered from rather than propagated: one test panicking must
-// not turn the other into a second, misleading failure.
-static PREFERRED_PORT_GUARD: Mutex<()> = Mutex::new(());
+// not turn the others into further, misleading failures.
+static PORT_GUARD: Mutex<()> = Mutex::new(());
 
-fn preferred_port_guard() -> std::sync::MutexGuard<'static, ()> {
-    PREFERRED_PORT_GUARD
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
+fn port_guard() -> std::sync::MutexGuard<'static, ()> {
+    PORT_GUARD.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 #[test]
 fn preferred_port_is_used_when_free() {
-    let _serial = preferred_port_guard();
+    let _serial = port_guard();
     // Only meaningful when nothing else on the machine holds 17680.
     let Ok(probe) = TcpListener::bind(("127.0.0.1", PREFERRED_PORT)) else {
         eprintln!("port {PREFERRED_PORT} is busy on this machine; skipping");
@@ -80,7 +86,7 @@ fn preferred_port_is_used_when_free() {
 
 #[test]
 fn port_selection_falls_back_when_the_preferred_port_is_taken() {
-    let _serial = preferred_port_guard();
+    let _serial = port_guard();
     // Hold the preferred port for the duration of the call.
     let Ok(holder) = TcpListener::bind(("127.0.0.1", PREFERRED_PORT)) else {
         eprintln!("port {PREFERRED_PORT} is busy on this machine; skipping");
@@ -351,7 +357,9 @@ fn a_descendant_still_holding_the_port_outlives_the_leader() {
     // The subshell ignores SIGTERM and keeps listening; the leader takes the
     // default disposition and dies, exactly like a server whose child shuts down
     // slower than its parent.
-    let Some(tree) = OrphanTree::spawn("( trap '' TERM; while :; do sleep 1; done ) &") else {
+    let Some(tree) =
+        OrphanTree::spawn("( trap '' TERM; : > {ready}; while :; do sleep 1; done ) &")
+    else {
         return;
     };
 
@@ -383,7 +391,7 @@ fn a_descendant_that_escaped_the_group_is_reported_rather_than_claimed_reaped() 
     // reach it. It exits on its own rather than being cleaned up by pid: killing
     // a pid read back from a file is the PID-reuse hazard the production code
     // goes to some length to avoid, and a test should not model it.
-    let Some(tree) = OrphanTree::spawn("setsid --fork sh -c 'sleep 5';") else {
+    let Some(tree) = OrphanTree::spawn("setsid --fork sh -c ': > {ready}; sleep 5';") else {
         return;
     };
 
@@ -421,11 +429,19 @@ struct OrphanTree {
     pid: i32,
     port: u16,
     _scratch: TempDir,
+    /// Held for as long as the tree owns its port, so the ephemeral port it
+    /// takes cannot land on one `pick_available_port` has just released.
+    _serial: std::sync::MutexGuard<'static, ()>,
 }
 
 impl OrphanTree {
     /// `descendant` is shell run by the leader before it settles into its own
-    /// sleep loop; it inherits fd 3, the listening socket.
+    /// sleep loop; it inherits fd 3, the listening socket. It must touch
+    /// `{ready}`, which is substituted with a path this waits for -- the leader
+    /// holds the port from birth, so "the port is taken" says nothing about
+    /// whether the descendant this test is about exists yet. Reaping before it
+    /// is forked kills the leader alone and frees the port, which fails one of
+    /// these tests and, worse, silently passes the other.
     ///
     /// Returns `None` where the tree cannot be built, which is a skip rather than
     /// a failure: `setsid` is util-linux, not POSIX.
@@ -435,8 +451,10 @@ impl OrphanTree {
             return None;
         }
 
+        let serial = port_guard();
         let scratch = TempDir::new("orphan");
         let pidfile = scratch.path().join("leader.pid");
+        let ready = scratch.path().join("descendant.ready");
         let listener =
             TcpListener::bind(("127.0.0.1", 0)).expect("a scratch port should be bindable");
         let port = listener
@@ -451,7 +469,8 @@ impl OrphanTree {
         // would pass for the wrong reason.
         let leader = format!(
             "exec 3<&0; echo $$ > {pidfile}; {descendant} while :; do sleep 1; done",
-            pidfile = pidfile.display()
+            pidfile = pidfile.display(),
+            descendant = descendant.replace("{ready}", &ready.display().to_string())
         );
         // `setsid` is invoked directly rather than through a shell: the script
         // has to reach the inner `sh` unexpanded, and `$$` inside a nested quoted
@@ -480,11 +499,13 @@ impl OrphanTree {
             pid,
             port,
             _scratch: scratch,
+            _serial: serial,
         };
         wait_for(Duration::from_secs(5), || {
-            (!port_is_bindable(port) && leads_own_process_group(pid)).then_some(())
+            (ready.exists() && !port_is_bindable(port) && leads_own_process_group(pid))
+                .then_some(())
         })
-        .expect("the tree should lead its own group and hold the port before the reap starts");
+        .expect("the descendant should exist, and the tree lead its own group and hold the port");
         Some(tree)
     }
 

--- a/TokenTrackerLinux/src-tauri/tests/server.rs
+++ b/TokenTrackerLinux/src-tauri/tests/server.rs
@@ -5,14 +5,17 @@
 use std::ffi::OsString;
 use std::fs;
 use std::net::TcpListener;
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use tokentracker_linux::server::{
-    boot_id, dashboard_url, leads_own_process_group, pick_available_port, process_start_time,
-    rotate_log_if_oversized, serve_args, server_log_paths, server_record_dirs, server_record_name,
-    sync_args, MAX_LOG_BYTES,
+    boot_id, dashboard_url, group_still_alive, leads_own_process_group, pick_available_port,
+    process_start_time, rotate_log_if_oversized, serve_args, server_log_paths, server_record_dirs,
+    server_record_name, stop_recorded_server, sync_args, ServerRecord, MAX_LOG_BYTES,
 };
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -336,4 +339,209 @@ fn only_real_group_leaders_can_be_signalled_by_group() {
     // SAFETY: getpgid(2) on our own pid.
     let pgid = unsafe { libc::getpgid(own) };
     assert_eq!(leads_own_process_group(own), pgid == own);
+}
+
+/// The case the whole mechanism exists for: `bin/tracker.js` re-executes itself
+/// through `spawnSync` when a proxy is configured, so the process holding the
+/// port is a grandchild. It can outlive the leader that SIGTERM kills, and a
+/// reaper that watches only the recorded pid then reports success while the port
+/// is still taken -- which sends startup to a random port and breaks OAuth.
+#[test]
+fn a_descendant_still_holding_the_port_outlives_the_leader() {
+    // The subshell ignores SIGTERM and keeps listening; the leader takes the
+    // default disposition and dies, exactly like a server whose child shuts down
+    // slower than its parent.
+    let Some(tree) = OrphanTree::spawn("( trap '' TERM; while :; do sleep 1; done ) &") else {
+        return;
+    };
+
+    let recovered = stop_recorded_server(
+        &tree.record(),
+        Duration::from_secs(5),
+        Duration::from_millis(250),
+    );
+
+    assert!(
+        recovered,
+        "the reap must report the port recovered only once nothing holds it"
+    );
+    assert!(
+        port_is_bindable(tree.port),
+        "the descendant kept port {}; reaping must wait for the whole process group, \
+         not just the recorded leader, or startup silently falls back to a random port",
+        tree.port
+    );
+}
+
+/// A descendant that called `setsid()` is outside the group, so no group signal
+/// can reach it. Nothing can be done about that here -- but claiming the port
+/// came back when it did not is what made this failure invisible in the first
+/// place, so the outcome has to be reported honestly.
+#[test]
+fn a_descendant_that_escaped_the_group_is_reported_rather_than_claimed_reaped() {
+    // The escapee inherits fd 3 and gets its own session, so no group signal can
+    // reach it. It exits on its own rather than being cleaned up by pid: killing
+    // a pid read back from a file is the PID-reuse hazard the production code
+    // goes to some length to avoid, and a test should not model it.
+    let Some(tree) = OrphanTree::spawn("setsid --fork sh -c 'sleep 5';") else {
+        return;
+    };
+
+    let recovered = stop_recorded_server(
+        &tree.record(),
+        Duration::from_secs(2),
+        Duration::from_millis(250),
+    );
+
+    assert!(
+        !recovered,
+        "port {} is still held by a process outside the group, so the reap must not \
+         report it recovered",
+        tree.port
+    );
+}
+
+#[test]
+fn a_group_signal_is_never_aimed_at_the_whole_session() {
+    // kill(-1, sig) is POSIX's broadcast to every process the caller may signal.
+    // Whatever else changes, these must never look like a live group.
+    assert!(!group_still_alive(1));
+    assert!(!group_still_alive(0));
+    assert!(!group_still_alive(-1));
+
+    // This process is in some group, and that group is trivially non-empty.
+    // SAFETY: getpgid(0) reports the caller's own group and cannot fail.
+    let own_group = unsafe { libc::getpgid(0) };
+    assert!(group_still_alive(own_group));
+}
+
+/// A server-shaped process tree, orphaned onto init the way a crashed app leaves
+/// one behind, holding a real listening socket.
+struct OrphanTree {
+    pid: i32,
+    port: u16,
+    _scratch: TempDir,
+}
+
+impl OrphanTree {
+    /// `descendant` is shell run by the leader before it settles into its own
+    /// sleep loop; it inherits fd 3, the listening socket.
+    ///
+    /// Returns `None` where the tree cannot be built, which is a skip rather than
+    /// a failure: `setsid` is util-linux, not POSIX.
+    fn spawn(descendant: &str) -> Option<Self> {
+        if !command_exists("setsid") {
+            eprintln!("setsid is unavailable on this machine; skipping");
+            return None;
+        }
+
+        let scratch = TempDir::new("orphan");
+        let pidfile = scratch.path().join("leader.pid");
+        let listener =
+            TcpListener::bind(("127.0.0.1", 0)).expect("a scratch port should be bindable");
+        let port = listener
+            .local_addr()
+            .expect("a bound listener has a local address")
+            .port();
+
+        // The socket rides in as stdin, so the tree holds the port with no
+        // dependency on a helper binary. `exec 3<&0` first: POSIX hands an
+        // asynchronous list `/dev/null` for stdin, so without the dup a
+        // backgrounded descendant would silently lose the socket and the test
+        // would pass for the wrong reason.
+        let leader = format!(
+            "exec 3<&0; echo $$ > {pidfile}; {descendant} while :; do sleep 1; done",
+            pidfile = pidfile.display()
+        );
+        // `setsid` is invoked directly rather than through a shell: the script
+        // has to reach the inner `sh` unexpanded, and `$$` inside a nested quoted
+        // string would be substituted by the outer shell, recording the wrong
+        // pid. `--fork` guarantees the parent exits, which orphans the tree onto
+        // init -- without it a leader left as this test's child would linger as a
+        // zombie, keep its `/proc/<pid>/stat`, and make a pid-only wait look
+        // correct.
+        let mut orphaner = Command::new("setsid")
+            .arg("--fork")
+            .arg("sh")
+            .arg("-c")
+            .arg(&leader)
+            .stdin(Stdio::from(OwnedFd::from(listener)))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("setsid should be spawnable");
+        orphaner
+            .wait()
+            .expect("setsid --fork should exit as soon as it has forked");
+
+        let pid = wait_for(Duration::from_secs(5), || read_pid(&pidfile))
+            .expect("the leader should record its pid");
+        let tree = Self {
+            pid,
+            port,
+            _scratch: scratch,
+        };
+        wait_for(Duration::from_secs(5), || {
+            (!port_is_bindable(port) && leads_own_process_group(pid)).then_some(())
+        })
+        .expect("the tree should lead its own group and hold the port before the reap starts");
+        Some(tree)
+    }
+
+    fn record(&self) -> ServerRecord {
+        ServerRecord {
+            pid: self.pid,
+            port: self.port,
+            start_time: process_start_time(self.pid).expect("a live pid has a start time"),
+            boot_id: boot_id().expect("Linux exposes a boot id"),
+            owner_pid: std::process::id() as i32,
+            owner_start_time: process_start_time(std::process::id() as i32)
+                .expect("this process has a start time"),
+        }
+    }
+}
+
+impl Drop for OrphanTree {
+    /// SIGKILL whatever survived, so a failing assertion cannot leak a process
+    /// tree that keeps its port for the rest of the run.
+    fn drop(&mut self) {
+        if group_still_alive(self.pid) {
+            // SAFETY: the group has members, so its pgid is still reserved and
+            // cannot have been recycled into a stranger's group.
+            unsafe {
+                libc::kill(-self.pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+fn command_exists(name: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {name}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn read_pid(path: &Path) -> Option<i32> {
+    fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+fn port_is_bindable(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+fn wait_for<T>(timeout: Duration, mut ready: impl FnMut() -> Option<T>) -> Option<T> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(value) = ready() {
+            return Some(value);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
 }

--- a/TokenTrackerLinux/src-tauri/tests/server.rs
+++ b/TokenTrackerLinux/src-tauri/tests/server.rs
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
 
 use tokentracker_linux::server::{
-    dashboard_url, pick_available_port, rotate_log_if_oversized, serve_args, server_log_paths,
-    sync_args, MAX_LOG_BYTES,
+    boot_id, dashboard_url, pick_available_port, process_start_time, rotate_log_if_oversized,
+    serve_args, server_log_paths, server_record_dirs, server_record_name, sync_args, MAX_LOG_BYTES,
 };
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -255,3 +255,61 @@ const _: () = {
     assert!(MAX_LOG_BYTES >= 1024 * 1024);
     assert!(MAX_LOG_BYTES <= 64 * 1024 * 1024);
 };
+
+#[test]
+fn records_never_land_in_a_world_writable_directory() {
+    let dirs = server_record_dirs(Some(PathBuf::from("/state")), Some(PathBuf::from("/home/u")));
+
+    assert_eq!(dirs[0], PathBuf::from("/state/tokentracker/servers"));
+    assert_eq!(
+        dirs[1],
+        PathBuf::from("/home/u/.local/state/tokentracker/servers")
+    );
+
+    // No /tmp fallback, unlike the log: /tmp is writable by every account, so a
+    // forged record there could make this user signal one of their own PIDs.
+    assert!(dirs.iter().all(|dir| !dir.starts_with("/tmp")));
+    assert!(server_log_paths(None, None)
+        .iter()
+        .any(|path| path.starts_with("/tmp")));
+    assert!(server_record_dirs(None, None).is_empty());
+}
+
+#[test]
+fn each_owner_gets_its_own_record_file() {
+    // Two concurrent login sessions on one account each run an app instance,
+    // so a shared filename would let one delete or overwrite the other's
+    // record and strand its server permanently.
+    assert_eq!(server_record_name(1234), "server-1234.json");
+    assert_ne!(server_record_name(1234), server_record_name(5678));
+}
+
+#[test]
+fn process_start_time_identifies_a_specific_process() {
+    let own = std::process::id() as i32;
+    let first = process_start_time(own).expect("our own start time is readable");
+
+    // Stable across reads: this is what makes it usable as an identity, so a
+    // recycled PID cannot be mistaken for the recorded process.
+    assert_eq!(process_start_time(own), Some(first));
+
+    // A PID that cannot exist has no start time, so nothing is ever signalled
+    // on its behalf.
+    assert_eq!(process_start_time(-1), None);
+}
+
+#[test]
+fn a_record_is_bound_to_the_current_boot() {
+    // Sandboxes and containers can hide /proc/sys/kernel/random/boot_id.
+    // Production treats that as "record nothing, signal nothing", so absence is
+    // a supported state rather than a test failure.
+    let Some(id) = boot_id() else {
+        return;
+    };
+
+    assert!(!id.is_empty());
+    // Stable within a boot, so it can validate a persisted record; it changes
+    // on reboot, which is what invalidates a stale one whose PID and
+    // since-boot start tick could otherwise be matched by an unrelated process.
+    assert_eq!(boot_id(), Some(id));
+}

--- a/TokenTrackerLinux/src-tauri/tests/server.rs
+++ b/TokenTrackerLinux/src-tauri/tests/server.rs
@@ -10,8 +10,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
 
 use tokentracker_linux::server::{
-    boot_id, dashboard_url, pick_available_port, process_start_time, rotate_log_if_oversized,
-    serve_args, server_log_paths, server_record_dirs, server_record_name, sync_args, MAX_LOG_BYTES,
+    boot_id, dashboard_url, leads_own_process_group, pick_available_port, process_start_time,
+    rotate_log_if_oversized, serve_args, server_log_paths, server_record_dirs, server_record_name,
+    sync_args, MAX_LOG_BYTES,
 };
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -258,7 +259,10 @@ const _: () = {
 
 #[test]
 fn records_never_land_in_a_world_writable_directory() {
-    let dirs = server_record_dirs(Some(PathBuf::from("/state")), Some(PathBuf::from("/home/u")));
+    let dirs = server_record_dirs(
+        Some(PathBuf::from("/state")),
+        Some(PathBuf::from("/home/u")),
+    );
 
     assert_eq!(dirs[0], PathBuf::from("/state/tokentracker/servers"));
     assert_eq!(
@@ -312,4 +316,24 @@ fn a_record_is_bound_to_the_current_boot() {
     // on reboot, which is what invalidates a stale one whose PID and
     // since-boot start tick could otherwise be matched by an unrelated process.
     assert_eq!(boot_id(), Some(id));
+}
+
+#[test]
+fn only_real_group_leaders_can_be_signalled_by_group() {
+    // kill(-1, sig) is POSIX's broadcast to every process the caller may
+    // signal, so a record naming pid 1 must never reach the negated-pid path:
+    // it would tear down the whole login session instead of one server.
+    assert!(!leads_own_process_group(1));
+    assert!(!leads_own_process_group(0));
+    assert!(!leads_own_process_group(-1));
+
+    // A pid that cannot exist leads no group either.
+    assert!(!leads_own_process_group(i32::MAX));
+
+    // The test binary is not a group leader (the shell that spawned it is), so
+    // negating its pid would signal a group it does not own.
+    let own = std::process::id() as i32;
+    // SAFETY: getpgid(2) on our own pid.
+    let pgid = unsafe { libc::getpgid(own) };
+    assert_eq!(leads_own_process_group(own), pgid == own);
 }


### PR DESCRIPTION
Follow-up to #512, which fixed the Wayland abort itself. This fixes the mess that abort leaves behind — it applies to any crash, not just the DMA-BUF one.

## Problem

A GTK/Wayland failure calls `_exit(1)`, so neither `Drop for TokenTrackerServer` nor Tauri's `RunEvent::ExitRequested` runs, and the bundled Node server outlives its parent.

I verified the `_exit` path rather than inferring it from the exit code: I registered an `atexit` hook at startup and instrumented it. The crashing run spawned a child — proving `TokenTrackerServer::start()` ran and the hook was registered — yet the hook never fired. So `atexit`-based cleanup cannot work here, and I dropped that approach.

The orphan is not merely idle. It keeps port 17680, so the next launch hits the `pick_available_port` fallback and lands on a random port — and per `server.rs`'s own comment, OAuth sign-in needs that exact port. It then fails silently until the orphan is killed by hand. While testing #512 I accumulated four orphans across runs, on 17680, 45859, 40603 and 40555.

## Approach

Record each spawned server's identity, and stop a stranded one at startup before `pick_available_port` runs.

Identity is a persisted record, **not a filesystem path**. My first attempt matched `/proc/<pid>/exe` against the resolved `node` path, and that is broken for the artifact you actually ship: an AppImage mounts at a fresh `/tmp/.mount_XXXXXX` on every launch, so an orphan's `node` and `tracker.js` paths never match the ones the next launch resolves.

The record pins one exact process:

| Field | Why |
| --- | --- |
| `start_time` (`/proc/<pid>/stat` field 22) | A recycled PID has a different start time, so signalling can't hit a stranger |
| `boot_id` | `start_time` counts ticks since boot and resets, so a record surviving an unclean shutdown can't match an unrelated process on the same PID at the same tick |
| `owner_pid` + `owner_start_time` | Single-instance locking runs over the session D-Bus, so a second login session on one account starts a second app. "Orphaned" must mean the owner is gone, not that the child is alive — otherwise one session kills the other's healthy server |

Records are one-per-owner (`server-<owner_pid>.json`) so concurrent sessions can't delete or overwrite each other's entry and strand a server permanently. They live under a `0700` state directory as `0600` files, never in `/tmp` (world-writable: a forged record there could make this user signal their own PIDs), and are read with `O_NOFOLLOW` plus `fstat` on the descriptor actually read, so a planted symlink or foreign-owned file is rejected rather than followed.

## Process group

Servers now spawn with `process_group(0)` and are signalled by group.

`bin/tracker.js` re-executes itself through `spawnSync` when a proxy is configured, and `shouldRelaunchForProxy` fires for exactly `serve` — so for proxied users the process holding the port is a **grandchild**, and the recorded pid is a blocked wrapper. Signalling only that pid left the real listener on 17680.

This also fixes `stop_child`, which had the same gap on every normal quit, and the startup-failure and `restart_process` paths, which called `Child::kill()` directly.

## Verification

Each behaviour was exercised against a real build, not just reasoned about:

- crash → orphan on 17680 → relaunch reaps it and **reclaims 17680** (an earlier version reaped but still lost the port to a random one, because signalling doesn't release the listening socket synchronously — hence the bounded wait with SIGKILL escalation)
- live owner → 0 reaps, both processes untouched, **its record preserved**
- stale `boot_id` → 0 reaps, nothing signalled
- symlinked record → rejected
- spawned server is its own group leader (`pgid == pid`); records are `0600` in a `0700` directory

`cargo test --locked` 59 passing (4 new), `cargo check --locked --all-targets` clean, Linux JS tests 21 passing, `validate:guardrails` and `validate:versions` clean.

`cargo fmt --check` and `clippy` could not be run locally (this box has cargo without the rustfmt/clippy components), so CI is the authority on those two.

## Trade-off worth your call

`restart_process` now routes through `stop_child`, which sends SIGTERM and polls up to 1s before SIGKILL. That runs under the `SERVER` mutex, so a health-monitor restart holds the lock up to ~1s longer than the previous immediate `kill()`. Bounded, and only on restart — but it does cut against the comment in `main.rs` about not holding that mutex. Happy to shorten the grace period if you'd rather have the latency back.

## Scope

Linux-only; no `src/` or `dashboard/` changes. No version bump — `scripts/version-files.cjs` drives nine files off `package.json`, so that's yours to make on the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux server startup, shutdown, and restart reliability.
  * Prevented stale or orphaned server processes from blocking new sessions or ports.
  * Enhanced cleanup of related processes, including descendants and proxy-launched processes.
  * Added safeguards to verify server identity and ownership before termination.
  * Added bounded shutdown timeouts with escalation when graceful termination fails.
  * Improved recovery after interrupted sessions and reporting when ports cannot be fully reclaimed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->