### PR TITLE
fix: unblock Copilot v2 migration for recovered buckets

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -14360,7 +14360,10 @@ async function migrateCopilotChatLogRecordDedup({
   }
 
   const keys = new Set([...oldTotals.keys(), ...newTotals.keys()]);
-  for (const key of keys) {
+  // Only keys that existed in the v2 contribution need coverage validation.
+  // A key that exists only in newTotals is a newly recovered Chat request; its
+  // old contribution is zero, so an absent old bucket is expected.
+  for (const key of oldTotals.keys()) {
     const [model, bucketStart] = JSON.parse(key);
     const oldUsage = oldTotals.get(key) || initTotals();
     if (!copilotTotalsCover(

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -14269,16 +14269,18 @@ async function migrateCopilotChatLogRecordDedup({
   touchedBuckets,
   seenIds,
 } = {}) {
+  // A v2 cursor can retain an offset for a rotated or deleted OTEL file that
+  // is no longer returned by discovery. Its historical contribution cannot be
+  // reconciled, but the stale offset must not block migration of new files.
+  const availableFiles = new Set(Array.isArray(files) ? files : []);
+  for (const filePath of Object.keys(fileOffsets || {})) {
+    if (!availableFiles.has(filePath)) delete fileOffsets[filePath];
+  }
   const trackedFiles = Object.keys(fileOffsets || {}).filter(
     (filePath) => Number(fileOffsets[filePath]?.size) > 0,
   );
   if (trackedFiles.length === 0) {
     return { applied: true, changed: false };
-  }
-
-  const availableFiles = new Set(Array.isArray(files) ? files : []);
-  if (trackedFiles.some((filePath) => !availableFiles.has(filePath))) {
-    return { applied: false, reason: "a previously parsed OTEL file is unavailable" };
   }
 
   const oldSeen = new Set();

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -6578,6 +6578,83 @@ test("parseCopilotIncremental repairs v2 Chat deduplication before upgrading the
   }
 });
 
+test("parseCopilotIncremental migrates v2 when a recovered request creates a new bucket", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-v2-new-bucket-"));
+  try {
+    const otelPath = path.join(tmp, "vscode-chat.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const first = makeCopilotChatLogRecord({
+      responseId: "v2-new-bucket-r1",
+      model: "gpt-4o-mini-2024-07-18",
+      inputTokens: 500,
+      outputTokens: 50,
+      cacheRead: 0,
+    });
+    const recovered = makeCopilotChatLogRecord({
+      responseId: "v2-new-bucket-r2",
+      model: "gpt-5.6-luna",
+      inputTokens: 800,
+      outputTokens: 90,
+      cacheRead: 0,
+    });
+    // v2 collapsed these two Chat LogRecords into the first request because
+    // they share a spanContext. v3 must recover the second model's bucket.
+    first.spanContext = { traceId: "v2-new-bucket-trace", spanId: "v2-new-bucket-span" };
+    recovered.spanContext = { traceId: "v2-new-bucket-trace", spanId: "v2-new-bucket-span" };
+    writeCopilotOtelFile(otelPath, [first, recovered]);
+    const stat = fssync.statSync(otelPath);
+    const firstModel = "gpt-4o-mini-2024-07-18";
+    const recoveredModel = "gpt-5.6-luna";
+    const hourStart = "2026-05-13T03:00:00.000Z";
+    const cursors = {
+      copilot: {
+        version: 2,
+        seenIds: ["v2-new-bucket-trace:v2-new-bucket-span"],
+        fileOffsets: {
+          [otelPath]: { size: stat.size, mtimeMs: stat.mtimeMs, ino: stat.ino },
+        },
+      },
+      hourly: {
+        version: 3,
+        buckets: {
+          [bucketKey("copilot", firstModel, hourStart)]: {
+            totals: {
+              input_tokens: 500,
+              cached_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+              output_tokens: 50,
+              reasoning_output_tokens: 0,
+              total_tokens: 550,
+              billable_total_tokens: 550,
+              conversation_count: 1,
+            },
+            queuedKey: null,
+          },
+        },
+        groupQueued: {},
+      },
+    };
+
+    const result = await parseCopilotIncremental({
+      otelPaths: [otelPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 0, "migration should process the historical prefix");
+    assert.equal(cursors.copilot.version, 3, "migration should advance the cursor");
+
+    const recoveredBucket = cursors.hourly.buckets[
+      bucketKey("copilot", recoveredModel, hourStart)
+    ];
+    assert.equal(recoveredBucket.totals.input_tokens, 800);
+    assert.equal(recoveredBucket.totals.output_tokens, 90);
+    assert.equal(recoveredBucket.totals.total_tokens, 890);
+    assert.equal(recoveredBucket.totals.conversation_count, 1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotIncremental reads short cache_creation + reasoning_tokens keys (Chat extension)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -6655,6 +6655,65 @@ test("parseCopilotIncremental migrates v2 when a recovered request creates a new
   }
 });
 
+test("parseCopilotIncremental prunes deleted v2 files before processing new files", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-v2-deleted-file-"));
+  try {
+    const oldPath = path.join(tmp, "copilot-otel-old.jsonl");
+    const newPath = path.join(tmp, "copilot-otel-new.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const oldRecord = makeCopilotChatLogRecord({
+      responseId: "v2-deleted-old",
+      inputTokens: 400,
+      outputTokens: 40,
+      cacheRead: 0,
+    });
+    oldRecord.spanContext = { traceId: "v2-deleted-trace", spanId: "v2-deleted-span" };
+    writeCopilotOtelFile(oldPath, [oldRecord]);
+    const oldStat = fssync.statSync(oldPath);
+
+    writeCopilotOtelFile(newPath, [
+      makeCopilotChatLogRecord({
+        responseId: "v2-new-file",
+        model: "gpt-5.6-luna",
+        inputTokens: 700,
+        outputTokens: 80,
+        cacheRead: 0,
+      }),
+    ]);
+    await fs.rm(oldPath);
+
+    const cursors = {
+      copilot: {
+        version: 2,
+        seenIds: ["v2-deleted-trace:v2-deleted-span"],
+        fileOffsets: {
+          [oldPath]: { size: oldStat.size, mtimeMs: oldStat.mtimeMs, ino: oldStat.ino },
+        },
+      },
+    };
+    const result = await parseCopilotIncremental({
+      otelPaths: [newPath],
+      cursors,
+      queuePath,
+    });
+
+    assert.equal(result.eventsAggregated, 1, "the newly discovered file should be processed");
+    assert.equal(cursors.copilot.version, 3, "migration should advance past the deleted file");
+    assert.equal(cursors.copilot.fileOffsets[oldPath], undefined);
+    assert.equal(cursors.copilot.fileOffsets[newPath].size, fssync.statSync(newPath).size);
+
+    const [bucket] = (await readJsonLines(queuePath)).filter(
+      (entry) => entry.source === "copilot",
+    );
+    assert.equal(bucket.model, "gpt-5.6-luna");
+    assert.equal(bucket.input_tokens, 700);
+    assert.equal(bucket.output_tokens, 80);
+    assert.equal(bucket.total_tokens, 780);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseCopilotIncremental reads short cache_creation + reasoning_tokens keys (Chat extension)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-copilot-"));
   try {


### PR DESCRIPTION
## Problem

After #527, the Copilot cursor migration from v2 to v3 rebuilds historical Chat deduplication totals using both the legacy and corrected dedup keys.

Two valid states could leave the migration retrying forever:

1. Corrected deduplication recovers a request whose model/hour bucket exists only in the new totals. Validating the union of old and new buckets calls `copilotTotalsCover(undefined, oldUsage)` for that new bucket and aborts the migration.
2. A v2 cursor retains an offset for an OTEL file that has since been rotated or deleted. The path is no longer in the discovered file list, so the availability check aborts before the cursor can be persisted or new files can be processed.

In both cases the cursor remains at v2 and the same historical prefix is retried on every sync, leaving Copilot usage missing or stale.

## Fix

- Validate coverage only for buckets that contributed to the existing v2 totals, while retaining the union of old and new buckets for subtract/add reconciliation.
- Prune tracked file offsets whose paths are absent from the current discovered file list before deciding whether migration can proceed. Existing historical totals are preserved, and newly discovered files can advance the cursor to v3.

## Regression tests

Adds synthetic migration cases for:

- a recovered request creating a new model/hour bucket;
- a deleted old OTEL file alongside a newly discovered file.

Verified with:

`node --test test/rollout-parser.test.js` — 257 passed
`git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Copilot usage tracking across native and WSL environments by recognizing additional telemetry locations.
  - Prevented duplicate Copilot activity from being counted and improved recovery when telemetry files are moved or removed.
  - Improved migration of existing Copilot usage data, including recovery into updated model categories.
  - Improved rollout metadata processing for unfinished requests, legacy records, network paths, and repeated ZCode usage updates.
  - Updated usage-data migrations for the latest Copilot and Grok formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->