### PR TITLE
fix: retain OpenCode Go limits on transient failures with disk cache

### DIFF
--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -743,8 +743,7 @@ async function fetchOpencodeGoLimits({
       return { ...api, source: "api" };
     }
     if (api?.auth_error) {
-      const { auth_error, ...result } = api;
-      return result;
+      return { ...api, source: "api" };
     }
     if (!cfg) return api || { configured: true, error: "OpenCode Go unavailable" };
   }

--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -649,7 +649,13 @@ async function scrapeOpencodeGoWeb({ cfg, fetchImpl, nowMs, timeoutMs }) {
     try {
       workspaceId = await resolveWorkspaceId(cfg.authCookie, fetchImpl, timeoutMs);
     } catch (err) {
-      return { configured: true, error: `Failed to resolve Workspace ID: ${sanitizeMessage(err?.message || err)}` };
+      const msg = sanitizeMessage(err?.message || err);
+      const isAuth = /401|403|Unauthorized or forbidden/i.test(msg);
+      return {
+        configured: true,
+        error: `Failed to resolve Workspace ID: ${msg}`,
+        ...(isAuth ? { auth_error: true } : {}),
+      };
     }
     if (!workspaceId) {
       return { configured: true, error: "Could not auto-resolve OpenCode Workspace ID from cookie. Please set OPENCODE_GO_WORKSPACE_ID manually." };

--- a/src/lib/opencode-go-limits.js
+++ b/src/lib/opencode-go-limits.js
@@ -266,6 +266,9 @@ async function resolveWorkspaceId(authCookie, fetchImpl, timeoutMs) {
         headers: postHeaders,
         body: "[]"
       });
+      if (response.status === 401 || response.status === 403) {
+        throw new Error("Unauthorized or forbidden (401/403)");
+      }
       text = await response.text();
       ids = parseWorkspaceIds(text);
     } catch (postErr) {

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -66,6 +66,13 @@ const CLAUDE_LIMITS_CACHE_FRESH_TTL_MS = 10 * 60 * 1000;
 // error, mirroring the Claude stale-fallback path.
 const CODEX_LIMITS_CACHE_FILE = "codex-usage-limits-cache.json";
 const CODEX_LIMITS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+// OpenCode Go hits opencode.ai over the public internet (15s timeout) with no local CLI to
+// fall back on. A transient 5xx / timeout previously left the panel blank until the next
+// 2-minute poll — persist the last successful windows so a blip serves stale bars instead
+// of a flash of "fetch failed" (mirrors Claude / Codex / Antigravity).
+const OPENCODE_GO_LIMITS_CACHE_FILE = "opencode-go-usage-limits-cache.json";
+const OPENCODE_GO_LIMITS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const OPENCODE_GO_LOCAL_ESTIMATE_CACHE_MAX_AGE_MS = 60 * 60 * 1000;
 // A 429 from the usage endpoint carries a long `retry-after` (often 20+ minutes). Persist
 // the cooldown so every surface — this process, the menu bar app's embedded server, a later
 // restart — stops calling until it expires. Hammering during the cooldown just renews the
@@ -2398,6 +2405,82 @@ function writeCodexLimitsCache(limits, { home, nowMs = Date.now() } = {}) {
   } catch (_error) {}
 }
 
