### PR TITLE
fix: preserve ZCode history before native usage

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5085,12 +5085,30 @@ function readZcodeNativeUsageMessages(dbPath, sqliteOptions = {}) {
 
 // Read only genuine ZCode assistant messages (its own GLM models via Z.ai /
 // BigModel), dropping any bundled sub-agent turns. See isZcodeNativeMessage.
+//
+// ZCode started writing model_usage after many installations had already
+// accumulated months of history in the OpenCode message tables. The native
+// table is authoritative from its first completed row onward, but it is not a
+// historical backfill. Keep legacy rows before that boundary so merely adding
+// the new table cannot make older usage disappear from TokenTracker.
 function readZcodeDbMessages(dbPath, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const nativeMessages = readZcodeNativeUsageMessages(dbPath, sqliteOptions);
-  if (nativeMessages !== null) return nativeMessages;
-  const all = readOpencodeDbMessages(dbPath, sqliteOptions);
-  return all.filter((m) => isZcodeNativeMessage(m.data));
+  const legacyMessages = readOpencodeDbMessages(dbPath, sqliteOptions)
+    .filter((message) => isZcodeNativeMessage(message.data));
+  if (nativeMessages === null) return legacyMessages;
+
+  const nativeStartMs = nativeMessages.reduce((earliest, message) => {
+    const timestampMs = coerceEpochMs(message?.timeUpdated);
+    return timestampMs > 0 ? Math.min(earliest, timestampMs) : earliest;
+  }, Number.POSITIVE_INFINITY);
+  if (!Number.isFinite(nativeStartMs)) return legacyMessages;
+
+  const historicalMessages = legacyMessages.filter((message) => {
+    const timestampMs = coerceEpochMs(message?.timeUpdated);
+    return timestampMs > 0 && timestampMs < nativeStartMs;
+  });
+  return [...historicalMessages, ...nativeMessages];
 }
 
 async function parseOpencodeDbIncremental({

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -3363,6 +3363,68 @@ test("readZcodeDbMessages queries a real native schema and ignores unfinished re
   }
 });
 
+test("readZcodeDbMessages preserves legacy history before native model_usage begins", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-zcode-native-history-"));
+  try {
+    const dbPath = path.join(tmp, "db.sqlite");
+    const legacyBeforeNative = {
+      id: "legacy-before-native",
+      sessionID: "session-real",
+      role: "assistant",
+      providerID: "builtin:zai-start-plan",
+      modelID: "GLM-5.2",
+      time: { created: 1781514000000, completed: 1781514060000 },
+      tokens: { input: 70, output: 10, reasoning: 0, cache: { read: 20, write: 0 } },
+    };
+    const legacyCoveredByNative = {
+      ...legacyBeforeNative,
+      id: "legacy-covered-by-native",
+      time: { created: 1787105605912, completed: 1787105665912 },
+    };
+    const beforeJson = JSON.stringify(legacyBeforeNative).replace(/'/g, "''");
+    const coveredJson = JSON.stringify(legacyCoveredByNative).replace(/'/g, "''");
+    runSqliteWrite(dbPath, `
+      CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL);
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE model_usage (
+        id TEXT PRIMARY KEY,
+        logical_request_id TEXT NOT NULL,
+        attempt_index INTEGER NOT NULL DEFAULT 0,
+        session_id TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        model_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_input_tokens INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO session VALUES ('session-real', '/real/project');
+      INSERT INTO message VALUES
+        ('legacy-before-native', 'session-real', 1781514000000, 1781514060000, '${beforeJson}'),
+        ('legacy-covered-by-native', 'session-real', 1787105605912, 1787105665912, '${coveredJson}');
+      INSERT INTO model_usage VALUES
+        ('native', 'logical-native', 0, 'session-real', 'builtin:zai-start-plan', 'GLM-5.3',
+         'completed', 1787105605912, 101, 21, 6, 11, 31);
+    `);
+
+    const rows = readZcodeDbMessages(dbPath);
+    assert.deepEqual(rows.map((row) => row.id), ["legacy-before-native", "native"]);
+    assert.equal(rows[0].data.modelID, "GLM-5.2");
+    assert.equal(rows[1].data.modelID, "GLM-5.3");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("readZcodeDbMessages snapshots native model_usage DBs on UNC paths", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-zcode-native-unc-"));
   try {


### PR DESCRIPTION
## Summary

Preserve ZCode usage recorded before the native model_usage table starts so upgrading cannot make historical GLM usage disappear.

model_usage is authoritative for new requests but is not a backfill. The previous reader selected it exclusively as soon as the schema existed, while the migration removed legacy queue buckets. On installations where the native table starts recently, that combination drops months of valid history.

This change merges genuine ZCode messages from the legacy tables before the first completed native usage row with native rows at and after that boundary. The strict timestamp boundary keeps native usage authoritative and avoids double-counting overlapping records.

## Scope

- [x] CLI (src/)
- [ ] Dashboard (dashboard/)
- [ ] macOS app (TokenTrackerBar/)
- [ ] Windows app (TokenTrackerWin/)
- [ ] Docs / CI / config

## Verification

- ZCode reader and migration tests: 7/7 passed
- TypeScript, local runtime, and Vite integration tests: 12/12 passed
- Dashboard production build passed
- Real affected database: restored 4,890 July GLM-5.2 records totaling 2,099,802,588 tokens, exactly matching the pre-migration queue backup
- Full npm test: 2,509 passed; the only local failure was the existing CodeBuddy discovery test reading 13 real host log files. The same test passes with a clean HOME.

## Checklist

- [ ] npm test passes without host-data isolation (see verification note)
- [x] No user-facing strings added
- [x] Commit follows conventional style
- [x] PR description explains why

## Regression coverage

The new SQLite fixture contains:

- a legacy GLM-5.2 row before native usage begins, which must remain;
- an overlapping legacy row after the native boundary, which must be excluded;
- a native GLM-5.3 row, which remains authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved historical usage data recorded before native usage tracking began.
  - Prevented duplicate or overlapping legacy usage entries from appearing when native records cover the same period.

- **Tests**
  - Added coverage for combining legacy and native usage history while excluding superseded legacy records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->