### PR TITLE
fix(usage): merge case-insensitive trend model segments

### DIFF
--- a/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
+++ b/dashboard/src/ui/dashboard/components/TrendMonitor.jsx
@@ -125,22 +125,46 @@ export function getModelColor(modelName) {
   return STACK_COLORS[index];
 }
 
+/**
+ * Collapse model keys that differ only by whitespace or letter case.
+ *
+ * Usage APIs preserve the model spelling emitted by each tool. A single trend
+ * bucket can therefore contain both `GPT-5.5` and `gpt-5.5`; treating object
+ * keys as case-sensitive makes the tooltip render two segments for one model.
+ * Keep the most-used spelling for display while summing every variant into one
+ * stable segment.
+ */
+export function mergeModelSegments(models) {
+  if (!models || typeof models !== "object") return [];
+  const byKey = new Map();
+  for (const [rawName, rawValue] of Object.entries(models)) {
+    const value = Number(rawValue);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    const name = String(rawName).trim() || "unknown";
+    const key = name.toLowerCase();
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, { name, value, displayWeight: value });
+      continue;
+    }
+    current.value += value;
+    if (value > current.displayWeight) {
+      current.name = name;
+      current.displayWeight = value;
+    }
+  }
+  return Array.from(byKey.values())
+    .map(({ name, value }) => ({ type: "model", name, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
 function getBarSegments(row) {
   if (!row) return [];
   const segments = [];
 
   // 1. 如果有 models，且 models 相加大于 0，则按模型拆分
   if (row.models && typeof row.models === "object") {
-    for (const [modelName, val] of Object.entries(row.models)) {
-      const numVal = Number(val);
-      if (Number.isFinite(numVal) && numVal > 0) {
-        segments.push({
-          type: "model",
-          name: modelName,
-          value: numVal,
-        });
-      }
-    }
+    segments.push(...mergeModelSegments(row.models));
   }
 
   // 2. 如果没有 models，或者 models 分量之和为 0，我们尝试按 Token 类型拆分

--- a/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/TrendMonitor.test.jsx
@@ -11,6 +11,7 @@ import {
   TrendMonitor,
   computeInterpolatedSeries,
   getTrendMonitorScale,
+  mergeModelSegments,
 } from "../TrendMonitor.jsx";
 
 describe("getTrendMonitorScale", () => {
@@ -144,6 +145,18 @@ describe("TrendMonitor", () => {
     fireEvent.mouseLeave(tooltip);
     act(() => vi.advanceTimersByTime(200));
     expect(container.querySelector('[data-trend-tooltip="true"]')).toBeNull();
+  });
+
+  it("merges model segments whose names differ only by case", () => {
+    expect(mergeModelSegments({
+      "GPT-5.5": 120,
+      "gpt-5.5": 80,
+      "Claude-Sonnet": 40,
+      " claude-sonnet ": 10,
+    })).toEqual([
+      { type: "model", name: "GPT-5.5", value: 200 },
+      { type: "model", name: "Claude-Sonnet", value: 50 },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- merge trend tooltip model segments case-insensitively after trimming whitespace
- preserve the spelling of the variant with the highest usage while summing all variants
- add a regression test for `GPT-5.5`/`gpt-5.5` and whitespace variants

## Verification
- baseline TrendMonitor tests: 12 passed
- modified TrendMonitor tests: 13 passed
- dashboard lint, typecheck and production build: passed
- UI hardcode and architecture guardrails: passed

This PR is scoped to the Usage Trend display and is independent of the Windows stability work in #540.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trend breakdowns by combining model names that differ only by capitalization or extra spaces.
  * Excluded invalid or non-positive usage values from model totals.
  * Sorted model segments by usage and displayed the most-used spelling for each model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->