### PR TITLE
fix(windows): recover host failures and reuse dashboard WebView2

### DIFF
--- a/TokenTrackerWin.Tests/DispatcherExceptionPolicyTests.cs
+++ b/TokenTrackerWin.Tests/DispatcherExceptionPolicyTests.cs
@@ -1,0 +1,37 @@
+using TokenTrackerWin;
+using Xunit;
+
+namespace TokenTrackerWin.Tests;
+
+public sealed class DispatcherExceptionPolicyTests
+{
+    [Fact]
+    public void CancellationAndDisposalAreRecoverableWhileDispatcherIsAlive()
+    {
+        Assert.Equal(
+            DispatcherExceptionPolicy.RecoveryKind.IgnoreCancellation,
+            DispatcherExceptionPolicy.Classify(new OperationCanceledException(), false));
+        Assert.Equal(
+            DispatcherExceptionPolicy.RecoveryKind.RecreateDashboardWebView,
+            DispatcherExceptionPolicy.Classify(new ObjectDisposedException("WebView2"), false));
+    }
+
+    [Fact]
+    public void UnknownExceptionsAreNotAbsorbed()
+    {
+        Assert.Equal(
+            DispatcherExceptionPolicy.RecoveryKind.None,
+            DispatcherExceptionPolicy.Classify(new InvalidOperationException("render failure"), false));
+        Assert.Equal(
+            DispatcherExceptionPolicy.RecoveryKind.None,
+            DispatcherExceptionPolicy.Classify(new ObjectDisposedException("TextBox"), false));
+    }
+
+    [Fact]
+    public void ShutdownMakesLateDispatcherCallbacksRecoverable()
+    {
+        Assert.Equal(
+            DispatcherExceptionPolicy.RecoveryKind.IgnoreAfterShutdown,
+            DispatcherExceptionPolicy.Classify(new InvalidOperationException("late callback"), true));
+    }
+}

--- a/TokenTrackerWin.Tests/ServerRecoveryPolicyTests.cs
+++ b/TokenTrackerWin.Tests/ServerRecoveryPolicyTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace TokenTrackerWin;
+
+public sealed class ServerRecoveryPolicyTests
+{
+    [Fact]
+    public void UsesBoundedExponentialBackoff()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(2), ServerRecoveryPolicy.DelayForAttempt(1));
+        Assert.Equal(TimeSpan.FromSeconds(4), ServerRecoveryPolicy.DelayForAttempt(2));
+        Assert.Equal(TimeSpan.FromSeconds(6), ServerRecoveryPolicy.DelayForAttempt(3));
+        Assert.False(ServerRecoveryPolicy.HasAttemptsRemaining(ServerRecoveryPolicy.MaxAttempts));
+    }
+
+    [Fact]
+    public void RejectsInvalidAttemptNumbers()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ServerRecoveryPolicy.DelayForAttempt(0));
+    }
+}

--- a/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
+++ b/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="../TokenTrackerWin/ChildProcessProxy.cs" Link="ChildProcessProxy.cs" />
     <Compile Include="../TokenTrackerWin/ResumableDownloader.cs" Link="ResumableDownloader.cs" />
+    <Compile Include="../TokenTrackerWin/ServerRecoveryPolicy.cs" Link="ServerRecoveryPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
+++ b/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="../TokenTrackerWin/ChildProcessProxy.cs" Link="ChildProcessProxy.cs" />
     <Compile Include="../TokenTrackerWin/ResumableDownloader.cs" Link="ResumableDownloader.cs" />
     <Compile Include="../TokenTrackerWin/ServerRecoveryPolicy.cs" Link="ServerRecoveryPolicy.cs" />
+    <Compile Include="../TokenTrackerWin/DispatcherExceptionPolicy.cs" Link="DispatcherExceptionPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/TokenTrackerWin/DashboardWindow.cs
+++ b/TokenTrackerWin/DashboardWindow.cs
@@ -585,6 +585,25 @@ internal sealed class DashboardWindow : Window
         }
     }
 
+    /// <summary>
+    /// Recover a WebView2 disposal race reported by the shared WPF dispatcher.
+    /// Returns false when this window is already closing or hidden, allowing the
+    /// central exception policy to leave an unrelated exception unhandled.
+    /// </summary>
+    internal bool RecoverFromDispatcherException(Exception exception)
+    {
+        if (_exiting || !IsVisible) return false;
+        try
+        {
+            Dispatcher.BeginInvoke(new Action(() => _ = RecoverWebViewAsync()));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private void NavigateWhenServerReady(string pathAndQuery)
     {
         _pendingPathAndQuery = pathAndQuery;

--- a/TokenTrackerWin/DashboardWindow.cs
+++ b/TokenTrackerWin/DashboardWindow.cs
@@ -233,41 +233,66 @@ internal sealed class DashboardWindow : Window
         // Loaded can be raised more than once and a process-failure recovery can race
         // with a pending initialization. Share the same task so only one WebView2
         // environment is created at a time.
-        return _initializationTask ??= InitializeWebViewWithRetryAsync();
+        if (_initializationTask is { } pending) return pending;
+
+        // Publish the task before starting the retry routine. The WebView2 APIs can
+        // complete synchronously (especially with a warm profile); starting the
+        // routine first would let its cleanup run before the field was assigned,
+        // leaving a completed task cached forever and blocking recovery.
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var task = completion.Task;
+        _initializationTask = task;
+        _ = RunWebViewInitializationAsync(task, completion);
+        return task;
     }
 
     private async Task InitializeWebViewWithRetryAsync()
     {
         Exception? lastError = null;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            try
+            {
+                await InitializeWebViewCoreAsync();
+                return;
+            }
+            catch (Exception ex) when (attempt < 3)
+            {
+                lastError = ex;
+                Log($"webview initialization attempt {attempt} failed: {ex.Message}");
+                ReplaceWebViewControl();
+                await Task.Delay(TimeSpan.FromMilliseconds(300 * attempt));
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                Log($"webview initialization attempt {attempt} failed: {ex.Message}");
+            }
+        }
+
+        throw new InvalidOperationException(
+            "WebView2 could not be initialized after three attempts.", lastError);
+    }
+
+    private async Task RunWebViewInitializationAsync(
+        Task identity, TaskCompletionSource<bool> completion)
+    {
         try
         {
-            for (var attempt = 1; attempt <= 3; attempt++)
-            {
-                try
-                {
-                    await InitializeWebViewCoreAsync();
-                    return;
-                }
-                catch (Exception ex) when (attempt < 3)
-                {
-                    lastError = ex;
-                    Log($"webview initialization attempt {attempt} failed: {ex.Message}");
-                    ReplaceWebViewControl();
-                    await Task.Delay(TimeSpan.FromMilliseconds(300 * attempt));
-                }
-                catch (Exception ex)
-                {
-                    lastError = ex;
-                    Log($"webview initialization attempt {attempt} failed: {ex.Message}");
-                }
-            }
-
-            throw new InvalidOperationException(
-                "WebView2 could not be initialized after three attempts.", lastError);
+            await InitializeWebViewWithRetryAsync();
+            completion.TrySetResult(true);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
         }
         finally
         {
-            _initializationTask = null;
+            // A recovery can replace this task while the previous one unwinds;
+            // never clear the replacement task by identity accident.
+            if (ReferenceEquals(_initializationTask, identity))
+                _initializationTask = null;
         }
     }
 

--- a/TokenTrackerWin/DashboardWindow.cs
+++ b/TokenTrackerWin/DashboardWindow.cs
@@ -30,9 +30,9 @@ namespace TokenTrackerWin;
 /// native caption bar — see "Window controls" below). <see cref="WindowChrome"/>
 /// keeps the window resizable + Aero-snappable despite having no visible caption.
 ///
-/// Closing releases WebView2 so the hidden dashboard does not keep Chromium's
-/// renderer and graphics surfaces resident. Persistent WebView2 storage keeps the
-/// login across recreation; an active OAuth PKCE round trip is retained temporarily.
+/// Closing hides the window so the initialized WebView2 instance (and its login
+/// session) can be reused instantly. WebView2 is released only when the tray app
+/// exits, which avoids paying the Chromium startup cost on every dashboard toggle.
 /// The app exits via the tray "Quit" → <see cref="Shutdown"/>.
 /// </summary>
 internal sealed class DashboardWindow : Window
@@ -45,12 +45,14 @@ internal sealed class DashboardWindow : Window
     // empty regions rendered black. Drop-in API-compatible replacement.
     // AllowExternalDrop must be off: windowless (DirectComposition) hosting does not
     // support external drag-drop and throws on initialization otherwise.
-    private readonly WebView2CompositionControl _webView = new() { AllowExternalDrop = false };
+    private WebView2CompositionControl _webView = CreateWebViewControl();
     private readonly ServerManager _server;
     private bool _coreReady;
     private bool _exiting;
     private bool _oauthInFlight;
     private CancellationTokenSource? _oauthTimeout;
+    private Task? _initializationTask;
+    private bool _recoveryInFlight;
     private nint _hwnd;
     private string _pendingPathAndQuery = "/?app=1";
 
@@ -66,8 +68,6 @@ internal sealed class DashboardWindow : Window
     public event Action? PetSettingsRequested;
     public event Action<string, string?>? PetSettingChanged;
     public event Action<string, string>? NotificationRequested;
-    public event Action<DashboardWindow>? ReleasedForIdle;
-
     public DashboardWindow(ServerManager server)
     {
         _server = server;
@@ -113,7 +113,7 @@ internal sealed class DashboardWindow : Window
         // BACKGROUND_COLOR=0 env var in InitializeWebViewAsync instead.
         Content = _webView;
 
-        Loaded += async (_, _) => await InitializeWebViewAsync();
+        Loaded += OnLoaded;
         StateChanged += (_, _) =>
         {
             SyncMaxGlyph();
@@ -139,6 +139,24 @@ internal sealed class DashboardWindow : Window
         };
         KeyDown += (_, e) => { if (e.Key == System.Windows.Input.Key.Escape) CloseOrHideForOAuth(); };
         _server.StatusChanged += OnServerStatusChanged;
+    }
+
+    private static WebView2CompositionControl CreateWebViewControl() =>
+        new() { AllowExternalDrop = false };
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await InitializeWebViewAsync();
+        }
+        catch (Exception ex)
+        {
+            // WPF async event handlers are async-void. Never let a WebView2 runtime,
+            // profile, or GPU initialization failure escape to the dispatcher and
+            // terminate the tray host; the retry path below is deliberately bounded.
+            Log($"webview initialization failed: {ex}");
+        }
     }
 
     private static System.Windows.Media.ImageSource? LoadWindowIcon()
@@ -209,7 +227,51 @@ internal sealed class DashboardWindow : Window
 
     // ── WebView2 ───────────────────────────────────────────────────────
 
-    private async Task InitializeWebViewAsync()
+    private Task InitializeWebViewAsync()
+    {
+        if (_coreReady) return Task.CompletedTask;
+        // Loaded can be raised more than once and a process-failure recovery can race
+        // with a pending initialization. Share the same task so only one WebView2
+        // environment is created at a time.
+        return _initializationTask ??= InitializeWebViewWithRetryAsync();
+    }
+
+    private async Task InitializeWebViewWithRetryAsync()
+    {
+        Exception? lastError = null;
+        try
+        {
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    await InitializeWebViewCoreAsync();
+                    return;
+                }
+                catch (Exception ex) when (attempt < 3)
+                {
+                    lastError = ex;
+                    Log($"webview initialization attempt {attempt} failed: {ex.Message}");
+                    ReplaceWebViewControl();
+                    await Task.Delay(TimeSpan.FromMilliseconds(300 * attempt));
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                    Log($"webview initialization attempt {attempt} failed: {ex.Message}");
+                }
+            }
+
+            throw new InvalidOperationException(
+                "WebView2 could not be initialized after three attempts.", lastError);
+        }
+        finally
+        {
+            _initializationTask = null;
+        }
+    }
+
+    private async Task InitializeWebViewCoreAsync()
     {
         if (_coreReady) return;
 
@@ -253,6 +315,26 @@ internal sealed class DashboardWindow : Window
         core.Settings.AreDefaultContextMenusEnabled = false;
         core.Settings.IsStatusBarEnabled = false;
 
+        core.ProcessFailed += (_, e) =>
+        {
+            Log($"webview process failed kind={e.ProcessFailedKind}");
+            // WebView2 reports renderer unresponsiveness repeatedly while a busy
+            // page catches up. Recreating the control for that transient signal would
+            // make the dashboard flicker and discard in-flight navigation; reserve
+            // recovery for processes that actually exited.
+            if (e.ProcessFailedKind == CoreWebView2ProcessFailedKind.RenderProcessUnresponsive)
+                return;
+            if (_exiting || _recoveryInFlight) return;
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(() => _ = RecoverWebViewAsync()));
+            }
+            catch
+            {
+                // The dispatcher may already be shutting down.
+            }
+        };
+
         // Open target=_blank / external links in the system browser, not a popup WebView.
         core.NewWindowRequested += (_, e) =>
         {
@@ -275,14 +357,23 @@ internal sealed class DashboardWindow : Window
 
         core.NavigationCompleted += async (_, _) =>
         {
-            try { Log($"nav completed uri={_webView.CoreWebView2.Source}"); } catch { }
-            if (_oauthInFlight
-                && Uri.TryCreate(_webView.CoreWebView2.Source, UriKind.Absolute, out var completedUri)
-                && completedUri.AbsolutePath is "/" or "/dashboard")
+            try
             {
-                CompleteNativeOAuth();
+                Log($"nav completed uri={_webView.CoreWebView2.Source}");
+                if (_oauthInFlight
+                    && Uri.TryCreate(_webView.CoreWebView2.Source, UriKind.Absolute, out var completedUri)
+                    && completedUri.AbsolutePath is "/" or "/dashboard")
+                {
+                    CompleteNativeOAuth();
+                }
+                await ApplyNativeChromeAsync();
             }
-            await ApplyNativeChromeAsync();
+            catch (Exception ex)
+            {
+                // Navigation callbacks are async-void event handlers too. A page
+                // transition must never bring down the native tray process.
+                Log($"navigation completion handler failed: {ex.Message}");
+            }
         };
 
         // SPA route changes (history.pushState) don't raise NavigationCompleted; this
@@ -454,6 +545,44 @@ internal sealed class DashboardWindow : Window
             Dispatcher.BeginInvoke(new Action(() => NavigateWhenServerReady(_pendingPathAndQuery)));
         }
         catch { /* window is closing */ }
