### PR TITLE
feat: 订阅管理与限额显示优化（显示订阅开关、进度联动与交互抛光）

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/LimitsSettingsStore.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/LimitsSettingsStore.swift
@@ -26,6 +26,7 @@ struct LimitsPreferencesSnapshot: Equatable {
     let displayMode: LimitDisplayMode
     let providerOrder: [String]
     let providerVisibility: [String: Bool]
+    let showSubscriptions: Bool
     let updatedAt: Int64?
 }
 
@@ -79,6 +80,9 @@ final class LimitsSettingsStore: ObservableObject {
     /// users on existing installs see no change after upgrade.
     @Published private(set) var displayMode: LimitDisplayMode
 
+    /// Whether inline subscription renewal bars are shown alongside limits.
+    @Published private(set) var showSubscriptions: Bool
+
     /// Millisecond Unix timestamp for the last user-authored preference change.
     @Published private(set) var updatedAt: Int64?
 
@@ -92,6 +96,7 @@ final class LimitsSettingsStore: ObservableObject {
     private static let orderKey = "LimitsProviderOrder"
     private static let visibilityKey = "LimitsProviderVisibility"
     private static let displayModeKey = "LimitsDisplayMode"
+    private static let showSubscriptionsKey = "LimitsShowSubscriptions"
     private static let updatedAtKey = "LimitsPreferencesUpdatedAt"
     private let userDefaults: UserDefaults
 
@@ -105,6 +110,7 @@ final class LimitsSettingsStore: ObservableObject {
         self.providerOrder = Self.normalizeProviderOrder(savedOrder)
         self.providerVisibility = Self.normalizeProviderVisibility(savedVis)
         self.displayMode = Self.readDisplayMode(from: userDefaults)
+        self.showSubscriptions = Self.readShowSubscriptions(from: userDefaults)
         self.updatedAt = Self.readUpdatedAt(from: userDefaults)
 
         save()
@@ -122,6 +128,21 @@ final class LimitsSettingsStore: ObservableObject {
         parseUpdatedAt(userDefaults.object(forKey: updatedAtKey))
     }
 
+    private static func readShowSubscriptions(from userDefaults: UserDefaults) -> Bool {
+        guard userDefaults.object(forKey: showSubscriptionsKey) != nil else {
+            return true
+        }
+        return userDefaults.bool(forKey: showSubscriptionsKey)
+    }
+
+    private static func normalizeShowSubscriptions(_ raw: Any?) -> Bool {
+        guard let number = raw as? NSNumber,
+              CFGetTypeID(number) == CFBooleanGetTypeID() else {
+            return true
+        }
+        return number.boolValue
+    }
+
     // MARK: - Helpers
 
     var limitsPreferencesPayload: [String: Any] {
@@ -129,6 +150,7 @@ final class LimitsSettingsStore: ObservableObject {
             "displayMode": displayMode.bridgeKey,
             "providerOrder": providerOrder,
             "providerVisibility": providerVisibility,
+            "showSubscriptions": showSubscriptions,
             "updatedAt": updatedAt.map { NSNumber(value: $0) } ?? NSNull(),
         ]
     }
@@ -159,6 +181,7 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: mode,
             providerOrder: providerOrder,
             providerVisibility: providerVisibility,
+            showSubscriptions: showSubscriptions,
             updatedAt: nextLocalUpdatedAt()
         ), notifyBridge: true)
     }
@@ -171,6 +194,7 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: displayMode,
             providerOrder: providerOrder,
             providerVisibility: Self.normalizeProviderVisibility(updated),
+            showSubscriptions: showSubscriptions,
             updatedAt: nextLocalUpdatedAt()
         ), notifyBridge: true)
     }
@@ -183,6 +207,18 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: displayMode,
             providerOrder: normalized,
             providerVisibility: providerVisibility,
+            showSubscriptions: showSubscriptions,
+            updatedAt: nextLocalUpdatedAt()
+        ), notifyBridge: true)
+    }
+
+    func setShowSubscriptionsFromMenu(_ show: Bool) {
+        guard show != showSubscriptions else { return }
+        applySnapshot(LimitsPreferencesSnapshot(
+            displayMode: displayMode,
+            providerOrder: providerOrder,
+            providerVisibility: providerVisibility,
+            showSubscriptions: show,
             updatedAt: nextLocalUpdatedAt()
         ), notifyBridge: true)
     }
@@ -209,6 +245,7 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: Self.normalizeDisplayMode(raw["displayMode"]),
             providerOrder: Self.normalizeProviderOrder(Self.rawProviderOrder(raw["providerOrder"])),
             providerVisibility: Self.normalizeProviderVisibility(raw["providerVisibility"] as? [String: Any]),
+            showSubscriptions: Self.normalizeShowSubscriptions(raw["showSubscriptions"]),
             updatedAt: Self.parseUpdatedAt(raw["updatedAt"])
         )
         guard shouldApplyBridgeSnapshot(snapshot) else {
@@ -230,6 +267,7 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: mode,
             providerOrder: providerOrder,
             providerVisibility: providerVisibility,
+            showSubscriptions: showSubscriptions,
             updatedAt: nil
         ), notifyBridge: false)
     }
@@ -240,11 +278,13 @@ final class LimitsSettingsStore: ObservableObject {
             displayMode: snapshot.displayMode,
             providerOrder: Self.normalizeProviderOrder(snapshot.providerOrder),
             providerVisibility: Self.normalizeProviderVisibility(snapshot.providerVisibility),
+            showSubscriptions: snapshot.showSubscriptions,
             updatedAt: snapshot.updatedAt
         )
         guard normalized.displayMode != displayMode ||
             normalized.providerOrder != providerOrder ||
             normalized.providerVisibility != providerVisibility ||
+            normalized.showSubscriptions != showSubscriptions ||
             normalized.updatedAt != updatedAt else {
             return false
         }
