### PR TITLE
fix(linux): guard bundle cleanup and write the Tauri icon atomically

### DIFF
--- a/TokenTrackerLinux/scripts/bundle-node-linux.sh
+++ b/TokenTrackerLinux/scripts/bundle-node-linux.sh
@@ -16,8 +16,44 @@ EMBED_DIR="${TOKENTRACKER_LINUX_EMBED_DIR:-$LINUX_DIR/EmbeddedServer}"
 DASHBOARD_DIST="${TOKENTRACKER_DASHBOARD_DIST:-$REPO_ROOT/dashboard/dist}"
 TAURI_ICON="${TOKENTRACKER_TAURI_ICON:-$LINUX_DIR/src-tauri/icons/icon.png}"
 
-node "$LINUX_DIR/scripts/sync-tauri-icon.mjs" "$REPO_ROOT/dashboard/public/icon-512.png" "$TAURI_ICON"
 TARGET_ARCH="${TARGET_ARCH:-x64}"
+if [[ "$TARGET_ARCH" != "x64" ]]; then
+  echo "Refusing to bundle unsupported Linux architecture: $TARGET_ARCH" >&2
+  exit 1
+fi
+
+assert_safe_embed_dir() {
+  local normalized="$EMBED_DIR"
+  while [[ "$normalized" != "/" && "$normalized" == */ ]]; do
+    normalized="${normalized%/}"
+  done
+  if [[ -z "$normalized" || "$normalized" != /* ]]; then
+    echo "Refusing to clean a non-absolute EmbeddedServer path: $EMBED_DIR" >&2
+    exit 1
+  fi
+  case "$normalized" in
+    /|"$SCRIPT_DIR"|"$LINUX_DIR"|"$REPO_ROOT")
+      echo "Refusing to clean unsafe EmbeddedServer path: $EMBED_DIR" >&2
+      exit 1
+      ;;
+  esac
+  if [[ "$(basename -- "$normalized")" != "EmbeddedServer" ]]; then
+    echo "Refusing to clean a path not named EmbeddedServer: $EMBED_DIR" >&2
+    exit 1
+  fi
+
+  local component="$normalized"
+  while [[ "$component" != "/" ]]; do
+    if [[ -L "$component" ]]; then
+      echo "Refusing to clean an EmbeddedServer path containing a symlink: $EMBED_DIR" >&2
+      exit 1
+    fi
+    component="$(dirname -- "$component")"
+  done
+}
+
+assert_safe_embed_dir
+
 NODE_PLATFORM="linux-${TARGET_ARCH}"
 NODE_TAR="node-v${NODE_VERSION}-${NODE_PLATFORM}.tar.gz"
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
@@ -27,6 +63,8 @@ if [[ "${1:-}" == "--clean" ]]; then
   echo "Cleaned $EMBED_DIR"
   exit 0
 fi
+
+node "$LINUX_DIR/scripts/sync-tauri-icon.mjs" "$REPO_ROOT/dashboard/public/icon-512.png" "$TAURI_ICON"
 
 rm -rf "$EMBED_DIR"
 mkdir -p "$EMBED_DIR"

--- a/TokenTrackerLinux/scripts/sync-tauri-icon.mjs
+++ b/TokenTrackerLinux/scripts/sync-tauri-icon.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { PNG } from 'pngjs';
 
@@ -33,7 +34,16 @@ export function syncTauriIcon(sourcePath = canonicalIconPath, destinationPath = 
   }
 
   if (!current?.equals(rgbaPng)) {
-    fs.writeFileSync(destinationPath, rgbaPng);
+    const temporaryPath = path.join(
+      path.dirname(destinationPath),
+      `.${path.basename(destinationPath)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    try {
+      fs.writeFileSync(temporaryPath, rgbaPng, { flag: 'wx' });
+      fs.renameSync(temporaryPath, destinationPath);
+    } finally {
+      fs.rmSync(temporaryPath, { force: true });
+    }
   }
 
   return destinationPath;

--- a/TokenTrackerLinux/test/sync-tauri-icon.test.mjs
+++ b/TokenTrackerLinux/test/sync-tauri-icon.test.mjs
@@ -85,8 +85,14 @@ test('icon sync replaces a destination symlink without writing through it', () =
     syncTauriIcon(canonicalIconPath, destination);
 
     assert.equal(fs.readFileSync(sentinel, 'utf8'), 'do not replace');
-    assert.equal(fs.lstatSync(destination).isSymbolicLink(), false);
-    assert.equal(pngHeader(fs.readFileSync(destination)).colorType, 6);
+    // O_NOFOLLOW: throws if the destination is still a symlink, and the same
+    // open serves the content read — no check-then-use race.
+    const fd = fs.openSync(destination, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      assert.equal(pngHeader(fs.readFileSync(fd)).colorType, 6);
+    } finally {
+      fs.closeSync(fd);
+    }
   } finally {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/TokenTrackerLinux/test/sync-tauri-icon.test.mjs
+++ b/TokenTrackerLinux/test/sync-tauri-icon.test.mjs
@@ -52,6 +52,8 @@ test('icon sync reads the destination directly without an exists-then-read race'
   const script = fs.readFileSync(new URL('../scripts/sync-tauri-icon.mjs', import.meta.url), 'utf8');
   assert.doesNotMatch(script, /existsSync\s*\(/);
   assert.match(script, /error\.code !== ['"]ENOENT['"]/);
+  assert.match(script, /writeFileSync\(temporaryPath/);
+  assert.match(script, /renameSync\(temporaryPath, destinationPath\)/);
 });
 
 test('sync writes a deterministic RGBA Tauri icon', () => {
@@ -66,6 +68,25 @@ test('sync writes a deterministic RGBA Tauri icon', () => {
 
     assert.deepEqual(first, second);
     assert.equal(pngHeader(first).colorType, 6);
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test('icon sync replaces a destination symlink without writing through it', () => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'tokentracker-icon-link-'));
+  const sentinel = path.join(temporaryDirectory, 'sentinel.txt');
+  const destination = path.join(temporaryDirectory, 'icon.png');
+
+  try {
+    fs.writeFileSync(sentinel, 'do not replace');
+    fs.symlinkSync(sentinel, destination);
+
+    syncTauriIcon(canonicalIconPath, destination);
+
+    assert.equal(fs.readFileSync(sentinel, 'utf8'), 'do not replace');
+    assert.equal(fs.lstatSync(destination).isSymbolicLink(), false);
+    assert.equal(pngHeader(fs.readFileSync(destination)).colorType, 6);
   } finally {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/test/linux-bundle.test.js
+++ b/test/linux-bundle.test.js
@@ -20,8 +20,13 @@ function writeExecutable(file, contents) {
   fs.writeFileSync(file, contents, { mode: 0o755 });
 }
 
+// realpath: macOS os.tmpdir() sits under the /var symlink, which the bundle script's guard refuses.
+function makeTempDir(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
 test("Linux bundle rebuilds an isolated runtime and synchronizes an isolated Tauri icon", () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-linux-bundle-"));
+  const tempDir = makeTempDir("tokentracker-linux-bundle-");
   const toolsDir = path.join(tempDir, "tools");
   const embeddedServer = path.join(tempDir, "EmbeddedServer");
   const dashboardDist = path.join(tempDir, "dashboard-dist");
@@ -118,4 +123,79 @@ chmod +x "$destination/node-v22.22.2-linux-x64/bin/node"
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+test("Linux bundle refuses to clean an unsafe output path", () => {
+  const tempDir = makeTempDir("tokentracker-linux-clean-");
+  const unsafeOutput = path.join(tempDir, "important-output");
+  const sentinel = path.join(unsafeOutput, "keep.txt");
+
+  try {
+    fs.mkdirSync(unsafeOutput, { recursive: true });
+    fs.writeFileSync(sentinel, "keep me");
+
+    const result = spawnSync("bash", [bundleScript, "--clean"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        TOKENTRACKER_LINUX_EMBED_DIR: unsafeOutput,
+      },
+      encoding: "utf8",
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /path not named EmbeddedServer/);
+    assert.equal(fs.readFileSync(sentinel, "utf8"), "keep me");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("Linux bundle refuses to clean through a symlinked parent directory", () => {
+  const tempDir = makeTempDir("tokentracker-linux-symlink-");
+  const realParent = path.join(tempDir, "real-parent");
+  const linkedParent = path.join(tempDir, "linked-parent");
+  const embeddedServer = path.join(realParent, "EmbeddedServer");
+  const sentinel = path.join(embeddedServer, "keep.txt");
+
+  try {
+    fs.mkdirSync(embeddedServer, { recursive: true });
+    fs.writeFileSync(sentinel, "keep me");
+    fs.symlinkSync(realParent, linkedParent, "dir");
+
+    const result = spawnSync("bash", [bundleScript, "--clean"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        TOKENTRACKER_LINUX_EMBED_DIR: path.join(linkedParent, "EmbeddedServer"),
+      },
+      encoding: "utf8",
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /path containing a symlink/);
+    assert.equal(fs.readFileSync(sentinel, "utf8"), "keep me");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("Linux bundle rejects unsupported architecture overrides before downloading", () => {
+  const result = spawnSync("bash", [bundleScript, "--clean"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      TARGET_ARCH: "../../unexpected",
+    },
+    encoding: "utf8",
+    timeout: 30_000,
+    maxBuffer: 1024 * 1024,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unsupported Linux architecture/);
 });


### PR DESCRIPTION
## What

Hardens the two destructive file operations in the Linux bundle scripts.

**`bundle-node-linux.sh`** runs `rm -rf "$EMBED_DIR"` on a path overridable via `TOKENTRACKER_LINUX_EMBED_DIR`, with no validation. It now refuses:

- relative or empty paths,
- `/`, the script directory, `TokenTrackerLinux/`, and the repo root,
- any path whose final component is not named `EmbeddedServer`,
- any path containing a symlinked component (so a link can't redirect the delete elsewhere).

A mistyped or unexpected override now fails loudly instead of deleting whatever it pointed at. Two smaller fixes in the same script: `TARGET_ARCH` is validated against the only supported value (`x64`) before anything downloads, and the icon sync moved below the `--clean` early-exit — cleaning no longer regenerates the icon it's cleaning up around.

**`sync-tauri-icon.mjs`** used a bare `writeFileSync`, which is non-atomic and writes *through* a symlink at the destination. It now writes to an exclusive (`wx`) temp file and renames it into place: the icon is replaced atomically, and a symlinked destination is replaced rather than followed.

## Tests

- Three new cases in `test/linux-bundle.test.js`: unsafe path refused, symlinked parent refused, bad `TARGET_ARCH` refused — each asserting a sentinel file survives. All verified to fail against the unhardened script.
- One new case in `TokenTrackerLinux/test/sync-tauri-icon.test.mjs`: a symlinked destination is replaced without writing through it, plus strengthened source assertions for the atomic write.
- Test temp dirs now go through `realpathSync`: macOS `os.tmpdir()` sits under the `/var → private/var` symlink, which the new guard would (correctly) refuse in the existing bundle test on the macOS CI job.

Behavior of the normal CI build path is unchanged — the workflow's plain `npm --prefix TokenTrackerLinux run bundle:node` invocation uses the default absolute, symlink-free path, and `--clean` has no CI callers.

Full `npm test`: 2492 tests, 0 failures. Guardrails validator clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux bundle safety by rejecting unsupported architectures and unsafe cleanup paths.
  * Prevented cleanup operations from following symlinks or removing protected locations.
  * Updated icon synchronization to safely replace files without overwriting symlink targets.
  * Ensured temporary files are removed even when icon synchronization encounters errors.

* **Tests**
  * Added coverage for unsafe architecture and cleanup path scenarios.
  * Added tests confirming symlink-safe icon replacement and temporary-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->