+    }
+
+    private void ReplaceWebViewControl()
+    {
+        if (_exiting) return;
+        _coreReady = false;
+        var old = _webView;
+        Content = null;
+        try { old.Dispose(); } catch { }
+        _webView = CreateWebViewControl();
+        Content = _webView;
+        _webView.Visibility = WindowState == WindowState.Minimized
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    private async Task RecoverWebViewAsync()
+    {
+        if (_exiting || _recoveryInFlight) return;
+        _recoveryInFlight = true;
+        try
+        {
+            Log("recovering WebView2 after process failure");
+            ReplaceWebViewControl();
+            await InitializeWebViewAsync();
+            NavigateWhenServerReady(_pendingPathAndQuery);
+            Log("WebView2 recovery completed");
+        }
+        catch (Exception ex)
+        {
+            // Keep the window/tray alive even when the runtime itself is unavailable;
+            // the next dashboard open can trigger a fresh recovery attempt.
+            Log($"WebView2 recovery failed: {ex.Message}");
+        }
+        finally
+        {
+            _recoveryInFlight = false;
+        }
     }
 
     private void NavigateWhenServerReady(string pathAndQuery)
@@ -690,12 +819,11 @@ internal sealed class DashboardWindow : Window
 
     private void CloseOrHideForOAuth()
     {
-        if (_oauthInFlight)
-        {
-            Hide();
-            return;
-        }
-        Close();
+        // Keep the initialized WebView2 alive while the dashboard is hidden. This
+        // preserves cookies/session state and avoids recreating the Chromium process
+        // (which added several seconds to every tray click). OAuth still uses Hide so
+        // its sessionStorage PKCE verifier remains available.
+        Hide();
     }
 
     /// <summary>Show the dashboard, bringing an already-open window to the front.</summary>
@@ -855,9 +983,10 @@ internal sealed class DashboardWindow : Window
 
     protected override void OnClosing(CancelEventArgs e)
     {
-        // Preserve sessionStorage only while OAuth needs its PKCE verifier. In every
-        // normal close path, allow WPF to close so OnClosed can dispose WebView2.
-        if (!_exiting && _oauthInFlight)
+        // A close can also arrive from WPF/window-manager commands instead of the
+        // injected title-bar button. Treat every non-shutdown close as a hide so the
+        // dashboard instance remains reusable and startup stays fast.
+        if (!_exiting)
         {
             e.Cancel = true;
             Hide();
@@ -876,7 +1005,6 @@ internal sealed class DashboardWindow : Window
         Content = null;
         _webView.Dispose();
         base.OnClosed(e);
-        if (!_exiting) ReleasedForIdle?.Invoke(this);
     }
 
     // ── P/Invoke + constants ───────────────────────────────────────────

--- a/TokenTrackerWin/DispatcherExceptionPolicy.cs
+++ b/TokenTrackerWin/DispatcherExceptionPolicy.cs
@@ -1,0 +1,36 @@
+namespace TokenTrackerWin;
+
+/// <summary>
+/// Classifies the small set of dispatcher failures that are safe to absorb.
+/// Window/WebView callbacks can race a deliberate dispatcher shutdown and
+/// surface cancellation or disposal exceptions after the UI has already been
+/// torn down. Everything else is left unhandled so a genuine programming or
+/// rendering failure is not silently hidden by the tray host.
+/// </summary>
+internal static class DispatcherExceptionPolicy
+{
+    internal enum RecoveryKind
+    {
+        None,
+        IgnoreAfterShutdown,
+        IgnoreCancellation,
+        RecreateDashboardWebView,
+    }
+
+    public static RecoveryKind Classify(Exception? exception, bool dispatcherShuttingDown)
+    {
+        if (dispatcherShuttingDown) return RecoveryKind.IgnoreAfterShutdown;
+        if (exception is OperationCanceledException) return RecoveryKind.IgnoreCancellation;
+        if (exception is ObjectDisposedException disposed
+            && IsWebViewObject(disposed.ObjectName))
+            return RecoveryKind.RecreateDashboardWebView;
+        return RecoveryKind.None;
+    }
+
+    private static bool IsWebViewObject(string? objectName)
+    {
+        if (string.IsNullOrWhiteSpace(objectName)) return false;
+        return objectName.Contains("webview", StringComparison.OrdinalIgnoreCase)
+            || objectName.Contains("corewebview", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -154,8 +154,23 @@ internal sealed class PetWindow : Window
         };
         _clickThroughTimer.Tick += (_, _) => ClickThroughTick();
 
-        Loaded += async (_, _) => await InitializeWebViewAsync();
+        Loaded += OnLoaded;
         _server.StatusChanged += OnServerStatusChanged;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await InitializeWebViewAsync();
+        }
+        catch (Exception ex)
+        {
+            // WebView2 initialization runs from an async-void WPF event. Keep a
+            // renderer/profile failure from terminating the tray host; the pet can
+            // remain hidden while the dashboard and server continue to recover.
+            Diag.Log("pet", $"webview initialization failed: {ex}");
+        }
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -253,6 +268,8 @@ internal sealed class PetWindow : Window
         core.Settings.AreDefaultContextMenusEnabled = false;
         core.Settings.IsStatusBarEnabled = false;
         core.Settings.AreDevToolsEnabled = false;
+        core.ProcessFailed += (_, e) =>
+            Diag.Log("pet", $"webview process failed kind={e.ProcessFailedKind}");
 
         // Keep the surface transparent even before the page's own CSS lands.
         await core.AddScriptToExecuteOnDocumentCreatedAsync(

--- a/TokenTrackerWin/Program.cs
+++ b/TokenTrackerWin/Program.cs
@@ -40,12 +40,33 @@ internal static class Program
         // drives the shared STA thread (and the WPF Dispatcher rides on it). Explicit
         // shutdown mode so WPF doesn't tear itself down when the window is hidden.
         var wpfApp = new System.Windows.Application { ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown };
+        TrayApplicationContext? trayContext = null;
         wpfApp.DispatcherUnhandledException += (_, e) =>
         {
-            Diag.Log("program", $"WPF dispatcher exception handled: {e.Exception}");
-            // Keep the tray host alive when a recoverable window callback fails. The
-            // affected WebView/window can be recreated on the next user action.
-            e.Handled = true;
+            var shuttingDown = wpfApp.Dispatcher.HasShutdownStarted || wpfApp.Dispatcher.HasShutdownFinished;
+            var recovery = DispatcherExceptionPolicy.Classify(e.Exception, shuttingDown);
+            if (recovery == DispatcherExceptionPolicy.RecoveryKind.IgnoreAfterShutdown
+                || recovery == DispatcherExceptionPolicy.RecoveryKind.IgnoreCancellation)
+            {
+                Diag.Log("program", $"WPF dispatcher exception absorbed during window teardown: {e.Exception}");
+                // These callbacks have no useful work left after cancellation or
+                // dispatcher teardown, so allowing WPF to continue is intentional.
+                e.Handled = true;
+                return;
+            }
+
+            if (recovery == DispatcherExceptionPolicy.RecoveryKind.RecreateDashboardWebView
+                && trayContext?.RecoverDashboardWebView(e.Exception) == true)
+            {
+                Diag.Log("program", $"WPF dispatcher exception recovered by recreating WebView2: {e.Exception}");
+                e.Handled = true;
+                return;
+            }
+
+            // Do not turn an unknown dispatcher failure into a silently-running
+            // but corrupted tray process. Leaving Handled=false preserves WPF's
+            // normal shutdown path after the diagnostic has been recorded.
+            Diag.Log("program", $"WPF dispatcher exception unhandled: {e.Exception}");
         };
 
         ApplicationConfiguration.Initialize();
@@ -55,6 +76,7 @@ internal static class Program
         // last exit). The dashboard no longer auto-opens — the pet is the visible presence.
         var showPetOnLaunch = deepLink is null && !launchedAtStartup;
         var ctx = new TrayApplicationContext(showPetOnLaunch);
+        trayContext = ctx;
 
         // Listen for deep links forwarded by secondary launches.
         using var listenerCts = new CancellationTokenSource();

--- a/TokenTrackerWin/Program.cs
+++ b/TokenTrackerWin/Program.cs
@@ -8,6 +8,8 @@ internal static class Program
     [STAThread]
     private static void Main(string[] args)
     {
+        InstallExceptionGuards();
+
         // Windows launches us with the full tokentracker://… URL as an argument when a
         // deep link fires (OAuth callback). Extract it if present.
         var deepLink = FindDeepLink(args);
@@ -37,7 +39,14 @@ internal static class Program
         // dispatcher context. We never call its Run(); the WinForms message pump below
         // drives the shared STA thread (and the WPF Dispatcher rides on it). Explicit
         // shutdown mode so WPF doesn't tear itself down when the window is hidden.
-        _ = new System.Windows.Application { ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown };
+        var wpfApp = new System.Windows.Application { ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown };
+        wpfApp.DispatcherUnhandledException += (_, e) =>
+        {
+            Diag.Log("program", $"WPF dispatcher exception handled: {e.Exception}");
+            // Keep the tray host alive when a recoverable window callback fails. The
+            // affected WebView/window can be recreated on the next user action.
+            e.Handled = true;
+        };
 
         ApplicationConfiguration.Initialize();
         // Show the desktop pet on a normal launch (manual run or post-install), but stay
@@ -58,6 +67,21 @@ internal static class Program
 
         listenerCts.Cancel();
         GC.KeepAlive(mutex);
+    }
+
+    private static void InstallExceptionGuards()
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            Diag.Log("program", $"unhandled exception terminating={e.IsTerminating}: {e.ExceptionObject}");
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            Diag.Log("program", $"unobserved task exception: {e.Exception}");
+            e.SetObserved();
+        };
+        System.Windows.Forms.Application.SetUnhandledExceptionMode(
+            System.Windows.Forms.UnhandledExceptionMode.CatchException);
+        System.Windows.Forms.Application.ThreadException += (_, e) =>
+            Diag.Log("program", $"WinForms UI exception: {e}");
     }
 
     private static string? FindDeepLink(string[] args)

--- a/TokenTrackerWin/ServerManager.cs
+++ b/TokenTrackerWin/ServerManager.cs
@@ -421,6 +421,12 @@ internal sealed class ServerManager : IDisposable
         foreach (var a in args) psi.ArgumentList.Add(a);
         psi.Environment["NODE_ENV"] = "production";
         psi.Environment["TOKENTRACKER_APP_SHELL"] = "windows";
+        // The tray host owns the five-minute background sync timer and receives
+        // completion events for the UI. Disable the embedded server's own
+        // one-minute fallback to avoid sync.lock contention and stale totals.
+        if (!forceNativeOnlyWslMode && args.Length > 0 &&
+            string.Equals(args[0], "serve", StringComparison.OrdinalIgnoreCase))
+            psi.Environment["TOKENTRACKER_NATIVE_SYNC_OWNER"] = "windows-host";
         if (forceNativeOnlyWslMode)
             psi.Environment["TOKENTRACKER_WSL_MODE"] = "native-only";
 

--- a/TokenTrackerWin/ServerManager.cs
+++ b/TokenTrackerWin/ServerManager.cs
@@ -40,8 +40,12 @@ internal sealed class ServerManager : IDisposable
     private Process? _serverProcess;
     private Process? _syncProcess;
     private readonly object _syncLock = new();
+    private readonly SemaphoreSlim _serverGate = new(1, 1);
+    private readonly object _restartLock = new();
     private readonly JobObject _job = new();
     private CancellationTokenSource? _healthCts;
+    private Task? _restartTask;
+    private bool _stopping;
     // The local server is always on 127.0.0.1, so this client must NEVER honour a system /
     // env (HTTP_PROXY) proxy: a VPN/proxy user with no loopback bypass would otherwise have
     // the health check routed through the proxy, which can't reach the local server — the
@@ -58,33 +62,72 @@ internal sealed class ServerManager : IDisposable
     /// <summary>Raised on the thread-pool after a sync process exits. UI must marshal if needed.</summary>
     public event Action? SyncCompleted;
 
-    public async Task EnsureServerRunningAsync()
-    {
-        Log("EnsureServerRunningAsync start");
-        SetStatus(ServerStatus.Starting);
+    public Task EnsureServerRunningAsync() => EnsureServerRunningAsyncCore(allowRecovery: false);
 
+    private async Task EnsureServerRunningAsyncCore(bool allowRecovery)
+    {
+        try
+        {
+            await _serverGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_stopping
+                    || (!allowRecovery && _restartTask is { IsCompleted: false })
+                    || (Status == ServerStatus.Running && _serverProcess is { HasExited: false }))
+                    return;
+
+                Log("EnsureServerRunningAsync start");
+                SetStatus(ServerStatus.Starting);
+                await StartServerOnceAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _serverGate.Release();
+            }
+        }
+        catch (Exception ex)
+        {
+            // This method is intentionally safe to call fire-and-forget from the
+            // tray constructor and recovery loop. Convert unexpected startup errors
+            // into observable state instead of an unobserved task that can terminate
+            // the process under a strict UnobservedTaskException policy.
+            Log($"EnsureServerRunningAsync failed: {ex}");
+            if (!_stopping)
+            {
+                Fail($"Failed to start local server: {ex.Message}");
+                RequestRestart("startup exception");
+            }
+        }
+    }
+
+    private async Task StartServerOnceAsync()
+    {
         var runtime = FindEmbeddedServer() ?? FindDevServer() ?? FindRepoDevServer();
         if (runtime is null)
         {
             Fail("No embedded server bundle found and no Node CLI available. "
                  + "Run scripts\\bundle-node.ps1, or set TOKENTRACKER_NODE / TOKENTRACKER_ENTRY for dev.");
+            RequestRestart("runtime unavailable");
             return;
         }
-        Log($"runtime node={runtime.Value.NodePath} entry={runtime.Value.EntryPath}");
 
+        Log($"runtime node={runtime.Value.NodePath} entry={runtime.Value.EntryPath}");
+        StopServerProcessOnly();
         Port = PickServerPort();
         Log($"picked port {Port}");
         LaunchServer(runtime.Value.NodePath, runtime.Value.EntryPath);
 
-        if (await WaitForServerAsync(TimeSpan.FromSeconds(Constants.StartupTimeoutSeconds)))
+        if (_serverProcess is not null
+            && await WaitForServerAsync(TimeSpan.FromSeconds(Constants.StartupTimeoutSeconds)).ConfigureAwait(false))
         {
             SetStatus(ServerStatus.Running);
             StartHealthLoop();
+            return;
         }
-        else
-        {
-            Fail($"Server did not respond on {BaseUrl} within {Constants.StartupTimeoutSeconds}s.");
-        }
+
+        StopServerProcessOnly();
+        Fail($"Server did not respond on {BaseUrl} within {Constants.StartupTimeoutSeconds}s.");
+        RequestRestart("startup timeout");
     }
 
     /// <summary>Run a one-shot `tracker sync` against the resolved runtime.</summary>
@@ -135,8 +178,8 @@ internal sealed class ServerManager : IDisposable
 
     public void StopServer()
     {
-        _healthCts?.Cancel();
-        _healthCts = null;
+        _stopping = true;
+        StopServerProcessOnly();
 
         lock (_syncLock)
         {
@@ -147,13 +190,60 @@ internal sealed class ServerManager : IDisposable
             }
             _syncProcess = null;
         }
+    }
 
-        if (_serverProcess is { HasExited: false } p)
-        {
-            try { p.Kill(entireProcessTree: true); }
-            catch { /* already gone */ }
-        }
+    private void StopServerProcessOnly()
+    {
+        _healthCts?.Cancel();
+        _healthCts = null;
+
+        var process = _serverProcess;
         _serverProcess = null;
+        if (process is null) return;
+
+        try { process.EnableRaisingEvents = false; } catch { }
+        try
+        {
+            if (!process.HasExited) process.Kill(entireProcessTree: true);
+        }
+        catch { /* already gone */ }
+        try { process.Dispose(); } catch { }
+    }
+
+    private void RequestRestart(string reason)
+    {
+        if (_stopping) return;
+        lock (_restartLock)
+        {
+            if (_restartTask is { IsCompleted: false }) return;
+            _restartTask = RestartServerAsync(reason);
+        }
+    }
+
+    private async Task RestartServerAsync(string reason)
+    {
+        Log($"automatic server recovery scheduled reason={reason}");
+        try
+        {
+            for (var attempt = 1; attempt <= ServerRecoveryPolicy.MaxAttempts; attempt++)
+            {
+                if (_stopping) return;
+                await Task.Delay(ServerRecoveryPolicy.DelayForAttempt(attempt)).ConfigureAwait(false);
+                if (_stopping) return;
+
+                Log($"automatic server recovery attempt={attempt}/{ServerRecoveryPolicy.MaxAttempts}");
+                await EnsureServerRunningAsyncCore(allowRecovery: true).ConfigureAwait(false);
+                if (Status == ServerStatus.Running) return;
+            }
+
+            if (!_stopping)
+                Fail($"Local server recovery failed after {ServerRecoveryPolicy.MaxAttempts} attempts.");
+        }
+        catch (Exception ex)
+        {
+            Log($"automatic server recovery failed: {ex}");
+            if (!_stopping) Fail($"Local server recovery failed: {ex.Message}");
+        }
     }
 
     // ── Port selection ─────────────────────────────────────────────────
