### PR TITLE
perf(macos): reduce pet atlas frame memory

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/DesktopPetWindowController.swift
@@ -616,7 +616,12 @@ final class PetCatalog: ObservableObject {
     static let shared = PetCatalog()
     private static let builtins: [PetCharacter] = [.clawd, .bot, .sprout, .byte, .ember]
     private static let hiddenBuiltinsFilename = ".hidden-builtins.json"
-    private struct Metadata { let displayName: String; let spriteVersionNumber: Int; let atlasURL: URL }
+    private struct Metadata {
+        let displayName: String
+        let spriteVersionNumber: Int
+        let atlasURL: URL
+        let atlasCacheKey: String
+    }
 
     @Published private(set) var characters: [PetCharacter] = builtins
     private var metadata: [String: Metadata] = [:]
@@ -668,11 +673,15 @@ final class PetCatalog: ObservableObject {
                       let displayName = object["displayName"] as? String,
                       !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
                 let version = (object["spriteVersionNumber"] as? NSNumber)?.intValue == 2 ? 2 : 1
+                let attributes = try? FileManager.default.attributesOfItem(atPath: atlasURL.path)
+                let modified = (attributes?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+                let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
                 seen.insert(character.rawValue)
                 discovered.append((character, Metadata(
                     displayName: displayName,
                     spriteVersionNumber: version,
-                    atlasURL: atlasURL
+                    atlasURL: atlasURL,
+                    atlasCacheKey: "\(character.rawValue)-\(modified)-\(size)"
                 )))
             }
         }
@@ -699,13 +708,7 @@ final class PetCatalog: ObservableObject {
             ?? Bundle.main.url(forResource: name, withExtension: "png")
     }
     func atlasCacheKey(for character: PetCharacter) -> String {
-        guard let url = metadata[character.rawValue]?.atlasURL,
-              let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
-            return character.rawValue
-        }
-        let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
-        let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
-        return "\(character.rawValue)-\(modified)-\(size)"
+        metadata[character.rawValue]?.atlasCacheKey ?? character.rawValue
     }
 }
 

--- a/TokenTrackerBar/TokenTrackerBar/Views/PetAtlasSpriteView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/PetAtlasSpriteView.swift
@@ -2,8 +2,8 @@ import AppKit
 import SwiftUI
 
 /// Renders Codex-compatible 8×9 (V1) and 8×11 (V2) companion atlases.
