### PR TITLE
fix: discover Copilot OTel logs and preserve chat usage

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1215,8 +1215,10 @@ function formatCopilotLines({ token, otel, sessionStore, appDb }) {
   const appDbState = appDb?.app_db_has_file
     ? `${appDb.app_db_mode || "set"} (${(appDb.app_db_paths || []).join(", ")})`
     : `not found (${appDb?.app_db_path || "unknown"})`;
+  const otelLocation =
+    otel.otel_path || otel.otel_detected_paths?.[0] || otel.otel_default_dir;
   const usageState = otel.otel_has_files
-    ? `set (${otel.otel_path || otel.otel_default_dir})`
+    ? `set (${otelLocation})`
     : otel.otel_enabled
       ? "enabled but no files yet"
       : "unset (OTEL export not enabled)";

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -13313,7 +13313,7 @@ async function parseCraftIncremental({
 //   COPILOT_OTEL_ENABLED=true
 //   COPILOT_OTEL_EXPORTER_TYPE=file
 //   COPILOT_OTEL_FILE_EXPORTER_PATH=$HOME/.copilot/otel/copilot-otel-...jsonl
-// We scan the default directory plus the env-overridden path.
+// We scan both known default directories plus the env-overridden path.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function resolveCopilotOtelPaths(env = process.env) {
@@ -13328,12 +13328,19 @@ function resolveCopilotOtelPaths(env = process.env) {
     } catch (_e) {}
   };
   if (process.platform !== "win32" || wsl.shouldProbeNative(env)) {
-    scanDir(path.join(home, ".copilot", "otel"));
+    for (const dir of [
+      path.join(home, ".copilot", "otel"),
+      path.join(home, ".copilot-otel"),
+    ]) {
+      scanDir(dir);
+    }
   }
   if (process.platform === "win32") {
     if (wsl.shouldProbeWsl(env)) {
-      const wslDir = wsl.discoverWslHome(".copilot/otel", { env });
-      if (wslDir) scanDir(wslDir);
+      for (const providerDir of [".copilot/otel", ".copilot-otel"]) {
+        const wslDir = wsl.discoverWslHome(providerDir, { env });
+        if (wslDir) scanDir(wslDir);
+      }
     }
   }
   const explicit = env.COPILOT_OTEL_FILE_EXPORTER_PATH;
@@ -13375,7 +13382,7 @@ function pickCopilotModel(attrs) {
   return null;
 }
 
-const COPILOT_PARSER_VERSION = 2;
+const COPILOT_PARSER_VERSION = 3;
 const COPILOT_USAGE_CLAIM_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const COPILOT_USAGE_CLAIM_MAX_ENTRIES = 10_000;
 
@@ -13432,12 +13439,166 @@ function incrementMapCount(map, key, amount = 1) {
   map.set(key, (map.get(key) || 0) + amount);
 }
 
-function getCopilotDedupKey(record, attrs = record?.attributes || {}) {
+function getCopilotResponseId(attrs = {}) {
+  const responseId = attrs["gen_ai.response.id"];
+  return typeof responseId === "string" && responseId.trim() ? responseId.trim() : "";
+}
+
+// v2 preferred spanContext for every OTEL envelope. Chat-extension LogRecords
+// can share that nested context across several model requests, so keep the old
+// key only for the one envelope that owns top-level traceId/spanId: CLI spans.
+function getCopilotLegacyDedupKey(record, attrs = record?.attributes || {}) {
   const traceId = record?.traceId || record?.spanContext?.traceId || "";
   const spanId = record?.spanId || record?.spanContext?.spanId || "";
-  const responseId =
-    typeof attrs["gen_ai.response.id"] === "string" ? attrs["gen_ai.response.id"] : "";
+  const responseId = getCopilotResponseId(attrs);
   return traceId && spanId ? `${traceId}:${spanId}` : responseId ? `resp:${responseId}` : null;
+}
+
+function getCopilotDedupKey(record, attrs = record?.attributes || {}) {
+  const responseId = getCopilotResponseId(attrs);
+  if (!isCopilotV1ChatSpan(record)) {
+    return responseId ? `resp:${responseId}` : null;
+  }
+
+  const traceId = record?.traceId || "";
+  const spanId = record?.spanId || "";
+  return traceId && spanId
+    ? `${traceId}:${spanId}`
+    : responseId
+      ? `resp:${responseId}`
+      : null;
+}
+
+function copilotOtelAggregateKey(model, bucketStart) {
+  return JSON.stringify([model, bucketStart]);
+}
+
+function addCopilotOtelAggregate(aggregates, model, bucketStart, delta) {
+  const key = copilotOtelAggregateKey(model, bucketStart);
+  let totals = aggregates.get(key);
+  if (!totals) {
+    totals = initTotals();
+    aggregates.set(key, totals);
+  }
+  addTotals(totals, delta);
+}
+
+function copilotTotalsCover(existing, required) {
+  if (!existing || typeof existing !== "object") return false;
+  for (const field of [
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_creation_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+    "billable_total_tokens",
+    "conversation_count",
+  ]) {
+    const actual = Number(existing[field] || 0);
+    const needed = Number(required?.[field] || 0);
+    if (!Number.isFinite(actual) || !Number.isFinite(needed) || actual < needed) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function extractCopilotOtelUsage(record) {
+  if (!isCopilotChatSpan(record)) return null;
+
+  const attrs = record.attributes || {};
+  const inputRaw = toNonNegativeInt(attrs["gen_ai.usage.input_tokens"]);
+  const output = toNonNegativeInt(attrs["gen_ai.usage.output_tokens"]);
+  const cacheRead = toNonNegativeInt(
+    attrs["gen_ai.usage.cache_read.input_tokens"] ??
+      attrs["gen_ai.usage.cache_read_input_tokens"] ??
+      attrs["gen_ai.usage.cached_input_tokens"],
+  );
+  // Copilot CLI: cache_write.input_tokens; Copilot Chat extension: cache_creation.input_tokens
+  const cacheWrite = toNonNegativeInt(
+    attrs["gen_ai.usage.cache_write.input_tokens"] ??
+      attrs["gen_ai.usage.cache_creation.input_tokens"] ??
+      attrs["gen_ai.usage.cache_write_input_tokens"] ??
+      attrs["gen_ai.usage.cache_creation_input_tokens"],
+  );
+  // Copilot CLI: reasoning.output_tokens; Copilot Chat extension: reasoning_tokens
+  const reasoning = toNonNegativeInt(
+    attrs["gen_ai.usage.reasoning.output_tokens"] ??
+      attrs["gen_ai.usage.reasoning_tokens"] ??
+      attrs["gen_ai.usage.reasoning_output_tokens"],
+  );
+  const reasoningClamped = Math.min(reasoning, output);
+  const outputWithoutReasoning = Math.max(0, output - reasoningClamped);
+  const cliSpan = isCopilotV1ChatSpan(record);
+  // CLI input includes both cache reads and writes. Chat-extension LogRecords
+  // expose cache creation separately, so preserve their existing input-minus-read semantics.
+  const cacheReadClamped = Math.min(cacheRead, inputRaw);
+  const cacheWriteClamped = Math.min(
+    cacheWrite,
+    Math.max(0, inputRaw - cacheReadClamped),
+  );
+  const cacheWriteForAccounting = cliSpan ? cacheWriteClamped : cacheWrite;
+  const input = Math.max(
+    0,
+    inputRaw - cacheReadClamped - (cliSpan ? cacheWriteClamped : 0),
+  );
+  const totalInteresting =
+    input +
+    outputWithoutReasoning +
+    cacheReadClamped +
+    cacheWriteForAccounting +
+    reasoningClamped;
+  if (totalInteresting === 0) return null;
+
+  // CLI Span uses endTime/startTime; Chat extension LogRecord uses hrTime/hrTimeObserved.
+  const tsMs =
+    copilotOtelTimeToMs(record.endTime) ||
+    copilotOtelTimeToMs(record.startTime) ||
+    copilotOtelTimeToMs(record.hrTime) ||
+    copilotOtelTimeToMs(record.hrTimeObserved);
+  if (!tsMs) return null;
+  const bucketStart = toUtcHalfHourStart(new Date(tsMs).toISOString());
+  if (!bucketStart) return null;
+
+  const model =
+    normalizeCopilotAppModel(pickCopilotModel(attrs)) ||
+    COPILOT_APP_DEFAULT_MODEL;
+  const cliSessionId =
+    typeof attrs["gen_ai.conversation.id"] === "string"
+      ? attrs["gen_ai.conversation.id"].trim()
+      : "";
+  const matchBase = {
+    sessionId: cliSessionId,
+    model,
+    output: outputWithoutReasoning,
+    cacheRead: cacheReadClamped,
+    cacheWrite: cacheWriteClamped,
+    reasoning: reasoningClamped,
+    tsMs,
+  };
+  return {
+    bucketStart,
+    cliSpan,
+    cliSessionId,
+    delta: {
+      input_tokens: input,
+      cached_input_tokens: cacheReadClamped,
+      cache_creation_input_tokens: cacheWriteForAccounting,
+      output_tokens: outputWithoutReasoning,
+      reasoning_output_tokens: reasoningClamped,
+      total_tokens:
+        input +
+        outputWithoutReasoning +
+        cacheReadClamped +
+        cacheWriteForAccounting +
+        reasoningClamped,
+      conversation_count: 1,
+    },
+    matchBase,
+    model,
+    tsMs,
+  };
 }
 
 function copilotUsageMatchKey({
@@ -13497,6 +13658,141 @@ function createCopilotStoreUsageMatcher(events) {
       return true;
     },
   };
+}
+
+// v2 may already have advanced the file cursor while collapsing several Chat
+// extension LogRecords that shared one nested spanContext. Recompute only that
+// envelope's historical contribution and apply the delta to the existing
+// Copilot buckets. CLI spans are deliberately left alone: their v2 key was the
+// correct top-level traceId:spanId key, and session-store adoption can coexist
+// with the OTEL parser.
+async function migrateCopilotChatLogRecordDedup({
+  files,
+  fileOffsets,
+  hourlyState,
+  touchedBuckets,
+  seenIds,
+} = {}) {
+  const trackedFiles = Object.keys(fileOffsets || {}).filter(
+    (filePath) => Number(fileOffsets[filePath]?.size) > 0,
+  );
+  if (trackedFiles.length === 0) {
+    return { applied: true, changed: false };
+  }
+
+  const availableFiles = new Set(Array.isArray(files) ? files : []);
+  if (trackedFiles.some((filePath) => !availableFiles.has(filePath))) {
+    return { applied: false, reason: "a previously parsed OTEL file is unavailable" };
+  }
+
+  const oldSeen = new Set();
+  const newSeen = new Set();
+  const oldTotals = new Map();
+  const newTotals = new Map();
+
+  for (const filePath of files) {
+    if (!Object.prototype.hasOwnProperty.call(fileOffsets, filePath)) continue;
+    const prevEntry = fileOffsets[filePath] || {};
+    const prevSize = Number(prevEntry.size) || 0;
+    if (prevSize <= 0) continue;
+
+    let stat;
+    try {
+      stat = fssync.statSync(filePath);
+    } catch (_e) {
+      return { applied: false, reason: "a previously parsed OTEL file is unreadable" };
+    }
+    if (
+      stat.size < prevSize ||
+      (typeof prevEntry.ino === "number" && stat.ino !== prevEntry.ino)
+    ) {
+      return { applied: false, reason: "a previously parsed OTEL file changed during migration" };
+    }
+
+    let stream;
+    try {
+      stream = fssync.createReadStream(filePath, {
+        encoding: "utf8",
+        start: 0,
+        end: prevSize - 1,
+      });
+      const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+      try {
+        for await (const line of rl) {
+          if (!line || !line.trim()) continue;
+          let record;
+          try {
+            record = JSON.parse(line);
+          } catch (_e) {
+            continue;
+          }
+          const usage = extractCopilotOtelUsage(record);
+          if (!usage || usage.cliSpan) continue;
+
+          const oldKey = getCopilotLegacyDedupKey(record, record.attributes || {});
+          const oldDuplicate = oldKey && oldSeen.has(oldKey);
+          if (oldKey) oldSeen.add(oldKey);
+          if (!oldDuplicate) {
+            addCopilotOtelAggregate(
+              oldTotals,
+              usage.model,
+              usage.bucketStart,
+              usage.delta,
+            );
+          }
+
+          const newKey = getCopilotDedupKey(record, record.attributes || {});
+          const newDuplicate = newKey && newSeen.has(newKey);
+          if (newKey) newSeen.add(newKey);
+          if (!newDuplicate) {
+            addCopilotOtelAggregate(
+              newTotals,
+              usage.model,
+              usage.bucketStart,
+              usage.delta,
+            );
+          }
+        }
+      } finally {
+        rl.close();
+      }
+    } catch (_e) {
+      return { applied: false, reason: "an OTEL file could not be scanned" };
+    } finally {
+      stream?.destroy();
+    }
+  }
+
+  const keys = new Set([...oldTotals.keys(), ...newTotals.keys()]);
+  for (const key of keys) {
+    const [model, bucketStart] = JSON.parse(key);
+    const oldUsage = oldTotals.get(key) || initTotals();
+    if (!copilotTotalsCover(
+      hourlyState.buckets[bucketKey("copilot", model, bucketStart)]?.totals,
+      oldUsage,
+    )) {
+      return {
+        applied: false,
+        reason: "existing Copilot buckets do not cover the old OTEL contribution",
+      };
+    }
+  }
+
+  let changed = false;
+  for (const key of keys) {
+    const [model, bucketStart] = JSON.parse(key);
+    const oldUsage = oldTotals.get(key) || initTotals();
+    const newUsage = newTotals.get(key) || initTotals();
+    if (totalsKey(oldUsage) === totalsKey(newUsage)) continue;
+    const bucket = getHourlyBucket(hourlyState, "copilot", model, bucketStart);
+    subtractTotals(bucket.totals, oldUsage);
+    addTotals(bucket.totals, newUsage);
+    touchedBuckets.add(bucketKey("copilot", model, bucketStart));
+    changed = true;
+  }
+
+  for (const id of newSeen) seenIds.add(id);
+  return { applied: true, changed };
 }
 
 // Migration helper: stream the bytes v1 already saw (0 -> prevSize), classify
@@ -13612,12 +13908,18 @@ async function parseCopilotIncremental({
     seenIds.size > 0 || Object.keys(fileOffsetsRaw).length > 0;
   let usageClaimsComplete =
     copilotState.usageClaimsComplete === true || !hadPriorUsageHistory;
+  const files = Array.isArray(otelPaths) && otelPaths.length > 0
+    ? otelPaths
+    : resolveCopilotOtelPaths(env || process.env);
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
   const migrationSkipLineHashes = new Map();
+  let cursorVersion = COPILOT_PARSER_VERSION;
   // One-shot v1->v2 migration:
   // - pure v2-only files: clear offset and re-read all skipped Chat records
   // - pure v1 CLI files: preserve offset to avoid replaying history beyond seenIds
   // - mixed files: clear offset, but skip old v1 CLI lines by hash during replay
-  if (priorVersion < COPILOT_PARSER_VERSION) {
+  if (priorVersion < 2) {
     for (const filePath of Object.keys(fileOffsets)) {
       const prevSize = Number(fileOffsets[filePath]?.size) || 0;
       const scan = await scanCopilotV1MigrationFile(filePath, prevSize);
@@ -13630,13 +13932,33 @@ async function parseCopilotIncremental({
     }
   }
 
-  const files = Array.isArray(otelPaths) && otelPaths.length > 0
-    ? otelPaths
-    : resolveCopilotOtelPaths(env || process.env);
+  // v2 used spanContext as the fallback key for Chat-extension LogRecords.
+  // Those records can share one context across multiple model requests, so
+  // repair the already-counted file prefix before switching to response.id.
+  // If the prefix cannot be verified, leave the cursor at v2 and retry on the
+  // next sync rather than replaying it with a different deduplication scheme.
+  if (priorVersion === 2) {
+    const migration = await migrateCopilotChatLogRecordDedup({
+      files,
+      fileOffsets,
+      hourlyState,
+      touchedBuckets,
+      seenIds,
+    });
+    if (!migration.applied) {
+      return {
+        recordsProcessed: 0,
+        eventsAggregated: 0,
+        bucketsQueued: 0,
+        usageClaims: recentOtelUsageEvents,
+      };
+    }
+  }
+
   if (files.length === 0) {
     cursors.copilot = {
       ...copilotState,
-      version: COPILOT_PARSER_VERSION,
+      version: cursorVersion,
       seenIds: Array.from(seenIds),
       fileOffsets,
       recentUsageEvents: recentOtelUsageEvents,
@@ -13650,9 +13972,6 @@ async function parseCopilotIncremental({
       usageClaims: recentOtelUsageEvents,
     };
   }
-
-  const hourlyState = normalizeHourlyState(cursors?.hourly);
-  const touchedBuckets = new Set();
   const cb = typeof onProgress === "function" ? onProgress : null;
   let recordsProcessed = 0;
   let eventsAggregated = 0;
@@ -13712,117 +14031,39 @@ async function parseCopilotIncremental({
       // gen_ai.response.id is per-LLM-call unique.
       const dedupKey = getCopilotDedupKey(record, attrs);
       if (dedupKey && seenIds.has(dedupKey)) continue;
-      if (skipCliSpans && isCopilotV1ChatSpan(record)) {
+      const cliSpan = isCopilotV1ChatSpan(record);
+      if (skipCliSpans && cliSpan) {
         if (dedupKey) seenIds.add(dedupKey);
         continue;
       }
 
-      const inputRaw = toNonNegativeInt(attrs["gen_ai.usage.input_tokens"]);
-      const output = toNonNegativeInt(attrs["gen_ai.usage.output_tokens"]);
-      const cacheRead = toNonNegativeInt(
-        attrs["gen_ai.usage.cache_read.input_tokens"] ??
-          attrs["gen_ai.usage.cache_read_input_tokens"] ??
-          attrs["gen_ai.usage.cached_input_tokens"],
-      );
-      // Copilot CLI: cache_write.input_tokens; Copilot Chat extension: cache_creation.input_tokens
-      const cacheWrite = toNonNegativeInt(
-        attrs["gen_ai.usage.cache_write.input_tokens"] ??
-          attrs["gen_ai.usage.cache_creation.input_tokens"] ??
-          attrs["gen_ai.usage.cache_write_input_tokens"] ??
-          attrs["gen_ai.usage.cache_creation_input_tokens"],
-      );
-      // Copilot CLI: reasoning.output_tokens; Copilot Chat extension: reasoning_tokens
-      const reasoning = toNonNegativeInt(
-        attrs["gen_ai.usage.reasoning.output_tokens"] ??
-          attrs["gen_ai.usage.reasoning_tokens"] ??
-          attrs["gen_ai.usage.reasoning_output_tokens"],
-      );
-      const reasoningClamped = Math.min(reasoning, output);
-      const outputWithoutReasoning = Math.max(0, output - reasoningClamped);
-      const cliSpan = isCopilotV1ChatSpan(record);
-      // CLI input includes both cache reads and writes. Chat-extension
-      // LogRecords expose cache creation separately, so preserve their existing
-      // input-minus-read semantics.
-      const cacheReadClamped = Math.min(cacheRead, inputRaw);
-      const cacheWriteClamped = Math.min(
-        cacheWrite,
-        Math.max(0, inputRaw - cacheReadClamped),
-      );
-      const cacheWriteForAccounting = cliSpan ? cacheWriteClamped : cacheWrite;
-      const input = Math.max(
-        0,
-        inputRaw - cacheReadClamped - (cliSpan ? cacheWriteClamped : 0),
-      );
-      const totalInteresting =
-        input +
-        outputWithoutReasoning +
-        cacheReadClamped +
-        cacheWriteForAccounting +
-        reasoningClamped;
-      if (totalInteresting === 0) continue;
-
-      // CLI Span uses endTime/startTime; Chat extension LogRecord uses hrTime/hrTimeObserved.
-      const tsMs =
-        copilotOtelTimeToMs(record.endTime) ||
-        copilotOtelTimeToMs(record.startTime) ||
-        copilotOtelTimeToMs(record.hrTime) ||
-        copilotOtelTimeToMs(record.hrTimeObserved);
-      if (!tsMs) continue;
-      const tsIso = new Date(tsMs).toISOString();
-      const bucketStart = toUtcHalfHourStart(tsIso);
-      if (!bucketStart) continue;
-
-      const model =
-        normalizeCopilotAppModel(pickCopilotModel(attrs)) ||
-        COPILOT_APP_DEFAULT_MODEL;
-      const cliSessionId =
-        typeof attrs["gen_ai.conversation.id"] === "string"
-          ? attrs["gen_ai.conversation.id"].trim()
-          : "";
-      if (cliSpan && !cliSessionId) usageClaimsComplete = false;
-      const matchBase = {
-        sessionId: cliSessionId,
-        model,
-        output: outputWithoutReasoning,
-        cacheRead: cacheReadClamped,
-        cacheWrite: cacheWriteClamped,
-        reasoning: reasoningClamped,
-        tsMs,
-      };
+      const usage = extractCopilotOtelUsage(record);
+      if (!usage) continue;
+      if (usage.cliSpan && !usage.cliSessionId) usageClaimsComplete = false;
       const matchedStoreUsage =
-        isCopilotV1ChatSpan(record) &&
+        usage.cliSpan &&
         storeUsageMatcher.consume({
-          ...matchBase,
-          input,
+          ...usage.matchBase,
+          input: usage.delta.input_tokens,
         });
       if (matchedStoreUsage) {
         if (dedupKey) seenIds.add(dedupKey);
         continue;
       }
 
-      const delta = {
-        input_tokens: input,
-        cached_input_tokens: cacheReadClamped,
-        cache_creation_input_tokens: cacheWriteForAccounting,
-        output_tokens: outputWithoutReasoning,
-        reasoning_output_tokens: reasoningClamped,
-        total_tokens:
-          input +
-          outputWithoutReasoning +
-          cacheReadClamped +
-          cacheWriteForAccounting +
-          reasoningClamped,
-        conversation_count: 1,
-      };
-
-      const bucket = getHourlyBucket(hourlyState, "copilot", model, bucketStart);
-      addTotals(bucket.totals, delta);
-      touchedBuckets.add(bucketKey("copilot", model, bucketStart));
+      const bucket = getHourlyBucket(
+        hourlyState,
+        "copilot",
+        usage.model,
+        usage.bucketStart,
+      );
+      addTotals(bucket.totals, usage.delta);
+      touchedBuckets.add(bucketKey("copilot", usage.model, usage.bucketStart));
       eventsAggregated++;
-      if (cliSpan && cliSessionId) {
+      if (usage.cliSpan && usage.cliSessionId) {
         recentOtelUsageEvents.push({
-          ...matchBase,
-          input,
+          ...usage.matchBase,
+          input: usage.delta.input_tokens,
           firstSeenAtMs: claimNowMs,
         });
       }
@@ -13864,7 +14105,7 @@ async function parseCopilotIncremental({
   cursors.hourly = hourlyState;
   cursors.copilot = {
     ...copilotState,
-    version: COPILOT_PARSER_VERSION,
+    version: cursorVersion,
     seenIds: cappedSeen,
     fileOffsets,
     recentUsageEvents: retainedRecentOtelUsageEvents,

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -1845,20 +1845,30 @@ function describeCopilotOtelStatus({ home, env = process.env } = {}) {
   const explicitPath = typeof env.COPILOT_OTEL_FILE_EXPORTER_PATH === "string"
     ? env.COPILOT_OTEL_FILE_EXPORTER_PATH
     : "";
-  const defaultDir = path.join(resolvedHome, ".copilot", "otel");
-  let hasFiles = false;
-  try {
-    if (fs.existsSync(defaultDir)) {
-      hasFiles = fs.readdirSync(defaultDir).some((entry) => entry.endsWith(".jsonl"));
-    }
-  } catch (_e) {}
-  if (!hasFiles && explicitPath && fs.existsSync(explicitPath)) hasFiles = true;
+  const defaultDirs = [
+    path.join(resolvedHome, ".copilot", "otel"),
+    path.join(resolvedHome, ".copilot-otel"),
+  ];
+  const detectedPaths = [];
+  for (const defaultDir of defaultDirs) {
+    try {
+      if (!fs.existsSync(defaultDir)) continue;
+      for (const entry of fs.readdirSync(defaultDir)) {
+        if (entry.endsWith(".jsonl")) {
+          detectedPaths.push(path.join(defaultDir, entry));
+        }
+      }
+    } catch (_e) {}
+  }
+  if (explicitPath && fs.existsSync(explicitPath)) detectedPaths.push(explicitPath);
   return {
     otel_enabled: enabled && (exporterType === "" || exporterType === "file"),
     otel_exporter_type: exporterType || null,
     otel_path: explicitPath || null,
-    otel_default_dir: defaultDir,
-    otel_has_files: hasFiles,
+    otel_default_dir: defaultDirs[0],
+    otel_default_dirs: defaultDirs,
+    otel_detected_paths: detectedPaths,
+    otel_has_files: detectedPaths.length > 0,
   };
 }
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -36,6 +36,7 @@ const {
   parseWslListVerbose,
   probeWslDistros,
   discoverWslHermesHome,
+  resolveCopilotOtelPaths,
   parseCopilotIncremental,
   parseKimiIncremental,
   parseCodebuddyIncremental,
@@ -73,6 +74,7 @@ const {
   resolveGooseDbPath,
   listRolloutFilesDeep,
   filterColdCodexRolloutFiles,
+  bucketKey,
 } = require("../src/lib/rollout");
 const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
@@ -5857,6 +5859,36 @@ function makeCopilotChatAttrs({
   return attrs;
 }
 
+test("resolveCopilotOtelPaths discovers both Copilot default locations", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-paths-"));
+  try {
+    const cliDir = path.join(tmp, ".copilot", "otel");
+    const chatDir = path.join(tmp, ".copilot-otel");
+    const explicitPath = path.join(tmp, "custom", "copilot.jsonl");
+    await fs.mkdir(cliDir, { recursive: true });
+    await fs.mkdir(chatDir, { recursive: true });
+    await fs.mkdir(path.dirname(explicitPath), { recursive: true });
+    await fs.writeFile(path.join(cliDir, "cli.jsonl"), "", "utf8");
+    await fs.writeFile(path.join(chatDir, "copilot.jsonl"), "", "utf8");
+    await fs.writeFile(path.join(cliDir, "ignored.txt"), "", "utf8");
+    await fs.writeFile(explicitPath, "", "utf8");
+
+    assert.deepEqual(
+      resolveCopilotOtelPaths({
+        HOME: tmp,
+        COPILOT_OTEL_FILE_EXPORTER_PATH: explicitPath,
+      }),
+      [
+        path.join(tmp, ".copilot", "otel", "cli.jsonl"),
+        path.join(tmp, ".copilot-otel", "copilot.jsonl"),
+        explicitPath,
+      ].sort(),
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 function makeCopilotChatSpan({
   traceId = "trace-a",
   spanId = "span-1",
@@ -6114,6 +6146,119 @@ test("parseCopilotIncremental handles Chat extension LogRecord shape (hrTime + r
   }
 });
 
+test("parseCopilotIncremental does not merge Chat records that share spanContext", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-shared-context-"));
+  try {
+    const otelPath = path.join(tmp, "vscode-chat.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const first = makeCopilotChatLogRecord({
+      responseId: "shared-context-r1",
+      inputTokens: 500,
+      outputTokens: 50,
+      cacheRead: 0,
+    });
+    const second = makeCopilotChatLogRecord({
+      responseId: "shared-context-r2",
+      inputTokens: 800,
+      outputTokens: 90,
+      cacheRead: 0,
+    });
+    first.spanContext = { traceId: "shared-trace", spanId: "shared-span" };
+    second.spanContext = { traceId: "shared-trace", spanId: "shared-span" };
+    writeCopilotOtelFile(otelPath, [first, second]);
+
+    const result = await parseCopilotIncremental({
+      otelPaths: [otelPath],
+      cursors: {},
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2);
+
+    const buckets = (await readJsonLines(queuePath)).filter(
+      (entry) => entry.source === "copilot",
+    );
+    assert.equal(buckets.length, 1);
+    assert.equal(buckets[0].input_tokens, 1300);
+    assert.equal(buckets[0].output_tokens, 140);
+    assert.equal(buckets[0].conversation_count, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseCopilotIncremental repairs v2 Chat deduplication before upgrading the cursor", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-v2-migration-"));
+  try {
+    const otelPath = path.join(tmp, "vscode-chat.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const first = makeCopilotChatLogRecord({
+      responseId: "v2-shared-r1",
+      inputTokens: 500,
+      outputTokens: 50,
+      cacheRead: 0,
+    });
+    const second = makeCopilotChatLogRecord({
+      responseId: "v2-shared-r2",
+      inputTokens: 800,
+      outputTokens: 90,
+      cacheRead: 0,
+    });
+    first.spanContext = { traceId: "v2-shared-trace", spanId: "v2-shared-span" };
+    second.spanContext = { traceId: "v2-shared-trace", spanId: "v2-shared-span" };
+    writeCopilotOtelFile(otelPath, [first, second]);
+    const stat = fssync.statSync(otelPath);
+    const model = "gpt-4o-mini-2024-07-18";
+    const hourStart = "2026-05-13T03:00:00.000Z";
+    const oldTotals = {
+      input_tokens: 500,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 50,
+      reasoning_output_tokens: 0,
+      total_tokens: 550,
+      billable_total_tokens: 550,
+      conversation_count: 1,
+    };
+    const cursors = {
+      copilot: {
+        version: 2,
+        seenIds: ["v2-shared-trace:v2-shared-span"],
+        fileOffsets: {
+          [otelPath]: { size: stat.size, mtimeMs: stat.mtimeMs, ino: stat.ino },
+        },
+      },
+      hourly: {
+        version: 3,
+        buckets: {
+          [bucketKey("copilot", model, hourStart)]: {
+            totals: oldTotals,
+            queuedKey: null,
+          },
+        },
+        groupQueued: {},
+      },
+    };
+
+    const result = await parseCopilotIncremental({
+      otelPaths: [otelPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 0, "the historical prefix is repaired during migration");
+    assert.equal(cursors.copilot.version, 3);
+
+    const [bucket] = (await readJsonLines(queuePath)).filter(
+      (entry) => entry.source === "copilot",
+    );
+    assert.equal(bucket.input_tokens, 1300);
+    assert.equal(bucket.output_tokens, 140);
+    assert.equal(bucket.total_tokens, 1440);
+    assert.equal(bucket.conversation_count, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotIncremental reads short cache_creation + reasoning_tokens keys (Chat extension)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
   try {
@@ -6213,7 +6358,7 @@ test("parseCopilotIncremental migration: v1 cursor with empty seenIds + non-empt
 
     const result = await parseCopilotIncremental({ otelPaths: [otelPath], cursors, queuePath });
     assert.equal(result.eventsAggregated, 2, "migration should re-read both records");
-    assert.equal(cursors.copilot.version, 2, "version should be bumped");
+    assert.equal(cursors.copilot.version, 3, "version should be bumped");
 
     const queued = await readJsonLines(queuePath);
     const b = queued.find((r) => r.source === "copilot");
@@ -6255,7 +6400,7 @@ test("parseCopilotIncremental migration: preserves CLI fileOffsets (no re-read o
       0,
       "CLI file should be skipped entirely (offset === size after migration)",
     );
-    assert.equal(cursors.copilot.version, 2);
+    assert.equal(cursors.copilot.version, 3);
     // Offset preserved (within tolerance for fresh stat) — confirms no full re-read happened
     assert.equal(
       cursors.copilot.fileOffsets[otelPath].size,

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -25,6 +25,7 @@ const {
   detectAntigravityProcess,
   fetchAntigravityLimits,
   fetchCopilotLimits,
+  describeCopilotOtelStatus,
 } = require("../src/lib/usage-limits");
 const { writeArkCodingPlanLimitsCache } = require("../src/lib/ark-coding-plan-limits");
 
@@ -308,6 +309,27 @@ function copilotTokenHex(token = makeCopilotTestToken()) {
 }
 
 describe("fetchCopilotLimits", () => {
+  it("detects VS Code Copilot files under .copilot-otel", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-otel-status-"));
+    try {
+      const chatDir = path.join(tmp, ".copilot-otel");
+      fs.mkdirSync(chatDir, { recursive: true });
+      fs.writeFileSync(path.join(chatDir, "copilot.jsonl"), "", "utf8");
+
+      const result = describeCopilotOtelStatus({ home: tmp, env: { HOME: tmp } });
+      assert.equal(result.otel_has_files, true);
+      assert.deepEqual(result.otel_default_dirs, [
+        path.join(tmp, ".copilot", "otel"),
+        chatDir,
+      ]);
+      assert.deepEqual(result.otel_detected_paths, [
+        path.join(chatDir, "copilot.jsonl"),
+      ]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("fetches Copilot limits with a schema-v0 auth.db token", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-limits-v0-"));
     try {


### PR DESCRIPTION
## Problem

Copilot Chat file-exporter logs can be written under ~/.copilot-otel, while TokenTracker only scanned ~/.copilot/otel. A desktop process that does not inherit the custom exporter environment therefore missed the file entirely. Chat-extension LogRecords can also share one nested spanContext across multiple model requests even when gen_ai.response.id differs, so the old deduplication key under-counted usage.

## Changes

- Discover both known default OTel directories plus the explicit exporter path.
- Use gen_ai.response.id for Chat LogRecord deduplication while retaining top-level traceId/spanId for CLI spans.
- Migrate verified v2 cursor prefixes so previously collapsed Chat records are corrected once without replaying CLI history.
- Show the detected OTel file in status output.
- Add resolver, deduplication, migration, and status regression tests.

## Scope

This PR does not invent token usage when VS Code emits no gen_ai.usage.* fields. That is an upstream VS Code issue tracked at https://github.com/microsoft/vscode/issues/331455; such a source file still needs an upstream exporter fix.

## Validation

- Copilot parser, session-store, App DB, and usage-limits tests: 429 passed, 0 failed.
- npm test was also run; unrelated local environment failures occurred for missing dashboard dependencies, Swift toolchain/module-cache permissions, and a missing dashboard artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Copilot usage detection now recognizes telemetry files from both standard telemetry locations and configured exporter paths.
  - Status information now reports all detected telemetry locations and provides clearer fallback path details.

- **Bug Fixes**
  - Copilot conversations with distinct response IDs are now counted separately, improving usage totals.
  - Existing usage data is migrated and corrected automatically when upgrading from the previous tracking format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->