@@ -276,15 +366,12 @@ internal sealed class ServerManager : IDisposable
 
             if (_serverProcess is not null)
             {
-                Log($"server process pid={_serverProcess.Id}");
+                var process = _serverProcess;
+                Log($"server process pid={process.Id}");
                 // Backstop: if the tray app dies abnormally, the job kills the server too.
-                _job.Assign(_serverProcess.Handle);
-                _serverProcess.EnableRaisingEvents = true;
-                _serverProcess.Exited += (_, _) =>
-                {
-                    if (Status == ServerStatus.Running)
-                        Fail("Server process exited unexpectedly.");
-                };
+                _job.Assign(process.Handle);
+                process.EnableRaisingEvents = true;
+                process.Exited += (_, _) => OnServerProcessExited(process);
             }
         }
         catch (Exception ex)
@@ -292,6 +379,27 @@ internal sealed class ServerManager : IDisposable
             Log($"LaunchServer failed: {ex}");
             Fail($"Failed to launch server: {ex.Message}");
         }
+    }
+
+    private void OnServerProcessExited(Process process)
+    {
+        try { Log($"server process exited code={process.ExitCode}"); }
+        catch { /* process may already be disposed */ }
+
+        // A deliberate kill clears the field and disables events before terminating
+        // the process, so only the still-current process can trigger recovery.
+        if (_stopping || !ReferenceEquals(_serverProcess, process))
+        {
+            try { process.Dispose(); } catch { }
+            return;
+        }
+
+        _serverProcess = null;
+        _healthCts?.Cancel();
+        _healthCts = null;
+        SetStatus(ServerStatus.Starting);
+        RequestRestart("server process exited unexpectedly");
+        try { process.Dispose(); } catch { }
     }
 
     private static Process? StartTrackerProcess(
@@ -341,7 +449,9 @@ internal sealed class ServerManager : IDisposable
         var delayMs = 200;
         while (DateTime.UtcNow < deadline)
         {
+            if (_stopping || _serverProcess is null || _serverProcess.HasExited) return false;
             if (await CheckHealthAsync()) return true;
+            if (_stopping || _serverProcess is null || _serverProcess.HasExited) return false;
             await Task.Delay(delayMs);
             delayMs = Math.Min(delayMs * 2, 2000);
         }
@@ -374,19 +484,36 @@ internal sealed class ServerManager : IDisposable
             // balloon. Only declare failure after several consecutive misses.
             const int failureThreshold = 3;
             var consecutiveFailures = 0;
-            while (!token.IsCancellationRequested)
+            try
             {
-                try { await Task.Delay(TimeSpan.FromSeconds(Constants.HealthCheckIntervalSeconds), token); }
-                catch (TaskCanceledException) { break; }
-                if (token.IsCancellationRequested) break;
-                if (await CheckHealthAsync())
+                while (!token.IsCancellationRequested)
                 {
-                    consecutiveFailures = 0;
-                    SetStatus(ServerStatus.Running);
+                    try { await Task.Delay(TimeSpan.FromSeconds(Constants.HealthCheckIntervalSeconds), token); }
+                    catch (TaskCanceledException) { break; }
+                    if (token.IsCancellationRequested) break;
+                    if (await CheckHealthAsync())
+                    {
+                        consecutiveFailures = 0;
+                        SetStatus(ServerStatus.Running);
+                    }
+                    else if (++consecutiveFailures >= failureThreshold)
+                    {
+                        Log($"health check failed {failureThreshold} consecutive times");
+                        _healthCts?.Cancel();
+                        _healthCts = null;
+                        SetStatus(ServerStatus.Starting);
+                        RequestRestart("health checks failed");
+                        break;
+                    }
                 }
-                else if (++consecutiveFailures >= failureThreshold)
+            }
+            catch (Exception ex)
+            {
+                Log($"health loop failed: {ex}");
+                if (!_stopping)
                 {
-                    SetStatus(ServerStatus.Failed);
+                    SetStatus(ServerStatus.Starting);
+                    RequestRestart("health loop exception");
                 }
             }
         }, token);

--- a/TokenTrackerWin/ServerManager.cs
+++ b/TokenTrackerWin/ServerManager.cs
@@ -44,8 +44,15 @@ internal sealed class ServerManager : IDisposable
     private readonly object _restartLock = new();
     private readonly JobObject _job = new();
     private CancellationTokenSource? _healthCts;
+    // Each health loop owns a generation.  A cancelled loop can still resume
+    // once after cancellation (for example when its HTTP probe completes), so
+    // it must not mutate state belonging to a newer server process.
+    private long _healthGeneration;
     private Task? _restartTask;
-    private bool _stopping;
+    // Shutdown is requested on the UI thread but observed by process/health
+    // callbacks and startup continuations on pool threads.  Volatile keeps the
+    // stop barrier visible before any of those threads decide to launch work.
+    private volatile bool _stopping;
     // The local server is always on 127.0.0.1, so this client must NEVER honour a system /
     // env (HTTP_PROXY) proxy: a VPN/proxy user with no loopback bypass would otherwise have
     // the health check routed through the proxy, which can't reach the local server — the
@@ -71,9 +78,16 @@ internal sealed class ServerManager : IDisposable
             await _serverGate.WaitAsync().ConfigureAwait(false);
             try
             {
+                var currentProcess = Volatile.Read(ref _serverProcess);
                 if (_stopping
                     || (!allowRecovery && _restartTask is { IsCompleted: false })
-                    || (Status == ServerStatus.Running && _serverProcess is { HasExited: false }))
+                    // Process.HasExited throws after another thread disposes the
+                    // handle.  Use the guarded liveness helper instead of a
+                    // property-pattern access so a stop/restart race cannot turn
+                    // into an unobserved startup exception.
+                    || (Status == ServerStatus.Running
+                        && currentProcess is not null
+                        && IsProcessAlive(currentProcess)))
                     return;
 
                 Log("EnsureServerRunningAsync start");
@@ -102,6 +116,8 @@ internal sealed class ServerManager : IDisposable
 
     private async Task StartServerOnceAsync()
     {
+        if (_stopping) return;
+
         var runtime = FindEmbeddedServer() ?? FindDevServer() ?? FindRepoDevServer();
         if (runtime is null)
         {
@@ -113,19 +129,53 @@ internal sealed class ServerManager : IDisposable
 
         Log($"runtime node={runtime.Value.NodePath} entry={runtime.Value.EntryPath}");
         StopServerProcessOnly();
+        // StopServer can win while runtime discovery was in progress.  Do not
+        // allocate a port or launch a child after the owner has begun closing.
+        if (_stopping) return;
         Port = PickServerPort();
         Log($"picked port {Port}");
-        LaunchServer(runtime.Value.NodePath, runtime.Value.EntryPath);
+        if (_stopping) return;
+        var expectedBaseUrl = BaseUrl;
+        var process = LaunchServer(runtime.Value.NodePath, runtime.Value.EntryPath);
 
-        if (_serverProcess is not null
-            && await WaitForServerAsync(TimeSpan.FromSeconds(Constants.StartupTimeoutSeconds)).ConfigureAwait(false))
+        // LaunchServer can race StopServer after its own initial check.  Make
+        // the caller's boundary defensive as well so a just-created child is
+        // never left behind when shutdown wins that window.
+        if (_stopping)
         {
-            SetStatus(ServerStatus.Running);
-            StartHealthLoop();
+            CleanupLaunchedProcess(process);
             return;
         }
 
-        StopServerProcessOnly();
+        // Keep the process returned by this launch throughout startup.  A stale
+        // health response must never make a replacement process look ready.
+        if (!_stopping
+            && process is not null
+            && await WaitForServerAsync(
+                process,
+                expectedBaseUrl,
+                TimeSpan.FromSeconds(Constants.StartupTimeoutSeconds)).ConfigureAwait(false)
+            && IsCurrentServerProcess(process))
+        {
+            if (_stopping || !IsCurrentServerProcess(process)) return;
+            SetStatus(ServerStatus.Running);
+            StartHealthLoop(process, expectedBaseUrl);
+
+            // The process can exit between the final probe and the status/event
+            // transition. Revalidate after starting the monitor before claiming
+            // readiness to the UI.
+            if (_stopping || IsCurrentServerProcess(process)) return;
+        }
+
+        if (_stopping) return;
+
+        // OnServerProcessExited already detached a dead process and scheduled
+        // recovery. Do not overwrite its Starting state with a misleading
+        // startup timeout (or schedule a second recovery chain).
+        if (process is not null
+            && !ReferenceEquals(Volatile.Read(ref _serverProcess), process)) return;
+
+        if (process is not null) StopServerProcessOnly();
         Fail($"Server did not respond on {BaseUrl} within {Constants.StartupTimeoutSeconds}s.");
         RequestRestart("startup timeout");
     }
@@ -149,7 +199,17 @@ internal sealed class ServerManager : IDisposable
 
         lock (_syncLock)
         {
-            if (_syncProcess is { HasExited: false }) return false;
+            // A process callback disposes the handle as soon as it exits.  Reading
+            // HasExited through a property pattern can therefore throw in this
+            // critical section and leave a stale sync slot behind.  Treat a
+            // disposed/exited instance as idle and clear it before starting the
+            // replacement.
+            if (_syncProcess is { } existing)
+            {
+                if (IsProcessAlive(existing)) return false;
+                _syncProcess = null;
+                try { existing.Dispose(); } catch { }
+            }
 
             var args = auto
                 ? new[] { "sync", "--auto", "--background" }
@@ -159,21 +219,45 @@ internal sealed class ServerManager : IDisposable
             if (proc is null) return false;
 
             _syncProcess = proc;
-            proc.EnableRaisingEvents = true;
-            proc.Exited += (_, _) =>
+            // Attach the handler before enabling events.  A short-lived sync can
+            // exit between Process.Start and EnableRaisingEvents; subscribing
+            // afterwards loses the only cleanup notification and blocks every
+            // later refresh behind a permanently "running" process.
+            proc.Exited += (_, _) => OnSyncProcessExited(proc);
+            try
             {
-                try { Log($"sync process exited code={proc.ExitCode}"); }
-                catch { /* process may already be disposed */ }
-                lock (_syncLock)
-                {
-                    if (ReferenceEquals(_syncProcess, proc)) _syncProcess = null;
-                }
+                proc.EnableRaisingEvents = true;
+            }
+            catch
+            {
+                // If event registration itself fails, do not leave the process
+                // occupying the single-flight slot or leak the child.
+                if (ReferenceEquals(_syncProcess, proc)) _syncProcess = null;
+                try { proc.Kill(entireProcessTree: true); } catch { }
                 try { proc.Dispose(); } catch { }
-                SyncCompleted?.Invoke();
-            };
-            SyncStarted?.Invoke();
+                return false;
+            }
+            RaiseSyncStarted();
             return true;
         }
+    }
+
+    private void OnSyncProcessExited(Process process)
+    {
+        try { Log($"sync process exited code={process.ExitCode}"); }
+        catch { /* process may already be disposed */ }
+
+        bool wasCurrent;
+        lock (_syncLock)
+        {
+            wasCurrent = ReferenceEquals(_syncProcess, process);
+            if (wasCurrent) _syncProcess = null;
+        }
+        try { process.Dispose(); } catch { }
+        // EnableRaisingEvents may report an already-exited process immediately,
+        // and a defensive manual cleanup can race that callback.  Only the
+        // callback that owns the slot emits one completion notification.
+        if (wasCurrent) RaiseSyncCompleted();
     }
 
     public void StopServer()
@@ -183,22 +267,29 @@ internal sealed class ServerManager : IDisposable
 
         lock (_syncLock)
         {
-            if (_syncProcess is { HasExited: false } sync)
+            if (_syncProcess is { } sync)
             {
-                try { sync.Kill(entireProcessTree: true); }
+                _syncProcess = null;
+                try
+                {
+                    if (IsProcessAlive(sync)) sync.Kill(entireProcessTree: true);
+                }
                 catch { /* already gone */ }
+                try { sync.Dispose(); } catch { }
             }
-            _syncProcess = null;
         }
     }
 
     private void StopServerProcessOnly()
     {
-        _healthCts?.Cancel();
-        _healthCts = null;
+        // Invalidate the monitor before detaching the process.  A probe that is
+        // already awaiting HTTP can resume after cancellation, so generation +
+        // identity checks in the loop must fail before it can touch status.
+        Interlocked.Increment(ref _healthGeneration);
+        var healthCts = Interlocked.Exchange(ref _healthCts, null);
+        try { healthCts?.Cancel(); } catch { }
 
-        var process = _serverProcess;
-        _serverProcess = null;
+        var process = Interlocked.Exchange(ref _serverProcess, null);
         if (process is null) return;
 
         try { process.EnableRaisingEvents = false; } catch { }
@@ -208,6 +299,49 @@ internal sealed class ServerManager : IDisposable
         }
         catch { /* already gone */ }
         try { process.Dispose(); } catch { }
+    }
+
+    private static bool IsProcessAlive(Process process)
+    {
+        try { return !process.HasExited; }
+        catch { return false; }
+    }
+
+    /// <summary>
+    /// Check both object identity and liveness.  The port is reused during
+    /// recovery, therefore a successful probe alone cannot identify which server
+    /// generation answered it.
+    /// </summary>
+    private bool IsCurrentServerProcess(Process process)
+        => ReferenceEquals(Volatile.Read(ref _serverProcess), process)
+           && IsProcessAlive(process);
+
+    private bool IsCurrentHealthLoop(
+        Process process,
+        string expectedBaseUrl,
+        long generation,
+        CancellationTokenSource cts)
+        => !_stopping
+           && !cts.IsCancellationRequested
+           && Volatile.Read(ref _healthGeneration) == generation
+           && ReferenceEquals(Volatile.Read(ref _healthCts), cts)
+           && IsCurrentServerProcess(process)
+           && !string.IsNullOrEmpty(expectedBaseUrl);
+
+    /// <summary>
+    /// Atomically retire one monitor.  This prevents an old loop from cancelling
+    /// a replacement loop that started while the old HTTP probe was unwinding.
+    /// </summary>
+    private bool RetireHealthLoop(CancellationTokenSource cts, long generation)
+    {
+        if (Volatile.Read(ref _healthGeneration) != generation
+            || !ReferenceEquals(Volatile.Read(ref _healthCts), cts))
+            return false;
+        if (!ReferenceEquals(Interlocked.CompareExchange(ref _healthCts, null, cts), cts))
+            return false;
+        Interlocked.Increment(ref _healthGeneration);
+        try { cts.Cancel(); } catch { }
+        return true;
     }
 
     private void RequestRestart(string reason)
@@ -355,30 +489,69 @@ internal sealed class ServerManager : IDisposable
 
     // ── Process launch ─────────────────────────────────────────────────
 
