### PR TITLE
perf: accelerate sync scans and dashboard startup

### DIFF
--- a/dashboard/scripts/copy-registry-plugin.mjs
+++ b/dashboard/scripts/copy-registry-plugin.mjs
@@ -46,6 +46,10 @@ function parseCsv(raw) {
     }
   }
 
+  if (inQuotes) {
+    throw new Error("Copy registry contains an unterminated quoted field");
+  }
+
   row.push(field);
   if (!row.every((cell) => cell.trim() === "")) rows.push(row);
   return rows;

--- a/dashboard/scripts/copy-registry-plugin.mjs
+++ b/dashboard/scripts/copy-registry-plugin.mjs
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLUGIN_DIR = path.dirname(fileURLToPath(import.meta.url));
+const COPY_PATH = path.resolve(PLUGIN_DIR, "..", "src", "content", "copy.csv");
+const PUBLIC_ID = "virtual:tokentracker-copy-registry";
+const RESOLVED_ID = `\0${PUBLIC_ID}`;
+const REQUIRED_COLUMNS = ["key", "module", "page", "component", "slot", "text"];
+
+function parseCsv(raw) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+
+    if (inQuotes) {
+      if (character === '"') {
+        if (raw[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += character;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inQuotes = true;
+    } else if (character === ",") {
+      row.push(field);
+      field = "";
+    } else if (character === "\n") {
+      row.push(field);
+      field = "";
+      if (!row.every((cell) => cell.trim() === "")) rows.push(row);
+      row = [];
+    } else if (character !== "\r") {
+      field += character;
+    }
+  }
+
+  row.push(field);
+  if (!row.every((cell) => cell.trim() === "")) rows.push(row);
+  return rows;
+}
+
+export function readCopyRegistry(copyPath = COPY_PATH) {
+  const rows = parseCsv(fs.readFileSync(copyPath, "utf8"));
+  if (!rows.length) throw new Error(`Copy registry is empty: ${copyPath}`);
+
+  const header = rows[0].map((cell) => cell.trim());
+  const missingColumns = REQUIRED_COLUMNS.filter((column) => !header.includes(column));
+  if (missingColumns.length) {
+    throw new Error(`Copy registry missing columns: ${missingColumns.join(", ")}`);
+  }
+
+  const columnIndexes = Object.fromEntries(header.map((column, index) => [column, index]));
+  const registry = Object.create(null);
+
+  rows.slice(1).forEach((cells, rowIndex) => {
+    const key = String(cells[columnIndexes.key] || "").trim();
+    const text = String(cells[columnIndexes.text] ?? "").trim();
+    if (!key) return;
+    if (Object.hasOwn(registry, key)) {
+      throw new Error(`Duplicate copy key '${key}' on row ${rowIndex + 2}`);
+    }
+    registry[key] = text;
+  });
+
+  return registry;
+}
+
+export function copyRegistryPlugin() {
+  return {
+    name: "tokentracker-copy-registry",
+    resolveId(id) {
+      return id === PUBLIC_ID ? RESOLVED_ID : null;
+    },
+    load(id) {
+      if (id !== RESOLVED_ID) return null;
+      this.addWatchFile(COPY_PATH);
+      return `export default ${JSON.stringify(readCopyRegistry())};`;
+    },
+  };
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from "./ui/foundation/ThemeProvider.jsx";
 import { useInsforgeAuth } from "./contexts/InsforgeAuthContext.jsx";
 import { LoginModalProvider } from "./contexts/LoginModalContext.jsx";
 import { getBackendBaseUrl, getLeaderboardBaseUrl } from "./lib/config";
-import { isMockEnabled } from "./lib/mock-data";
+import { isMockEnabled } from "./lib/mock-mode";
 import { isScreenshotModeEnabled } from "./lib/screenshot-mode";
 import { useCloudUsageSync } from "./hooks/use-cloud-usage-sync";
 import { AppLayout } from "./ui/components/Sidebar.jsx";

--- a/dashboard/src/App.navigation-preload.test.jsx
+++ b/dashboard/src/App.navigation-preload.test.jsx
@@ -68,7 +68,7 @@ vi.mock("./hooks/use-cloud-usage-sync", () => ({
   useCloudUsageSync: vi.fn(),
 }));
 
-vi.mock("./lib/mock-data", () => ({
+vi.mock("./lib/mock-mode", () => ({
   isMockEnabled: () => false,
 }));
 

--- a/dashboard/src/App.preload.test.jsx
+++ b/dashboard/src/App.preload.test.jsx
@@ -66,7 +66,7 @@ vi.mock("./hooks/use-cloud-usage-sync", () => ({
   useCloudUsageSync: vi.fn(),
 }));
 
-vi.mock("./lib/mock-data", () => ({
+vi.mock("./lib/mock-mode", () => ({
   isMockEnabled: () => false,
 }));
 

--- a/dashboard/src/lib/copy.ts
+++ b/dashboard/src/lib/copy.ts
@@ -1,4 +1,4 @@
-import copyRaw from "../content/copy.csv?raw";
+import copyRegistry from "virtual:tokentracker-copy-registry";
 import zhCore from "../content/i18n/zh/core.json";
 import zhDashboard from "../content/i18n/zh/dashboard.json";
 import zhMarketing from "../content/i18n/zh/marketing.json";
@@ -25,7 +25,6 @@ import {
   ZH_TW_LOCALE,
 } from "./locale";
 
-const REQUIRED_COLUMNS = ["key", "module", "page", "component", "slot", "text"];
 const LOCALE_REGISTRIES: Record<string, TranslationRegistry> = {
   [ZH_CN_LOCALE]: {
     ...zhCore,
@@ -57,104 +56,7 @@ const LOCALE_REGISTRIES: Record<string, TranslationRegistry> = {
 type AnyRecord = Record<string, any>;
 type TranslationRegistry = Record<string, string>;
 
-let cachedRegistry: any = null;
 let currentLocale = resolvePreferredLocale(getInitialLocalePreference());
-
-function parseCsv(raw: any) {
-  const rows: any[] = [];
-  let row: any[] = [];
-  let field = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < raw.length; i += 1) {
-    const ch = raw[i];
-
-    if (inQuotes) {
-      if (ch === '"') {
-        const next = raw[i + 1];
-        if (next === '"') {
-          field += '"';
-          i += 1;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        field += ch;
-      }
-      continue;
-    }
-
-    if (ch === '"') {
-      inQuotes = true;
-      continue;
-    }
-
-    if (ch === ",") {
-      row.push(field);
-      field = "";
-      continue;
-    }
-
-    if (ch === "\n") {
-      row.push(field);
-      field = "";
-      if (!row.every((cell) => cell.trim() === "")) rows.push(row);
-      row = [];
-      continue;
-    }
-
-    if (ch === "\r") continue;
-    field += ch;
-  }
-
-  row.push(field);
-  if (!row.every((cell) => cell.trim() === "")) rows.push(row);
-  return rows;
-}
-
-function buildRegistry(raw: any) {
-  const rows = parseCsv(raw || "");
-  if (!rows.length) return { map: new Map(), rows: [] };
-
-  const header = rows[0].map((cell: any) => String(cell).trim());
-  const missing = REQUIRED_COLUMNS.filter((col) => !header.includes(col));
-  if (missing.length) {
-    if (import.meta?.env?.DEV) {
-      console.error("Copy registry missing columns:", missing.join(", "));
-    }
-    return { map: new Map(), rows: [] };
-  }
-
-  const idx = Object.fromEntries(header.map((col: any, index: number) => [col, index]));
-  const entries: any[] = [];
-  const map = new Map();
-
-  rows.slice(1).forEach((cells: any[], rowIndex: number) => {
-    const record = {
-      key: String(cells[idx.key] || "").trim(),
-      module: String(cells[idx.module] || "").trim(),
-      page: String(cells[idx.page] || "").trim(),
-      component: String(cells[idx.component] || "").trim(),
-      slot: String(cells[idx.slot] || "").trim(),
-      text: String(cells[idx.text] ?? "").trim(),
-    };
-
-    if (!record.key) return;
-    if (map.has(record.key) && import.meta?.env?.DEV) {
-      console.warn(`Duplicate copy key: ${record.key} (row ${rowIndex + 2})`);
-    }
-
-    map.set(record.key, record);
-    entries.push(record);
-  });
-
-  return { map, rows: entries };
-}
-
-function getRegistry() {
-  if (!cachedRegistry) cachedRegistry = buildRegistry(copyRaw);
-  return cachedRegistry;
-}
 
 function getLocaleRegistry() {
   return (LOCALE_REGISTRIES[currentLocale] || {}) as TranslationRegistry;
@@ -177,10 +79,6 @@ function normalizeText(text: any) {
   return String(text).replace(/\\n/g, "\n");
 }
 
-function resolveCopyValue(record: any, key: any) {
-  return getTranslatedText(key) || record?.text || key;
-}
-
 export function setCopyLocale(locale: any) {
   currentLocale = normalizeResolvedLocale(locale);
 }
@@ -193,10 +91,13 @@ export function getCopyLocale() {
 }
 
 export function copy(key: any, params?: AnyRecord) {
-  const registry = getRegistry();
-  const record = registry.map.get(key);
-  if (!record && import.meta?.env?.DEV) {
-    console.warn(`Missing copy key: ${key}`);
+  const normalizedKey = String(key);
+  const baseText = Object.hasOwn(copyRegistry, normalizedKey)
+    ? copyRegistry[normalizedKey]
+    : undefined;
+  if (typeof baseText !== "string" && import.meta?.env?.DEV) {
+    console.warn(`Missing copy key: ${normalizedKey}`);
   }
-  return interpolate(normalizeText(resolveCopyValue(record, key)), params);
+  const text = getTranslatedText(normalizedKey) || baseText || normalizedKey;
+  return interpolate(normalizeText(text), params);
 }

--- a/dashboard/src/lib/mock-data.ts
+++ b/dashboard/src/lib/mock-data.ts
@@ -4,6 +4,9 @@ import {
   getHeatmapRangeLocal,
 } from "./activity-heatmap";
 import { formatDateLocal, formatDateUTC } from "./date-range";
+import { isMockEnabled } from "./mock-mode";
+
+export { isMockEnabled } from "./mock-mode";
 
 type AnyRecord = Record<string, any>;
 type HourRow = {
@@ -47,21 +50,6 @@ const MOCK_LEADERBOARD_NAMES = [
   "LINK",
   "BLADE",
 ];
-
-export function isMockEnabled() {
-  if (typeof window !== "undefined") {
-    const params = new URLSearchParams(window.location.search);
-    const q = String(params.get("mock") || "").toLowerCase();
-    // 显式关闭：?mock=0 / false / off 优先于环境变量（便于联调真实接口）
-    if (q === "0" || q === "false" || q === "off" || q === "no") return false;
-    if (q === "1" || q === "true" || q === "on" || q === "yes") return true;
-  }
-  if (typeof import.meta !== "undefined" && import.meta.env) {
-    const flag = String(import.meta.env.VITE_TOKENTRACKER_MOCK || "").toLowerCase();
-    if (flag === "1" || flag === "true") return true;
-  }
-  return false;
-}
 
 function readMockNowRaw() {
   if (typeof import.meta !== "undefined" && import.meta.env) {

--- a/dashboard/src/lib/mock-mode.ts
+++ b/dashboard/src/lib/mock-mode.ts
@@ -1,0 +1,13 @@
+export function isMockEnabled() {
+  if (typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search);
+    const queryValue = String(params.get("mock") || "").toLowerCase();
+    if (["0", "false", "off", "no"].includes(queryValue)) return false;
+    if (["1", "true", "on", "yes"].includes(queryValue)) return true;
+  }
+  if (typeof import.meta !== "undefined" && import.meta.env) {
+    const flag = String(import.meta.env.VITE_TOKENTRACKER_MOCK || "").toLowerCase();
+    if (flag === "1" || flag === "true") return true;
+  }
+  return false;
+}

--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -23,6 +23,11 @@ declare module "*?raw" {
   export default content;
 }
 
+declare module "virtual:tokentracker-copy-registry" {
+  const registry: Record<string, string>;
+  export default registry;
+}
+
 declare module "react" {
   export type Dispatch<T> = (value: T) => void;
   export type SetStateAction<T> = T | ((prev: T) => T);

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 import os from "node:os";
+import { copyRegistryPlugin } from "./scripts/copy-registry-plugin.mjs";
 
 const COPY_REQUIRED_KEYS = [
   "landing.meta.title",
@@ -1264,7 +1265,13 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    plugins: [react(), richLinkMetaPlugin(), routeSeoPagesPlugin(), localDataApiPlugin()],
+    plugins: [
+      copyRegistryPlugin(),
+      react(),
+      richLinkMetaPlugin(),
+      routeSeoPagesPlugin(),
+      localDataApiPlugin(),
+    ],
     ...(Object.keys(define).length ? { define } : {}),
     build: {
       rollupOptions: {

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,8 +1,9 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { copyRegistryPlugin } from "./scripts/copy-registry-plugin.mjs";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [copyRegistryPlugin(), react()],
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test/setupTests.ts"],

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -724,14 +724,21 @@ async function cmdSync(argv, context = {}) {
         ? cursors.codexDayInventoryCache
         : { version: 1, days: {} };
     if (sourceAllowed("codex")) cursors.codexDayInventoryCache = codexDayInventoryCache;
-    for (const entry of sources) {
-      if (seenSessions.has(entry.sessionsDir)) continue;
+    const uniqueSources = sources.filter((entry) => {
+      if (seenSessions.has(entry.sessionsDir)) return false;
       seenSessions.add(entry.sessionsDir);
-      const files = entry.deep
-        ? await listRolloutFilesDeep(entry.sessionsDir)
-        : await listRolloutFiles(entry.sessionsDir, entry.codexInventoryCache
+      return true;
+    });
+    const sourceFileGroups = await Promise.all(uniqueSources.map((entry) => (
+      entry.deep
+        ? listRolloutFilesDeep(entry.sessionsDir)
+        : listRolloutFiles(entry.sessionsDir, entry.codexInventoryCache
           ? { dayInventoryCache: codexDayInventoryCache }
-          : undefined);
+          : undefined)
+    )));
+    for (let sourceIndex = 0; sourceIndex < uniqueSources.length; sourceIndex++) {
+      const entry = uniqueSources[sourceIndex];
+      const files = sourceFileGroups[sourceIndex];
       for (const filePath of files) {
         rolloutFiles.push({ path: filePath, source: entry.source });
       }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -24,6 +24,26 @@ const CLAUDE_MEM_OBSERVER_PROJECT_REF =
   "https://local.tokentracker/claude-mem/observer-sessions";
 const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_CODEX_COLD_SKIP_RECENT_DAYS = 2;
+const FILE_METADATA_CONCURRENCY = 32;
+
+async function mapConcurrent(items, concurrency, mapper) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(
+    items.length,
+    Math.max(1, Math.floor(Number(concurrency) || 1)),
+  );
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 async function listRolloutFiles(sessionsDir, options = {}) {
   const out = [];
@@ -41,23 +61,37 @@ async function listRolloutFiles(sessionsDir, options = {}) {
       dayInventoryCache.days = {};
     }
   }
-  const years = await safeReadDir(sessionsDir);
-  for (const y of years) {
-    if (!/^[0-9]{4}$/.test(y.name) || !y.isDirectory()) continue;
-    const yearDir = path.join(sessionsDir, y.name);
-    const months = await safeReadDir(yearDir);
-    for (const m of months) {
-      if (!/^[0-9]{2}$/.test(m.name) || !m.isDirectory()) continue;
-      const monthDir = path.join(yearDir, m.name);
+  const years = (await safeReadDir(sessionsDir))
+    .filter((entry) => /^[0-9]{4}$/.test(entry.name) && entry.isDirectory());
+  const monthGroups = await mapConcurrent(
+    years,
+    FILE_METADATA_CONCURRENCY,
+    async (year) => {
+      const yearDir = path.join(sessionsDir, year.name);
+      const months = await safeReadDir(yearDir);
+      return months
+        .filter((entry) => /^[0-9]{2}$/.test(entry.name) && entry.isDirectory())
+        .map((entry) => path.join(yearDir, entry.name));
+    },
+  );
+  const monthDirs = monthGroups.flat();
+  const dayGroups = await mapConcurrent(
+    monthDirs,
+    FILE_METADATA_CONCURRENCY,
+    async (monthDir) => {
       const days = await safeReadDir(monthDir);
-      for (const d of days) {
-        if (!/^[0-9]{2}$/.test(d.name) || !d.isDirectory()) continue;
-        const dayDir = path.join(monthDir, d.name);
-        const files = await listRolloutDayFiles(dayDir, { dayInventoryCache, stats });
-        out.push(...files);
-      }
-    }
-  }
+      return days
+        .filter((entry) => /^[0-9]{2}$/.test(entry.name) && entry.isDirectory())
+        .map((entry) => path.join(monthDir, entry.name));
+    },
+  );
+  const dayDirs = dayGroups.flat();
+  const fileGroups = await mapConcurrent(
+    dayDirs,
+    FILE_METADATA_CONCURRENCY,
+    (dayDir) => listRolloutDayFiles(dayDir, { dayInventoryCache, stats }),
+  );
+  for (const files of fileGroups) out.push(...files);
 
   out.sort((a, b) => a.localeCompare(b));
   return out;
@@ -354,6 +388,18 @@ async function parseRolloutIncremental({
     return false;
   };
 
+  // Metadata reads are independent while parsing and bucket mutation are not.
+  // Prefetch stats with bounded concurrency, then retain the original stable
+  // file order for parsing, deduplication, cursor updates, and queue writes.
+  const rolloutStats = await mapConcurrent(
+    rolloutFiles,
+    FILE_METADATA_CONCURRENCY,
+    async (entry) => {
+      const filePath = typeof entry === "string" ? entry : entry?.path;
+      if (!filePath) return null;
+      return fs.stat(filePath).catch(() => null);
+    },
+  );
   for (let idx = 0; idx < rolloutFiles.length; idx++) {
     const entry = rolloutFiles[idx];
     const filePath = typeof entry === "string" ? entry : entry?.path;
@@ -363,7 +409,7 @@ async function parseRolloutIncremental({
         ? defaultSource
         : normalizeSourceInput(entry?.source) || defaultSource;
     if (syncDiagnostics && fileSource === DEFAULT_SOURCE) syncDiagnostics.stat_candidates += 1;
-    const st = await fs.stat(filePath).catch(() => null);
+    const st = rolloutStats[idx];
     if (!st || !st.isFile()) continue;
 
     const key = filePath;

--- a/test/codex-source-scoped-cache.test.js
+++ b/test/codex-source-scoped-cache.test.js
@@ -519,6 +519,48 @@ test("full auto sync still scans flat Codex archives", async () => {
   });
 });
 
+test("full sync discovers live and archived Codex roots concurrently", async () => {
+  await withTempSyncEnv(async () => {
+    const codexHome = process.env.CODEX_HOME;
+    await writeCodexRollout(
+      codexHome,
+      "2026-06-30",
+      "019f16bd-aaaa-7222-8333-444444444444",
+      12,
+    );
+    await writeArchivedCodexRollout(
+      codexHome,
+      "2026-06-29",
+      "019f16bd-bbbb-7222-8333-444444444444",
+      8,
+    );
+
+    const liveRoot = path.join(codexHome, "sessions");
+    const archiveRoot = path.join(codexHome, "archived_sessions");
+    const realReaddir = fs.readdir;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    fs.readdir = async function delayedRootReaddir(target, ...args) {
+      const tracked = String(target) === liveRoot || String(target) === archiveRoot;
+      if (!tracked) return realReaddir.call(this, target, ...args);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return await realReaddir.call(this, target, ...args);
+      } finally {
+        inFlight -= 1;
+      }
+    };
+    try {
+      await cmdSync(["--auto"]);
+    } finally {
+      fs.readdir = realReaddir;
+    }
+    assert.equal(maxInFlight, 2);
+  });
+});
+
 test("background auto sync stays bounded and skips deep Codex archives", async () => {
   await withTempSyncEnv(async (home) => {
     const codexHome = process.env.CODEX_HOME;
@@ -847,6 +889,46 @@ test("Codex day inventory cache reduces repeated old-day readdir", async () => {
       `codex day inventory cache readdir counts: first=${first.count} second=${second.count}`,
     );
   } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("Codex rollout discovery bounds concurrent day-directory reads", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-discovery-"));
+  const realReaddir = fs.readdir;
+  try {
+    const sessionsDir = path.join(tmp, "sessions");
+    const expected = [];
+    for (let day = 1; day <= 31; day += 1) {
+      expected.push(await writeCodexRollout(
+        tmp,
+        `2026-07-${String(day).padStart(2, "0")}`,
+        `019f16bd-${String(day).padStart(4, "0")}-7000-8000-aaaaaaaaaaaa`,
+        day,
+      ));
+    }
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    fs.readdir = async function delayedReaddir(target, ...args) {
+      const isDayDirectory = path.dirname(String(target)) === path.join(sessionsDir, "2026", "07");
+      if (!isDayDirectory) return realReaddir.call(this, target, ...args);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return await realReaddir.call(this, target, ...args);
+      } finally {
+        inFlight -= 1;
+      }
+    };
+
+    const found = await listRolloutFiles(sessionsDir);
+    assert.deepEqual(found, expected.sort((a, b) => a.localeCompare(b)));
+    assert.ok(maxInFlight > 1, `expected concurrent day reads, observed ${maxInFlight}`);
+    assert.ok(maxInFlight <= 32, `day read concurrency must stay bounded, observed ${maxInFlight}`);
+  } finally {
+    fs.readdir = realReaddir;
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/copy-registry-plugin.test.js
+++ b/test/copy-registry-plugin.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const pluginPath = path.resolve(__dirname, "..", "dashboard", "scripts", "copy-registry-plugin.mjs");
+
+test("copy registry rejects an unterminated quoted field", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copy-registry-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const copyPath = path.join(tempDir, "copy.csv");
+  fs.writeFileSync(
+    copyPath,
+    'key,module,page,component,slot,text\nexample,core,home,Hero,title,"unfinished\n',
+    "utf8",
+  );
+
+  const { readCopyRegistry } = await import(pathToFileURL(pluginPath).href);
+  assert.throws(
+    () => readCopyRegistry(copyPath),
+    /Copy registry contains an unterminated quoted field/,
+  );
+});

--- a/test/helpers/load-dashboard-module.js
+++ b/test/helpers/load-dashboard-module.js
@@ -1,11 +1,14 @@
 const path = require("node:path");
 const fs = require("node:fs");
+const { pathToFileURL } = require("node:url");
 const { build } = require("esbuild");
 
 const repoRoot = path.join(__dirname, "..", "..");
 
 async function loadDashboardModule(relativePath) {
   const entryPoint = path.join(repoRoot, relativePath);
+  const copyPluginPath = path.join(repoRoot, "dashboard", "scripts", "copy-registry-plugin.mjs");
+  const { readCopyRegistry } = await import(pathToFileURL(copyPluginPath).href);
   const requireShim = `import { createRequire } from "node:module"; const require = createRequire(${JSON.stringify(entryPoint)});`;
   const result = await build({
     entryPoints: [entryPoint],
@@ -25,6 +28,19 @@ async function loadDashboardModule(relativePath) {
           }));
           build.onLoad({ filter: /.*/, namespace: "raw-file" }, async (args) => ({
             contents: `export default ${JSON.stringify(await fs.promises.readFile(args.path, "utf8"))};`,
+            loader: "js",
+          }));
+        },
+      },
+      {
+        name: "copy-registry-loader",
+        setup(build) {
+          build.onResolve({ filter: /^virtual:tokentracker-copy-registry$/ }, () => ({
+            path: "tokentracker-copy-registry",
+            namespace: "copy-registry",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "copy-registry" }, () => ({
+            contents: `export default ${JSON.stringify(readCopyRegistry())};`,
             loader: "js",
           }));
         },

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -1363,6 +1363,48 @@ test("parseRolloutIncremental keeps project EOF fast path scoped to codex source
   }
 });
 
+test("parseRolloutIncremental bounds concurrent metadata reads while preserving parse order", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-stat-"));
+  const realStat = fs.stat;
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const rolloutFiles = [];
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    for (let index = 0; index < 40; index += 1) {
+      const rolloutPath = path.join(tmp, `rollout-${String(index).padStart(2, "0")}.jsonl`);
+      await fs.writeFile(rolloutPath, "", "utf8");
+      const stat = await realStat(rolloutPath);
+      rolloutFiles.push(rolloutPath);
+      cursors.files[rolloutPath] = { inode: stat.ino || 0, offset: stat.size };
+    }
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    fs.stat = async function delayedStat(target, ...args) {
+      if (!rolloutFiles.includes(String(target))) {
+        return realStat.call(this, target, ...args);
+      }
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return await realStat.call(this, target, ...args);
+      } finally {
+        inFlight -= 1;
+      }
+    };
+
+    const result = await parseRolloutIncremental({ rolloutFiles, cursors, queuePath });
+    assert.equal(result.filesProcessed, 0);
+    assert.ok(maxInFlight > 1, `expected concurrent stat calls, observed ${maxInFlight}`);
+    assert.ok(maxInFlight <= 32, `stat concurrency must stay bounded, observed ${maxInFlight}`);
+    assert.deepEqual(Object.keys(cursors.files), rolloutFiles);
+  } finally {
+    fs.stat = realStat;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("filterColdCodexRolloutFiles skips historical EOF Codex files without statting them", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-rollout-"));
   const realStat = fs.stat;


### PR DESCRIPTION
## Why

Codex sync currently performs directory discovery and file metadata reads serially. On large session histories, filesystem latency dominates sync time. The dashboard also eagerly parses the full copy CSV and imports mock generators on its startup path.

## What changed

- discover Codex year/month/day directories with bounded concurrency
- prefetch rollout file metadata with a 32-worker bound while preserving stable parse, deduplication, cursor, and queue order
- enumerate unique live/archive/native/WSL Codex roots concurrently while retaining source priority
- generate the dashboard copy registry at Vite build time instead of parsing CSV in the browser
- isolate lightweight mock-mode detection from the large mock data module
- add regression coverage for concurrency bounds, ordering, root discovery, and the virtual copy registry test loader

Scope note: this branch starts from the upstream `main` branch and intentionally excludes fork-only networking, cloud-sync, authentication, and release changes.

## Validation

- `node --test test/codex-source-scoped-cache.test.js` (27/27)
- focused rollout metadata concurrency/order regression passed
- `npm run test` in `dashboard/` (636/636)
- dashboard production build, TypeScript, and ESLint passed
- copy registry, locale coverage, UI hardcode, and architecture guardrail validators passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined copy registry supporting localized, parameterized text with consistent formatting.
  - Mock mode can now be enabled or disabled through clear URL or environment settings.

- **Performance**
  - Improved synchronization and rollout processing through bounded concurrent file discovery and metadata checks.
  - Preserved stable ordering, filtering, caching, and resource usage.

- **Reliability**
  - Added validation for missing, duplicate, and malformed copy entries.
  - Added clearer development-time warnings when copy is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->