### PR TITLE
fix: replace text-glyph refresh spinner with a real SVG icon

### DIFF
--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import { motion, useReducedMotion } from "motion/react";
-import { Info, Loader2, SquareArrowOutUpRight } from "lucide-react";
+import { Info, Loader2, RefreshCw, SquareArrowOutUpRight } from "lucide-react";
 
 // Solid (fill-based) monochrome all-tools mark — matches the fill-based
 // mono provider icons, unlike lucide's stroke-only Layers3. Drawn bold and
@@ -157,9 +157,12 @@ function RefreshButton({ loading, onClick }) {
             ? { duration: 1, repeat: Infinity, ease: "linear" }
             : { duration: 0.3 }
         }
-        style={{ display: "inline-block" }}
+        style={{ display: "inline-flex" }}
       >
-        ↻
+        {/* Real arc geometry: the previous "↻" text glyph is a non-circular,
+            font-dependent shape whose glyph-box center sits off the arc's
+            visual center, so the spin wobbled instead of reading as a circle. */}
+        <RefreshCw className="h-3.5 w-3.5" strokeWidth={2} />
       </motion.span>
     </Button>
   );


### PR DESCRIPTION
## 问题

Share 按钮旁的刷新按钮的转圈动画，旋转的是一个 Unicode 字符“↻”（U+21BB）。用字体字形做 spinner 有两个问题：

- 字形不是几何圆形，弧线粗细取决于平台字体，不同系统渲染效果不一致，看起来“转圈不够圆”。
- 字形包围盒的中心与弧线的视觉中心不重合，旋转时围绕错误的中心，会有偏摆感。

## 改动

- 把字符换成 lucide 的 `RefreshCw` 图标——几何上的真圆弧，旋转中心就是图标中心。`lucide-react` 已是项目依赖，图标族和尺寸（`h-3.5 w-3.5`）与旁边 Share 按钮的 `SquareArrowOutUpRight` 保持一致。
- 旋转动画逻辑原样保留（rotate 360°/结束后回正，仍尊重 `useReducedMotion` 减弱动态设置）。
- 旋转容器从 `inline-block` 改为 `inline-flex`，消除 SVG 在 span 内的基线偏移。

## 验证

- `vite build` 通过。
- 在本地真实数据的仪表盘（vite dev server）上验证：静态图标是与 Share 按钮一致视觉重量的规整圆弧，点击刷新旋转正常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the usage dashboard refresh control with a clearer refresh icon.
  * Improved icon alignment and presentation while loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->