-/// Frames are cropped once and cached; the transparent desktop window only swaps the
-/// resulting NSImage, avoiding per-frame decoding or layout work.
+/// Frames are copied into cell-sized bitmaps once and cached; the transparent desktop
+/// window only swaps the resulting NSImage, avoiding full-atlas decodes per frame.
 struct PetAtlasSpriteView: View {
     let character: PetCharacter
     let state: ClawdCompanionView.ClawdState
@@ -85,47 +85,57 @@ private final class PetAtlasFrameCache {
     static let shared = PetAtlasFrameCache()
 
     private let lock = NSLock()
-    private var atlases: [String: CGImage] = [:]
+    private var cacheKey: String?
+    private var atlas: CGImage?
     private var frames: [String: NSImage] = [:]
     private let cellWidth = 192
     private let cellHeight = 208
 
     func frame(character: PetCharacter, row: Int, column: Int) -> NSImage? {
-        let key = "\(character.atlasCacheKey)-\(row)-\(column)"
+        let cacheKey = character.atlasCacheKey
+        let frameKey = "\(row)-\(column)"
         lock.lock()
-        if let cached = frames[key] {
-            lock.unlock()
-            return cached
+        defer { lock.unlock() }
+
+        if self.cacheKey != cacheKey {
+            self.cacheKey = cacheKey
+            atlas = nil
+            frames.removeAll(keepingCapacity: true)
         }
-        guard let atlas = atlas(for: character) else {
-            lock.unlock()
-            return nil
-        }
+        if let cached = frames[frameKey] { return cached }
+        guard let atlas = atlas(for: character) else { return nil }
         let rect = CGRect(
             x: column * cellWidth,
             y: row * cellHeight,
             width: cellWidth,
             height: cellHeight
         )
-        guard let cropped = atlas.cropping(to: rect) else {
-            lock.unlock()
-            return nil
-        }
-        let image = NSImage(cgImage: cropped, size: NSSize(width: cellWidth, height: cellHeight))
-        frames[key] = image
-        lock.unlock()
+        guard let cropped = atlas.cropping(to: rect),
+              let context = CGContext(
+                data: nil,
+                width: cellWidth,
+                height: cellHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: cellWidth * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else { return nil }
+        context.interpolationQuality = .none
+        context.draw(cropped, in: CGRect(x: 0, y: 0, width: cellWidth, height: cellHeight))
+        guard let copied = context.makeImage() else { return nil }
+        let image = NSImage(cgImage: copied, size: NSSize(width: cellWidth, height: cellHeight))
+        frames[frameKey] = image
         return image
     }
 
     private func atlas(for character: PetCharacter) -> CGImage? {
-        let cacheKey = character.atlasCacheKey
-        if let cached = atlases[cacheKey] { return cached }
-        let url = character.atlasURL
-        guard let url, let image = NSImage(contentsOf: url),
+        if let atlas { return atlas }
+        guard let url = character.atlasURL,
+              let image = NSImage(contentsOf: url),
               let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
-        atlases[cacheKey] = cgImage
+        atlas = cgImage
         return cgImage
     }
 }

--- a/test/pet-parity.test.js
+++ b/test/pet-parity.test.js
@@ -227,6 +227,30 @@ test("atlas row timings match between PetAtlasAnimated.jsx and PetAtlasSpriteVie
   }
 });
 
+test("macOS caches materialized atlas cells instead of lazy full-atlas crops", () => {
+  assert.match(atlasSwiftSource, /let context = CGContext\(/);
+  assert.match(atlasSwiftSource, /context\.draw\(cropped,/);
+  assert.match(atlasSwiftSource, /let copied = context\.makeImage\(\)/);
+  assert.match(atlasSwiftSource, /NSImage\(cgImage: copied,/);
+  assert.doesNotMatch(
+    atlasSwiftSource,
+    /NSImage\(cgImage: cropped,/,
+    "caching a cropped WebP proxy makes ImageIO retain one full atlas decode per frame",
+  );
+  assert.match(atlasSwiftSource, /if self\.cacheKey != cacheKey/);
+  assert.match(atlasSwiftSource, /frames\.removeAll\(keepingCapacity: true\)/);
+
+  const cacheKeyFunction = macControllerSource.match(
+    /func atlasCacheKey\(for character: PetCharacter\) -> String \{[\s\S]*?\n    \}/,
+  )?.[0];
+  assert.ok(cacheKeyFunction, "PetCatalog.atlasCacheKey must stay source-inspectable");
+  assert.doesNotMatch(
+    cacheKeyFunction,
+    /attributesOfItem/,
+    "animation frames must not stat the imported atlas on every cache lookup",
+  );
+});
+
 test("V2 look directions use the same 16-cell row mapping on web, macOS, and Windows", () => {
   assert.match(atlasJsSource, /9 \+ Math\.floor\(lookIndex \/ 8\)/);
   assert.match(atlasJsSource, /lookIndex % 8/);


### PR DESCRIPTION
## Summary

- materialize pet-atlas cells into independent 192x208 bitmaps before caching them
- keep only the active character's atlas and frame cache
- compute imported-atlas cache metadata during catalog refresh instead of on every animation frame
- add regression coverage for the cache/materialization structure

## Why

`CGImage.cropping(to:)` leaves a lazy ImageIO-backed crop. Caching those crops as `NSImage`s caused each rendered frame to retain a full decoded WebP atlas. On the selected 1536x1872 `monthly-salary-cat` atlas, the running macOS app showed 570 MB of ImageIO allocations across 52 regions.

## Measurement

A focused AppKit harness rendered every one of the atlas's 72 cells into `NSImageView`s, waited four seconds for rendering to settle, and measured with macOS `footprint`:

| Cache strategy | Physical footprint |
| --- | ---: |
| Lazy `CGImage.cropping` frames | 812 MB |
| Materialized 192x208 frames | 45 MB |

That is a 767 MB / 94.5% reduction in the worst-case harness. A separate byte-level render comparison confirmed all 72 copied frames are pixel-identical to the lazy crops.

## Validation

- `npm test`: 2,510 passed, 0 failed, 2 skipped
- `xcodebuild ... -scheme TokenTrackerBarTests ... test`: 160 passed, 0 failed
- macOS `TokenTrackerBar` Debug build with code signing disabled
- architecture guardrails and version validation
- Swift source parsing
- `git diff --check`
- independent defect-first review: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved desktop pet animation rendering by pre-rendering and caching individual atlas frames.
  * Reduced repeated filesystem metadata lookups when loading pet artwork.
  * Updated caching behavior to efficiently switch between different artwork versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->