### PR TITLE
fix(opencode): handle large SQLite histories

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -4422,8 +4422,7 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   // by the existing cursor-key + #426 fingerprint dedup in
   // parseOpencodeDbIncremental, so unioning here is safe — the downstream
   // parser collapses identical sessionID|messageID pairs before bucketing.
-  const collectRows = (rows, isV2) => {
-    const out = [];
+  const appendRows = (rows, isV2, out) => {
     for (const row of rows) {
       if (!row || typeof row.data !== "string") continue;
       let data;
@@ -4450,7 +4449,6 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
         data,
       });
     }
-    return out;
   };
 
   const readGeneration = (sql) => {
@@ -4477,11 +4475,11 @@ function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
     const out = [];
 
     const rows1 = readGeneration(OPENCODE_DB_V1_MESSAGE_SQL);
-    if (rows1) out.push(...collectRows(rows1, false));
+    if (rows1) appendRows(rows1, false, out);
 
     if (probe?.hasRows) {
       const rows2 = readGeneration(buildV2Sql(probe.sessionTable));
-      if (rows2) out.push(...collectRows(rows2, true));
+      if (rows2) appendRows(rows2, true, out);
     }
 
     return out;

--- a/test/opencode2-parser.test.js
+++ b/test/opencode2-parser.test.js
@@ -185,6 +185,30 @@ const skipTests = !sqlite
 // without throwing. node:test allows a conditional describe via function
 // evaluation, but the simplest approach is to guard the test() calls.
 
+test("readOpencodeDbMessages handles histories larger than the JavaScript argument limit", async () => {
+  await withTmp(async (tmp) => {
+    const dbPath = path.join(tmp, "opencode.db");
+    await fs.writeFile(dbPath, "", "utf8");
+    const data = JSON.stringify(v1AssistantMessage({ id: "msg", sessionID: "ses" }));
+    const largeHistory = Array.from({ length: 150_000 }, (_, index) => ({
+      id: `msg_${index}`,
+      session_id: "ses",
+      time_updated: index,
+      data,
+    }));
+    const sqliteOptions = {
+      execFileSync(_command, args) {
+        return JSON.stringify(args.at(-1).includes("sqlite_master")
+          ? [{ hasRows: 0, sessionTable: "session" }]
+          : largeHistory);
+      },
+    };
+
+    const rows = readOpencodeDbMessages(dbPath, sqliteOptions);
+    assert.equal(rows.length, largeHistory.length);
+  });
+});
+
 if (sqlite) {
   test("readOpencodeDbMessages reads the opencode2 session_message schema (type B: session_v2)", async () => {
     await withTmp(async (tmp) => {


### PR DESCRIPTION
## Summary

- append parsed OpenCode v1/v2 rows directly to the shared result array
- avoid exceeding JavaScript's function argument limit on large SQLite histories
- cover the regression with a 150,000-row reader test

## Reproduction

TokenTracker 0.93.4 crashes while reading a 23 GB `opencode.db` containing about 171,000 assistant messages:

```text
RangeError: Maximum call stack size exceeded
    at readOpencodeDbMessages (.../src/lib/rollout.js:4480:20)
```

The variadic `out.push(...collectRows(...))` turns every parsed row into a function argument. Appending rows directly preserves the existing v1/v2 union behavior without that limit. On the reproducing database, the read now completes in about 5.3 seconds instead of crashing.

## Test plan

- `node --test test/opencode2-parser.test.js`
- `npm test` (2,428 passed, 2 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very large message datasets, preventing failures when processing 150,000 or more rows.
  * Preserved existing parsing, deduplication, and output behavior.

* **Tests**
  * Added regression coverage for large database result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->