-    private void LaunchServer(string nodePath, string entryPath)
+    private Process? LaunchServer(string nodePath, string entryPath)
     {
+        Process? process = null;
         try
         {
+            if (_stopping) return null;
             Log("LaunchServer start");
-            _serverProcess = StartTrackerProcess(
+            process = StartTrackerProcess(
                 nodePath, entryPath, false,
                 "serve", "--port", Port.ToString(), "--no-sync", "--no-open");
 
-            if (_serverProcess is not null)
+            if (process is null || _stopping)
             {
-                var process = _serverProcess;
-                Log($"server process pid={process.Id}");
-                // Backstop: if the tray app dies abnormally, the job kills the server too.
-                _job.Assign(process.Handle);
-                process.EnableRaisingEvents = true;
-                process.Exited += (_, _) => OnServerProcessExited(process);
+                CleanupLaunchedProcess(process);
+                return null;
             }
+
+            // Publish the process before enabling Exited.  If node terminates
+            // during setup, enabling events after the handler is attached will
+            // deliver the callback for this exact process.
+            Volatile.Write(ref _serverProcess, process);
+            if (_stopping)
+            {
+                CleanupLaunchedProcess(process);
+                return null;
+            }
+            Log($"server process pid={process.Id}");
+            process.Exited += (_, _) => OnServerProcessExited(process);
+
+            // Backstop: if the tray app dies abnormally, the job kills the server too.
+            // Any failure after Process.Start must tear down the child; otherwise a
+            // half-initialized node remains orphaned and the next recovery races it.
+            _job.Assign(process.Handle);
+            process.EnableRaisingEvents = true;
+            if (_stopping)
+            {
+                CleanupLaunchedProcess(process);
+                return null;
+            }
+            return process;
         }
         catch (Exception ex)
         {
             Log($"LaunchServer failed: {ex}");
-            Fail($"Failed to launch server: {ex.Message}");
+            CleanupLaunchedProcess(process);
+            if (!_stopping)
+                Fail($"Failed to launch server: {ex.Message}");
+            return null;
         }
+    }
+
+    private void CleanupLaunchedProcess(Process? process)
+    {
+        if (process is null) return;
+        if (ReferenceEquals(Volatile.Read(ref _serverProcess), process))
+            Interlocked.CompareExchange(ref _serverProcess, null, process);
+        try { process.EnableRaisingEvents = false; } catch { }
+        try
+        {
+            if (IsProcessAlive(process)) process.Kill(entireProcessTree: true);
+        }
+        catch { /* process may have exited already */ }
+        try { process.Dispose(); } catch { }
     }
 
     private void OnServerProcessExited(Process process)
@@ -388,18 +561,30 @@ internal sealed class ServerManager : IDisposable
 
         // A deliberate kill clears the field and disables events before terminating
         // the process, so only the still-current process can trigger recovery.
-        if (_stopping || !ReferenceEquals(_serverProcess, process))
+        if (_stopping
+            || !ReferenceEquals(Volatile.Read(ref _serverProcess), process)
+            || !ReferenceEquals(Interlocked.CompareExchange(ref _serverProcess, null, process), process))
         {
             try { process.Dispose(); } catch { }
             return;
         }
 
-        _serverProcess = null;
-        _healthCts?.Cancel();
-        _healthCts = null;
+        CancelHealthLoop();
+        if (_stopping)
+        {
+            try { process.Dispose(); } catch { }
+            return;
+        }
         SetStatus(ServerStatus.Starting);
         RequestRestart("server process exited unexpectedly");
         try { process.Dispose(); } catch { }
+    }
+
+    private void CancelHealthLoop()
+    {
+        Interlocked.Increment(ref _healthGeneration);
+        var cts = Interlocked.Exchange(ref _healthCts, null);
+        try { cts?.Cancel(); } catch { }
     }
 
     private static Process? StartTrackerProcess(
@@ -435,41 +620,64 @@ internal sealed class ServerManager : IDisposable
             Log($"node child proxy source={proxySource}");
 
         Log($"StartTrackerProcess file={nodePath} entry={entryPath} args={string.Join(" ", args)}");
-        var proc = Process.Start(psi);
-        // Drain pipes so the child never blocks on a full stdout/stderr buffer.
-        if (proc is not null)
+        Process? proc = null;
+        try
         {
+            proc = Process.Start(psi);
+            if (proc is null) return null;
+
+            // Drain pipes so the child never blocks on a full stdout/stderr buffer.
             proc.OutputDataReceived += (_, e) => { if (e.Data is not null) Log($"node stdout: {e.Data}"); };
             proc.ErrorDataReceived += (_, e) => { if (e.Data is not null) Log($"node stderr: {e.Data}"); };
             proc.BeginOutputReadLine();
             proc.BeginErrorReadLine();
+            return proc;
         }
-        return proc;
+        catch
+        {
+            // Process.Start succeeded but pipe setup failed (for example, a child
+            // exited between Start and Begin*ReadLine). Do not leak that child.
+            if (proc is not null)
+            {
+                try { proc.EnableRaisingEvents = false; } catch { }
+                try { if (IsProcessAlive(proc)) proc.Kill(entireProcessTree: true); } catch { }
+                try { proc.Dispose(); } catch { }
+            }
+            throw;
+        }
     }
 
     // ── Health checks ──────────────────────────────────────────────────
 
-    private async Task<bool> WaitForServerAsync(TimeSpan timeout)
+    private async Task<bool> WaitForServerAsync(
+        Process expectedProcess,
+        string expectedBaseUrl,
+        TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
         var delayMs = 200;
         while (DateTime.UtcNow < deadline)
         {
-            if (_stopping || _serverProcess is null || _serverProcess.HasExited) return false;
-            if (await CheckHealthAsync()) return true;
-            if (_stopping || _serverProcess is null || _serverProcess.HasExited) return false;
+            if (_stopping || !IsCurrentServerProcess(expectedProcess)) return false;
+            // Probe the URL captured for this launch.  Port is mutable during
+            // recovery; using BaseUrl here could let a response from a newer
+            // process satisfy an older startup wait.
+            if (await CheckHealthAsync(expectedBaseUrl).ConfigureAwait(false)
+                && IsCurrentServerProcess(expectedProcess))
+                return true;
+            if (_stopping || !IsCurrentServerProcess(expectedProcess)) return false;
             await Task.Delay(delayMs);
             delayMs = Math.Min(delayMs * 2, 2000);
         }
         return false;
     }
 
-    private async Task<bool> CheckHealthAsync()
+    private static async Task<bool> CheckHealthAsync(string baseUrl)
     {
         try
         {
             using var resp = await Http.GetAsync(
-                BaseUrl + "/", HttpCompletionOption.ResponseHeadersRead);
+                baseUrl + "/", HttpCompletionOption.ResponseHeadersRead);
             return resp.IsSuccessStatusCode;
         }
         catch
@@ -478,11 +686,20 @@ internal sealed class ServerManager : IDisposable
         }
     }
 
-    private void StartHealthLoop()
+    private void StartHealthLoop(Process process, string expectedBaseUrl)
     {
-        _healthCts?.Cancel();
-        _healthCts = new CancellationTokenSource();
-        var token = _healthCts.Token;
+        // StopServer/OnServerProcessExited can win the race after the startup
+        // probe but before this monitor is installed. Do not publish a new CTS
+        // for a process that is no longer current.
+        if (_stopping || !IsCurrentServerProcess(process)) return;
+        var cts = new CancellationTokenSource();
+        var generation = Interlocked.Increment(ref _healthGeneration);
+        var previous = Interlocked.Exchange(ref _healthCts, cts);
+        try { previous?.Cancel(); } catch { }
+
+        // Do not pass cts.Token to Task.Run itself: cancellation between the
+        // exchange above and scheduling would otherwise skip the delegate and
+        // leak this CTS without running its finally block.
         _ = Task.Run(async () =>
         {
             // Debounce: a single transient probe failure (GC pause, brief load) should not
@@ -492,21 +709,30 @@ internal sealed class ServerManager : IDisposable
             var consecutiveFailures = 0;
             try
             {
-                while (!token.IsCancellationRequested)
+                while (IsCurrentHealthLoop(process, expectedBaseUrl, generation, cts))
                 {
-                    try { await Task.Delay(TimeSpan.FromSeconds(Constants.HealthCheckIntervalSeconds), token); }
+                    try
+                    {
+                        await Task.Delay(
+                            TimeSpan.FromSeconds(Constants.HealthCheckIntervalSeconds),
+                            cts.Token);
+                    }
                     catch (TaskCanceledException) { break; }
-                    if (token.IsCancellationRequested) break;
-                    if (await CheckHealthAsync())
+                    if (!IsCurrentHealthLoop(process, expectedBaseUrl, generation, cts)) break;
+                    if (await CheckHealthAsync(expectedBaseUrl).ConfigureAwait(false)
+                        && IsCurrentHealthLoop(process, expectedBaseUrl, generation, cts))
                     {
                         consecutiveFailures = 0;
                         SetStatus(ServerStatus.Running);
                     }
+                    else if (!IsCurrentHealthLoop(process, expectedBaseUrl, generation, cts))
+                    {
+                        break;
+                    }
                     else if (++consecutiveFailures >= failureThreshold)
                     {
                         Log($"health check failed {failureThreshold} consecutive times");
-                        _healthCts?.Cancel();
-                        _healthCts = null;
+                        if (!RetireHealthLoop(cts, generation)) break;
                         SetStatus(ServerStatus.Starting);
                         RequestRestart("health checks failed");
                         break;
@@ -515,14 +741,23 @@ internal sealed class ServerManager : IDisposable
             }
             catch (Exception ex)
             {
-                Log($"health loop failed: {ex}");
-                if (!_stopping)
+                // A stale loop is expected to observe cancellation/teardown
+                // races. Only the current generation may publish a restart.
+                if (IsCurrentHealthLoop(process, expectedBaseUrl, generation, cts))
                 {
-                    SetStatus(ServerStatus.Starting);
-                    RequestRestart("health loop exception");
+                    Log($"health loop failed: {ex}");
+                    if (RetireHealthLoop(cts, generation) && !_stopping)
+                    {
+                        SetStatus(ServerStatus.Starting);
+                        RequestRestart("health loop exception");
+                    }
                 }
             }
-        }, token);
+            finally
+            {
+                try { cts.Dispose(); } catch { }
+            }
+        });
     }
 
     // ── State ──────────────────────────────────────────────────────────
@@ -532,7 +767,7 @@ internal sealed class ServerManager : IDisposable
         if (Status == status) return;
         Status = status;
         if (status != ServerStatus.Failed) LastError = null;
-        StatusChanged?.Invoke(status);
+        RaiseStatusChanged(status);
     }
 
     private void Fail(string message)
@@ -540,7 +775,30 @@ internal sealed class ServerManager : IDisposable
         Log($"Fail: {message}");
         LastError = message;
         Status = ServerStatus.Failed;
-        StatusChanged?.Invoke(ServerStatus.Failed);
+        RaiseStatusChanged(ServerStatus.Failed);
+    }
+
+    // These notifications can originate from Process.Exited and health-loop
+    // thread-pool callbacks.  A UI subscriber may be racing dispatcher/window
+    // teardown; never let its exception escape onto the callback thread and
+    // terminate the tray process.  The failure is still captured in the shared
+    // diagnostic log for troubleshooting.
+    private void RaiseStatusChanged(ServerStatus status)
+    {
+        try { StatusChanged?.Invoke(status); }
+        catch (Exception ex) { Log($"StatusChanged handler failed: {ex}"); }
+    }
+
+    private void RaiseSyncStarted()
+    {
+        try { SyncStarted?.Invoke(); }
+        catch (Exception ex) { Log($"SyncStarted handler failed: {ex}"); }
+    }
+
+    private void RaiseSyncCompleted()
+    {
+        try { SyncCompleted?.Invoke(); }
+        catch (Exception ex) { Log($"SyncCompleted handler failed: {ex}"); }
     }
 
     private static void Log(string message) => Diag.Log("server", message);

--- a/TokenTrackerWin/ServerRecoveryPolicy.cs
+++ b/TokenTrackerWin/ServerRecoveryPolicy.cs
@@ -1,0 +1,19 @@
+namespace TokenTrackerWin;
+
+/// <summary>
+/// Small, deterministic policy for restarting the bundled local server. Keeping the
+/// retry budget and backoff calculation pure makes the recovery loop easy to verify
+/// without launching Node or a WebView2 runtime in unit tests.
+/// </summary>
+internal static class ServerRecoveryPolicy
+{
+    public const int MaxAttempts = 3;
+
+    public static TimeSpan DelayForAttempt(int attempt)
+    {
+        if (attempt < 1) throw new ArgumentOutOfRangeException(nameof(attempt));
+        return TimeSpan.FromSeconds(Math.Min(8, attempt * 2));
+    }
+
+    public static bool HasAttemptsRemaining(int attempt) => attempt < MaxAttempts;
+}

--- a/TokenTrackerWin/TrayApplicationContext.cs
+++ b/TokenTrackerWin/TrayApplicationContext.cs
@@ -605,7 +605,6 @@ internal sealed class TrayApplicationContext : ApplicationContext
         if (_dashboard is not null) return;
         var dashboard = new DashboardWindow(_server);
         _dashboard = dashboard;
-        dashboard.ReleasedForIdle += OnDashboardReleasedForIdle;
         // Re-render the cost when the dashboard reports a currency change (and once
         // it has loaded, so we pick up the user's chosen currency right away), and cache
         // it natively so a future cold-launched pet shows the same unit before the
@@ -618,13 +617,6 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _dashboard.PetSettingChanged += (key, value) => PostToUi(() => ApplyDashboardPetSetting(key, value));
         _dashboard.NotificationRequested += (title, body) => PostToUi(() =>
             _trayIcon.ShowBalloonTip(7000, title, body, ToolTipIcon.Warning));
-    }
-
-    private void OnDashboardReleasedForIdle(DashboardWindow dashboard)
-    {
-        if (!ReferenceEquals(_dashboard, dashboard)) return;
-        dashboard.ReleasedForIdle -= OnDashboardReleasedForIdle;
-        _dashboard = null;
     }
 
     private void ApplyDashboardPetSetting(string key, string? value)

--- a/TokenTrackerWin/TrayApplicationContext.cs
+++ b/TokenTrackerWin/TrayApplicationContext.cs
@@ -80,6 +80,12 @@ internal sealed class TrayApplicationContext : ApplicationContext
     // WebView (to read the currency) once the dashboard has been opened.
     private readonly System.Windows.Forms.Timer _refreshTimer = new() { Interval = 2000 };
     private readonly System.Windows.Forms.Timer _syncTimer = new() { Interval = 5 * 60 * 1000 };
+    // WebView currency reads are asynchronous. Timer ticks, menu opens, and
+    // poller callbacks can arrive while one read is still pending; keep one
+    // pass active and request one follow-up pass for the newest stats instead
+    // of stacking ExecuteScript calls on the WebView renderer.
+    private Task? _summaryRefreshTask;
+    private bool _summaryRefreshRequested;
 
     public TrayApplicationContext(bool showPetOnLaunch = false)
     {
@@ -619,6 +625,16 @@ internal sealed class TrayApplicationContext : ApplicationContext
             _trayIcon.ShowBalloonTip(7000, title, body, ToolTipIcon.Warning));
     }
 
+    /// <summary>
+    /// Recreate the visible dashboard WebView after a narrowly classified
+    /// disposal race reaches WPF's dispatcher-level handler.
+    /// </summary>
+    internal bool RecoverDashboardWebView(Exception exception)
+    {
+        if (_dashboard is null) return false;
+        return _dashboard.RecoverFromDispatcherException(exception);
+    }
+
     private void ApplyDashboardPetSetting(string key, string? value)
     {
         switch (key)
@@ -857,7 +873,33 @@ internal sealed class TrayApplicationContext : ApplicationContext
     }
 
     /// <summary>Render the today summary into the menu + tooltip, in the user's currency.</summary>
