### PR TITLE
fix(pet): 修复 bot 角色在后台 30fps 空转导致的高 CPU 占用

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Views/BotSpriteView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/BotSpriteView.swift
@@ -10,6 +10,9 @@ struct BotSpriteView: View {
     let state: String
     /// Stored colour preference: a palette id, or "auto" to follow the appearance.
     let colorId: String
+    /// Whether the view is currently visible. When false the TimelineView is paused
+    /// to avoid 30fps background rendering (popover/floating panel hidden).
+    var isVisible: Bool = true
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -41,7 +44,7 @@ struct BotSpriteView: View {
     private var engineState: String { BotFrames.engineState(forPetState: state) }
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / Self.displayFps, paused: reduceMotion)) { context in
+        TimelineView(.animation(minimumInterval: 1.0 / Self.displayFps, paused: !isVisible || reduceMotion)) { context in
             Canvas(rendersAsynchronously: false) { ctx, canvasSize in
                 draw(in: &ctx, side: min(canvasSize.width, canvasSize.height), now: context.date)
             }

--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -482,7 +482,8 @@ struct ClawdCompanionView: View {
             case .vector where BotFrames.isAvailable:
                 BotSpriteView(
                     state: clawdState.petStateName,
-                    colorId: characterStore.botColor
+                    colorId: characterStore.botColor,
+                    isVisible: isCharacterTimelineVisible
                 )
             case .vector:
                 // Pre-rendered clips missing or schema-stale (run gen:bot-frames).


### PR DESCRIPTION
## 问题

- 现象：菜单栏图标已切到静态（static），且已关闭桌面宠物（DesktopPetShow=0），但 TokenTracker 仍稳定占用 19.8% CPU
<img width="1726" height="456" alt="image" src="https://github.com/user-attachments/assets/de849338-66dc-427d-9053-b13b8b843c5f" />
- 采样定位：`MenuBarAnimator.tick` 已为 0，但 `BotSpriteView.draw` + `TimelineView` 仍在后台以 30fps 持续渲染
- 影响：只要当前角色是 `bot`（默认角色），即使弹窗未打开、悬浮宠物已隐藏，仍会空转。切到 `clawd` 后 CPU 立即回落到 <5%

## 根因

`BotSpriteView` 的 `TimelineView` 只判断了 `reduceMotion`：

```swift
TimelineView(.animation(minimumInterval: 1/30, paused: reduceMotion))
```

而 `PetAtlasSpriteView` 和 `clawdCanvas` 都通过 `CompanionAnimationPolicy.isCharacterTimelineVisible`（即 `isPopoverVisible || isFloatingPetVisible`）来暂停，弹窗/悬浮窗隐藏时不渲染。`bot` 分支漏掉了这个判断。

## 修复

- `BotSpriteView` 新增 `isVisible: Bool = true` 属性，改为 `paused: !isVisible || reduceMotion`
- `ClawdCompanionView.characterView` 中传入 `isCharacterTimelineVisible`，与其它两个渲染分支对齐

改动：2 文件，6 行，无行为变更（可见时仍 30fps，隐藏时暂停）

## 验证

- 复现：static 图标 + bot + DesktopPetShow=0 -> 19.8% CPU，采样 `BotSpriteView` 12 次/3s
- 修复后：同条件采样 `BotSpriteView` 0 次，CPU <5%
- 回归：展开弹窗或显示悬浮宠物时，bot 动画正常恢复 30fps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription renewal and expiry progress bars alongside usage limits.
  * Added a setting to show or hide subscription information.
  * Added automatic subscription syncing and support for opening subscription management directly from settings.
  * Subscription rows now open inline editing, with renewal summaries and deletion controls.
* **Improvements**
  * Added subscription status badges for auto-renewing and expiring plans.
  * Added accessibility labels to settings controls and localized subscription text.
  * Reduced background animation rendering when views are hidden or motion reduction is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->