+function resolveOpencodeGoLimitsCachePath({ home } = {}) {
+  return path.join(home || os.homedir(), ".tokentracker", "tracker", OPENCODE_GO_LIMITS_CACHE_FILE);
+}
+
+function hasOpencodeGoWindow(limits) {
+  return Boolean(limits?.primary_window || limits?.secondary_window || limits?.tertiary_window);
+}
+
+function isOpencodeGoCacheWindowUsable(window, { nowMs } = {}) {
+  if (!window || typeof window !== "object") return false;
+  const resetAtMs = parseTimeMs(window.reset_at);
+  if (resetAtMs === null) return true;
+  return resetAtMs > nowMs;
+}
+
+function normalizeOpencodeGoCachedLimits(
+  raw,
+  { nowMs = Date.now(), maxAgeMs } = {},
+) {
+  const effectiveMaxAge = Number.isFinite(maxAgeMs)
+    ? maxAgeMs
+    : raw?.source === "local-estimate"
+      ? OPENCODE_GO_LOCAL_ESTIMATE_CACHE_MAX_AGE_MS
+      : OPENCODE_GO_LIMITS_CACHE_MAX_AGE_MS;
+  const cachedAtMs = parseTimeMs(raw?.cached_at);
+  if (!Number.isFinite(cachedAtMs)) return null;
+  if (cachedAtMs > nowMs + 60_000) return null;
+  if (nowMs - cachedAtMs > effectiveMaxAge) return null;
+
+  const cached = {
+    configured: true,
+    error: null,
+    source: typeof raw?.source === "string" ? raw.source : "api",
+    subscription_status: typeof raw?.subscription_status === "string" ? raw.subscription_status : null,
+    plan_label: typeof raw?.plan_label === "string" ? raw.plan_label : null,
+    primary_window: isOpencodeGoCacheWindowUsable(raw?.primary_window, { nowMs }) ? raw.primary_window : null,
+    secondary_window: isOpencodeGoCacheWindowUsable(raw?.secondary_window, { nowMs }) ? raw.secondary_window : null,
+    tertiary_window: isOpencodeGoCacheWindowUsable(raw?.tertiary_window, { nowMs }) ? raw.tertiary_window : null,
+    stale: true,
+    cached_at: raw.cached_at,
+  };
+  return hasOpencodeGoWindow(cached) ? cached : null;
+}
+
+function readOpencodeGoLimitsCache({ home, nowMs = Date.now() } = {}) {
+  const cachePath = resolveOpencodeGoLimitsCachePath({ home });
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    return normalizeOpencodeGoCachedLimits(parsed?.opencodeGo, { nowMs });
+  } catch (_error) {
+    return null;
+  }
+}
+
+function writeOpencodeGoLimitsCache(limits, { home, nowMs = Date.now() } = {}) {
+  if (!limits?.configured || limits.error || !hasOpencodeGoWindow(limits)) return;
+  const cachePath = resolveOpencodeGoLimitsCachePath({ home });
+  const payload = {
+    opencodeGo: {
+      source: limits.source || "api",
+      subscription_status: limits.subscription_status || null,
+      plan_label: limits.plan_label || null,
+      primary_window: limits.primary_window || null,
+      secondary_window: limits.secondary_window || null,
+      tertiary_window: limits.tertiary_window || null,
+      cached_at: new Date(nowMs).toISOString(),
+    },
+  };
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    const tmpPath = `${cachePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, cachePath);
+  } catch (_error) {}
+}
+
 function resolveClaudeRateLimitPath({ home } = {}) {
   return path.join(home || os.homedir(), ".tokentracker", "tracker", CLAUDE_RATE_LIMIT_FILE);
 }
@@ -3063,7 +3146,7 @@ async function fetchUsageLimitsUncached({
     : null;
 
   const providerFetch = withFetchTimeout(fetchImpl, providerTimeoutMs);
-  const [claudeResult, codexResult, cursor, kimi, gemini, kiro, antigravity, copilot, grok, zcode, opencodeGo, qoder, qoderCn, codingPlan, claudeServiceStatus] = await Promise.all([
+  const [claudeResult, codexResult, cursor, kimi, gemini, kiro, antigravity, copilot, grok, zcode, opencodeGoRaw, qoder, qoderCn, codingPlan, claudeServiceStatus] = await Promise.all([
     claudeToken && !freshClaudeCache && !claudeRetryAtMs
       ? withProviderTimeout(fetchClaudeUsageLimits(claudeToken, { fetchImpl: providerFetch, maxAttempts: 1 }), "Claude", providerTimeoutMs).then(
           (value) => ({ status: "fulfilled", value }),
@@ -3273,6 +3356,37 @@ async function fetchUsageLimitsUncached({
       codex = cached;
     } else {
       codex = { configured: true, error: codexResult?.reason?.message || "Unknown error" };
+    }
+  }
+
+  // OpenCode Go: persist last successful windows so a transient timeout/5xx
+  // (common on GFW-affected routes to opencode.ai) serves stale bars instead of
+  // a flashing "fetch failed". Mirrors Codex / Claude / Antigravity.
+  // Auth errors (401/403 invalid key, missing subscription, expired cookie) are
+  // actionable and must not be hidden behind stale cache — they carry
+  // `auth_error:true` from opencode-go-limits.js.
+  const opencodeGoIsAuthError =
+    Boolean(opencodeGoRaw?.auth_error) ||
+    (typeof opencodeGoRaw?.error === "string" &&
+      /Not signed in|auth cookie|Refresh the auth cookie/i.test(opencodeGoRaw.error));
+  let opencodeGo;
+  if (opencodeGoRaw && opencodeGoRaw.configured === false) {
+    opencodeGo = opencodeGoRaw;
+  } else if (opencodeGoIsAuthError) {
+    opencodeGo = opencodeGoRaw;
+  } else if (opencodeGoRaw && !opencodeGoRaw.error && hasOpencodeGoWindow(opencodeGoRaw)) {
+    opencodeGo = {
+      ...opencodeGoRaw,
+      stale: false,
+      cached_at: new Date(nowMs).toISOString(),
+    };
+    writeOpencodeGoLimitsCache(opencodeGo, { home, nowMs });
+  } else {
+    const cached = readOpencodeGoLimitsCache({ home, nowMs });
+    if (cached) {
+      opencodeGo = cached;
+    } else {
+      opencodeGo = opencodeGoRaw || { configured: true, error: "Unknown error" };
     }
   }
 

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -3368,11 +3368,15 @@ async function fetchUsageLimitsUncached({
   const opencodeGoIsAuthError =
     Boolean(opencodeGoRaw?.auth_error) ||
     (typeof opencodeGoRaw?.error === "string" &&
-      /Not signed in|auth cookie|Refresh the auth cookie/i.test(opencodeGoRaw.error));
+      /Not signed in|auth cookie|Refresh the auth cookie|Failed to resolve Workspace ID.*401|Failed to resolve Workspace ID.*403/i.test(
+        opencodeGoRaw.error,
+      ));
   let opencodeGo;
   if (opencodeGoRaw && opencodeGoRaw.configured === false) {
     opencodeGo = opencodeGoRaw;
   } else if (opencodeGoIsAuthError) {
+    opencodeGo = opencodeGoRaw;
+  } else if (opencodeGoRaw?.subscription_status === "inactive") {
     opencodeGo = opencodeGoRaw;
   } else if (opencodeGoRaw && !opencodeGoRaw.error && hasOpencodeGoWindow(opencodeGoRaw)) {
     opencodeGo = {


### PR DESCRIPTION
### 问题

OpenCode Go 额度接口 `GET https://opencode.ai/zen/go/v1/usage` 走公网 15s 超时，无本地 CLI 兜底。之前瞬时 5xx / 超时直接返回 `{error: 'fetch failed'}`，前端显示为额度条消失，2 分钟后成功又出现，表现为闪现（复现：本机 `fetchOpencodeGoLimits` 返回 `fetch failed`，而 Claude/Codex 都有磁盘缓存兜底）。

### 修复

- 新增 `opencode-go-usage-limits-cache.json` 磁盘缓存，对齐 Claude/Codex/Antigravity 模式：
  - 成功时写入 `stale:false + cached_at`，失败时读缓存 `stale:true` 返回，不再闪
  - `reset_at` 过期窗口自动丢弃，`hasWindow` 为空则不缓存
- 保留 `auth_error` 透传，401/403（key 无效/未订阅）直接报错，不藏在旧缓存后（需用户修 key）
- `local-estimate` 估算值 1小时过期，其它来源 7天，避免成本估算长期滞后

### 验证

- `node --test test/opencode-go-limits.test.js` 48 项通过
- `node --test test/usage-limits.test.js` 109 项通过
- 手动验证：成功→写盘→第二次 `fetch failed` 返回 `stale:true` 旧三窗口；401 返回错误不走缓存；`local-estimate` 2小时前过期正确


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent caching for OpenCode Go usage limits.
  * Displays recent cached usage data when live usage information is temporarily unavailable, using reset-aware freshness checks.

* **Bug Fixes**
  * API authentication errors are now clearly identified as API errors.
  * Improved detection of workspace authentication failures.
  * Prevented authentication and unconfigured states from being saved as cached usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->