### PR TITLE
fix(serve): only stop a verified TokenTracker server on a busy port

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -372,19 +372,36 @@ const TRACKER_ENTRY_RE = new RegExp(
   String.raw`(?:^|[\\/])\.?bin[\\/](?:tracker\.js|tokentracker-cli|tokentracker-tracker|tokentracker|tracker)$`,
   "i",
 );
-// `ps -o command=` joins argv with spaces and drops all quoting, so the script
-// path is only unambiguous relative to the `serve` argument that follows it --
-// splitting on whitespace would reject an install under `~/Token Tracker/`.
-const NODE_SERVE_COMMAND_RE = /^(\S+)\s+(.+?)\s+serve(?:\s|$)/i;
 const NODE_EXECUTABLE_RE = /(?:^|[\\/])node(?:\.exe)?$/i;
+// Every `serve` token that could be the subcommand rather than part of a path.
+const SERVE_BOUNDARY_RE = /\s+serve(?=\s|$)/g;
 
-// The script path a `node ... serve` command would run, or null.
+// The tracker entry path a `node ... serve` command would run, or null.
+//
+// `ps -o command=` joins argv with spaces and drops all quoting, so the script
+// path is only delimited by the `serve` argument after it -- splitting on
+// whitespace would reject an install under `~/Token Tracker/`. But `serve` can
+// occur inside the install path too, so every boundary is tried and the one
+// whose prefix is actually a tracker entry wins; taking the first would parse
+// `~/my serve dir/bin/tracker.js` as `~/my`.
 function parseServeScriptPath(command) {
   const value = String(command || "").replaceAll("\0", " ").trim();
   if (!value) return null;
-  const match = NODE_SERVE_COMMAND_RE.exec(value);
-  if (!match || !NODE_EXECUTABLE_RE.test(match[1])) return null;
-  return match[2].replace(/^["']/, "").replace(/["']$/, "");
+
+  const executable = /^\S+(?=\s)/.exec(value);
+  if (!executable || !NODE_EXECUTABLE_RE.test(executable[0])) return null;
+  const rest = value.slice(executable[0].length);
+
+  SERVE_BOUNDARY_RE.lastIndex = 0;
+  for (let match = SERVE_BOUNDARY_RE.exec(rest); match; match = SERVE_BOUNDARY_RE.exec(rest)) {
+    const candidate = rest
+      .slice(0, match.index)
+      .trim()
+      .replace(/^["']/, "")
+      .replace(/["']$/, "");
+    if (TRACKER_ENTRY_RE.test(candidate)) return candidate;
+  }
+  return null;
 }
 
 // How far above the entry script a package.json may sit. `bin/tracker.js` puts
@@ -410,7 +427,7 @@ function isTrackerPackageRoot(dir) {
 // is a failed bind rather than a killed stranger.
 function isTokenTrackerServeCommand(command) {
   const script = parseServeScriptPath(command);
-  if (!script || !TRACKER_ENTRY_RE.test(script)) return false;
+  if (!script) return false;
 
   let resolved;
   try {

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -378,13 +378,55 @@ const TRACKER_ENTRY_RE = new RegExp(
 const NODE_SERVE_COMMAND_RE = /^(\S+)\s+(.+?)\s+serve(?:\s|$)/i;
 const NODE_EXECUTABLE_RE = /(?:^|[\\/])node(?:\.exe)?$/i;
 
-function isTokenTrackerServeCommand(command) {
+// The script path a `node ... serve` command would run, or null.
+function parseServeScriptPath(command) {
   const value = String(command || "").replaceAll("\0", " ").trim();
-  if (!value) return false;
+  if (!value) return null;
   const match = NODE_SERVE_COMMAND_RE.exec(value);
-  if (!match || !NODE_EXECUTABLE_RE.test(match[1])) return false;
-  const script = match[2].replace(/^["']/, "").replace(/["']$/, "");
-  return TRACKER_ENTRY_RE.test(script);
+  if (!match || !NODE_EXECUTABLE_RE.test(match[1])) return null;
+  return match[2].replace(/^["']/, "").replace(/["']$/, "");
+}
+
+// How far above the entry script a package.json may sit. `bin/tracker.js` puts
+// it one level up; the npm bin shims resolve into
+// `node_modules/<pkg>/bin/tracker.js`, which is the same shape.
+const TRACKER_PACKAGE_SEARCH_DEPTH = 3;
+
+function isTrackerPackageRoot(dir) {
+  try {
+    const manifest = JSON.parse(fssync.readFileSync(path.join(dir, "package.json"), "utf8"));
+    return manifest?.name === NPM_PACKAGE_NAME;
+  } catch (_e) {
+    return false;
+  }
+}
+
+// The path shape alone is not identifying: plenty of unrelated projects ship a
+// `bin/tracker.js`, and matching on that would signal one of them. Resolve the
+// script and require a real `${NPM_PACKAGE_NAME}` package around it.
+//
+// Fails closed. A server whose script cannot be resolved -- deleted, or in a
+// mount namespace this process cannot read -- is left alone, so the worst case
+// is a failed bind rather than a killed stranger.
+function isTokenTrackerServeCommand(command) {
+  const script = parseServeScriptPath(command);
+  if (!script || !TRACKER_ENTRY_RE.test(script)) return false;
+
+  let resolved;
+  try {
+    resolved = fssync.realpathSync(script);
+  } catch (_e) {
+    return false;
+  }
+
+  let dir = path.dirname(path.dirname(resolved));
+  for (let depth = 0; depth < TRACKER_PACKAGE_SEARCH_DEPTH; depth++) {
+    if (isTrackerPackageRoot(dir)) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
 }
 
 async function ensurePortFree(port) {
@@ -590,6 +632,7 @@ module.exports = {
   ensurePortFree,
   isRunningUnderWsl,
   isTokenTrackerServeCommand,
+  parseServeScriptPath,
   resolveDefaultPort,
   shouldServeSpaFallback,
   startNativeBackgroundSync,

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -334,9 +334,15 @@ function startNativeBackgroundSync({
   };
 }
 
+// `-sTCP:LISTEN` matters: `lsof -i tcp:<port>` matches any socket with that
+// port as its LOCAL *or* REMOTE endpoint, so without it a browser merely
+// connected to the dashboard is reported alongside the server that owns it.
 function findPidOnPort(port) {
   try {
-    const out = cp.execFileSync("lsof", ["-ti", `tcp:${port}`], { encoding: "utf8", timeout: 5000 });
+    const out = cp.execFileSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
     const pids = out.trim().split(/\s+/).map(Number).filter((n) => Number.isFinite(n) && n > 0);
     return pids;
   } catch (_e) {
@@ -344,13 +350,54 @@ function findPidOnPort(port) {
   }
 }
 
+function readProcessCommand(pid) {
+  try {
+    return cp
+      .execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+        encoding: "utf8",
+        timeout: 5000,
+      })
+      .trim();
+  } catch (_e) {
+    return "";
+  }
+}
+
+// A TokenTracker server is always `node <somewhere>/bin/<entry> serve`: either
+// the real script (npm global, embedded desktop runtime, repo checkout) or one
+// of the published npm bin shims, which `ps` reports by the shim path rather
+// than the resolved script. Requiring the `bin/` component keeps an unrelated
+// `node /srv/other/tracker.js serve` from looking like ours.
+const TRACKER_ENTRY_RE = new RegExp(
+  String.raw`(?:^|[\\/])\.?bin[\\/](?:tracker\.js|tokentracker-cli|tokentracker-tracker|tokentracker|tracker)$`,
+  "i",
+);
+// `ps -o command=` joins argv with spaces and drops all quoting, so the script
+// path is only unambiguous relative to the `serve` argument that follows it --
+// splitting on whitespace would reject an install under `~/Token Tracker/`.
+const NODE_SERVE_COMMAND_RE = /^(\S+)\s+(.+?)\s+serve(?:\s|$)/i;
+const NODE_EXECUTABLE_RE = /(?:^|[\\/])node(?:\.exe)?$/i;
+
+function isTokenTrackerServeCommand(command) {
+  const value = String(command || "").replaceAll("\0", " ").trim();
+  if (!value) return false;
+  const match = NODE_SERVE_COMMAND_RE.exec(value);
+  if (!match || !NODE_EXECUTABLE_RE.test(match[1])) return false;
+  const script = match[2].replace(/^["']/, "").replace(/["']$/, "");
+  return TRACKER_ENTRY_RE.test(script);
+}
+
 async function ensurePortFree(port) {
   const pids = findPidOnPort(port);
   if (pids.length === 0) return;
 
-  // Don't kill ourselves
+  // Only stop a verified TokenTracker server. `--port` may name a port owned by
+  // an unrelated application, and failing to bind is far safer than terminating
+  // a process merely because it happens to hold that port.
   const self = process.pid;
-  const targets = pids.filter((p) => p !== self);
+  const targets = pids.filter(
+    (pid) => pid !== self && isTokenTrackerServeCommand(readProcessCommand(pid)),
+  );
   if (targets.length === 0) return;
 
   process.stdout.write(`Stopping previous server on port ${port} (pid ${targets.join(", ")})...\n`);
@@ -366,8 +413,10 @@ async function ensurePortFree(port) {
     if (findPidOnPort(port).length === 0) return;
   }
 
-  // Force kill if still alive
+  // Re-check identity before escalating: the pid may have exited during the
+  // wait above and been recycled by an unrelated process.
   for (const pid of targets) {
+    if (!isTokenTrackerServeCommand(readProcessCommand(pid))) continue;
     try {
       process.kill(pid, "SIGKILL");
     } catch (_e) {}
@@ -538,7 +587,9 @@ module.exports = {
   listenOnAvailablePort,
   getLocalServerUrl,
   parseArgs,
+  ensurePortFree,
   isRunningUnderWsl,
+  isTokenTrackerServeCommand,
   resolveDefaultPort,
   shouldServeSpaFallback,
   startNativeBackgroundSync,

--- a/test/serve-port-hint.test.js
+++ b/test/serve-port-hint.test.js
@@ -178,6 +178,19 @@ test("serve-command parsing survives ps output quirks", () => {
     "/opt/app/tokentracker/bin/tracker.js",
   );
 
+  // `serve` can occur inside the install path as well as being the subcommand,
+  // so the delimiter is chosen by which prefix is actually a tracker entry.
+  // Taking the first boundary would parse this as "/home/u/my".
+  assert.equal(
+    parseServeScriptPath("node /home/u/my serve dir/bin/tracker.js serve --port 7680"),
+    "/home/u/my serve dir/bin/tracker.js",
+  );
+  // ...and equally, a later `serve` among the arguments must not win.
+  assert.equal(
+    parseServeScriptPath("node /opt/tt/bin/tracker.js serve --dir /my serve/x"),
+    "/opt/tt/bin/tracker.js",
+  );
+
   // Not a node `serve` invocation at all.
   assert.equal(parseServeScriptPath("python3 /usr/lib/tokentracker/bin/tracker.js serve"), null);
   assert.equal(parseServeScriptPath("node /usr/lib/tokentracker/bin/tracker.js sync"), null);
@@ -215,6 +228,17 @@ test("port cleanup only targets a real TokenTracker package", (t) => {
   const shim = path.join(shimDir, "tokentracker-cli");
   fs.symlinkSync(ours, shim);
   assert.equal(isTokenTrackerServeCommand(`node ${shim} serve`), true);
+
+  // The same, end to end: a genuine package under a directory containing
+  // " serve " must still be recognised, or its cleanup silently stops working.
+  const oddDir = path.join(root, "my serve dir");
+  fs.mkdirSync(path.join(oddDir, "bin"), { recursive: true });
+  fs.writeFileSync(path.join(oddDir, "bin", "tracker.js"), "");
+  fs.writeFileSync(path.join(oddDir, "package.json"), JSON.stringify({ name: NPM_PACKAGE_NAME }));
+  assert.equal(
+    isTokenTrackerServeCommand(`node ${path.join(oddDir, "bin", "tracker.js")} serve --port 7680`),
+    true,
+  );
 
   // A lookalike path that does not exist resolves to nothing, so it is never
   // signalled -- the case that made a bare path-shape check unsafe.

--- a/test/serve-port-hint.test.js
+++ b/test/serve-port-hint.test.js
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const http = require("node:http");
+const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
@@ -11,6 +12,7 @@ const {
   isTokenTrackerServeCommand,
   listenOnAvailablePort,
   NPM_PACKAGE_NAME,
+  parseServeScriptPath,
   parseArgs,
   isRunningUnderWsl,
   resolveDefaultPort,
@@ -164,39 +166,61 @@ test("isRunningUnderWsl is false off Linux regardless of env", (t) => {
   assert.equal(resolveDefaultPort({ WSL_DISTRO_NAME: "Ubuntu" }), 7680);
 });
 
-test("port cleanup only targets a verified TokenTracker server", () => {
-  // `--port` may name a port owned by an unrelated application. Failing to
-  // bind is far safer than terminating a process that was never ours, so
-  // ensurePortFree identifies its target before signalling it.
-  const ours = [
-    "node /usr/lib/tokentracker/bin/tracker.js serve --port 7680",
-    "/opt/app/EmbeddedServer/node /opt/app/EmbeddedServer/tokentracker/bin/tracker.js serve --no-open",
-    // `ps -o command=` drops quoting, so the script path is only unambiguous
-    // relative to the `serve` argument that follows it.
-    "node /home/u/Token Tracker/bin/tracker.js serve",
-    // The published npm bin shims: ps reports the shim, not the resolved script.
-    "node /home/u/.local/bin/tokentracker-cli serve",
-  ];
-  for (const command of ours) {
-    assert.equal(isTokenTrackerServeCommand(command), true, command);
-  }
+test("serve-command parsing survives ps output quirks", () => {
+  // `ps -o command=` joins argv with spaces and drops all quoting, so the
+  // script path is only unambiguous relative to the `serve` argument after it.
+  assert.equal(
+    parseServeScriptPath("node /home/u/Token Tracker/bin/tracker.js serve"),
+    "/home/u/Token Tracker/bin/tracker.js",
+  );
+  assert.equal(
+    parseServeScriptPath("/opt/app/node /opt/app/tokentracker/bin/tracker.js serve --no-open"),
+    "/opt/app/tokentracker/bin/tracker.js",
+  );
 
-  const notOurs = [
-    // Requiring the bin/ component keeps a lookalike path from matching.
-    "node /srv/other/tracker.js serve",
-    "node /usr/lib/tokentracker/bin/tracker.js.bak serve",
-    // Our own sync process is not a server holding the port.
-    "node /usr/lib/tokentracker/bin/tracker.js sync",
-    "python3 /usr/lib/tokentracker/bin/tracker.js serve",
-    // Whatever else may legitimately own the port.
-    "/usr/bin/postgres -D /var/lib/pgsql serve",
-    "nginx: worker process",
-    // ps prints nothing once the pid is gone; never treat that as a match.
-    "",
-  ];
-  for (const command of notOurs) {
-    assert.equal(isTokenTrackerServeCommand(command), false, command);
-  }
+  // Not a node `serve` invocation at all.
+  assert.equal(parseServeScriptPath("python3 /usr/lib/tokentracker/bin/tracker.js serve"), null);
+  assert.equal(parseServeScriptPath("node /usr/lib/tokentracker/bin/tracker.js sync"), null);
+  assert.equal(parseServeScriptPath("/usr/bin/postgres -D /var/lib/pgsql serve"), null);
+  assert.equal(parseServeScriptPath("nginx: worker process"), null);
+  // ps prints nothing once the pid is gone; never treat that as a match.
+  assert.equal(parseServeScriptPath(""), null);
+});
+
+test("port cleanup only targets a real TokenTracker package", (t) => {
+  // Path shape alone is not identifying: unrelated projects ship a
+  // `bin/tracker.js` too, so the entry must resolve into a genuine
+  // tokentracker-cli package before anything is signalled.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-serve-id-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const install = (name, pkgName) => {
+    const dir = path.join(root, name);
+    fs.mkdirSync(path.join(dir, "bin"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "bin", "tracker.js"), "");
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: pkgName }));
+    return path.join(dir, "bin", "tracker.js");
+  };
+
+  const ours = install("ours", NPM_PACKAGE_NAME);
+  assert.equal(isTokenTrackerServeCommand(`node ${ours} serve --port 7680`), true);
+
+  // Same layout, different package: someone else's tracker.
+  const theirs = install("theirs", "some-other-tracker");
+  assert.equal(isTokenTrackerServeCommand(`node ${theirs} serve`), false);
+
+  // The npm bin shim is a symlink into the package; realpath must be followed.
+  const shimDir = path.join(root, "node_modules", ".bin");
+  fs.mkdirSync(shimDir, { recursive: true });
+  const shim = path.join(shimDir, "tokentracker-cli");
+  fs.symlinkSync(ours, shim);
+  assert.equal(isTokenTrackerServeCommand(`node ${shim} serve`), true);
+
+  // A lookalike path that does not exist resolves to nothing, so it is never
+  // signalled -- the case that made a bare path-shape check unsafe.
+  assert.equal(isTokenTrackerServeCommand("node /srv/other/bin/tracker.js serve"), false);
+  // tracker.js outside a bin/ directory is rejected before any filesystem work.
+  assert.equal(isTokenTrackerServeCommand("node /srv/other/tracker.js serve"), false);
 });
 
 test("port scan is limited to listeners, not everything touching the port", () => {

--- a/test/serve-port-hint.test.js
+++ b/test/serve-port-hint.test.js
@@ -1,10 +1,14 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const http = require("node:http");
+const path = require("node:path");
 const { test } = require("node:test");
 
 const {
   buildPortInUseHint,
   isPortUnavailableError,
+  ensurePortFree,
+  isTokenTrackerServeCommand,
   listenOnAvailablePort,
   NPM_PACKAGE_NAME,
   parseArgs,
@@ -158,4 +162,90 @@ test("isRunningUnderWsl is false off Linux regardless of env", (t) => {
   mockPlatform(t, "darwin");
   assert.equal(isRunningUnderWsl({ WSL_DISTRO_NAME: "Ubuntu" }), false);
   assert.equal(resolveDefaultPort({ WSL_DISTRO_NAME: "Ubuntu" }), 7680);
+});
+
+test("port cleanup only targets a verified TokenTracker server", () => {
+  // `--port` may name a port owned by an unrelated application. Failing to
+  // bind is far safer than terminating a process that was never ours, so
+  // ensurePortFree identifies its target before signalling it.
+  const ours = [
+    "node /usr/lib/tokentracker/bin/tracker.js serve --port 7680",
+    "/opt/app/EmbeddedServer/node /opt/app/EmbeddedServer/tokentracker/bin/tracker.js serve --no-open",
+    // `ps -o command=` drops quoting, so the script path is only unambiguous
+    // relative to the `serve` argument that follows it.
+    "node /home/u/Token Tracker/bin/tracker.js serve",
+    // The published npm bin shims: ps reports the shim, not the resolved script.
+    "node /home/u/.local/bin/tokentracker-cli serve",
+  ];
+  for (const command of ours) {
+    assert.equal(isTokenTrackerServeCommand(command), true, command);
+  }
+
+  const notOurs = [
+    // Requiring the bin/ component keeps a lookalike path from matching.
+    "node /srv/other/tracker.js serve",
+    "node /usr/lib/tokentracker/bin/tracker.js.bak serve",
+    // Our own sync process is not a server holding the port.
+    "node /usr/lib/tokentracker/bin/tracker.js sync",
+    "python3 /usr/lib/tokentracker/bin/tracker.js serve",
+    // Whatever else may legitimately own the port.
+    "/usr/bin/postgres -D /var/lib/pgsql serve",
+    "nginx: worker process",
+    // ps prints nothing once the pid is gone; never treat that as a match.
+    "",
+  ];
+  for (const command of notOurs) {
+    assert.equal(isTokenTrackerServeCommand(command), false, command);
+  }
+});
+
+test("port scan is limited to listeners, not everything touching the port", () => {
+  // `lsof -i tcp:<port>` matches a socket whose LOCAL *or REMOTE* port matches,
+  // so without -sTCP:LISTEN a browser connected to the dashboard is reported
+  // alongside the server it is talking to.
+  const source = fs.readFileSync(path.join(__dirname, "..", "src", "commands", "serve.js"), "utf8");
+  assert.match(source, /"-sTCP:LISTEN"/);
+});
+
+// Proves ensurePortFree consults the identity check rather than merely owning
+// one: a unit test of isTokenTrackerServeCommand alone still passes if the
+// filter is deleted from the kill path.
+test("ensurePortFree leaves an unrelated listener running", async (t) => {
+  const cp = require("node:child_process");
+  const hasLsof = (() => {
+    try {
+      cp.execFileSync("lsof", ["-v"], { stdio: "ignore", timeout: 5000 });
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  })();
+  if (!hasLsof) return t.skip("ensurePortFree is a no-op without lsof");
+
+  // A separate process, because ensurePortFree skips its own pid for free.
+  const child = cp.spawn(
+    process.execPath,
+    [
+      "-e",
+      "const n=require('net');n.createServer(c=>c.on('error',()=>{}))" +
+        ".listen(0,'127.0.0.1',function(){process.stdout.write(String(this.address().port))});" +
+        "setInterval(()=>{},1000);",
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+  t.after(() => child.kill("SIGKILL"));
+
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("listener never reported a port")), 10000);
+    child.stdout.once("data", (chunk) => {
+      clearTimeout(timer);
+      resolve(Number(String(chunk).trim()));
+    });
+  });
+  assert.ok(port > 0, "child should report its port");
+
+  await ensurePortFree(port);
+
+  assert.equal(child.exitCode, null, "an unrelated listener must survive port cleanup");
+  assert.equal(child.signalCode, null, "an unrelated listener must not be signalled");
 });


### PR DESCRIPTION
`serve --port <n>` sets `portExplicit`, which wires `ensurePortFree` into `listenOnAvailablePort`. That function kills **every pid `lsof` reports for the port** — SIGTERM, then SIGKILL three seconds later — with no check that the process was ever ours:

```js
const targets = pids.filter((p) => p !== self);
```

The only protection is "not my own pid". A caller-supplied port may be owned by an unrelated application, and failing to bind is far safer than terminating a stranger's process.

Two independent problems, both fixed here.

## 1. No identity check before signalling

A TokenTracker server is always `node <somewhere>/bin/<entry> serve` — either the real script (npm global, embedded desktop runtime, repo checkout) or one of the published npm bin shims, which `ps` reports by the shim path rather than the resolved script.

Path shape alone is **not** identifying, though: plenty of unrelated projects ship a `bin/tracker.js`. So the entry is resolved through `realpathSync` and must have a `package.json` named `tokentracker-cli` within three levels above it. That covers every real layout — repo checkout, npm global, embedded desktop runtime, and the bin shims, which are symlinks into the package and resolve to the same place.

This fails closed: an entry that cannot be resolved (deleted, or inside a mount namespace this process cannot read) is left alone, so the worst case is a failed bind rather than a killed stranger.

Identity is rechecked before the SIGKILL escalation, since the pid may have exited during the three-second wait and been recycled by something else.

The matching is deliberately conservative about `ps -o command=`, which joins argv with spaces and drops all quoting — so the script path is only unambiguous relative to the `serve` argument that follows it. Splitting on whitespace would reject an install under `~/Token Tracker/`.

## 2. The port scan matched clients, not just listeners

`lsof -i tcp:<port>` matches a socket whose **local or remote** port matches. I confirmed this directly: with a listener on 17680 and one client attached, `lsof -ti tcp:17680` returned both pids; adding `-sTCP:LISTEN` returned only the listener. So a browser merely connected to the dashboard was reported as occupying the port, and was equally liable to be killed.

## Windows is unaffected

`findPidOnPort` shells out to `lsof`, which doesn't exist on Windows — the call throws, the catch returns `[]`, and `ensurePortFree` is already a no-op there. This change adds a `ps` call on the same path, so it stays Unix-only and Windows behaviour is identical before and after.

## Verified against live processes

Not just unit-tested:

- An unrelated `node` listener on the port **survives** `ensurePortFree`, and the bind then fails with `EADDRINUSE` — the correct outcome
- A real `node bin/tracker.js serve --port …` on the same port **is** still stopped and the port released, so the cleanup feature still works
- The matcher was exercised against realistic commands: npm global install, embedded desktop runtime, a path containing a space, the npm bin shims (all matched); a lookalike `tracker.js` outside `bin/`, a `.bak` suffix, our own `sync` process, `python3` instead of node, postgres and nginx, and the empty string `ps` prints once a pid is gone (all rejected)
- Both halves are mutation-tested: deleting the identity filter from the kill path fails the new integration test, and dropping `-sTCP:LISTEN` fails the scan test. An earlier version of my tests passed with the filter removed, so the integration test exists specifically to close that gap

`npm test` — 2427 passing, 0 failing. `validate:guardrails`, `validate:copy`, `validate:ui-hardcode`, `validate:versions` and the architecture guardrails all clean.

## Scope

`ensurePortFree` is newly exported so the kill path can be tested against a real process rather than only through the matcher. No version bump — `scripts/version-files.cjs` drives nine files off `package.json`, so that's yours on the next release. This touches `src/`, so by the CLAUDE.md matrix it ships npm plus all three desktop apps whenever you next cut one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup when the configured port is already in use.
  * Prevents unrelated processes from being terminated during port cleanup.
  * Ensures only actively listening endpoints are considered when checking port availability.
  * Adds additional safeguards before forcefully stopping a server process.
  * Improves recognition of the correct server process, including when launched through a package-managed command or symlink.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