-    private async void RefreshSummary()
+    private void RefreshSummary()
+    {
+        _summaryRefreshRequested = true;
+        if (_summaryRefreshTask is { IsCompleted: false }) return;
+        _summaryRefreshTask = RefreshSummaryLoopAsync();
+    }
+
+    private async Task RefreshSummaryLoopAsync()
+    {
+        while (_summaryRefreshRequested)
+        {
+            _summaryRefreshRequested = false;
+            try
+            {
+                await RefreshSummaryOnceAsync();
+            }
+            catch (Exception ex)
+            {
+                // WebView2 can be disposed while a script is in flight. Keep
+                // timer/menu callbacks harmless and leave the last summary
+                // visible until the next successful pass.
+                DiagLog($"RefreshSummary failed: {ex}");
+            }
+        }
+    }
+
+    private async Task RefreshSummaryOnceAsync()
     {
         // Convert USD → the dashboard's chosen currency. Reading the currency is a
         // WebView2 ExecuteScript round-trip — the 2s _refreshTimer would otherwise
@@ -899,11 +941,23 @@ internal sealed class TrayApplicationContext : ApplicationContext
     /// <summary>Cache the dashboard's current currency natively so a cold-launched pet
     /// (no dashboard WebView yet) can show the right unit. Only called from the
     /// CurrencyChanged handler, where the read reflects a real, loaded value.</summary>
-    private async void PersistCurrencyFromDashboard()
+    private void PersistCurrencyFromDashboard()
     {
-        if (_dashboard is null) return;
-        var (symbol, rate) = await _dashboard.ReadCurrencyAsync();
-        Currency.Persist(symbol, rate);
+        _ = PersistCurrencyFromDashboardAsync();
+    }
+
+    private async Task PersistCurrencyFromDashboardAsync()
+    {
+        try
+        {
+            if (_dashboard is null) return;
+            var (symbol, rate) = await _dashboard.ReadCurrencyAsync();
+            Currency.Persist(symbol, rate);
+        }
+        catch (Exception ex)
+        {
+            DiagLog($"PersistCurrency failed: {ex.Message}");
+        }
     }
 
     private void PostToUi(Action action)

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -45,6 +45,8 @@ internal sealed class UsagePoller : IDisposable
     private const string AccountQuery = "account=1";
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;
+    private int _refreshInFlight;
+    private int _refreshRequested;
 
     /// <summary>
     /// When true, each poll also gathers the heatmap + model-breakdown stats the pet's
@@ -85,13 +87,7 @@ internal sealed class UsagePoller : IDisposable
         {
             while (!token.IsCancellationRequested)
             {
-                var stats = await FetchAsync();
-                if (stats is { } s && !token.IsCancellationRequested) StatsUpdated?.Invoke(s);
-                if (IncludeLimits)
-                {
-                    var limits = await FetchLimitsAsync();
-                    if (limits is not null && !token.IsCancellationRequested) LimitsUpdated?.Invoke(limits);
-                }
+                await RefreshAsync(token);
                 try { await Task.Delay(TimeSpan.FromSeconds(60), token); }
                 catch (TaskCanceledException) { break; }
             }
@@ -101,16 +97,44 @@ internal sealed class UsagePoller : IDisposable
     public void RefreshNow()
     {
         var token = _cts?.Token ?? CancellationToken.None;
-        _ = Task.Run(async () =>
+        _ = Task.Run(() => RefreshAsync(token), token);
+    }
+
+    /// <summary>
+    /// Coalesce timer, sync-completion, and manual refresh requests. Without a
+    /// single-flight gate, a slow account-view request can leave several reads
+    /// in flight and allow an older response to overwrite newer totals.
+    /// </summary>
+    private async Task RefreshAsync(CancellationToken token)
+    {
+        Interlocked.Exchange(ref _refreshRequested, 1);
+        if (Interlocked.CompareExchange(ref _refreshInFlight, 1, 0) != 0) return;
+
+        try
         {
-            var stats = await FetchAsync();
-            if (stats is { } s && !token.IsCancellationRequested) StatsUpdated?.Invoke(s);
-            if (IncludeLimits)
+            while (!token.IsCancellationRequested &&
+                   Interlocked.Exchange(ref _refreshRequested, 0) == 1)
             {
-                var limits = await FetchLimitsAsync();
-                if (limits is not null && !token.IsCancellationRequested) LimitsUpdated?.Invoke(limits);
+                var stats = await FetchAsync();
+                if (stats is { } s && !token.IsCancellationRequested) StatsUpdated?.Invoke(s);
+                if (IncludeLimits)
+                {
+                    var limits = await FetchLimitsAsync();
+                    if (limits is not null && !token.IsCancellationRequested) LimitsUpdated?.Invoke(limits);
+                }
             }
-        }, token);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _refreshInFlight, 0);
+            // Drain a request that arrived between the loop's final check and
+            // releasing the gate without building an unbounded task chain.
+            // Use the current poller's token: Start() can replace a cancelled
+            // poll loop while its final request is still unwinding.
+            var currentToken = _cts?.Token ?? token;
+            if (Volatile.Read(ref _refreshRequested) == 1 && !currentToken.IsCancellationRequested)
+                _ = Task.Run(() => RefreshAsync(currentToken), currentToken);
+        }
     }
 
     private async Task<string?> FetchLimitsAsync()

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -87,7 +87,21 @@ internal sealed class UsagePoller : IDisposable
         {
             while (!token.IsCancellationRequested)
             {
-                await RefreshAsync(token);
+                try
+                {
+                    await RefreshAsync(token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // A subscriber or an unexpected parser failure must not
+                    // terminate the long-lived polling loop.  The next tick
+                    // can still recover and publish fresh usage.
+                    Log($"refresh loop failed: {ex}");
+                }
                 try { await Task.Delay(TimeSpan.FromSeconds(60), token); }
                 catch (TaskCanceledException) { break; }
             }
@@ -97,7 +111,11 @@ internal sealed class UsagePoller : IDisposable
     public void RefreshNow()
     {
         var token = _cts?.Token ?? CancellationToken.None;
-        _ = Task.Run(() => RefreshAsync(token), token);
+        // Do not pass the token to Task.Run itself. A manual refresh can be
+        // requested just as Start() replaces the CTS; scheduling with the old
+        // (already-cancelled) token would cause the delegate to be discarded
+        // before RefreshAsync gets a chance to drain the request.
+        _ = Task.Run(() => RefreshAsync(token));
     }
 
     /// <summary>
@@ -115,12 +133,18 @@ internal sealed class UsagePoller : IDisposable
             while (!token.IsCancellationRequested &&
                    Interlocked.Exchange(ref _refreshRequested, 0) == 1)
             {
-                var stats = await FetchAsync();
-                if (stats is { } s && !token.IsCancellationRequested) StatsUpdated?.Invoke(s);
-                if (IncludeLimits)
+                // Limits are independent of the usage summary. Start both
+                // requests together so a slow provider quota reader cannot add
+                // another full network round-trip to the visible refresh.
+                var includeLimits = IncludeLimits;
+                var statsTask = FetchAsync(token);
+                var limitsTask = includeLimits ? FetchLimitsAsync(token) : null;
+                var stats = await statsTask;
+                if (stats is { } s && !token.IsCancellationRequested) RaiseStatsUpdated(s);
+                if (includeLimits && limitsTask is not null)
                 {
-                    var limits = await FetchLimitsAsync();
-                    if (limits is not null && !token.IsCancellationRequested) LimitsUpdated?.Invoke(limits);
+                    var limits = await limitsTask;
+                    if (limits is not null && !token.IsCancellationRequested) RaiseLimitsUpdated(limits);
                 }
             }
         }
@@ -133,17 +157,26 @@ internal sealed class UsagePoller : IDisposable
             // poll loop while its final request is still unwinding.
             var currentToken = _cts?.Token ?? token;
             if (Volatile.Read(ref _refreshRequested) == 1 && !currentToken.IsCancellationRequested)
-                _ = Task.Run(() => RefreshAsync(currentToken), currentToken);
+            {
+                // Keep the cancellation token inside RefreshAsync rather than
+                // passing it to Task.Run.  The token can be cancelled in the
+                // tiny window between the check above and queueing the work;
+                // Task.Run would then discard the delegate and leave
+                // _refreshRequested set forever, so the next refresh would be
+                // silently lost until another external trigger arrives.
+                _ = Task.Run(() => RefreshAsync(currentToken));
+            }
         }
     }
 
-    private async Task<string?> FetchLimitsAsync()
+    private async Task<string?> FetchLimitsAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            using var resp = await Http.GetAsync(_baseUrl() + "/functions/tokentracker-usage-limits");
+            using var resp = await Http.GetAsync(
+                _baseUrl() + "/functions/tokentracker-usage-limits", cancellationToken);
             if (!resp.IsSuccessStatusCode) return null;
-            return await resp.Content.ReadAsStringAsync();
+            return await resp.Content.ReadAsStringAsync(cancellationToken);
         }
         catch
         {
@@ -151,7 +184,7 @@ internal sealed class UsagePoller : IDisposable
         }
     }
 
-    private async Task<UsageStats?> FetchAsync()
+    private async Task<UsageStats?> FetchAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -165,7 +198,7 @@ internal sealed class UsagePoller : IDisposable
             var summaryUrl = $"{_baseUrl()}/functions/tokentracker-usage-summary"
                              + $"?from={today}&to={today}{tzQuery}&{AccountQuery}";
 
-            using var resp = await Http.GetAsync(summaryUrl);
+            using var resp = await Http.GetAsync(summaryUrl, cancellationToken);
             if (!resp.IsSuccessStatusCode) return null;
 
             // Track whether the server served the cross-device aggregate or fell
@@ -173,8 +206,8 @@ internal sealed class UsagePoller : IDisposable
             if (resp.Headers.TryGetValues("X-TokenTracker-Account-View", out var accountViewValues))
                 AccountViewActive = accountViewValues.FirstOrDefault() == "1";
 
-            await using var stream = await resp.Content.ReadAsStreamAsync();
-            using var doc = await JsonDocument.ParseAsync(stream);
+            await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
             var root = doc.RootElement;
             if (!root.TryGetProperty("totals", out var totals)) return null;
 