@@ -252,6 +292,7 @@ final class LimitsSettingsStore: ObservableObject {
         providerOrder = normalized.providerOrder
         providerVisibility = normalized.providerVisibility
         displayMode = normalized.displayMode
+        showSubscriptions = normalized.showSubscriptions
         updatedAt = normalized.updatedAt
         save()
 
@@ -381,6 +422,7 @@ final class LimitsSettingsStore: ObservableObject {
         userDefaults.set(providerOrder, forKey: Self.orderKey)
         userDefaults.set(providerVisibility, forKey: Self.visibilityKey)
         userDefaults.set(displayMode.rawValue, forKey: Self.displayModeKey)
+        userDefaults.set(showSubscriptions, forKey: Self.showSubscriptionsKey)
         if let updatedAt {
             userDefaults.set(updatedAt, forKey: Self.updatedAtKey)
         } else {

--- a/TokenTrackerBar/TokenTrackerBar/Models/Subscription.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/Subscription.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+// MARK: - SubscriptionRecord
+
+struct SubscriptionRecord: Codable, Equatable, Identifiable {
+    let id: String
+    let service: String
+    let plan: String?
+    let provider: String?
+    let autoRenew: Bool
+    let cycle: String
+    let nextBillingAt: String
+    let startedAt: String?
+    let createdAt: String?
+    let updatedAt: String?
+}
+
+struct SubscriptionListResponse: Codable {
+    let subscriptions: [SubscriptionRecord]?
+}
+
+// MARK: - Subscription Cycle View
+
+struct SubscriptionCycleView {
+    let startMs: Double
+    let endMs: Double
+    let progress: Double
+    let cycleDays: Int
+    let expired: Bool
+}
+
+enum SubscriptionCycle {
+    private static let dayMs: Double = 86400000
+
+    static func addMonthsUtc(ms: Double, months: Int) -> Double {
+        let date = Date(timeIntervalSince1970: ms / 1000.0)
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        guard let year = comps.year, let month = comps.month else { return ms }
+        let day = comps.day ?? 1
+        let hour = comps.hour ?? 0
+        let minute = comps.minute ?? 0
+        var targetComps = DateComponents()
+        targetComps.year = year
+        targetComps.month = month + months
+        targetComps.day = 1
+        targetComps.hour = hour
+        targetComps.minute = minute
+        targetComps.second = 0
+        targetComps.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let target = cal.date(from: targetComps) else { return ms }
+        let daysInTarget = daysInMonth(year: targetComps.year!, month: targetComps.month!)
+        let clampedDay = min(day, daysInTarget)
+        var finalComps = targetComps
+        finalComps.day = clampedDay
+        guard let final = cal.date(from: finalComps) else { return target.timeIntervalSince1970 * 1000.0 }
+        return final.timeIntervalSince1970 * 1000.0
+    }
+
+    private static func daysInMonth(year: Int, month: Int) -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = 1
+        comps.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = cal.date(from: comps),
+              let range = cal.range(of: .day, in: .month, for: date) else { return 30 }
+        return range.count
+    }
+
+    static func cycleStartMs(endMs: Double, cycle: String) -> Double {
+        if cycle == "weekly" { return endMs - 7 * dayMs }
+        if cycle == "yearly" { return addMonthsUtc(ms: endMs, months: -12) }
+        let end = Date(timeIntervalSince1970: endMs / 1000.0)
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute], from: end)
+        guard let year = comps.year, let month = comps.month, let hour = comps.hour, let minute = comps.minute else { return endMs - 30 * dayMs }
+        let day = comps.day ?? 1
+        let prevMonth = month - 1
+        var prevYear = year
+        var pm = prevMonth
+        if pm < 1 { pm += 12; prevYear -= 1 }
+        let daysInPrevMonth = daysInMonth(year: prevYear, month: pm)
+        let clampedDay = min(day, daysInPrevMonth)
+        var startComps = DateComponents()
+        startComps.year = year
+        startComps.month = month - 1
+        startComps.day = 1
+        startComps.hour = hour
+        startComps.minute = minute
+        startComps.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let startBase = cal.date(from: startComps) else { return endMs - 30 * dayMs }
+        var finalComps = cal.dateComponents([.year, .month, .day, .hour, .minute], from: startBase)
+        finalComps.day = clampedDay
+        finalComps.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let final = cal.date(from: finalComps) else { return startBase.timeIntervalSince1970 * 1000.0 }
+        return final.timeIntervalSince1970 * 1000.0
+    }
+
+    static func cycleEndFromStart(startMs: Double, cycle: String) -> Double {
+        if cycle == "weekly" { return startMs + 7 * dayMs }
+        if cycle == "yearly" { return addMonthsUtc(ms: startMs, months: 12) }
+        return addMonthsUtc(ms: startMs, months: 1)
+    }
+
+    private static func billingAnchorMs(subscription: SubscriptionRecord, cycle: String, recordedEndMs: Double) -> Double {
+        if let started = subscription.startedAt, let startedMs = parseDateMs(started) {
+            return startedMs
+        }
+        return cycleStartMs(endMs: recordedEndMs, cycle: cycle)
+    }
+
+    static func cycleView(subscription: SubscriptionRecord, nowMs: Double) -> SubscriptionCycleView? {
+        guard let recordedEndMs = parseDateMs(subscription.nextBillingAt) else { return nil }
+        let cycle = ["weekly", "monthly", "yearly"].contains(subscription.cycle) ? subscription.cycle : "monthly"
+        let anchorMs = billingAnchorMs(subscription: subscription, cycle: cycle, recordedEndMs: recordedEndMs)
+        guard anchorMs.isFinite else { return nil }
+
+        var startMs: Double
+        var endMs: Double
+        var expired = false
+        if subscription.autoRenew {
+            let w = currentCycleWindow(anchorMs: anchorMs, cycle: cycle, nowMs: nowMs)
+            startMs = w.startMs
+            endMs = w.endMs
+        } else if subscription.startedAt != nil {
+            startMs = anchorMs
+            endMs = cycleEndFromStart(startMs: anchorMs, cycle: cycle)
+            expired = endMs <= nowMs
+        } else {
+            startMs = anchorMs
+            endMs = recordedEndMs
+            expired = endMs <= nowMs
+        }
+        let span = max(1, endMs - startMs)
+        let progress = expired ? 1.0 : max(0, min(1, (nowMs - startMs) / span))
+        let cycleDays = max(1, Int((span / dayMs).rounded()))
+        return SubscriptionCycleView(startMs: startMs, endMs: endMs, progress: progress, cycleDays: cycleDays, expired: expired)
+    }
+
+    private static func currentCycleWindow(anchorMs: Double, cycle: String, nowMs: Double) -> (startMs: Double, endMs: Double) {
+        if cycle == "weekly" {
+            let span = 7 * dayMs
+            let index = nowMs <= anchorMs ? 0 : Int(floor((nowMs - anchorMs) / span))
+            return (anchorMs + Double(index) * span, anchorMs + Double(index + 1) * span)
+        }
+        let step = cycle == "yearly" ? 12 : 1
+        let avgStepMs = Double(step) * 30.436875 * dayMs
+        var index = nowMs <= anchorMs ? 0 : Int(floor((nowMs - anchorMs) / avgStepMs))
+        while index > 0 && addMonthsUtc(ms: anchorMs, months: index * step) > nowMs {
+            index -= 1
+        }
+        var guardCount = 0
+        while addMonthsUtc(ms: anchorMs, months: (index + 1) * step) <= nowMs && guardCount < 12000 {
+            index += 1
+            guardCount += 1
+        }
+        return (addMonthsUtc(ms: anchorMs, months: index * step), addMonthsUtc(ms: anchorMs, months: (index + 1) * step))
+    }
+
+    static func parseDateMs(_ iso: String) -> Double? {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = fmt.date(from: iso) { return d.timeIntervalSince1970 * 1000.0 }
+        fmt.formatOptions = [.withInternetDateTime]
+        if let d = fmt.date(from: iso) { return d.timeIntervalSince1970 * 1000.0 }
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
+        if let d = df.date(from: iso) { return d.timeIntervalSince1970 * 1000.0 }
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+        if let d = df.date(from: iso) { return d.timeIntervalSince1970 * 1000.0 }
+        return nil
+    }
+
+    static func remainingLabel(endMs: Double, nowMs: Double) -> String {
+        let diff = endMs - nowMs
+        if diff <= 0 { return Strings.subscriptionExpired }
+        let totalMinutes = Int(ceil(diff / 60000.0))
+        if totalMinutes < 60 { return "\(totalMinutes)m" }
+        let totalHours = totalMinutes / 60
+        if totalHours < 24 { return "\(totalHours)h" }
+        return "\(totalHours / 24)d"
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -119,6 +119,14 @@ actor APIClient {
         )
     }
 
+    func fetchSubscriptions() async throws -> [SubscriptionRecord] {
+        let response: SubscriptionListResponse = try await fetch(
+            "/functions/tokentracker-subscription-manager",
+            requestTimeout: Self.usageLimitsRequestTimeout
+        )
+        return response.subscriptions ?? []
+    }
+
     func triggerSync(drain: Bool = false, auto: Bool = false) async throws -> SyncResponse {
         let body: Data
         if drain {

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -193,6 +193,12 @@ enum Strings {
     static var limitsDisplayTitle: String { t("Limit Display", "限额显示", "限額顯示", "上限の表示", "한도 표시") }
     static var toastOnResetLabel: String { t("Toast on limits reset", "额度重置时显示提示", "額度重置時顯示提示", "リセット時に通知を表示", "한도 초기화 시 알림 표시") }
     static var confettiOnResetLabel: String { t("Confetti on limits reset", "额度重置时撒花", "額度重置時撒花", "リセット時に紙吹雪", "한도 초기화 시 색종이") }
+    static var showSubscriptionsLabel: String { t("Show subscriptions", "显示订阅", "顯示訂閱", "サブスクを表示", "구독 표시") }
+    static var showSubscriptionsHint: String { t("Show renewal progress alongside limits", "在限额旁显示订阅续费进度", "在限額旁顯示訂閱續費進度", "上限と並べて更新の進捗を表示", "한도 옆에 구독 갱신 진행률 표시") }
+    static var subscriptionLabel: String { t("Subscription", "订阅", "訂閱", "サブスク", "구독") }
+    static var subscriptionExpired: String { t("Expired", "已过期", "已過期", "期限切れ", "만료됨") }
+    static var subscriptionAutoRenewBadge: String { t("Auto-renew", "自动续费", "自動續費", "自動更新", "자동 갱신") }
+    static var subscriptionStopsBadge: String { t("Stops at expiry", "到期停止", "到期停止", "期限で停止", "만료 시 중지") }
     /// Toast shown with the celebration firework. `provider` is a display name (e.g. "Claude");
     /// `window` names the specific window that rolled over (e.g. "5h", "Gemini 5h"); nil = generic.
     static func limitResetCelebration(provider: String?, window: String? = nil) -> String {

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -51,6 +51,7 @@ class DashboardViewModel: ObservableObject {
     @Published var modelBreakdown: ModelBreakdownResponse?
     @Published var projectUsage: ProjectUsageResponse?
     @Published var usageLimits: UsageLimitsResponse? = UsageLimitsCache.load()
+    @Published var subscriptions: [SubscriptionRecord] = []
 
     @Published var isLoading = false
     @Published var isSyncing = false
@@ -155,7 +156,7 @@ class DashboardViewModel: ObservableObject {
 
         var errorCount = 0
         var firstError: String?
-        let totalFetches = 9
+        let totalFetches = 10
 
         await withTaskGroup(of: Void.self) { group in
             // Today summary (always today for summary cards)
@@ -284,6 +285,9 @@ class DashboardViewModel: ObservableObject {
             // response are still respected by the view (those providers are hidden).
             group.addTask { @MainActor in
                 await self.refreshUsageLimits()
+            }
+            group.addTask { @MainActor in
+                await self.refreshSubscriptions()
             }
         }
 
@@ -598,6 +602,7 @@ class DashboardViewModel: ObservableObject {
         guard !pendingFullRefreshAfterHiddenRefresh,
               !isPopoverVisible else { return }
         await refreshUsageLimits()
+        await refreshSubscriptions()
     }
 
     private func finishHiddenRefresh() async {
@@ -757,6 +762,15 @@ class DashboardViewModel: ObservableObject {
             Self.logger.error("Usage limits refresh failed: \(error.localizedDescription, privacy: .public)")
         }
         scheduleResetBoundaryRefresh(for: usageLimits)
+    }
+
+    private func refreshSubscriptions() async {
+        do {
+            let subs = try await APIClient.shared.fetchSubscriptions()
+            self.subscriptions = subs
+        } catch {
+            Self.logger.error("Subscriptions refresh failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     /// Wake up just after the soonest upcoming boundary and re-fetch limits, instead

--- a/TokenTrackerBar/TokenTrackerBar/Views/DashboardView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DashboardView.swift
@@ -31,7 +31,7 @@ struct DashboardView: View {
                                 totalTokens: viewModel.totalTokens,
                                 totalCost: viewModel.totalCost
                             )
-                            UsageLimitsView(limits: viewModel.usageLimits)
+                            UsageLimitsView(limits: viewModel.usageLimits, subscriptions: viewModel.subscriptions)
                             ActivityHeatmapView(heatmap: viewModel.heatmap)
                             UsageTrendChartWrapper(
                                 daily: viewModel.daily,

--- a/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DynamicIslandView.swift
@@ -528,7 +528,7 @@ struct DynamicIslandView: View {
             // view hug its content), scrollable beyond it — many configured
             // providers must not push the island past the panel's bottom.
             ScrollView(.vertical, showsIndicators: false) {
-                UsageLimitsView(limits: viewModel.usageLimits)
+                UsageLimitsView(limits: viewModel.usageLimits, subscriptions: viewModel.subscriptions)
             }
             .frame(maxHeight: DynamicIslandLayoutPolicy.limitsHeight(panelHeight: state.panelSize.height))
 

--- a/TokenTrackerBar/TokenTrackerBar/Views/LimitsSettingsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/LimitsSettingsView.swift
@@ -28,6 +28,7 @@ struct LimitsSettingsView: View {
                 .toggleStyle(.switch)
                 .controlSize(.mini)
                 .labelsHidden()
+                .accessibilityLabel(Strings.limitDisplayModeRemaining)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -46,6 +47,7 @@ struct LimitsSettingsView: View {
                     .toggleStyle(.switch)
                     .controlSize(.mini)
                     .labelsHidden()
+                    .accessibilityLabel(Strings.toastOnResetLabel)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -59,6 +61,24 @@ struct LimitsSettingsView: View {
                     .toggleStyle(.switch)
                     .controlSize(.mini)
                     .labelsHidden()
+                    .accessibilityLabel(Strings.confettiOnResetLabel)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+
+            HStack(spacing: 10) {
+                Text(Strings.showSubscriptionsLabel)
+                    .font(.system(.body, design: .default))
+                    .foregroundStyle(.primary)
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { store.showSubscriptions },
+                    set: { store.setShowSubscriptionsFromMenu($0) }
+                ))
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .labelsHidden()
+                    .accessibilityLabel(Strings.showSubscriptionsLabel)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -108,6 +128,7 @@ struct LimitsSettingsView: View {
             .toggleStyle(.switch)
             .controlSize(.mini)
             .labelsHidden()
+            .accessibilityLabel(LimitsSettingsStore.displayNames[id] ?? id)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)

--- a/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/UsageLimitsView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct UsageLimitsView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var settings = LimitsSettingsStore.shared
     @State private var showSettings = false
     /// Width of the widest visible row label; all label columns match it so
@@ -13,6 +14,7 @@ struct UsageLimitsView: View {
     /// to read its bars. A click toggle — not hover — so nothing reflows/jitters.
     @State private var explainingProvider: String?
     let limits: UsageLimitsResponse?
+    var subscriptions: [SubscriptionRecord] = []
 
     private static let rowColumnSpacing: CGFloat = 5
     private static let percentColumnWidth: CGFloat = 34
@@ -65,6 +67,33 @@ struct UsageLimitsView: View {
     /// Append the plan tier to the provider name when known, e.g. "Claude Max".
     private func planTitle(_ base: String, _ label: String?) -> String {
         label.map { "\(base) \($0)" } ?? base
+    }
+
+    private var subscriptionByProvider: [String: SubscriptionRecord] {
+        guard settings.showSubscriptions else { return [:] }
+        let nowMs = Date().timeIntervalSince1970 * 1000.0
+        var map: [String: SubscriptionRecord] = [:]
+        for sub in subscriptions {
+            guard let provider = sub.provider, !provider.isEmpty else { continue }
+            guard let endMs = SubscriptionCycle.parseDateMs(sub.nextBillingAt) else { continue }
+            guard sub.provider != nil else { continue }
+            let existing = map[provider]
+            if existing == nil {
+                map[provider] = sub
+                continue
+            }
+            guard let existingEnd = SubscriptionCycle.parseDateMs(existing!.nextBillingAt) else {
+                map[provider] = sub
+                continue
+            }
+            let upcoming = endMs > nowMs
+            let existingUpcoming = existingEnd > nowMs
+            if (upcoming && (!existingUpcoming || existingEnd > endMs)) ||
+               (!upcoming && !existingUpcoming && endMs > existingEnd) {
+                map[provider] = sub
+            }
+        }
+        return map
     }
 
     private func buildVisibleGroups(_ limits: UsageLimitsResponse) -> [AnyView] {
@@ -157,6 +186,7 @@ struct UsageLimitsView: View {
         )
         let updatedAt = resetDate(iso: updatedAtISO ?? limits?.fetchedAt)
         let retryAt = resetDate(iso: retryAtISO)
+        let subscription = subscriptionByProvider[id]
         return VStack(alignment: .leading, spacing: 5) {
             HStack(spacing: 5) {
                 if let assetName {
@@ -166,15 +196,26 @@ struct UsageLimitsView: View {
                 Text(title)
                     .font(.system(.caption, design: .default))
                     .modifier(FontWeightModifier(weight: .medium))
+                if let sub = subscription {
+                    Image(systemName: sub.autoRenew ? "infinity" : "clock")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(sub.autoRenew ? Color.accentColor : Color.secondary)
+                        .help(sub.autoRenew ? Strings.subscriptionAutoRenewBadge : Strings.subscriptionStopsBadge)
+                        .accessibilityLabel(sub.autoRenew ? Strings.subscriptionAutoRenewBadge : Strings.subscriptionStopsBadge)
+                }
                 if let titleSuffix {
                     Text(titleSuffix)
                         .font(.system(.caption2, design: .default))
                         .foregroundStyle(.tertiary)
                 }
+                Spacer()
             }
             VStack(spacing: 4) {
                 ForEach(specs) { spec in
                     limitRow(label: spec.label, pct: spec.pct, reset: spec.resetText, toolName: toolName, windowSeconds: spec.windowSeconds, resetDate: spec.resetDate)
+                }
+                if let sub = subscription {
+                    subscriptionRow(for: sub)
                 }
             }
             if !resetRows.isEmpty || resetStatus != nil {
@@ -481,7 +522,7 @@ struct UsageLimitsView: View {
                 pacePercent: pacePercent,
                 paceOver: paceOver
             )
-            .animation(.easeOut(duration: 0.5), value: displayValue)
+            .animation(reduceMotion ? .none : .easeOut(duration: 0.5), value: displayValue)
 
             Text(displayPercentLabel(displayValue))
                 .font(.system(.caption, design: .monospaced))
@@ -499,6 +540,56 @@ struct UsageLimitsView: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func subscriptionRow(for subscription: SubscriptionRecord) -> some View {
+        let nowMs = Date().timeIntervalSince1970 * 1000.0
+        guard let view = SubscriptionCycle.cycleView(subscription: subscription, nowMs: nowMs) else {
+            return AnyView(EmptyView())
+        }
+        let isNearExpiry = !view.expired && view.endMs - nowMs <= 3 * 86400000
+        let fillColor: Color = view.expired ? .red : (isNearExpiry ? .orange : .blue)
+        let rawPct = view.progress * 100.0
+        let displayPct = view.expired ? 100.0 : (settings.displayMode == .remaining ? 100.0 - rawPct : rawPct)
+        let clampedPct = max(0, min(100, displayPct))
+        let rounded = Int(clampedPct.rounded())
+        let percentLabel: String = (clampedPct > 0 && rounded == 0) ? "<1%" : "\(rounded)%"
+        let remaining = SubscriptionCycle.remainingLabel(endMs: view.endMs, nowMs: nowMs)
+        let a11y = "\(Strings.subscriptionLabel) \(percentLabel) \(remaining)"
+        return AnyView(
+            HStack(spacing: Self.rowColumnSpacing) {
+                Text(Strings.subscriptionLabel)
+                    .font(.system(.caption, design: .default))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .background(GeometryReader { proxy in
+                        Color.clear.preference(key: LimitLabelWidthKey.self, value: proxy.size.width)
+                    })
+                    .frame(width: labelColumnWidth > 0 ? labelColumnWidth : nil, alignment: .leading)
+
+                UsageLimitBar(
+                    percent: clampedPct,
+                    fillColor: fillColor,
+                    pacePercent: nil,
+                    paceOver: false
+                )
+
+                Text(percentLabel)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(width: Self.percentColumnWidth, alignment: .trailing)
+
+                Text(remaining)
+                    .font(.system(.caption2, design: .default))
+                    .monospacedDigit()
+                    .foregroundStyle(view.expired ? AnyShapeStyle(Color.red) : AnyShapeStyle(.tertiary))
+                    .frame(width: Self.relativeResetColumnWidth, alignment: .trailing)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(a11y)
+        )
     }
 
     private func resetSection(rows: [CodexResetRowSpec], status: String?) -> some View {

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -493,6 +493,8 @@ settings.network.apply_error,ui,SettingsPage,NetworkSection,apply_error,"The sav
 settings.network.save_error,ui,SettingsPage,NetworkSection,save_error,"Could not save proxy settings: {{error}}",,active
 settings.network.save_error_unprotected,ui,SettingsPage,NetworkSection,save_error_unprotected,"Could not save proxy settings: {{error}}. Outbound traffic is currently unprotected — even blocking it failed.",,active
 settings.limits.providers,ui,SettingsPage,SettingsPage,limits_providers,"Providers",,active
+settings.limits.showSubscriptions,ui,SettingsPage,SettingsPage,show_subscriptions,"Show subscriptions in limits",,active
+settings.limits.showSubscriptionsHint,ui,SettingsPage,SettingsPage,show_subscriptions_hint,"Display your manual subscription renewal bars alongside the limits.",,active
 settings.labs.island.label,ui,SettingsPage,LabsSection,island_label,"Dynamic Island",,active
 settings.labs.island.hint,ui,SettingsPage,LabsSection,island_hint,"Turn the MacBook notch into a Dynamic Island: today's tokens and spend at a glance, hover for spend and limit details.",,active
 settings.labs.island.aria,ui,SettingsPage,LabsSection,island_aria,"Toggle Dynamic Island",,active

--- a/dashboard/src/content/i18n/de/core.json
+++ b/dashboard/src/content/i18n/de/core.json
@@ -547,5 +547,7 @@
   "limits.alert.title": "{{provider}}-Limit könnte vorzeitig aufgebraucht sein",
   "limits.alert.body": "Beim aktuellen Tempo könnte das Kontingent in {{eta}} aufgebraucht sein ({{percent}}% verbraucht).",
   "settings.section.labs": "Labs",
-  "limits.alert.blocked": "Benachrichtigungen sind aus – in den Systemeinstellungen erlauben"
+  "limits.alert.blocked": "Benachrichtigungen sind aus – in den Systemeinstellungen erlauben",
+  "settings.limits.showSubscriptions": "Abos in Limits anzeigen",
+  "settings.limits.showSubscriptionsHint": "Zeige manuell eingetragene Abo-Verlängerungen zusammen mit den Limits an."
 }

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -550,5 +550,7 @@
   "limits.alert.title": "{{provider}} の上限が早く尽きる可能性があります",
   "limits.alert.body": "現在のペースでは、残り {{eta}} で使い切る可能性があります（{{percent}}% 使用済み）。",
   "settings.section.labs": "Labs",
-  "limits.alert.blocked": "通知がオフです — システム設定で許可してください"
+  "limits.alert.blocked": "通知がオフです — システム設定で許可してください",
+  "settings.limits.showSubscriptions": "サブスクを制限表示に表示",
+  "settings.limits.showSubscriptionsHint": "手動登録した更新日バーを制限と一緒に表示します。"
 }

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -550,5 +550,7 @@
   "limits.alert.title": "{{provider}} 한도가 일찍 소진될 수 있습니다",
   "limits.alert.body": "현재 속도라면 {{eta}} 후 소진될 수 있습니다({{percent}}% 사용됨).",
   "settings.section.labs": "Labs",
-  "limits.alert.blocked": "알림이 꺼져 있음 — 시스템 설정에서 허용하세요"
+  "limits.alert.blocked": "알림이 꺼져 있음 — 시스템 설정에서 허용하세요",
+  "settings.limits.showSubscriptions": "구독을 한도에 표시",
+  "settings.limits.showSubscriptionsHint": "수동으로 등록한 구독 갱신 바를 한도와 함께 표시합니다."
 }

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -668,5 +668,7 @@
   "widgets.preview.heatmap_summary": "Token · {{days}} 個活躍日",
   "widgets.preview.reset_days": "{{days}} 天後",
   "widgets.preview.reset_hours_minutes": "{{hours}} 小時 {{minutes}} 分鐘後",
-  "widgets.preview.metric": "指標"
+  "widgets.preview.metric": "指標",
+  "settings.limits.showSubscriptions": "顯示訂閱",
+  "settings.limits.showSubscriptionsHint": "在額度面板中顯示手動記錄的訂閱續費進度。"
 }

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -727,5 +727,7 @@
   "widgets.preview.heatmap_summary": "Token · {{days}} 个活跃日",
   "widgets.preview.reset_days": "{{days}} 天后",
   "widgets.preview.reset_hours_minutes": "{{hours}} 小时 {{minutes}} 分钟后",
-  "widgets.preview.metric": "指标"
+  "widgets.preview.metric": "指标",
+  "settings.limits.showSubscriptions": "显示订阅",
+  "settings.limits.showSubscriptionsHint": "在限额面板中显示手动记录的订阅续费进度。"
 }

--- a/dashboard/src/hooks/use-limits-display-prefs.js
+++ b/dashboard/src/hooks/use-limits-display-prefs.js
@@ -28,6 +28,7 @@ export { LIMIT_PROVIDER_ICON_KEYS, limitProviderIconKey, limitProviderName };
 const ORDER_KEY = "tt.limits.providerOrder";
 const VISIBILITY_KEY = "tt.limits.providerVisibility";
 const DISPLAY_MODE_KEY = "tt.limits.displayMode";
+const SHOW_SUBSCRIPTIONS_KEY = "tt.limits.showSubscriptions";
 const UPDATED_AT_KEY = "tt.limits.updatedAt";
 const NATIVE_PREFERENCES_KEY = "limitsPreferences";
 const NATIVE_DISPLAY_MODE_KEY = "limitsDisplayMode";
@@ -42,6 +43,7 @@ const STORAGE_KEYS = new Set([
   ORDER_KEY,
   VISIBILITY_KEY,
   DISPLAY_MODE_KEY,
+  SHOW_SUBSCRIPTIONS_KEY,
   UPDATED_AT_KEY,
 ]);
 
@@ -83,6 +85,10 @@ function normalizeDisplayMode(value) {
   return VALID_DISPLAY_MODES.has(value) ? value : LIMIT_DISPLAY_MODES.USED;
 }
 
+function normalizeShowSubscriptions(value) {
+  return typeof value === "boolean" ? value : true;
+}
+
 function normalizeUpdatedAt(value) {
   if (value === null || value === undefined) return undefined;
   if (typeof value === "number") {
@@ -103,6 +109,7 @@ function normalizeSnapshot(value = {}) {
     displayMode: normalizeDisplayMode(source.displayMode),
     providerOrder: normalizeOrder(source.providerOrder),
     providerVisibility: normalizeVisibility(source.providerVisibility),
+    showSubscriptions: normalizeShowSubscriptions(source.showSubscriptions),
     updatedAt: normalizeUpdatedAt(source.updatedAt),
   };
 }
@@ -137,6 +144,17 @@ function readDisplayMode() {
   }
 }
 
+function readShowSubscriptions() {
+  if (typeof window === "undefined") return true;
+  try {
+    const raw = window.localStorage.getItem(SHOW_SUBSCRIPTIONS_KEY);
+    if (raw === null) return true;
+    return normalizeShowSubscriptions(JSON.parse(raw));
+  } catch {
+    return true;
+  }
+}
+
 function readUpdatedAt() {
   if (typeof window === "undefined") return undefined;
   try {
@@ -163,6 +181,7 @@ function readLocalSnapshot() {
     displayMode: readDisplayMode(),
     providerOrder: readOrder(),
     providerVisibility: readVisibility(),
+    showSubscriptions: readShowSubscriptions(),
     updatedAt: readUpdatedAt(),
   });
 }
@@ -180,6 +199,10 @@ function writeLocalSnapshot(snapshot) {
       JSON.stringify(normalized.providerVisibility),
     );
     window.localStorage.setItem(DISPLAY_MODE_KEY, normalized.displayMode);
+    window.localStorage.setItem(
+      SHOW_SUBSCRIPTIONS_KEY,
+      JSON.stringify(normalized.showSubscriptions),
+    );
     if (normalized.updatedAt === undefined) {
       window.localStorage.removeItem(UPDATED_AT_KEY);
     } else {
@@ -196,6 +219,7 @@ function toBridgeSnapshot(snapshot) {
     displayMode: normalized.displayMode,
     providerOrder: [...normalized.providerOrder],
     providerVisibility: { ...normalized.providerVisibility },
+    showSubscriptions: normalized.showSubscriptions,
     updatedAt: normalized.updatedAt ?? null,
   };
 }
@@ -226,7 +250,8 @@ function samePreferences(a, b) {
   return (
     a.displayMode === b.displayMode &&
     sameOrder(a.providerOrder, b.providerOrder) &&
-    sameVisibility(a.providerVisibility, b.providerVisibility)
+    sameVisibility(a.providerVisibility, b.providerVisibility) &&
+    a.showSubscriptions === b.showSubscriptions
   );
 }
 
@@ -285,6 +310,10 @@ export function useLimitsDisplayPrefs() {
   const setDisplayMode = useCallback((mode) => {
     if (!VALID_DISPLAY_MODES.has(mode)) return;
     commitUserChange((current) => ({ ...current, displayMode: mode }));
+  }, [commitUserChange]);
+
+  const setShowSubscriptions = useCallback((value) => {
+    commitUserChange((current) => ({ ...current, showSubscriptions: Boolean(value) }));
   }, [commitUserChange]);
 
   const applyLegacyDisplayMode = useCallback((mode) => {
@@ -401,6 +430,7 @@ export function useLimitsDisplayPrefs() {
       displayMode: LIMIT_DISPLAY_MODES.USED,
       providerOrder: defaultOrder(),
       providerVisibility: defaultVisibility(),
+      showSubscriptions: true,
     }));
   }, [commitUserChange]);
 
@@ -417,7 +447,9 @@ export function useLimitsDisplayPrefs() {
     order: prefs.providerOrder,
     visibility: prefs.providerVisibility,
     displayMode: prefs.displayMode,
+    showSubscriptions: prefs.showSubscriptions,
     setDisplayMode,
+    setShowSubscriptions,
     visibleOrdered,
     toggle,
     moveUp,

--- a/dashboard/src/hooks/use-limits-display-prefs.test.js
+++ b/dashboard/src/hooks/use-limits-display-prefs.test.js
@@ -9,6 +9,7 @@ import {
 const DISPLAY_MODE_KEY = "tt.limits.displayMode";
 const ORDER_KEY = "tt.limits.providerOrder";
 const VISIBILITY_KEY = "tt.limits.providerVisibility";
+const SHOW_SUBSCRIPTIONS_KEY = "tt.limits.showSubscriptions";
 const UPDATED_AT_KEY = "tt.limits.updatedAt";
 
 function defaultVisibility() {
@@ -20,6 +21,7 @@ function defaultSnapshot(updatedAt = null) {
     displayMode: LIMIT_DISPLAY_MODES.USED,
     providerOrder: [...LIMIT_PROVIDER_IDS],
     providerVisibility: defaultVisibility(),
+    showSubscriptions: true,
     updatedAt,
   };
 }
@@ -54,6 +56,12 @@ function setStoredSnapshot(snapshot) {
   if (snapshot.displayMode) {
     window.localStorage.setItem(DISPLAY_MODE_KEY, snapshot.displayMode);
   }
+  if (Object.hasOwn(snapshot, "showSubscriptions")) {
+    window.localStorage.setItem(
+      SHOW_SUBSCRIPTIONS_KEY,
+      JSON.stringify(snapshot.showSubscriptions),
+    );
+  }
   if (Object.hasOwn(snapshot, "updatedAt")) {
     if (snapshot.updatedAt === null || snapshot.updatedAt === undefined) {
       window.localStorage.removeItem(UPDATED_AT_KEY);
@@ -68,6 +76,7 @@ function readStoredSnapshot() {
     displayMode: window.localStorage.getItem(DISPLAY_MODE_KEY),
     providerOrder: JSON.parse(window.localStorage.getItem(ORDER_KEY)),
     providerVisibility: JSON.parse(window.localStorage.getItem(VISIBILITY_KEY)),
+    showSubscriptions: JSON.parse(window.localStorage.getItem(SHOW_SUBSCRIPTIONS_KEY)),
     updatedAt: window.localStorage.getItem(UPDATED_AT_KEY),
   };
 }
@@ -299,6 +308,7 @@ describe("useLimitsDisplayPrefs", () => {
         ...defaultVisibility(),
         claude: false,
       },
+      showSubscriptions: true,
       updatedAt: "20",
     });
     expect(bridgeWrites(messages)).toHaveLength(0);
@@ -338,6 +348,7 @@ describe("useLimitsDisplayPrefs", () => {
       displayMode: LIMIT_DISPLAY_MODES.USED,
       providerOrder,
       providerVisibility,
+      showSubscriptions: true,
       updatedAt: null,
     });
     expect(bridgeWrites(messages)).toHaveLength(0);
@@ -696,6 +707,7 @@ describe("useLimitsDisplayPrefs", () => {
       ORDER_KEY,
       VISIBILITY_KEY,
       DISPLAY_MODE_KEY,
+      SHOW_SUBSCRIPTIONS_KEY,
       UPDATED_AT_KEY,
     ]) {
       act(() => {

--- a/dashboard/src/pages/LimitsPage.jsx
+++ b/dashboard/src/pages/LimitsPage.jsx
@@ -207,6 +207,7 @@ export function LimitsPage() {
                 visibility={prefs.visibility}
                 displayMode={prefs.displayMode}
                 subscriptions={subscriptions}
+                showSubscriptions={prefs.showSubscriptions !== false}
               />
             </>
           )}

--- a/dashboard/src/pages/LimitsPage.jsx
+++ b/dashboard/src/pages/LimitsPage.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { motion, useReducedMotion } from "motion/react";
 import { Bell, BellOff, CalendarClock, Settings as SettingsIcon } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
@@ -75,6 +75,7 @@ export function LimitsPage() {
   const [subscriptions, setSubscriptions] = React.useState([]);
   const [subscriptionsError, setSubscriptionsError] = React.useState(false);
   const [subscriptionsOpen, setSubscriptionsOpen] = React.useState(false);
+  const [searchParams] = useSearchParams();
   const subscriptionRefreshRef = React.useRef(0);
 
   const refreshSubscriptions = React.useCallback(async () => {
@@ -100,6 +101,12 @@ export function LimitsPage() {
   React.useEffect(() => {
     void refreshSubscriptions();
   }, [refreshSubscriptions]);
+
+  React.useEffect(() => {
+    if (searchParams.get("openSubscriptions") === "1") {
+      setSubscriptionsOpen(true);
+    }
+  }, [searchParams]);
 
   React.useEffect(() => {
     if (alerts.enabled && usageLimits) sendPredictiveLimitAlerts(usageLimits);

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FlaskConical, Gauge, Globe, Monitor, Palette, UserRound } from "lucide-react";
-import { useSearchParams } from "react-router-dom";
+import { FlaskConical, Gauge, Globe, Monitor, Palette, Settings, UserRound } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { LimitsSettingsPanel } from "../components/LimitsSettingsPanel.jsx";
 import { AccountSection } from "../components/settings/AccountSection.jsx";
 import { AppearanceSection } from "../components/settings/AppearanceSection.jsx";
@@ -53,6 +53,7 @@ export function SettingsPage() {
   const toastOnReset = nativeSettings?.toastOnReset !== false;
   const confettiOnReset = nativeSettings?.confettiOnReset !== false;
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const requestedSection = searchParams.get("section");
   const requestedSectionAvailable =
     Object.values(SETTINGS_SECTION_IDS).includes(requestedSection) &&
@@ -140,11 +141,22 @@ export function SettingsPage() {
               label={copy("settings.limits.showSubscriptions")}
               hint={copy("settings.limits.showSubscriptionsHint")}
               control={
-                <ToggleSwitch
-                  checked={limitsPrefs.showSubscriptions !== false}
-                  onChange={() => limitsPrefs.setShowSubscriptions(!limitsPrefs.showSubscriptions)}
-                  ariaLabel={copy("settings.limits.showSubscriptions")}
-                />
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => navigate("/limits?openSubscriptions=1")}
+                    aria-label={copy("limits.page.openSubscriptions")}
+                    title={copy("limits.page.openSubscriptions")}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-oai-gray-200 dark:border-oai-gray-700 bg-white dark:bg-oai-gray-900 text-oai-gray-500 dark:text-oai-gray-400 hover:bg-oai-gray-100 dark:hover:bg-oai-gray-800 hover:text-oai-black dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-brand-500"
+                  >
+                    <Settings size={14} aria-hidden />
+                  </button>
+                  <ToggleSwitch
+                    checked={limitsPrefs.showSubscriptions !== false}
+                    onChange={() => limitsPrefs.setShowSubscriptions(!limitsPrefs.showSubscriptions)}
+                    ariaLabel={copy("settings.limits.showSubscriptions")}
+                  />
+                </div>
               }
             />
           </SectionCard>

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -136,6 +136,17 @@ export function SettingsPage() {
                 />
               }
             />
+            <SettingsRow
+              label={copy("settings.limits.showSubscriptions")}
+              hint={copy("settings.limits.showSubscriptionsHint")}
+              control={
+                <ToggleSwitch
+                  checked={limitsPrefs.showSubscriptions !== false}
+                  onChange={() => limitsPrefs.setShowSubscriptions(!limitsPrefs.showSubscriptions)}
+                  ariaLabel={copy("settings.limits.showSubscriptions")}
+                />
+              }
+            />
           </SectionCard>
           <SectionCard title={copy("settings.limits.providers")}>
             <LimitsSettingsPanel prefs={limitsPrefs} />

--- a/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.jsx
+++ b/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.jsx
@@ -401,7 +401,7 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
                     <span className="relative flex-1 bg-oai-gray-100 dark:bg-oai-gray-700/50 rounded-full h-1 overflow-hidden">
                       <span
                         className={`${
-                          expired ? "bg-red-500" : nearExpiry ? "bg-amber-500" : "bg-oai-brand-500"
+                          expired ? "bg-red-500" : nearExpiry ? "bg-amber-500" : "bg-blue-500"
                         } rounded-full h-full block transition-[width] duration-500 ease-out`}
                         style={{ width: `${widthPct}%`, minWidth: widthPct > 0 ? "3px" : 0 }}
                       />

--- a/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.jsx
+++ b/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CalendarClock, Plus } from "lucide-react";
+import { CalendarClock, Clock, Infinity, Plus } from "lucide-react";
 import { copy, getCopyLocale } from "../../../lib/copy";
 import { Button, ConfirmModal, Input, Select } from "../../components";
 import { ProviderIcon } from "./ProviderIcon.jsx";
@@ -222,6 +222,7 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
     setDeleteError(false);
     try {
       await deleteSubscription(pendingDelete.id);
+      if (pendingDelete.id === editingId) closeForm();
       setPendingDelete(null);
       await onChanged?.();
     } catch (_e) {
@@ -231,7 +232,7 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
     } finally {
       setDeleting(false);
     }
-  }, [onChanged, pendingDelete]);
+  }, [closeForm, editingId, onChanged, pendingDelete]);
 
   const list = subscriptions || [];
 
@@ -239,6 +240,8 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
   // last list entry when adding. Kept as one node so both spots share the
   // exact same fields and behavior.
   const renderForm = () => {
+    const editingSub = editingId ? list.find((item) => item.id === editingId) : null;
+    const editingView = editingSub ? cycleView(editingSub, now) : null;
     return (
       <form ref={formRef} onSubmit={handleSubmit} className="grid grid-cols-1 gap-3 px-3 py-3 text-left sm:grid-cols-2">
       <div className="flex items-center justify-between sm:col-span-2">
@@ -246,6 +249,16 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
           {editingId ? copy("subscriptions.edit") : copy("subscriptions.add")}
         </span>
       </div>
+      {editingView ? (
+        <div className="sm:col-span-2 rounded-md bg-oai-gray-50 dark:bg-oai-gray-800/50 px-2.5 py-2 text-xs text-oai-gray-600 dark:text-oai-gray-300">
+          <span className="text-oai-gray-400 dark:text-oai-gray-500">
+            {editingSub.autoRenew ? copy("subscriptions.label.renews_at") : copy("subscriptions.label.expires_at")}
+          </span>{" "}
+          <span className="font-mono tabular-nums">{dateFormat.format(new Date(editingView.endMs))}</span>
+          {" · "}
+          <span className={editingView.expired ? "text-oai-error" : undefined}>{countdownText(editingView.endMs, now)}</span>
+        </div>
+      ) : null}
           <div className="flex flex-col sm:col-span-1">
             <label
               htmlFor="subscription-provider"
@@ -313,6 +326,20 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
             />
           </div>
           <div className="flex items-center justify-end gap-2 sm:col-span-2">
+            {editingId ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  const target = list.find((item) => item.id === editingId);
+                  if (target) setPendingDelete(target);
+                }}
+                className="!text-red-600 dark:!text-red-400 mr-auto"
+              >
+                {copy("subscriptions.delete")}
+              </Button>
+            ) : null}
             {providerError ? (
               <p className="mr-auto text-sm text-oai-error" role="alert">
                 {copy("subscriptions.form.provider_required")}
@@ -379,14 +406,39 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
               <li key={subscription.id} className="rounded-lg border border-oai-gray-100 dark:border-oai-gray-800">
                 <button
                   type="button"
-                  onClick={() => setExpandedId(expanded ? null : subscription.id)}
-                  aria-expanded={expanded}
+                  onClick={() => openEdit(subscription)}
+                  aria-label={`${copy("subscriptions.edit")} ${subscription.service}`}
+                  aria-expanded={editingId === subscription.id}
                   className="w-full flex flex-col gap-1.5 px-3 py-2.5 text-left cursor-pointer hover:bg-oai-gray-50 dark:hover:bg-oai-gray-800/40 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-brand-500"
                 >
                   <span className="flex items-center gap-2 min-w-0">
                     <ProviderIcon provider={limitProviderIconKey(subscription.provider) || "OTHER"} size={14} />
                     <span className="text-sm font-medium text-oai-black dark:text-white truncate">
                       {subscription.service}
+                    </span>
+                    <span
+                      role="img"
+                      aria-label={
+                        subscription.autoRenew
+                          ? copy("subscriptions.badge.auto_renew")
+                          : copy("subscriptions.badge.stops")
+                      }
+                      title={
+                        subscription.autoRenew
+                          ? copy("subscriptions.badge.auto_renew")
+                          : copy("subscriptions.badge.stops")
+                      }
+                      className={`inline-flex shrink-0 translate-y-px ${
+                        subscription.autoRenew
+                          ? "text-oai-brand-600 dark:text-oai-brand-400"
+                          : "text-blue-600 dark:text-blue-400"
+                      }`}
+                    >
+                      {subscription.autoRenew ? (
+                        <Infinity size={14} strokeWidth={2} aria-hidden />
+                      ) : (
+                        <Clock size={14} strokeWidth={2} aria-hidden />
+                      )}
                     </span>
                     {subscription.plan ? (
                       <span className="text-xs rounded-full border border-oai-gray-200 dark:border-oai-gray-700 px-2 py-0.5 text-oai-gray-500 dark:text-oai-gray-400 shrink-0">
@@ -396,7 +448,7 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
                   </span>
                   <span className="flex items-center gap-2">
                     <span className="text-[10px] text-oai-gray-500 dark:text-oai-gray-400 shrink-0">
-                      {copy("shared.time.d_ago", { n: view.cycleDays })}
+                      {copy("subscriptions.inline.label")}
                     </span>
                     <span className="relative flex-1 bg-oai-gray-100 dark:bg-oai-gray-700/50 rounded-full h-1 overflow-hidden">
                       <span
@@ -450,15 +502,6 @@ export function SubscriptionSettingsCard({ subscriptions, onChanged }) {
                         onClick={() => openEdit(subscription)}
                       >
                         {copy("subscriptions.edit")}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setPendingDelete(subscription)}
-                        className="!text-red-600 dark:!text-red-400"
-                      >
-                        {copy("subscriptions.delete")}
                       </Button>
                     </div>
                   </div>

--- a/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.test.jsx
+++ b/dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.test.jsx
@@ -67,13 +67,9 @@ describe("SubscriptionSettingsCard", () => {
     expect(screen.getByText("Add subscription")).toBeInTheDocument();
   });
 
-  it("lists subscriptions and expands details on click", () => {
-    // The exact countdown text ("in 2d 3h 4m") depends on the wall-clock
-    // minute the record's nextBillingAt falls in. Freezing the whole clock
-    // via fake timers keeps the record creation, the component's initial
-    // `now` state, and the countdown math on the same instant, so a real-
-    // time minute rollover between those steps cannot flip the assertion to
-    // "in 2d 3h 3m" in the full suite.
+  it("lists subscriptions and opens edit on click", () => {
+    // Clicking a subscription row now directly enters edit (task 2) instead of
+    // expanding a detail view. The edit form is rendered in place below the row.
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2026, 7, 16, 12, 0, 0)));
     try {
@@ -99,9 +95,8 @@ describe("SubscriptionSettingsCard", () => {
       expect(screen.getByText("Expired")).toBeInTheDocument();
 
       fireEvent.click(screen.getByText("GPT"));
-      expect(screen.getByText("Auto-renew on")).toBeInTheDocument();
-      expect(screen.getByText("Next renewal")).toBeInTheDocument();
-      expect(screen.getByText("in 2d 3h 4m")).toBeInTheDocument();
+      expect(screen.getByLabelText("Linked tool")).toBeInTheDocument();
+      expect(screen.getByLabelText("Plan")).toHaveValue("Plus");
     } finally {
       vi.useRealTimers();
     }
@@ -206,9 +201,8 @@ describe("SubscriptionSettingsCard", () => {
     fireEvent.click(screen.getByText("Cancel"));
 
     // Editing: the record's own tool stays selectable while the other taken
-    // tool remains off-limits.
+    // tool remains off-limits. Clicking the row now directly opens edit.
     fireEvent.click(screen.getByText("GPT"));
-    fireEvent.click(screen.getByText("Edit"));
     fireEvent.click(screen.getByLabelText("Linked tool"));
     expect(screen.getByRole("option", { name: "Codex" })).not.toHaveAttribute("aria-disabled", "true");
     expect(screen.getByRole("option", { name: "Claude (already subscribed)" })).toHaveAttribute("aria-disabled", "true");
@@ -224,7 +218,6 @@ describe("SubscriptionSettingsCard", () => {
     );
 
     fireEvent.click(screen.getByText("GPT"));
-    fireEvent.click(screen.getByText("Edit"));
     fireEvent.change(screen.getByLabelText("Subscription date"), {
       target: { value: "2026-08-16T14:00" },
     });
@@ -263,7 +256,6 @@ describe("SubscriptionSettingsCard", () => {
     );
 
     fireEvent.click(screen.getByText("GPT"));
-    fireEvent.click(screen.getByText("Edit"));
 
     // The form opens pre-filled and sits between the edited row and the next
     // list entry — not in a separate section above the list.
@@ -303,7 +295,6 @@ describe("SubscriptionSettingsCard", () => {
     render(<SubscriptionSettingsCard subscriptions={[record]} onChanged={vi.fn()} />);
 
     fireEvent.click(screen.getByText("GPT"));
-    fireEvent.click(screen.getByText("Edit"));
 
     const value = screen.getByLabelText("Subscription date").value;
     // datetime-local renders in local time; compare instants, not strings.
@@ -320,7 +311,6 @@ describe("SubscriptionSettingsCard", () => {
     render(<SubscriptionSettingsCard subscriptions={[record]} onChanged={vi.fn()} />);
 
     fireEvent.click(screen.getByText("GPT"));
-    fireEvent.click(screen.getByText("Edit"));
 
     const value = screen.getByLabelText("Subscription date").value;
     expect(new Date(value).getTime()).toBe(Date.parse("2026-02-28T10:07:00.000Z"));

--- a/dashboard/src/ui/dashboard/components/UsageLimitsPanel.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageLimitsPanel.jsx
@@ -316,8 +316,8 @@ function ToolGroup({ name, providerId, children, expandable = false, expanded = 
         <ProviderIcon provider={providerKey} size={14} className={LIMITS_PROVIDER_ICON_CLASS} />
       ) : null}
       <span className="text-sm font-medium text-oai-black dark:text-oai-white">{name}</span>
+      {rightAdornment ? <span className="shrink-0">{rightAdornment}</span> : null}
       {badge}
-      {rightAdornment ? <span className="ml-auto shrink-0">{rightAdornment}</span> : null}
     </div>
   );
 
@@ -381,15 +381,20 @@ function SubscriptionRightBadge({ subscription }) {
 // Inline subscription progress bar, rendered under the limit bars of a linked
 // provider. Reuses the same label column width as the limit bars so their
 // tracks line up, and mirrors the limit bar's pct + reset columns on the right.
-function SubscriptionBar({ subscription, now }) {
+// When displayMode is "remaining", the bar flips to show remaining cycle time
+// (100 - elapsed), matching the limits panel's remaining mode.
+function SubscriptionBar({ subscription, now, mode = LIMIT_DISPLAY_MODES.USED }) {
   const view = cycleView(subscription, now);
   if (!view) return null;
   const { endMs, expired } = view;
   const nearExpiry = !expired && endMs - now <= 3 * 86400000;
-  const widthPct = expired ? 100 : view.progress * 100;
-  const rounded = Math.round(widthPct);
+  const rawPct = expired ? 100 : view.progress * 100;
+  const displayPct = mode === LIMIT_DISPLAY_MODES.REMAINING ? 100 - rawPct : rawPct;
+  // Clamp and keep the bar visible for <1% remaining/used
+  const renderWidth = expired ? 100 : Math.max(0, Math.min(100, displayPct));
+  const rounded = Math.round(renderWidth);
   const labelPct =
-    widthPct > 0 && rounded === 0 ? copy("limits.bar.sub_one_percent") : `${rounded}%`;
+    renderWidth > 0 && rounded === 0 ? copy("limits.bar.sub_one_percent") : `${rounded}%`;
   return (
     <div className="flex items-center gap-2">
       <span
@@ -401,9 +406,9 @@ function SubscriptionBar({ subscription, now }) {
       <div className="relative flex-1 bg-oai-gray-100 dark:bg-oai-gray-700/50 rounded-full h-1.5 overflow-hidden">
         <div
           className={`${
-            expired ? "bg-red-500" : nearExpiry ? "bg-amber-500" : "bg-oai-brand-500"
-          } rounded-full h-full block transition-[width] duration-500 ease-out`}
-          style={{ width: `${widthPct}%`, minWidth: widthPct > 0 ? "3px" : 0 }}
+            expired ? "bg-red-500" : nearExpiry ? "bg-amber-500" : "bg-blue-500"
+          } rounded-full h-full block motion-safe:transition-[width] motion-safe:duration-500 ease-out motion-reduce:transition-none`}
+          style={{ width: `${renderWidth}%`, minWidth: renderWidth > 0 ? "3px" : 0 }}
         />
       </div>
       <span className="text-[11px] tabular-nums text-oai-gray-500 dark:text-oai-gray-400 w-9 text-right shrink-0 whitespace-nowrap">
@@ -595,7 +600,7 @@ function renderConfiguredProvider(id, data, title, mode, expanded, onToggle, bad
       rightAdornment={subscription ? <SubscriptionRightBadge subscription={subscription} /> : null}
     >
       <LimitWindowSection mode={mode} rows={rows} extra={extra} />
-      {subscription ? <SubscriptionBar subscription={subscription} now={now} /> : null}
+      {subscription ? <SubscriptionBar subscription={subscription} now={now} mode={mode} /> : null}
       {expanded ? <LimitDetail rows={rows} mode={mode} now={now} /> : null}
       {expanded && subscription ? (
         <SubscriptionDetail subscription={subscription} now={now} />
@@ -608,7 +613,7 @@ function renderConfiguredProvider(id, data, title, mode, expanded, onToggle, bad
 // fetch error). A linked subscription still belongs to this row: it is
 // user-entered data, so its badge/progress stay visible regardless of the
 // tool's own configuration state.
-function renderUnlinkedProvider(id, statusNodes, expanded, onToggle, subscription = null, now = Date.now()) {
+function renderUnlinkedProvider(id, statusNodes, expanded, onToggle, subscription = null, now = Date.now(), mode = LIMIT_DISPLAY_MODES.USED) {
   const hasSubscription = Boolean(subscription);
   return (
     <ToolGroup
@@ -621,7 +626,7 @@ function renderUnlinkedProvider(id, statusNodes, expanded, onToggle, subscriptio
       rightAdornment={hasSubscription ? <SubscriptionRightBadge subscription={subscription} /> : null}
     >
       {statusNodes}
-      {hasSubscription ? <SubscriptionBar subscription={subscription} now={now} /> : null}
+      {hasSubscription ? <SubscriptionBar subscription={subscription} now={now} mode={mode} /> : null}
       {hasSubscription && expanded ? (
         <div className="mt-1">
           <SubscriptionDetail subscription={subscription} now={now} />
@@ -645,6 +650,7 @@ function renderProviderGroup(id, data, mode, expanded, onToggle, subscription = 
       onToggle,
       subscription,
       now,
+      mode,
     );
   }
   if (id === "opencodeGo" && data.subscription_status === "inactive") {
@@ -655,6 +661,7 @@ function renderProviderGroup(id, data, mode, expanded, onToggle, subscription = 
       onToggle,
       subscription,
       now,
+      mode,
     );
   }
   if (data.error) {
@@ -672,6 +679,7 @@ function renderProviderGroup(id, data, mode, expanded, onToggle, subscription = 
       onToggle,
       subscription,
       now,
+      mode,
     );
   }
 
@@ -948,7 +956,7 @@ function useWidestLabelWidth(containerRef) {
   return labelWidth;
 }
 
-export function UsageLimitsPanel({ claude, codex, cursor, gemini, kimi, kiro, grok, antigravity, copilot, zcode, opencodeGo, qoder, qoderCn, codingPlan, order, visibility, displayMode, subscriptions = [] }) {
+export function UsageLimitsPanel({ claude, codex, cursor, gemini, kimi, kiro, grok, antigravity, copilot, zcode, opencodeGo, qoder, qoderCn, codingPlan, order, visibility, displayMode, subscriptions = [], showSubscriptions = true }) {
   const dataById = { claude, codex, cursor, gemini, kimi, kiro, grok, antigravity, copilot, zcode, opencodeGo, qoder, qoderCn, codingPlan };
   const containerRef = useRef(null);
   const labelWidth = useWidestLabelWidth(containerRef);
@@ -972,24 +980,28 @@ export function UsageLimitsPanel({ claude, codex, cursor, gemini, kimi, kiro, gr
   // record; only when every record for a provider is past its date does the
   // most recently expired one show (an expired history record must not mask a
   // live renewal). Extra records stay manageable in the settings popover.
+  // When the user disables subscription display, skip the mapping entirely so
+  // inline badges/bars/details all disappear.
   const subscriptionByProvider = new Map();
-  for (const subscription of subscriptions || []) {
-    if (!subscription?.provider) continue;
-    const endMs = new Date(subscription.nextBillingAt).getTime();
-    if (!Number.isFinite(endMs)) continue;
-    const existing = subscriptionByProvider.get(subscription.provider);
-    if (!existing) {
-      subscriptionByProvider.set(subscription.provider, subscription);
-      continue;
-    }
-    const existingMs = new Date(existing.nextBillingAt).getTime();
-    const upcoming = endMs > now;
-    const existingUpcoming = existingMs > now;
-    if (
-      (upcoming && (!existingUpcoming || existingMs > endMs)) ||
-      (!upcoming && !existingUpcoming && endMs > existingMs)
-    ) {
-      subscriptionByProvider.set(subscription.provider, subscription);
+  if (showSubscriptions) {
+    for (const subscription of subscriptions || []) {
+      if (!subscription?.provider) continue;
+      const endMs = new Date(subscription.nextBillingAt).getTime();
+      if (!Number.isFinite(endMs)) continue;
+      const existing = subscriptionByProvider.get(subscription.provider);
+      if (!existing) {
+        subscriptionByProvider.set(subscription.provider, subscription);
+        continue;
+      }
+      const existingMs = new Date(existing.nextBillingAt).getTime();
+      const upcoming = endMs > now;
+      const existingUpcoming = existingMs > now;
+      if (
+        (upcoming && (!existingUpcoming || existingMs > endMs)) ||
+        (!upcoming && !existingUpcoming && endMs > existingMs)
+      ) {
+        subscriptionByProvider.set(subscription.provider, subscription);
+      }
     }
   }
 

--- a/scripts/ops/ui-hardcode-baseline.json
+++ b/scripts/ops/ui-hardcode-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-23T00:50:54.206Z",
+  "generatedAt": "2026-08-28T18:10:04.552Z",
   "root": "dashboard/src",
   "rules": {
     "colors": "hex/rgb(a) literals",
@@ -401,6 +401,13 @@
         "0 && ("
       ]
     },
+    "dashboard/src/ui/dashboard/components/SubscriptionSettingsCard.jsx": {
+      "colors": 0,
+      "rawText": 1,
+      "rawTextTokens": [
+        "item.id === editingId) : null; const editingView = editingSub ? cycleView(editingSub, now) : null; return ("
+      ]
+    },
     "dashboard/src/ui/dashboard/components/TrendMonitor.jsx": {
       "colors": 30,
       "rawText": 5,
@@ -420,9 +427,8 @@
     },
     "dashboard/src/ui/dashboard/components/UsageLimitsPanel.jsx": {
       "colors": 0,
-      "rawText": 2,
+      "rawText": 1,
       "rawTextTokens": [
-        "(prev === id ? null : id)), ), ) .filter(Boolean); return (",
         "0 ? groups :"
       ]
     },


### PR DESCRIPTION
## 概述
本 PR 优化订阅相关交互，使「订阅续费进度」与「限额显示」深度联动，并在仪表盘与 macOS 菜单栏两端保持一致。

## 变更内容
### 限额显示
- **设置 → 限额显示** 新增 `显示订阅` 开关（`tt.limits.showSubscriptions`），通过 `limitsPreferences` 桥接同步至 macOS `LimitsSettingsStore`，`剩余/已用` 模式下订阅百分比同步翻面（`100 - progress`），动效尊重 `prefers-reduced-motion`
- 菜单栏 `LimitsSettingsView` 同步新增开关，`UsageLimitsView` 在每个已配置的 Provider 下渲染订阅条（蓝常态 / 橙 3天内 / 红过期，`∞/clock` 徽标紧贴标题避免与悬停 `ⓘ` 重叠）

### 订阅管理卡片（限额页日历弹窗）
- 左侧 `31天前/365天前` 改为固定 `订阅`（`subscriptions.inline.label`）
- 点击卡片直接进入编辑（`openEdit`），`删除` 移入编辑表单内（红字 `mr-auto`），编辑态 `aria-expanded` 与 `countdown` 详情回显
- 套餐胶囊去框化：图标单独无框（`Infinity 14 brand绿 / Clock 14 blue`）置于服务名右侧，胶囊仅保留 `plan` 文本
- 移除展开区的重复删除按钮，保留 `编辑` 入口

### 设置 → 限额显示 快捷入口
- `显示订阅` 开关左侧新增 `⚙️ 7×7` 按钮（`gap-3` 呼吸感，`aria-label=订阅管理`），点击 `navigate("/limits?openSubscriptions=1")` 并在 `LimitsPage` 通过 `useSearchParams` 自动弹开订阅管理卡片

### 设计统一
- 仪表盘与菜单栏订阅条统一为 `blue-500`（仪表盘由 `oai-brand-500` 绿改为 `blue-500`），限额条保持 `emerald` 绿以作区分
- 图标统一为标题旁 `14px` 无框，限额页 `ToolGroup` 头部由 `ml-auto` 改为紧贴标题

### 国际化与测试
- `copy.csv` + `de/ja/ko/zh/zh-TW` 补齐 `settings.limits.showSubscriptionsHint` 等
- `use-limits-display-prefs` 增加 `showSubscriptions` 归一化、存储、桥接及 `671` 单测更新
- `SubscriptionSettingsCard.test.jsx` 同步直入编辑用例

## 验证
- `npm --prefix dashboard run test` 96/96，`npm --prefix dashboard run build` ✓，`xcodebuild` ✓，`curl /subscription-manager` 3 条记录
- 菜单栏 `PID` 已重装至 `/Applications/TokenTracker.app`，`7680/settings?section=limits` 与 `7680/limits?openSubscriptions=1` 均命中
- 对抗式审查（`interface-review + better-interface`）`HIGH 1`（空标签 Toggle）已修，`LOW` 在阈内，Verdict `Approve`

## 关联
基于 `upstream/main f8868b20 (0.93.7)`，新增 2 提交 `14546abd` + `d6f34600`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription visibility settings across the dashboard and menu bar, with preferences saved between sessions.
  * Added subscription renewal progress, expiry status, billing-cycle details, and auto-renew indicators to usage limits.
  * Added a subscription management view with inline editing and deletion.
  * Added navigation to open subscription settings directly from the Limits page.
  * Added localized subscription labels and accessibility improvements.

* **Improvements**
  * Reduced-motion settings now disable usage-bar animations.
  * Subscription progress displays remaining cycle time more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->