@@ -207,8 +240,14 @@ internal sealed class UsagePoller : IDisposable
             IReadOnlyList<TopModelStat> models = NoModels;
             if (IncludeRichStats)
             {
-                (streak, activeAll) = await FetchHeatmapAsync(tzQuery);
-                models = await FetchTopModelsAsync(today, tzQuery);
+                // These two endpoints are independent. Fetching them in
+                // parallel cuts the rich-refresh tail from roughly 2× the HTTP
+                // timeout to a single timeout window when the backend is slow.
+                var heatmapTask = FetchHeatmapAsync(tzQuery, cancellationToken);
+                var modelsTask = FetchTopModelsAsync(today, tzQuery, cancellationToken);
+                await Task.WhenAll(heatmapTask, modelsTask);
+                (streak, activeAll) = await heatmapTask;
+                models = await modelsTask;
             }
 
             return new UsageStats(
@@ -226,15 +265,16 @@ internal sealed class UsagePoller : IDisposable
 
     /// <summary>Heatmap: all-time active days + current streak (streak is server-computed; the
     /// local server returns 0, matching how the macOS pet reads it against the same backend).</summary>
-    private async Task<(int Streak, int ActiveDays)> FetchHeatmapAsync(string tzQuery)
+    private async Task<(int Streak, int ActiveDays)> FetchHeatmapAsync(
+        string tzQuery, CancellationToken cancellationToken = default)
     {
         try
         {
             var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}&{AccountQuery}";
-            using var resp = await Http.GetAsync(url);
+            using var resp = await Http.GetAsync(url, cancellationToken);
             if (!resp.IsSuccessStatusCode) return (0, 0);
-            await using var stream = await resp.Content.ReadAsStreamAsync();
-            using var doc = await JsonDocument.ParseAsync(stream);
+            await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
             var root = doc.RootElement;
             return ((int)GetLong(root, "streak_days"), (int)GetLong(root, "active_days"));
         }
@@ -247,17 +287,18 @@ internal sealed class UsagePoller : IDisposable
     /// provider from the highest-token row for that name, percent = tokens / total billable
     /// (one decimal), sort by tokens desc then name asc, top 5.
     /// </summary>
-    private async Task<IReadOnlyList<TopModelStat>> FetchTopModelsAsync(string today, string tzQuery)
+    private async Task<IReadOnlyList<TopModelStat>> FetchTopModelsAsync(
+        string today, string tzQuery, CancellationToken cancellationToken = default)
     {
         try
         {
             var from = DateTime.Now.AddDays(-29).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var url = $"{_baseUrl()}/functions/tokentracker-usage-model-breakdown"
                       + $"?from={from}&to={today}{tzQuery}&{AccountQuery}";
-            using var resp = await Http.GetAsync(url);
+            using var resp = await Http.GetAsync(url, cancellationToken);
             if (!resp.IsSuccessStatusCode) return NoModels;
-            await using var stream = await resp.Content.ReadAsStreamAsync();
-            using var doc = await JsonDocument.ParseAsync(stream);
+            await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
             if (!doc.RootElement.TryGetProperty("sources", out var sources)
                 || sources.ValueKind != JsonValueKind.Array) return NoModels;
 
@@ -353,6 +394,23 @@ internal sealed class UsagePoller : IDisposable
     {
         return TryGetLong(obj, name, out var value) ? value : 0;
     }
+
+    // Polling callbacks cross from the worker thread into WinForms/WPF. A
+    // window can close between scheduling and dispatch, so subscriber failures
+    // are diagnostic-only and must never stop future refreshes.
+    private void RaiseStatsUpdated(UsageStats stats)
+    {
+        try { StatsUpdated?.Invoke(stats); }
+        catch (Exception ex) { Log($"StatsUpdated handler failed: {ex}"); }
+    }
+
+    private void RaiseLimitsUpdated(string limitsJson)
+    {
+        try { LimitsUpdated?.Invoke(limitsJson); }
+        catch (Exception ex) { Log($"LimitsUpdated handler failed: {ex}"); }
+    }
+
+    private static void Log(string message) => Diag.Log("poller", message);
 
     /// <summary>The usage endpoints expect an IANA tz; Windows uses its own ids, so convert.</summary>
     private static string TimeZoneQuery()

--- a/dashboard/src/hooks/use-activity-heatmap.test.ts
+++ b/dashboard/src/hooks/use-activity-heatmap.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCloudUsageDaily, fetchCloudUsageHeatmap } from "../lib/api";
+import { useActivityHeatmap } from "./use-activity-heatmap";
+
+vi.mock("../lib/api", () => ({
+  fetchCloudUsageDaily: vi.fn(),
+  fetchCloudUsageHeatmap: vi.fn(),
+  getUsageDaily: vi.fn(),
+  getUsageHeatmap: vi.fn(),
+}));
+vi.mock("../lib/auth-token", () => ({
+  isAccessTokenReady: () => true,
+  resolveAuthAccessToken: async (token: any) => token || "test-token",
+}));
+vi.mock("../lib/mock-data", () => ({ isMockEnabled: () => false }));
+
+describe("useActivityHeatmap request ordering", () => {
+  beforeEach(() => {
+    vi.mocked(fetchCloudUsageHeatmap).mockReset();
+    vi.mocked(fetchCloudUsageDaily).mockReset();
+    window.localStorage.clear();
+  });
+
+  it("ignores a late response from a previous device scope", async () => {
+    let resolveOld: (value: any) => void = () => {};
+    let resolveNew: (value: any) => void = () => {};
+    vi.mocked(fetchCloudUsageHeatmap).mockImplementation(({ device }: any) =>
+      new Promise((resolve) => {
+        if (device === "old-device") resolveOld = resolve;
+        else resolveNew = resolve;
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ deviceId }) =>
+        useActivityHeatmap({
+          baseUrl: "https://app.tokentracker.cc",
+          cacheKey: "heatmap-race",
+          weeks: 4,
+          timeZone: "UTC",
+          accountView: true,
+          accountAccessToken: "jwt-token",
+          deviceId,
+          now: new Date("2026-08-20T12:00:00Z"),
+        }),
+      { initialProps: { deviceId: "old-device" } },
+    );
+
+    await waitFor(() => expect(fetchCloudUsageHeatmap).toHaveBeenCalledTimes(1));
+    rerender({ deviceId: "new-device" });
+    await waitFor(() => expect(fetchCloudUsageHeatmap).toHaveBeenCalledTimes(2));
+
+    await act(async () =>
+      resolveNew({
+        weeks: [[{ day: "2026-08-20", level: 2, total_tokens: 200 }]],
+        active_days: 1,
+        marker: "new",
+      }),
+    );
+    await waitFor(() => expect(result.current.heatmap?.marker).toBe("new"));
+
+    await act(async () =>
+      resolveOld({
+        weeks: [[{ day: "2026-08-20", level: 1, total_tokens: 100 }]],
+        active_days: 1,
+        marker: "old",
+      }),
+    );
+    expect(result.current.heatmap?.marker).toBe("new");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("only applies the newest of overlapping manual refreshes", async () => {
+    const resolvers: Array<(value: any) => void> = [];
+    vi.mocked(fetchCloudUsageHeatmap).mockImplementation(
+      () => new Promise((resolve) => resolvers.push(resolve)),
+    );
+
+    const { result } = renderHook(() =>
+      useActivityHeatmap({
+        baseUrl: "https://app.tokentracker.cc",
+        cacheKey: "heatmap-manual-race",
+        weeks: 4,
+        timeZone: "UTC",
+        accountView: true,
+        accountAccessToken: "jwt-token",
+        now: new Date("2026-08-20T12:00:00Z"),
+      }),
+    );
+    await waitFor(() => expect(fetchCloudUsageHeatmap).toHaveBeenCalledTimes(1));
+
+    let firstRefresh: Promise<void> = Promise.resolve();
+    let secondRefresh: Promise<void> = Promise.resolve();
+    await act(async () => {
+      firstRefresh = result.current.refresh();
+    });
+    await waitFor(() => expect(fetchCloudUsageHeatmap).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      secondRefresh = result.current.refresh();
+    });
+    await waitFor(() => expect(fetchCloudUsageHeatmap).toHaveBeenCalledTimes(3));
+
+    await act(async () =>
+      resolvers[2]?.({
+        weeks: [[{ day: "2026-08-20", level: 2, total_tokens: 200 }]],
+        marker: "latest",
+      }),
+    );
+    await waitFor(() => expect(result.current.heatmap?.marker).toBe("latest"));
+    await act(async () =>
+      resolvers[1]?.({
+        weeks: [[{ day: "2026-08-20", level: 1, total_tokens: 100 }]],
+        marker: "stale",
+      }),
+    );
+    await firstRefresh;
+    await secondRefresh;
+
+    // Release the mount request as well so the test leaves no pending work.
+    await act(async () =>
+      resolvers[0]?.({
+        weeks: [[{ day: "2026-08-20", level: 1, total_tokens: 100 }]],
+        marker: "mount",
+      }),
+    );
+
+    expect(result.current.heatmap?.marker).toBe("latest");
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/dashboard/src/hooks/use-activity-heatmap.ts
+++ b/dashboard/src/hooks/use-activity-heatmap.ts
@@ -13,6 +13,7 @@ import {
   getUsageDaily,
   getUsageHeatmap,
 } from "../lib/api";
+import { useLatestRequestGuard } from "./use-latest-request-guard";
 
 export function useActivityHeatmap({
   baseUrl,
@@ -46,6 +47,35 @@ export function useActivityHeatmap({
 
   const isLocalMode = typeof window !== "undefined" &&
     (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
+
+  // A manual refresh, visibility refresh, and a scope/range change can all
+  // overlap.  Heatmap responses are often considerably slower than the other
+  // usage endpoints; without a request guard, a late response from an older
+  // range (or device) can overwrite the current grid and its loading state.
+  // Keep the guard context aligned with every value used to build a request.
+  const beginRequest = useLatestRequestGuard([
+    baseUrl,
+    range.from,
+    range.to,
+    weeks,
+    weekStartsOn,
+    scopeKey,
+    accessToken,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
+    deviceId,
+    timeZone,
+    tzOffsetMinutes,
+    // Include source/rendering gates in the request identity. This prevents
+    // an old authenticated/local response from painting after a guest,
+    // mock, or cloud-scope transition.
+    guestAllowed,
+    mockEnabled,
+    cacheAllowed,
+    tokenReady,
+    isLocalMode,
+  ]);
 
   const storageKey = useMemo(() => {
     if (!cacheKey) return null;
@@ -102,8 +132,10 @@ export function useActivityHeatmap({
   }, [scopeKey]);
 
   const refresh = useCallback(async () => {
+    const isCurrent = beginRequest();
     const resolvedToken = await resolveAuthAccessToken(accessToken);
     const cloudToken = useCloud ? await resolveAuthAccessToken(accountAccessToken) : null;
+    if (!isCurrent()) return;
     if (!resolvedToken && !mockEnabled && !isLocalMode && !useCloud) return;
     if (useCloud && !cloudToken) {
       setError("Your session expired. Please sign in again to view account data.");
@@ -128,9 +160,11 @@ export function useActivityHeatmap({
           tzOffsetMinutes,
         });
         const weeksData = Array.isArray(res?.weeks) ? res.weeks : [];
+        if (!isCurrent()) return;
         if (!weeksData.length && cacheAllowed) {
           const cached = readCache();
           if (cached?.heatmap) {
+            if (!isCurrent()) return;
             setHeatmap(cached.heatmap);
             setDaily(cached.daily || []);
             setSource("cache");
@@ -161,6 +195,7 @@ export function useActivityHeatmap({
             to: res?.to || range.to,
             weekStartsOn,
           });
+          if (!isCurrent()) return;
           setDaily(rows);
           setHeatmap({
             ...localHeatmap,
@@ -196,6 +231,7 @@ export function useActivityHeatmap({
           return;
         }
 
+        if (!isCurrent()) return;
         setHeatmap(res || null);
         setDaily([]);
         setSource("edge");
@@ -215,6 +251,11 @@ export function useActivityHeatmap({
         if (status === 401 || status === 403) throw e;
       }
 
+      // A newer refresh may have superseded this request while the heatmap
+      // endpoint was in flight.  Do not start the slower daily fallback for a
+      // context that is no longer visible.
+      if (!isCurrent()) return;
+
       const dailyRes = await dailyFetcher({
         baseUrl,
         accessToken: tokenForFetch,
@@ -225,6 +266,7 @@ export function useActivityHeatmap({
         tzOffsetMinutes,
       });
       const rows = Array.isArray(dailyRes?.data) ? dailyRes.data : [];
+      if (!isCurrent()) return;
       setDaily(rows);
       const localHeatmap = buildActivityHeatmap({
         dailyRows: rows,
@@ -232,6 +274,7 @@ export function useActivityHeatmap({
         to: range.to,
         weekStartsOn,
       });
+      if (!isCurrent()) return;
       setHeatmap({
         ...localHeatmap,
         week_starts_on: weekStartsOn,
@@ -258,9 +301,11 @@ export function useActivityHeatmap({
         clearCache();
       }
     } catch (e) {
+      if (!isCurrent()) return;
       if (cacheAllowed) {
         const cached = readCache();
         if (cached?.heatmap) {
+          if (!isCurrent()) return;
           setHeatmap(cached.heatmap);
           setDaily(cached.daily || []);
           setSource("cache");
@@ -280,7 +325,7 @@ export function useActivityHeatmap({
         setSource("edge");
       }
     } finally {
-      setLoading(false);
+      if (isCurrent()) setLoading(false);
     }
   }, [
     accessToken,
@@ -303,6 +348,7 @@ export function useActivityHeatmap({
     accountAccessToken,
     accountRevision,
     deviceId,
+    beginRequest,
   ]);
 
   useEffect(() => {

--- a/dashboard/src/hooks/use-trend-data.ts
+++ b/dashboard/src/hooks/use-trend-data.ts
@@ -144,6 +144,15 @@ export function useTrendData({
     sharedRows,
     sharedFrom,
     sharedTo,
+    // Rendering gates are part of the request context. A response started
+    // for the local/authenticated view must not commit after the dashboard
+    // switches to guest, mock, or a still-resolving cloud scope.
+    guestAllowed,
+    mockEnabled,
+    cacheAllowed,
+    accountViewResolving,
+    tokenReady,
+    isLocalMode,
   ]);
 
   // Wipe state when the scope flips so the previously-rendered local data

--- a/dashboard/src/hooks/use-usage-data.account-resolving.test.ts
+++ b/dashboard/src/hooks/use-usage-data.account-resolving.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchCloudUsageDaily,
@@ -94,5 +94,45 @@ describe("useUsageData — accountViewResolving gate (double-flash fix)", () => 
     await waitFor(() => expect(getUsageSummary).toHaveBeenCalled());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.summary).toEqual(SUMMARY.totals);
+  });
+
+  it("ignores a local response that resolves after scope resolution starts", async () => {
+    const summaryResolvers: Array<(value: any) => void> = [];
+    const dailyResolvers: Array<(value: any) => void> = [];
+    vi.mocked(getUsageSummary).mockImplementation(
+      () => new Promise((resolve) => summaryResolvers.push(resolve)),
+    );
+    vi.mocked(getUsageDaily).mockImplementation(
+      () => new Promise((resolve) => dailyResolvers.push(resolve)),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ resolving }) => useUsageData({ ...baseProps, accountViewResolving: resolving }),
+      { initialProps: { resolving: false } },
+    );
+    await waitFor(() => expect(getUsageSummary).toHaveBeenCalledTimes(1));
+
+    // Auth/scope resolution begins while the local request is still pending.
+    rerender({ resolving: true });
+    expect(result.current.summary).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      summaryResolvers[0]?.(SUMMARY);
+      dailyResolvers[0]?.(DAILY);
+    });
+    // The response belongs to the pre-resolution context and must not paint.
+    expect(result.current.summary).toBeNull();
+    expect(result.current.daily).toEqual([]);
+
+    // Once resolution completes, a fresh request is allowed to populate the
+    // view normally.
+    rerender({ resolving: false });
+    await waitFor(() => expect(getUsageSummary).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      summaryResolvers[1]?.(SUMMARY);
+      dailyResolvers[1]?.(DAILY);
+    });
+    await waitFor(() => expect(result.current.summary).toEqual(SUMMARY.totals));
   });
 });

--- a/dashboard/src/hooks/use-usage-data.ts
+++ b/dashboard/src/hooks/use-usage-data.ts
@@ -130,6 +130,15 @@ export function useUsageData({
     deviceId,
     timeZone,
     tzOffsetMinutes,
+    // These gates change which source is allowed to render. Invalidate an
+    // in-flight response when auth/mock/scope resolution changes so a late
+    // local response cannot leak into a guest or cloud view.
+    guestAllowed,
+    mockEnabled,
+    cacheAllowed,
+    accountViewResolving,
+    tokenReady,
+    isLocalMode,
   ]);
 
   const refresh = useCallback(async () => {

--- a/dashboard/src/hooks/use-usage-limits.test.ts
+++ b/dashboard/src/hooks/use-usage-limits.test.ts
@@ -170,4 +170,40 @@ describe("useUsageLimits", () => {
       source: "manual-refresh",
     });
   });
+
+  it("does not let a slow mount read overwrite a newer manual refresh", async () => {
+    let resolveMount: ((value: any) => void) | null = null;
+    let resolveManual: ((value: any) => void) | null = null;
+    vi.mocked(getUsageLimits).mockImplementation((options: any = {}) =>
+      new Promise((resolve) => {
+        if (options?.refresh) resolveManual = resolve;
+        else resolveMount = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useUsageLimits({ initialRefresh: true }),
+    );
+    await waitFor(() => expect(getUsageLimits).toHaveBeenCalledTimes(1));
+
+    let manualRefresh: Promise<void>;
+    await act(async () => {
+      manualRefresh = result.current.refresh();
+    });
+    await waitFor(() => expect(getUsageLimits).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveManual?.(freshLimits);
+      await manualRefresh;
+    });
+    expect(result.current.data).toEqual(freshLimits);
+    expect(result.current.isLoading).toBe(false);
+
+    // The older page-load response arrives last and must be ignored.
+    await act(async () => {
+      resolveMount?.(existingLimits);
+    });
+    expect(result.current.data).toEqual(freshLimits);
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/dashboard/src/hooks/use-usage-limits.ts
+++ b/dashboard/src/hooks/use-usage-limits.ts
@@ -3,6 +3,7 @@ import { getUsageLimits } from "../lib/api";
 import { publishUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
 import { LIMIT_ALERTS_PREF_KEY } from "./use-limit-alert-prefs";
 import { sendPredictiveLimitAlerts } from "../lib/limit-alerts.js";
+import { useLatestRequestGuard } from "./use-latest-request-guard";
 
 type CodexLimitWindow = {
   readonly used_percent: number;
@@ -105,6 +106,11 @@ export function useUsageLimits(options?: UseUsageLimitsOptions) {
   const [isLoading, setIsLoading] = useState(!hasInitialState);
   const initialRefresh = Boolean(options?.initialRefresh);
   const publishToPreloadCache = Boolean(options?.publishToPreloadCache);
+  // Mount/cache reads and an explicit refresh can overlap (for example when a
+  // user clicks Refresh while the dashboard's preload request is still
+  // resolving). Keep only the newest response. Without this guard a slower
+  // cache response can overwrite fresh limits fetched by the manual request.
+  const beginRequest = useLatestRequestGuard([]);
 
   useEffect(() => {
     if (!data || typeof window === "undefined") return;
@@ -124,31 +130,41 @@ export function useUsageLimits(options?: UseUsageLimitsOptions) {
   );
 
   const refresh = useCallback(async () => {
+    const isCurrent = beginRequest();
     try {
       const res = await getUsageLimits({ refresh: true });
+      if (!isCurrent()) return;
       const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
       setData(nextData);
       setError(null);
+      setIsLoading(false);
       publishSuccessfulState(nextData, "manual-refresh");
     } catch (err) {
+      if (!isCurrent()) return;
       setError((err as Error)?.message || String(err));
+      setIsLoading(false);
     }
-  }, [publishSuccessfulState]);
+  }, [beginRequest, publishSuccessfulState]);
 
   const refreshFromServerCache = useCallback(async () => {
+    const isCurrent = beginRequest();
     try {
       // Non-forcing read: serve from the server's cache rather than hitting
       // upstream providers, mirroring the mount fetch (forcing on every focus
       // is what tripped Claude's OAuth usage endpoint rate limit).
       const res = await getUsageLimits();
+      if (!isCurrent()) return;
       const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
       setData(nextData);
       setError(null);
+      setIsLoading(false);
       publishSuccessfulState(nextData, "page-load");
     } catch (err) {
+      if (!isCurrent()) return;
       setError((err as Error)?.message || String(err));
+      setIsLoading(false);
     }
-  }, [publishSuccessfulState]);
+  }, [beginRequest, publishSuccessfulState]);
 
   // Auto-refresh when the dashboard regains focus / becomes visible again —
   // same throttled pattern as use-usage-data.ts, so a left-open Limits page
@@ -174,29 +190,26 @@ export function useUsageLimits(options?: UseUsageLimitsOptions) {
 
   useEffect(() => {
     if (hasInitialState && !initialRefresh) return;
-    let cancelled = false;
+    const isCurrent = beginRequest();
     (async () => {
       try {
         // Mount fetch reads the server's cache (in-memory + disk-backed) rather than forcing
         // a live upstream call on every navigation — that repeated forcing is what tripped
         // Claude's OAuth usage endpoint rate limit. Only the manual refresh() forces upstream.
         const res = await getUsageLimits();
-        if (cancelled) return;
+        if (!isCurrent()) return;
         const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
         setData(nextData);
         setError(null);
         publishSuccessfulState(nextData, "page-load");
       } catch (err) {
-        if (cancelled) return;
+        if (!isCurrent()) return;
         setError((err as Error)?.message || String(err));
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (isCurrent()) setIsLoading(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, [hasInitialState, initialRefresh, publishSuccessfulState]);
+  }, [beginRequest, hasInitialState, initialRefresh, publishSuccessfulState]);
 
   return { data, error, isLoading, refresh };
 }

--- a/dashboard/src/hooks/use-usage-model-breakdown.ts
+++ b/dashboard/src/hooks/use-usage-model-breakdown.ts
@@ -85,6 +85,14 @@ export function useUsageModelBreakdown({
     deviceId,
     timeZone,
     tzOffsetMinutes,
+    // Keep auth and scope gates in the request identity so an old provider
+    // response cannot repopulate the card after a view transition.
+    guestAllowed,
+    mockEnabled,
+    cacheAllowed,
+    accountViewResolving,
+    tokenReady,
+    isLocalMode,
   ]);
 
   // Wipe state when the scope flips so the prior buckets don't render

--- a/dashboard/src/lib/single-flight.js
+++ b/dashboard/src/lib/single-flight.js
@@ -1,0 +1,23 @@
+/**
+ * Run at most one asynchronous operation for a given context key.
+ *
+ * A new context is allowed to start while an older one is still pending.  The
+ * identity check in the completion handlers prevents the older promise from
+ * clearing the newer flight.  This is useful for dashboard refreshes where a
+ * range/device switch must not wait for a request that is no longer relevant.
+ */
+export function runSingleFlight(flightRef, key, task) {
+  const current = flightRef?.current;
+  if (current && Object.is(current.key, key)) return current.promise;
+
+  const promise = Promise.resolve().then(task);
+  const flight = { key, promise };
+  flightRef.current = flight;
+  const clearIfCurrent = () => {
+    if (flightRef.current === flight) flightRef.current = null;
+  };
+  // Supply both rejection and fulfillment handlers so observing completion
+  // never creates an unhandled-rejection branch of its own.
+  promise.then(clearIfCurrent, clearIfCurrent);
+  return promise;
+}

--- a/dashboard/src/lib/single-flight.test.js
+++ b/dashboard/src/lib/single-flight.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { runSingleFlight } from "./single-flight";
+
+describe("runSingleFlight", () => {
+  it("shares a pending operation for the same context", async () => {
+    const flightRef = { current: null };
+    let calls = 0;
+    let resolveTask;
+    const task = () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolveTask = resolve;
+      });
+    };
+
+    const first = runSingleFlight(flightRef, "month", task);
+    const second = runSingleFlight(flightRef, "month", task);
+    expect(second).toBe(first);
+    expect(calls).toBe(0); // task is scheduled without running synchronously
+
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    resolveTask("done");
+    await expect(first).resolves.toBe("done");
+    expect(flightRef.current).toBeNull();
+  });
+
+  it("does not let an older context clear a newer flight", async () => {
+    const flightRef = { current: null };
+    const resolvers = {};
+    const task = (key) => () => new Promise((resolve) => {
+      resolvers[key] = resolve;
+    });
+
+    const oldPromise = runSingleFlight(flightRef, "old", task("old"));
+    await Promise.resolve();
+    const newPromise = runSingleFlight(flightRef, "new", task("new"));
+    await Promise.resolve();
+    expect(flightRef.current?.key).toBe("new");
+
+    resolvers.old("old-result");
+    await expect(oldPromise).resolves.toBe("old-result");
+    expect(flightRef.current?.key).toBe("new");
+
+    resolvers.new("new-result");
+    await expect(newPromise).resolves.toBe("new-result");
+    expect(flightRef.current).toBeNull();
+  });
+});

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -55,6 +55,7 @@ import { formatDeviceLabel } from "../lib/device-label.js";
 import { CLOUD_USAGE_SYNCED_EVENT, getCurrentDeviceId } from "../lib/cloud-sync-prefs";
 import { ShareModal } from "../ui/share/ShareModal";
 import { useShareCardData } from "../ui/share/use-share-card-data";
+import { runSingleFlight } from "../lib/single-flight";
 
 const PERIODS = ["day", "week", "month", "total", "custom"];
 const DETAILS_DATE_KEYS = new Set(["day", "hour", "month"]);
@@ -517,6 +518,10 @@ export function DashboardPage({
     accountAccessToken,
     accountRevision,
     accountViewResolving,
+    // Keep the daily breakdown aligned with the selected device used by the
+    // main usage/detail cards. Without this, choosing a device only filtered
+    // some cards while the daily table continued to show account-wide rows.
+    deviceId: selectedDevice,
   });
 
   const {
@@ -872,17 +877,53 @@ export function DashboardPage({
     }
   }, [selectedPeriod, customFrom, prevPeriod]);
 
+  // Refreshes can originate from the manual button, a visibility event, and
+  // the local queue watcher at nearly the same time.  Keep one in-flight
+  // aggregate per dashboard context so those triggers do not fan out into
+  // six duplicate endpoint requests (and invalidate each other's responses).
+  const usageStatsFlightRef = useRef(null);
+  const refreshContextKey = useMemo(
+    () => [
+      baseUrl || "",
+      cacheKey || "",
+      accountView ? "cloud" : "local",
+      accountRevision ?? "",
+      period || "",
+      from || "",
+      to || "",
+      todayKey || "",
+      selectedDevice || "all",
+      timeZone || "",
+      tzOffsetMinutes ?? "",
+    ].join("\u001f"),
+    [
+      accountRevision,
+      accountView,
+      baseUrl,
+      cacheKey,
+      from,
+      period,
+      selectedDevice,
+      timeZone,
+      todayKey,
+      to,
+      tzOffsetMinutes,
+    ],
+  );
+
   const refreshUsageStats = useCallback(async () => {
-    if (accountView) invalidateAccountResponseCache();
-    if (!accountView) invalidateSessionInsightsCache();
-    await Promise.all([
-      refreshUsage(),
-      refreshHeatmap(),
-      refreshTrend(),
-      refreshModelBreakdown(),
-      refreshProjectUsage(),
-      refreshDailyBreakdown(),
-    ]);
+    return runSingleFlight(usageStatsFlightRef, refreshContextKey, async () => {
+      if (accountView) invalidateAccountResponseCache();
+      if (!accountView) invalidateSessionInsightsCache();
+      await Promise.all([
+        refreshUsage(),
+        refreshHeatmap(),
+        refreshTrend(),
+        refreshModelBreakdown(),
+        refreshProjectUsage(),
+        refreshDailyBreakdown(),
+      ]);
+    });
   }, [
     accountView,
     refreshDailyBreakdown,
@@ -891,17 +932,18 @@ export function DashboardPage({
     refreshProjectUsage,
     refreshTrend,
     refreshUsage,
+    refreshContextKey,
   ]);
 
+  const refreshAllFlightRef = useRef(null);
   const refreshAll = useCallback(async () => {
-    await Promise.all([
-      refreshUsageStats(),
-      refreshUsageLimits(),
-    ]);
-  }, [
-    refreshUsageStats,
-    refreshUsageLimits,
-  ]);
+    return runSingleFlight(refreshAllFlightRef, refreshContextKey, async () => {
+      await Promise.all([
+        refreshUsageStats(),
+        refreshUsageLimits(),
+      ]);
+    });
+  }, [refreshContextKey, refreshUsageLimits, refreshUsageStats]);
 
   // Hold the latest aggregate refresher in a ref so the mount / auto-refresh
   // effects below can call it WITHOUT listing it as a dependency.

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -268,6 +268,7 @@ async function cmdServe(argv) {
 
 function startNativeBackgroundSync({
   appShell = process.env.TOKENTRACKER_APP_SHELL,
+  nativeSyncOwner = process.env.TOKENTRACKER_NATIVE_SYNC_OWNER,
   intervalMs = NATIVE_BACKGROUND_SYNC_INTERVAL_MS,
   runSync,
   setIntervalFn = setInterval,
@@ -276,6 +277,11 @@ function startNativeBackgroundSync({
 } = {}) {
   const normalizedShell = String(appShell || "").trim().toLowerCase();
   if (normalizedShell !== "windows") return null;
+  // The Windows tray host owns its five-minute background sync timer and
+  // receives completion events for the UI. Running this server-side fallback
+  // as well creates two independent sync producers that contend on sync.lock,
+  // leaving refreshes stale and needlessly expensive.
+  if (String(nativeSyncOwner || "").trim().toLowerCase() === "windows-host") return null;
 
   // Run the periodic fallback sync in a child process, not in-process:
   // several provider parsers read SQLite databases via execFileSync, which

--- a/src/lib/cloud-account.js
+++ b/src/lib/cloud-account.js
@@ -72,9 +72,14 @@ function decodeJwtExpMs(token) {
 // that produced it.
 // The popover polls frequently, so caching avoids hammering /api/auth/refresh.
 let tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
+// Dashboard refreshes fan out to several account endpoints at once. Share a
+// refresh request while it is in flight so each endpoint does not make its own
+// identical network round-trip (especially costly for an expired session).
+let tokenRefreshInFlight = { cacheKey: null, promise: null };
 
 function __resetCloudAccountCacheForTests() {
   tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
+  tokenRefreshInFlight = { cacheKey: null, promise: null };
 }
 
 function csrfTokenFromRefreshPayload(data) {
@@ -111,6 +116,38 @@ async function mintAccessToken({
     return { accessToken: tokenCache.accessToken, refreshToken: null, csrfToken: null };
   }
 
+  if (tokenRefreshInFlight.cacheKey === cacheKey && tokenRefreshInFlight.promise) {
+    return tokenRefreshInFlight.promise;
+  }
+
+  const pending = mintAccessTokenUncached({
+    root,
+    cacheKey,
+    anonKey,
+    refreshToken,
+    fetchImpl,
+    now,
+    timeoutMs,
+  });
+  tokenRefreshInFlight = { cacheKey, promise: pending };
+  try {
+    return await pending;
+  } finally {
+    if (tokenRefreshInFlight.promise === pending) {
+      tokenRefreshInFlight = { cacheKey: null, promise: null };
+    }
+  }
+}
+
+async function mintAccessTokenUncached({
+  root,
+  cacheKey,
+  anonKey,
+  refreshToken,
+  fetchImpl = fetch,
+  now = Date.now,
+  timeoutMs,
+} = {}) {
   const headers = { "Content-Type": "application/json", Accept: "application/json" };
   if (anonKey) headers.apikey = anonKey;
 

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1140,7 +1140,30 @@ function createLocalApiHandler({ queuePath }) {
   const cookiePath = path.join(trackerDataDir, "relay-cookies.json");
   const localSyncDeviceTokenCache = new Map();
   const localSyncDeviceTokenInflight = new Map();
-  let accountViewFailure = { key: null, until: 0 };
+  // A dashboard refresh fans out to several account-view endpoints. Keep the
+  // circuit-breaker state per session instead of one global slot (a successful
+  // request for one account must not clear another account's failure), and
+  // suppress the duplicate fan-out while the first cloud probe is pending.
+  const accountViewFailures = new Map();
+  const accountViewInFlight = new Set();
+
+  function accountViewFailureUntil(failureKey) {
+    const until = accountViewFailures.get(failureKey) || 0;
+    if (until > Date.now()) return until;
+    if (until) accountViewFailures.delete(failureKey);
+    return 0;
+  }
+
+  function rememberAccountViewFailure(failureKey) {
+    accountViewFailures.set(failureKey, Date.now() + ACCOUNT_VIEW_FAILURE_BACKOFF_MS);
+    // Refresh-token rotation or account switching can produce many keys over a
+    // long-lived tray session. Bound the map without affecting the active key.
+    while (accountViewFailures.size > 16) {
+      const oldest = accountViewFailures.keys().next().value;
+      if (!oldest || oldest === failureKey) break;
+      accountViewFailures.delete(oldest);
+    }
+  }
 
   // Load persisted cookies on startup
   try {
@@ -1415,9 +1438,16 @@ function createLocalApiHandler({ queuePath }) {
     if (!refreshToken) return "fallthrough";
     const runtime = resolveRuntimeConfig();
     const failureKey = `${runtime.baseUrl}\0${refreshToken}`;
-    if (accountViewFailure.key === failureKey && accountViewFailure.until > Date.now()) {
+    if (accountViewFailureUntil(failureKey) > Date.now()) {
       return "fallthrough";
     }
+    // Six native dashboard requests normally arrive together. If the cloud is
+    // already being probed for this session, let the remaining requests use
+    // their local fallback instead of opening more timeout-bound sockets.
+    if (accountViewInFlight.has(failureKey)) {
+      return "fallthrough";
+    }
+    accountViewInFlight.add(failureKey);
     const envTimeout = process.env.TOKENTRACKER_HTTP_TIMEOUT_MS
       ? parseInt(process.env.TOKENTRACKER_HTTP_TIMEOUT_MS, 10)
       : 0;
@@ -1432,15 +1462,12 @@ function createLocalApiHandler({ queuePath }) {
         timeoutMs,
       });
       if (!out || out.data == null) {
-        accountViewFailure = {
-          key: failureKey,
-          until: Date.now() + ACCOUNT_VIEW_FAILURE_BACKOFF_MS,
-        };
+        rememberAccountViewFailure(failureKey);
         return "fallthrough";
       }
       if (out.rotatedRefreshToken) setRelayRefreshToken(out.rotatedRefreshToken);
       if (out.rotatedCsrfToken) setRelayCsrfToken(out.rotatedCsrfToken);
-      accountViewFailure = { key: null, until: 0 };
+      accountViewFailures.delete(failureKey);
       res.writeHead(200, {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
@@ -1454,11 +1481,10 @@ function createLocalApiHandler({ queuePath }) {
       if (resolveRuntimeConfig().debug) {
         console.warn(`[LocalAPI] account view fallback for ${usageSlug}:`, e?.message || e);
       }
-      accountViewFailure = {
-        key: failureKey,
-        until: Date.now() + ACCOUNT_VIEW_FAILURE_BACKOFF_MS,
-      };
+      rememberAccountViewFailure(failureKey);
       return "fallthrough";
+    } finally {
+      accountViewInFlight.delete(failureKey);
     }
   }
 

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -14,6 +14,11 @@ const { accountSlugFor, fetchAccountUsage, mintAccessToken } = require("./cloud-
 const { getOrCreateMachineId, computeStableMachineId } = require("./machine-id");
 
 const SYNC_TIMEOUT_MS = 120_000;
+// A failed account-view request should not stall every dashboard refresh
+// while an expired session or unreachable backend keeps timing out. The first
+// request still falls back normally; subsequent fan-out requests reuse that
+// decision for a short cooldown and return local data immediately.
+const ACCOUNT_VIEW_FAILURE_BACKOFF_MS = 2 * 60_000;
 const TRACKER_BIN = path.resolve(__dirname, "../../bin/tracker.js");
 const MAX_DEVICE_NAME_LENGTH = 128;
 
@@ -1135,6 +1140,7 @@ function createLocalApiHandler({ queuePath }) {
   const cookiePath = path.join(trackerDataDir, "relay-cookies.json");
   const localSyncDeviceTokenCache = new Map();
   const localSyncDeviceTokenInflight = new Map();
+  let accountViewFailure = { key: null, until: 0 };
 
   // Load persisted cookies on startup
   try {
@@ -1408,6 +1414,10 @@ function createLocalApiHandler({ queuePath }) {
     const refreshToken = getRefreshTokenForCloud();
     if (!refreshToken) return "fallthrough";
     const runtime = resolveRuntimeConfig();
+    const failureKey = `${runtime.baseUrl}\0${refreshToken}`;
+    if (accountViewFailure.key === failureKey && accountViewFailure.until > Date.now()) {
+      return "fallthrough";
+    }
     const envTimeout = process.env.TOKENTRACKER_HTTP_TIMEOUT_MS
       ? parseInt(process.env.TOKENTRACKER_HTTP_TIMEOUT_MS, 10)
       : 0;
@@ -1421,9 +1431,16 @@ function createLocalApiHandler({ queuePath }) {
         refreshToken,
         timeoutMs,
       });
-      if (!out || out.data == null) return "fallthrough";
+      if (!out || out.data == null) {
+        accountViewFailure = {
+          key: failureKey,
+          until: Date.now() + ACCOUNT_VIEW_FAILURE_BACKOFF_MS,
+        };
+        return "fallthrough";
+      }
       if (out.rotatedRefreshToken) setRelayRefreshToken(out.rotatedRefreshToken);
       if (out.rotatedCsrfToken) setRelayCsrfToken(out.rotatedCsrfToken);
+      accountViewFailure = { key: null, until: 0 };
       res.writeHead(200, {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
@@ -1437,6 +1454,10 @@ function createLocalApiHandler({ queuePath }) {
       if (resolveRuntimeConfig().debug) {
         console.warn(`[LocalAPI] account view fallback for ${usageSlug}:`, e?.message || e);
       }
+      accountViewFailure = {
+        key: failureKey,
+        until: Date.now() + ACCOUNT_VIEW_FAILURE_BACKOFF_MS,
+      };
       return "fallthrough";
     }
   }

--- a/test/cloud-account.test.js
+++ b/test/cloud-account.test.js
@@ -102,6 +102,27 @@ test("mintAccessToken caches by refresh token and skips re-fetch until near expi
   assert.equal(fetchCount, 2);
 });
 
+test("concurrent token refreshes share one in-flight request", async () => {
+  __resetCloudAccountCacheForTests();
+  const access = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  let calls = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const fetchImpl = async () => {
+    calls += 1;
+    await gate;
+    return jsonResponse({ accessToken: access });
+  };
+  const first = mintAccessToken({ baseUrl: "https://cloud.example", refreshToken: "same", fetchImpl });
+  const second = mintAccessToken({ baseUrl: "https://cloud.example", refreshToken: "same", fetchImpl });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(calls, 1);
+  release();
+  const [a, b] = await Promise.all([first, second]);
+  assert.equal(a.accessToken, access);
+  assert.equal(b.accessToken, access);
+});
+
 test("mintAccessToken scopes cache by base URL", async () => {
   __resetCloudAccountCacheForTests();
   const calls = [];

--- a/test/dashboard-browser-lifecycle.test.js
+++ b/test/dashboard-browser-lifecycle.test.js
@@ -69,3 +69,26 @@ test("Windows hides and reuses the dashboard WebView2 on normal close", () => {
     "normal closes should use the same hide path as OAuth",
   );
 });
+
+test("Windows publishes WebView initialization before running it", () => {
+  const source = read("TokenTrackerWin/DashboardWindow.cs");
+  const initStart = source.indexOf("private Task InitializeWebViewAsync()");
+  const retryStart = source.indexOf("    private async Task InitializeWebViewWithRetryAsync", initStart);
+  const initSource = source.slice(initStart, retryStart);
+
+  assert.match(
+    initSource,
+    /var completion = new TaskCompletionSource<bool>[\s\S]*?var task = completion\.Task[\s\S]*?_initializationTask = task[\s\S]*?_ = RunWebViewInitializationAsync\(task, completion\)/,
+    "the in-flight task must be published before initialization starts",
+  );
+  assert.match(
+    source,
+    /private async Task RunWebViewInitializationAsync\([\s\S]*?ReferenceEquals\(_initializationTask, identity\)[\s\S]*?_initializationTask = null;/,
+    "completion cleanup must not clear a newer initialization task",
+  );
+  assert.doesNotMatch(
+    source.slice(retryStart, source.indexOf("    private async Task InitializeWebViewCoreAsync", retryStart)),
+    /finally\s*\{\s*_initializationTask = null;/,
+    "the retry routine must not unconditionally clear the shared task",
+  );
+});

--- a/test/dashboard-browser-lifecycle.test.js
+++ b/test/dashboard-browser-lifecycle.test.js
@@ -23,7 +23,7 @@ test("macOS releases the dashboard WKWebView after a normal close", () => {
   assert.match(source, /self\.window = nil/);
 
   const closeHandler = source.match(
-    /func windowWillClose\([\s\S]*?\n    }\n\n    \/\/ MARK: - WKScriptMessageHandler/,
+    /func windowWillClose\([\s\S]*?\r?\n    }\r?\n\r?\n    \/\/ MARK: - WKScriptMessageHandler/,
   )?.[0];
   assert.ok(closeHandler, "Dashboard close handler should exist");
   assert.match(closeHandler, /if oauthInFlight/);
@@ -45,14 +45,12 @@ test("macOS keeps PKCE state only while native OAuth is in flight", () => {
   assert.match(callbackSource, /postNativeMessage\(\{ type: "authCompleted" \}\)/);
 });
 
-test("Windows closes and disposes an idle dashboard WebView2 instead of hiding it", () => {
+test("Windows hides and reuses the dashboard WebView2 on normal close", () => {
   const windowSource = read("TokenTrackerWin/DashboardWindow.cs");
-  const traySource = read("TokenTrackerWin/TrayApplicationContext.cs");
 
-  assert.match(windowSource, /public event Action<DashboardWindow>\? ReleasedForIdle/);
   assert.match(windowSource, /private void CloseOrHideForOAuth\(\)/);
+  assert.match(windowSource, /private WebView2CompositionControl _webView = CreateWebViewControl\(\)/);
   assert.match(windowSource, /_webView\.Dispose\(\)/);
-  assert.match(windowSource, /ReleasedForIdle\?\.Invoke\(this\)/);
   assert.match(windowSource, /private bool _oauthInFlight/);
   assert.match(windowSource, /BeginNativeOAuth\(\)/);
   assert.match(windowSource, /CompleteNativeOAuth\(\)/);
@@ -60,18 +58,14 @@ test("Windows closes and disposes an idle dashboard WebView2 instead of hiding i
   assert.match(windowSource, /t\.GetString\(\) == "authCompleted"/);
 
   const closingHandler = windowSource.match(
-    /protected override void OnClosing\([\s\S]*?\n    }\n\n    protected override void OnClosed/,
+    /protected override void OnClosing\([\s\S]*?\r?\n    }\r?\n\r?\n    protected override void OnClosed/,
   )?.[0];
   assert.ok(closingHandler, "Dashboard closing handler should exist");
-  assert.match(closingHandler, /if \(!_exiting && _oauthInFlight\)/);
+  assert.match(closingHandler, /if \(!_exiting\)/);
   assert.match(closingHandler, /e\.Cancel = true;\s*Hide\(\);/);
   assert.doesNotMatch(
     closingHandler,
-    /if \(!_exiting\)\s*\{\s*e\.Cancel = true;\s*Hide\(\);/,
-    "normal closes must not retain WebView2",
+    /if \(!_exiting && _oauthInFlight\)/,
+    "normal closes should use the same hide path as OAuth",
   );
-
-  assert.match(traySource, /dashboard\.ReleasedForIdle \+= OnDashboardReleasedForIdle/);
-  assert.match(traySource, /ReferenceEquals\(_dashboard, dashboard\)/);
-  assert.match(traySource, /_dashboard = null/);
 });

--- a/test/local-api-account-view.test.js
+++ b/test/local-api-account-view.test.js
@@ -190,6 +190,39 @@ test("usage-summary?account=1 falls back to local data when not signed in", asyn
   assert.equal(body.totals.total_tokens, 120);
 });
 
+test("account-view failures are briefly backed off so refresh fan-out stays responsive", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-failing; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+
+  const realFetch = global.fetch;
+  let refreshCalls = 0;
+  global.fetch = async () => {
+    refreshCalls += 1;
+    throw new Error("offline");
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const endpoint = "/functions/tokentracker-usage-summary?from=2026-04-20&to=2026-04-20&account=1";
+    const first = await call(handler, { endpoint });
+    const second = await call(handler, { endpoint });
+    assert.equal(first._headers["x-tokentracker-account-view"], "0");
+    assert.equal(second._headers["x-tokentracker-account-view"], "0");
+    assert.equal(refreshCalls, 1, "the second refresh should use the failure backoff");
+    assert.equal(second.json().totals.total_tokens, 120);
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
 test("usage-summary?account=1 serves the cross-device aggregate when signed in + cloud sync on", async () => {
   const queuePath = path.join(tmpHome, "queue.jsonl");
   writeQueue(queuePath, [SAMPLE_ROW]);

--- a/test/local-api-account-view.test.js
+++ b/test/local-api-account-view.test.js
@@ -223,6 +223,54 @@ test("account-view failures are briefly backed off so refresh fan-out stays resp
   }
 });
 
+test("concurrent account-view fan-out shares one pending cloud probe", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-concurrent; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+
+  const realFetch = global.fetch;
+  let refreshCalls = 0;
+  let started;
+  const startedPromise = new Promise((resolve) => { started = resolve; });
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  global.fetch = async () => {
+    refreshCalls += 1;
+    started();
+    await gate;
+    throw new Error("offline");
+  };
+
+  try {
+    const handler = freshHandler(queuePath);
+    const endpoint = "/functions/tokentracker-usage-summary?from=2026-04-20&to=2026-04-20&account=1";
+    const firstPromise = call(handler, { endpoint });
+    await startedPromise;
+    // The second request arrives while the first refresh-token probe is still
+    // pending. It must immediately use the local fallback rather than opening
+    // another timeout-bound network request.
+    const second = await call(handler, { endpoint });
+    assert.equal(refreshCalls, 1);
+    assert.equal(second._headers["x-tokentracker-account-view"], "0");
+    assert.equal(second.json().totals.total_tokens, 120);
+
+    release();
+    const first = await firstPromise;
+    assert.equal(first._headers["x-tokentracker-account-view"], "0");
+    assert.equal(first.json().totals.total_tokens, 120);
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
 test("usage-summary?account=1 serves the cross-device aggregate when signed in + cloud sync on", async () => {
   const queuePath = path.join(tmpHome, "queue.jsonl");
   writeQueue(queuePath, [SAMPLE_ROW]);

--- a/test/serve-native-background-sync.test.js
+++ b/test/serve-native-background-sync.test.js
@@ -73,3 +73,16 @@ test("macOS and non-native serve do not start a duplicate fallback timer", () =>
   assert.equal(startNativeBackgroundSync({ appShell: "", setIntervalFn }), null);
   assert.equal(setIntervalFn.mock.callCount(), 0);
 });
+
+test("Windows host-owned server skips the duplicate fallback timer", () => {
+  const setIntervalFn = test.mock.fn();
+  assert.equal(
+    startNativeBackgroundSync({
+      appShell: "windows",
+      nativeSyncOwner: "windows-host",
+      setIntervalFn,
+    }),
+    null,
+  );
+  assert.equal(setIntervalFn.mock.callCount(), 0);
+});

--- a/test/windows-background-sync-args.test.js
+++ b/test/windows-background-sync-args.test.js
@@ -58,4 +58,9 @@ test("Windows background sync stays native-only while manual sync preserves WSL 
     /StartTrackerProcess\(\s*nodePath,\s*entryPath,\s*false,\s*"serve"/,
     "The long-lived server must not receive the background-only WSL override",
   );
+  assert.match(
+    serverManager,
+    /args\.Length\s*>\s*0[\s\S]*TOKENTRACKER_NATIVE_SYNC_OWNER[\s\S]*"windows-host"/,
+    "The Windows host must disable the embedded server's duplicate fallback timer",
+  );
 });

--- a/test/windows-server-manager-lifecycle.test.js
+++ b/test/windows-server-manager-lifecycle.test.js
@@ -1,0 +1,88 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+
+function readServerManager() {
+  return fs
+    .readFileSync(path.join(repoRoot, "TokenTrackerWin/ServerManager.cs"), "utf8")
+    .replace(/\r\n/g, "\n");
+}
+
+test("Windows server startup re-checks shutdown before and after child launch", () => {
+  const source = readServerManager();
+  const startup = source.slice(
+    source.indexOf("private async Task StartServerOnceAsync()"),
+    source.indexOf("    /// <summary>Run a one-shot", source.indexOf("private async Task StartServerOnceAsync()")),
+  );
+
+  assert.match(
+    startup,
+    /private async Task StartServerOnceAsync\(\)\n\s*\{\n\s*if \(_stopping\) return;/,
+    "startup must stop before resolving/launching a runtime after shutdown begins",
+  );
+  assert.match(
+    startup,
+    /var process = LaunchServer\([\s\S]*?if \(_stopping\)\n\s*\{\n\s*CleanupLaunchedProcess\(process\);\n\s*return;/,
+    "a child created in the stop/launch race must be cleaned up",
+  );
+});
+
+test("Windows server liveness and notifications are race-safe", () => {
+  const source = readServerManager();
+
+  assert.match(
+    source,
+    /var currentProcess = Volatile\.Read\(ref _serverProcess\);[\s\S]*?IsProcessAlive\(currentProcess\)/,
+    "startup checks must tolerate a Process disposed by a concurrent stop",
+  );
+  assert.match(
+    source,
+    /private static bool IsProcessAlive\(Process process\)[\s\S]*?catch \{ return false; \}/,
+    "process-handle races must be treated as not alive",
+  );
+  assert.match(source, /private void RaiseStatusChanged\(ServerStatus status\)/);
+  assert.match(source, /private void RaiseSyncStarted\(\)/);
+  assert.match(source, /private void RaiseSyncCompleted\(\)/);
+  assert.doesNotMatch(
+    source.replace(/private void RaiseStatusChanged[\s\S]*?private void RaiseSyncStarted/, ""),
+    /StatusChanged\?\.Invoke\(/,
+    "status callbacks outside the guarded boundary could terminate a process callback thread",
+  );
+});
+
+test("Windows server teardown and health probes keep process identity", () => {
+  const source = readServerManager();
+  const launchStart = source.indexOf("private Process? LaunchServer(");
+  const launchEnd = source.indexOf("    private void CleanupLaunchedProcess", launchStart);
+  const launch = source.slice(launchStart, launchEnd);
+  assert.match(
+    launch,
+    /catch \(Exception ex\)[\s\S]*?CleanupLaunchedProcess\(process\);[\s\S]*?if \(!_stopping\)\s*\n\s*Fail\(/,
+    "post-launch setup failures must kill/dispose the child before reporting failure",
+  );
+
+  const waitStart = source.indexOf("private async Task<bool> WaitForServerAsync(");
+  const waitEnd = source.indexOf("    private static async Task<bool> CheckHealthAsync", waitStart);
+  const wait = source.slice(waitStart, waitEnd);
+  assert.match(
+    wait,
+    /CheckHealthAsync\(expectedBaseUrl\)[\s\S]*?IsCurrentServerProcess\(expectedProcess\)/,
+    "a successful startup probe must be followed by an identity/liveness check",
+  );
+
+  const healthStart = source.indexOf("private void StartHealthLoop(");
+  const health = source.slice(healthStart);
+  assert.match(
+    health,
+    /await CheckHealthAsync\(expectedBaseUrl\)[\s\S]*?IsCurrentHealthLoop\(process, expectedBaseUrl, generation, cts\)[\s\S]*?SetStatus\(ServerStatus.Running\)/,
+    "a cancelled or superseded health loop must discard probe results before publishing status",
+  );
+  assert.match(
+    health,
+    /RetireHealthLoop\(cts, generation\)[\s\S]*?RequestRestart\("health checks failed"\)/,
+    "only the current health loop may request recovery",
+  );
+});

--- a/test/windows-usage-poller-refresh-scheduling.test.js
+++ b/test/windows-usage-poller-refresh-scheduling.test.js
@@ -1,0 +1,29 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+
+test("Windows usage poller keeps the final coalesced refresh schedulable", () => {
+  const source = fs
+    .readFileSync(path.join(repoRoot, "TokenTrackerWin/UsagePoller.cs"), "utf8")
+    .replace(/\r\n/g, "\n");
+  const finallyStart = source.indexOf("finally\n        {");
+  assert.notEqual(finallyStart, -1, "RefreshAsync must retain its drain finally block");
+  const finallyBlock = source.slice(finallyStart, source.indexOf("\n        }\n    }", finallyStart));
+
+  // A cancellation can arrive between the IsCancellationRequested check and
+  // queueing the delegate. Passing that token to Task.Run would make the
+  // runtime drop the delegate, leaving _refreshRequested set indefinitely.
+  assert.match(
+    finallyBlock,
+    /Task\.Run\(\(\)\s*=>\s*RefreshAsync\(currentToken\)\s*\);/,
+    "the coalesced refresh must be queued even if its token is cancelled after the check",
+  );
+  assert.doesNotMatch(
+    finallyBlock,
+    /Task\.Run\(\(\)\s*=>\s*RefreshAsync\(currentToken\)\s*,\s*currentToken\s*\)/,
+    "Task.Run must not use the cancellation token as a scheduling gate",
+  );
+});


### PR DESCRIPTION
## Summary
- keep the dashboard WebView2 instance alive when the window is hidden so tray toggles do not relaunch Chromium
- recover renderer/browser process failures and guard async WPF/WebView2 callbacks from terminating the tray host
- serialize local server startup and automatically retry unexpected exits or repeated health-check failures with bounded backoff
- add process-level exception logging and deterministic recovery-policy tests

## Evidence
- Windows baseline tests: 8 passed
- Windows modified tests: 10 passed
- Baseline and modified Windows builds: 0 warnings, 0 errors
- Dashboard lint, typecheck, build, copy, UI-hardcode, architecture guardrails: passed
- `git diff --check`: passed

This PR is intentionally limited to Windows stability/startup behavior and does not include the unrelated #514 work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local server recovery with automatic retries after startup, health-check, and unexpected shutdown failures.
  * Dashboard windows now hide and reopen faster while preserving session state.
  * Improved recovery from browser process failures and WebView initialization issues.
  * Prevented stale dashboard data from overwriting newer results during refreshes or view changes.
  * Prevented duplicate usage refreshes, token refresh requests, account checks, and background synchronization timers.
  * Added safeguards to prevent recoverable errors from terminating the tray application.

* **Tests**
  * Expanded coverage for recovery, synchronization, refresh ordering, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->