### PR TITLE
fix: 兼容新版 Qoder（com.qoder.app.stable）的 JSONL 存储与 credit 计费

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -499,10 +499,10 @@ async function cmdStatus(argv = []) {
   });
   const qoderActive = formatResolvedPaths(qoderPaths);
   // New JSONL location (com.qoder.app.stable + ~/.qoder/projects)
+  const qoderProjectsDirResolved = resolveQoderProjectsDir({ home, env: process.env });
   let qoderNewFiles = [];
   try {
-    const qoderProjectsDir = resolveQoderProjectsDir({ home, env: process.env });
-    qoderNewFiles = await listQoderNewSessionFiles(qoderProjectsDir);
+    qoderNewFiles = await listQoderNewSessionFiles(qoderProjectsDirResolved);
   } catch (_e) {
     qoderNewFiles = [];
   }
@@ -510,7 +510,7 @@ async function cmdStatus(argv = []) {
   const qoderInstalled = qoderActive.length > 0 || qoderNewInstalled;
   const qoderDbPath = qoderActive.join(" | ");
   const qoderNewPath = qoderNewFiles.length > 0
-    ? `${resolveQoderProjectsDir({ home, env: process.env })} (${qoderNewFiles.length} sessions)`
+    ? `${qoderProjectsDirResolved} (${qoderNewFiles.length} sessions)`
     : "";
 
   // Qoder CN (国内版) — same schema, separate Application Support/QoderCN dir.

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -71,6 +71,8 @@ const {
   resolveZedDbPath,
   resolveQoderDbPaths,
   resolveQoderCnDbPaths,
+  resolveQoderProjectsDir,
+  listQoderNewSessionFiles,
   resolveClaudeScienceDbPaths,
   resolveAnythingllmDbPath,
   resolveGooseDbPath,
@@ -488,15 +490,28 @@ async function cmdStatus(argv = []) {
   const zcodeInstalled = zcodeActive.length > 0;
   const zcodeDbPath = zcodeActive.join(" | ");
 
-  // Qoder Desktop 1.18+ — token usage lives in SharedClientCache/local.db.
+  // Qoder Desktop 1.18+ — token usage lives in SharedClientCache/local.db (legacy)
+  // and since 2026-08 (app 0.1.2+) also in ~/.qoder/projects JSONL (credit-based).
   const qoderPaths = resolveQoderDbPaths({
     home,
     env: process.env,
     platform: process.platform,
   });
   const qoderActive = formatResolvedPaths(qoderPaths);
-  const qoderInstalled = qoderActive.length > 0;
+  // New JSONL location (com.qoder.app.stable + ~/.qoder/projects)
+  let qoderNewFiles = [];
+  try {
+    const qoderProjectsDir = resolveQoderProjectsDir({ home, env: process.env });
+    qoderNewFiles = await listQoderNewSessionFiles(qoderProjectsDir);
+  } catch (_e) {
+    qoderNewFiles = [];
+  }
+  const qoderNewInstalled = qoderNewFiles.length > 0;
+  const qoderInstalled = qoderActive.length > 0 || qoderNewInstalled;
   const qoderDbPath = qoderActive.join(" | ");
+  const qoderNewPath = qoderNewFiles.length > 0
+    ? `${resolveQoderProjectsDir({ home, env: process.env })} (${qoderNewFiles.length} sessions)`
+    : "";
 
   // Qoder CN (国内版) — same schema, separate Application Support/QoderCN dir.
   const qoderCnPaths = resolveQoderCnDbPaths({
@@ -1089,7 +1104,7 @@ async function cmdStatus(argv = []) {
         ? `- ZCode: passive reader (${zcodeDbPath})`
         : null,
       qoderInstalled
-        ? `- Qoder: passive reader (${qoderDbPath})`
+        ? `- Qoder: passive reader (${[qoderDbPath, qoderNewPath].filter(Boolean).join(" + ") || "not found"}${qoderNewInstalled && qoderActive.length > 0 ? " [legacy DB + new JSONL (both tracked)]" : ""}${qoderNewInstalled && qoderActive.length === 0 ? " [new JSONL only]" : ""})`
         : null,
       qoderCnInstalled
         ? `- Qoder CN: passive reader (${qoderCnDbPath})`

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -72,6 +72,7 @@ const {
   resolveQoderDbPaths,
   resolveQoderCnDbPaths,
   resolveQoderProjectsDir,
+  resolveQoderCnProjectsDir,
   listQoderNewSessionFiles,
   resolveClaudeScienceDbPaths,
   resolveAnythingllmDbPath,
@@ -127,6 +128,13 @@ function formatResolvedPaths(paths, filename) {
     try { if (fssync.existsSync(file)) active.push(`${label}: ${file}`); } catch (_e) {}
   }
   return active;
+}
+
+// Combine a legacy DB path with its new-JSONL projects-dir path for the
+// machine-readable summary. Either side may be "" (absent); both absent
+// yields "" so callers can fall back to "not found".
+function summarizeQoderDetail(dbPath, newPath) {
+  return [dbPath, newPath].filter(Boolean).join(" + ") || "";
 }
 
 // The Trae SOLO entitlement snapshot is read directly from the Trae Local
@@ -520,8 +528,28 @@ async function cmdStatus(argv = []) {
     platform: process.platform,
   });
   const qoderCnActive = formatResolvedPaths(qoderCnPaths);
-  const qoderCnInstalled = qoderCnActive.length > 0;
+  // CN new-JSONL mirrors sync.js: CN and international currently share
+  // ~/.qoder/projects, and sync only parses the CN dir when it diverges from
+  // the international one (same files must not count under two sources). Only
+  // report CN JSONL when the dirs diverge.
+  const qoderCnProjectsDirResolved = resolveQoderCnProjectsDir({ home, env: process.env });
+  const qoderCnSharesIntlDir = path.normalize(qoderCnProjectsDirResolved) === path.normalize(qoderProjectsDirResolved)
+    || (process.platform === "win32"
+      && path.normalize(qoderCnProjectsDirResolved).toLowerCase() === path.normalize(qoderProjectsDirResolved).toLowerCase());
+  let qoderCnNewFiles = [];
+  if (!qoderCnSharesIntlDir) {
+    try {
+      qoderCnNewFiles = await listQoderNewSessionFiles(qoderCnProjectsDirResolved);
+    } catch (_e) {
+      qoderCnNewFiles = [];
+    }
+  }
+  const qoderCnNewInstalled = qoderCnNewFiles.length > 0;
+  const qoderCnInstalled = qoderCnActive.length > 0 || qoderCnNewInstalled;
   const qoderCnDbPath = qoderCnActive.join(" | ");
+  const qoderCnNewPath = qoderCnNewFiles.length > 0
+    ? `${qoderCnProjectsDirResolved} (${qoderCnNewFiles.length} sessions)`
+    : "";
 
   // Claude Science — token usage lives on the `frames` table of operon-cli.db.
   // Unlike the native/WSL pair other providers resolve to, this is an open-ended
@@ -952,10 +980,10 @@ async function cmdStatus(argv = []) {
           ? { installed: true, detail: zcodeDbPath }
           : { installed: false },
         qoder: qoderInstalled
-          ? { installed: true, detail: qoderDbPath }
+          ? { installed: true, detail: summarizeQoderDetail(qoderDbPath, qoderNewPath) }
           : { installed: false },
         "qoder-cn": qoderCnInstalled
-          ? { installed: true, detail: qoderCnDbPath }
+          ? { installed: true, detail: summarizeQoderDetail(qoderCnDbPath, qoderCnNewPath) }
           : { installed: false },
         "claude-science": claudeScienceInstalled
           ? { installed: true, detail: claudeScienceDbPath }
@@ -1107,7 +1135,7 @@ async function cmdStatus(argv = []) {
         ? `- Qoder: passive reader (${[qoderDbPath, qoderNewPath].filter(Boolean).join(" + ") || "not found"}${qoderNewInstalled && qoderActive.length > 0 ? " [legacy DB + new JSONL (both tracked)]" : ""}${qoderNewInstalled && qoderActive.length === 0 ? " [new JSONL only]" : ""})`
         : null,
       qoderCnInstalled
-        ? `- Qoder CN: passive reader (${qoderCnDbPath})`
+        ? `- Qoder CN: passive reader (${summarizeQoderDetail(qoderCnDbPath, qoderCnNewPath) || "not found"}${qoderCnNewInstalled && qoderCnActive.length > 0 ? " [legacy DB + new JSONL (both tracked)]" : ""}${qoderCnNewInstalled && qoderCnActive.length === 0 ? " [new JSONL only]" : ""})`
         : null,
       claudeScienceInstalled
         ? `- Claude Science: passive reader (${claudeScienceDbPath})`
@@ -1453,4 +1481,4 @@ function parseEpochMsToIso(v) {
   return d.toISOString();
 }
 
-module.exports = { cmdStatus };
+module.exports = { cmdStatus, summarizeQoderDetail };

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1283,7 +1283,7 @@ async function cmdSync(argv, context = {}) {
             projectQueuePath,
             onProgress: makeProviderProgress("Qoder (new)"),
             sourceKey: "qoder",
-            cursorKey: "qoder",
+            cursorKey: "qoderNew",
           });
           qoderResult = {
             recordsProcessed: qoderResult.recordsProcessed + (parsed.messagesProcessed || 0),
@@ -1354,7 +1354,11 @@ async function cmdSync(argv, context = {}) {
       try {
         const cnProjectsDir = resolveQoderCnProjectsDir({ home, env: process.env });
         const intlProjectsDir = resolveQoderProjectsDir({ home, env: process.env });
-        if (cnProjectsDir !== intlProjectsDir) {
+        const projectsDirKey = (p) => {
+          const normalized = path.normalize(p);
+          return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+        };
+        if (projectsDirKey(cnProjectsDir) !== projectsDirKey(intlProjectsDir)) {
           const sessionFiles = await listQoderNewSessionFiles(cnProjectsDir);
           if (sessionFiles.length > 0) {
             if (progress?.enabled) {
@@ -1367,7 +1371,7 @@ async function cmdSync(argv, context = {}) {
               projectQueuePath,
               onProgress: makeProviderProgress("Qoder CN (new)"),
               sourceKey: "qoder-cn",
-              cursorKey: "qoder-cn",
+              cursorKey: "qoderCnNew",
             });
             qoderCnResult = {
               recordsProcessed: qoderCnResult.recordsProcessed + (parsed.messagesProcessed || 0),

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -33,6 +33,10 @@ const {
   resolveQoderDbPaths,
   resolveQoderCnDbPaths,
   readQoderDbMessages,
+  resolveQoderProjectsDir,
+  resolveQoderCnProjectsDir,
+  listQoderNewSessionFiles,
+  parseQoderNewIncremental,
   resolveKiroDbPath,
   resolveKiroJsonlPath,
   resolveKiroBasePath,
@@ -1259,6 +1263,39 @@ async function cmdSync(argv, context = {}) {
       }
     }
 
+    // Qoder new (JSONL) — com.qoder.app.stable / ~/.qoder/projects (2026-08+)
+    // The new Electron app no longer writes SharedClientCache/local.db; all
+    // recent sessions live in ~/.qoder/projects as flat JSONL with credit-based
+    // usage. Parse them into the same "qoder" source so history is continuous.
+    // The legacy DB block above remains as a fallback for pre-migration rows.
+    if (sourceAllowed("qoder")) {
+      try {
+        const projectsDir = resolveQoderProjectsDir({ home, env: process.env });
+        const sessionFiles = await listQoderNewSessionFiles(projectsDir);
+        if (sessionFiles.length > 0) {
+          if (progress?.enabled) {
+            progress.start(`Parsing Qoder (new) ${renderBar(0)} | buckets 0`);
+          }
+          const parsed = await parseQoderNewIncremental({
+            sessionFiles,
+            cursors,
+            queuePath,
+            projectQueuePath,
+            onProgress: makeProviderProgress("Qoder (new)"),
+            sourceKey: "qoder",
+            cursorKey: "qoder",
+          });
+          qoderResult = {
+            recordsProcessed: qoderResult.recordsProcessed + (parsed.messagesProcessed || 0),
+            eventsAggregated: qoderResult.eventsAggregated + (parsed.eventsAggregated || 0),
+            bucketsQueued: qoderResult.bucketsQueued + (parsed.bucketsQueued || 0),
+          };
+        }
+      } catch (err) {
+        warnProviderParseFailure("Qoder (new)", err, opts);
+      }
+    }
+
     // ── Qoder CN (国内版) — same SharedClientCache/local.db schema, separate
     // Application Support/QoderCN data directory. Tracked as its own source
     // with its own cursor namespace: the two DBs each number rowids from 1, so
@@ -1307,6 +1344,40 @@ async function cmdSync(argv, context = {}) {
         } catch (err) {
           warnProviderParseFailure("Qoder CN", err, opts);
         }
+      }
+    }
+
+    // Qoder CN new (JSONL) — currently shares ~/.qoder/projects with international;
+    // keep distinct parsing only when CN projects dir diverges (future CN split)
+    // to avoid double-counting the same JSONL under two sources.
+    if (sourceAllowed("qoder-cn")) {
+      try {
+        const cnProjectsDir = resolveQoderCnProjectsDir({ home, env: process.env });
+        const intlProjectsDir = resolveQoderProjectsDir({ home, env: process.env });
+        if (cnProjectsDir !== intlProjectsDir) {
+          const sessionFiles = await listQoderNewSessionFiles(cnProjectsDir);
+          if (sessionFiles.length > 0) {
+            if (progress?.enabled) {
+              progress.start(`Parsing Qoder CN (new) ${renderBar(0)} | buckets 0`);
+            }
+            const parsed = await parseQoderNewIncremental({
+              sessionFiles,
+              cursors,
+              queuePath,
+              projectQueuePath,
+              onProgress: makeProviderProgress("Qoder CN (new)"),
+              sourceKey: "qoder-cn",
+              cursorKey: "qoder-cn",
+            });
+            qoderCnResult = {
+              recordsProcessed: qoderCnResult.recordsProcessed + (parsed.messagesProcessed || 0),
+              eventsAggregated: qoderCnResult.eventsAggregated + (parsed.eventsAggregated || 0),
+              bucketsQueued: qoderCnResult.bucketsQueued + (parsed.bucketsQueued || 0),
+            };
+          }
+        }
+      } catch (err) {
+        warnProviderParseFailure("Qoder CN (new)", err, opts);
       }
     }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5824,10 +5824,16 @@ function normalizeQoderNewTokens(usage) {
   if (!usage || typeof usage !== "object") return null;
   const credits = Number(usage.credits ?? usage.original_credits ?? 0);
   const billable = usage.billable !== false;
-  const input = Number(usage.input_tokens ?? 0);
-  const cached = Number(usage.cache_read_input_tokens ?? usage.cached_tokens ?? 0);
-  const cacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
-  const output = Number(usage.output_tokens ?? 0);
+  let input = Number(usage.input_tokens ?? 0);
+  let cached = Number(usage.cache_read_input_tokens ?? usage.cached_tokens ?? 0);
+  let cacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
+  let output = Number(usage.output_tokens ?? 0);
+  // Guard against malformed numbers (NaN/Infinity/negative) — align with
+  // legacy normalizeQoderTokens which returns null on such input.
+  if (!Number.isFinite(input) || input < 0) input = 0;
+  if (!Number.isFinite(cached) || cached < 0) cached = 0;
+  if (!Number.isFinite(cacheCreation) || cacheCreation < 0) cacheCreation = 0;
+  if (!Number.isFinite(output) || output < 0) output = 0;
   // New SDK reports 0 tokens but non-zero credits — estimate tokens from credits
   // so the dashboard still shows activity. Keep estimate conservative and mark
   // precision so it is distinguishable from exact local.db rows.

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5837,7 +5837,7 @@ function normalizeQoderNewTokens(usage) {
   // New SDK reports 0 tokens but non-zero credits — estimate tokens from credits
   // so the dashboard still shows activity. Keep estimate conservative and mark
   // precision so it is distinguishable from exact local.db rows.
-  if (input > 0 || cached > 0 || output > 0) {
+  if (input > 0 || cached > 0 || cacheCreation > 0 || output > 0) {
     const inp = Math.max(0, Math.trunc(input));
     const cach = Math.max(0, Math.trunc(cached));
     const out = Math.max(0, Math.trunc(output));

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5726,9 +5726,15 @@ async function parseQoderDbIncremental({
 // credit-billed SDK: {input_tokens:0, output_tokens:0, credits:3.2, billable:true}.
 // Token breakdown is unavailable in the new format; we estimate tokens from
 // credits for dashboard continuity and mark the bucket usage_precision so the
-// estimate is distinguishable from exact DB rows.
-// Old local.db is kept as a legacy fallback; both sources share the "qoder"
-// cursor namespace via disjoint messageKey prefixes (row: vs jsonl:).
+// estimate is distinguishable from exact DB rows. Cost remains unknown — no
+// authoritative credit→USD rate is published, so total_cost_usd stays 0 and
+// dashboard falls back to token pricing (which will be 0 for unpriced qoder
+// models, intentionally not a pseudo-precise $ value).
+// Old local.db is kept as a legacy fallback; both sources now use distinct
+// cursor namespaces (qoder vs qoderNew) via disjoint messageKey prefixes
+// (row: vs jsonl:) but upload under the same source="qoder".
+const QODER_CREDITS_ESTIMATE_TOKENS_PER_CREDIT = 1500;
+
 function resolveQoderProjectsDir({ home = os.homedir(), env = process.env, platform = process.platform, deps = {} } = {}) {
   const override = typeof env.QODER_PROJECTS_DIR === "string" && env.QODER_PROJECTS_DIR.trim()
     ? path.resolve(env.QODER_PROJECTS_DIR.trim())
@@ -5791,17 +5797,19 @@ function qoderNewModelFromRecord(record) {
   return normalizeModelInput(direct) || "qoder-agent";
 }
 
-function qoderNewMessageKey(record, filePath) {
+function qoderNewMessageKey(record, filePath, lineIndex = 0) {
   const msgId = normalizeMessageKeyPart(record?.message?.id)
     || normalizeMessageKeyPart(record?.uuid)
-    || normalizeMessageKeyPart(record?.message?.id)
+    || normalizeMessageKeyPart(record?.id)
     || null;
   const sessionId = normalizeMessageKeyPart(record?.sessionId || record?.session_id);
-  // Prefix to avoid collision with legacy row: keys
+  // Prefix to avoid collision with legacy row: keys; fallback includes line index
+  // so multiple no-id records in the same file remain distinct.
+  const fallbackSuffix = Number.isFinite(lineIndex) ? `${filePath}:${lineIndex}` : filePath;
   if (sessionId && msgId) return `jsonl:${sessionId}|${msgId}`;
   if (msgId) return `jsonl:${msgId}`;
-  if (sessionId) return `jsonl:${sessionId}|${record?.uuid || filePath}`;
-  return `jsonl:${filePath}|${record?.uuid || ""}`;
+  if (sessionId) return `jsonl:${sessionId}|${record?.uuid || fallbackSuffix}`;
+  return `jsonl:${fallbackSuffix}|${record?.uuid || ""}`;
 }
 
 function qoderNewTimestampMs(record) {
@@ -5841,11 +5849,11 @@ function normalizeQoderNewTokens(usage) {
     };
   }
   if (Number.isFinite(credits) && credits > 0 && billable) {
-    // Heuristic: 1 credit ≈ 1500 tokens (calibrated against legacy prompt_tokens
-    // vs credit samples from DSH003). Token split is unknown, so attribute to
-    // input for cost continuity; dashboard cost will be derived via pricing if
-    // available, otherwise authoritative cost below covers it.
-    const estimated = Math.max(1, Math.round(credits * 1500));
+    // No authoritative credit→USD rate is published. Preserve token continuity
+    // via a documented heuristic; cost stays unknown (0) so dashboard does not
+    // render a pseudo-precise $ value. Token split is unknown, so attribute to
+    // input.
+    const estimated = Math.max(1, Math.round(credits * QODER_CREDITS_ESTIMATE_TOKENS_PER_CREDIT));
     return {
       input_tokens: estimated,
       cached_input_tokens: 0,
@@ -5872,11 +5880,38 @@ async function parseQoderNewIncremental({
   projectQueuePath,
   onProgress,
   sourceKey = "qoder",
-  cursorKey = "qoder",
+  cursorKey = "qoderNew",
   publicRepoResolver,
 } = {}) {
   await ensureDir(path.dirname(queuePath));
   const files = Array.isArray(sessionFiles) ? sessionFiles : [];
+  // One-time migration: pre-#549 stored JSONL keys under the legacy "qoder"
+  // cursor (same namespace as SQLite). Move them to the new isolated namespace
+  // so history is not double-counted and legacy multi-install state is preserved.
+  if (cursorKey === "qoderNew" && cursors?.qoder && !cursors?.qoderNew) {
+    const legacy = normalizeQoderState(cursors.qoder);
+    const jsonlEntries = Object.entries(legacy.messages).filter(([k]) => k.startsWith("jsonl:"));
+    if (jsonlEntries.length > 0) {
+      const migrated = {};
+      for (const [k, v] of jsonlEntries) {
+        migrated[k] = v;
+        delete legacy.messages[k];
+      }
+      cursors.qoderNew = { messages: migrated, updatedAt: legacy.updatedAt || new Date().toISOString() };
+    }
+  }
+  if (cursorKey === "qoderCnNew" && cursors?.["qoder-cn"] && !cursors?.["qoderCnNew"]) {
+    const legacy = normalizeQoderState(cursors["qoder-cn"]);
+    const jsonlEntries = Object.entries(legacy.messages).filter(([k]) => k.startsWith("jsonl:"));
+    if (jsonlEntries.length > 0) {
+      const migrated = {};
+      for (const [k, v] of jsonlEntries) {
+        migrated[k] = v;
+        delete legacy.messages[k];
+      }
+      cursors["qoderCnNew"] = { messages: migrated, updatedAt: legacy.updatedAt || new Date().toISOString() };
+    }
+  }
   const hourlyState = normalizeHourlyState(cursors?.hourly);
   const qoderState = normalizeQoderState(cursors?.[cursorKey]);
   const projectEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
@@ -5899,7 +5934,8 @@ async function parseQoderNewIncremental({
       continue;
     }
     const lines = raw.split("\n");
-    for (const line of lines) {
+    for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+      const line = lines[lineIdx];
       if (!line.trim()) continue;
       let record;
       try {
@@ -5921,7 +5957,7 @@ async function parseQoderNewIncremental({
       if (!timestampMs) continue;
       const bucketStart = toUtcHalfHourStart(new Date(timestampMs).toISOString());
       if (!bucketStart) continue;
-      const messageKey = qoderNewMessageKey(record, filePath);
+      const messageKey = qoderNewMessageKey(record, filePath, lineIdx);
       if (!messageKey) continue;
       const model = qoderNewModelFromRecord(record);
       const totals = base ? {
@@ -5932,7 +5968,7 @@ async function parseQoderNewIncremental({
         reasoning_output_tokens: 0,
         total_tokens: base.total_tokens,
         billable_total_tokens: base.billable_total_tokens,
-        total_cost_usd: Number.isFinite(base.credits) && base.credits > 0 ? base.credits * 0.02 : 0,
+        total_cost_usd: 0,
         usage_precision: base.usage_precision || undefined,
         conversation_count: 1,
       } : {
@@ -5949,10 +5985,11 @@ async function parseQoderNewIncremental({
       let projectKey = null;
       let projectRef = null;
       if (projectEnabled) {
-        const cwd = typeof record?.cwd === "string" ? record.cwd.trim() : "";
-        if (cwd) {
+        const rawCwd = typeof record?.cwd === "string" ? record.cwd.trim() : "";
+        if (rawCwd) {
+          const startDir = wsl.mapWslCwdToUnc(rawCwd, filePath);
           const context = await resolveProjectContextForPath({
-            startDir: cwd,
+            startDir,
             projectMetaCache,
             publicRepoCache,
             publicRepoResolver,
@@ -5994,22 +6031,15 @@ async function parseQoderNewIncremental({
       && prev.bucketStart === cur.bucketStart
       && prev.model === cur.model
       && (prev.projectKey || null) === (cur.projectKey || null)
-      && (prev.total_cost_usd || 0) === (cur.totals.total_cost_usd || 0);
+      && (prev.totals?.total_cost_usd || 0) === (cur.totals.total_cost_usd || 0);
     if (unchanged) continue;
     if (prev.totals && prev.bucketStart && prev.model) {
       const oldBucket = getHourlyBucket(hourlyState, sourceKey, prev.model, prev.bucketStart);
       subtractTotals(oldBucket.totals, prev.totals);
-      // subtractTotals does not handle total_cost_usd tick rounding for authoritative cost; apply manually
-      if (prev.totals.total_cost_usd) {
-        oldBucket.totals.total_cost_usd = Math.max(0, Number((oldBucket.totals.total_cost_usd - prev.totals.total_cost_usd).toFixed(4)));
-      }
       touchedBuckets.add(bucketKey(sourceKey, prev.model, prev.bucketStart));
       if (projectEnabled && prev.projectKey) {
         const oldProjectBucket = getProjectBucket(projectState, prev.projectKey, sourceKey, prev.bucketStart, prev.projectRef || null);
         subtractTotals(oldProjectBucket.totals, prev.totals);
-        if (prev.totals.total_cost_usd) {
-          oldProjectBucket.totals.total_cost_usd = Math.max(0, Number((oldProjectBucket.totals.total_cost_usd - prev.totals.total_cost_usd).toFixed(4)));
-        }
         projectTouchedBuckets.add(projectBucketKey(prev.projectKey, sourceKey, prev.bucketStart));
       }
     }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5718,6 +5718,370 @@ async function parseQoderDbIncremental({
   return { messagesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
 }
 
+// ── Qoder (new) — ~/.qoder/projects JSONL (com.qoder.app.stable, 2026-08+) ──
+//
+// Qoder 2026-08 (app 0.1.2+) migrated from SharedClientCache/cache/db/local.db
+// to Electron main.sqlite + ~/.qoder/projects/<slug>/<sessionId>.jsonl.
+// The new transcript's message.usage no longer carries prompt_tokens — it is a
+// credit-billed SDK: {input_tokens:0, output_tokens:0, credits:3.2, billable:true}.
+// Token breakdown is unavailable in the new format; we estimate tokens from
+// credits for dashboard continuity and mark the bucket usage_precision so the
+// estimate is distinguishable from exact DB rows.
+// Old local.db is kept as a legacy fallback; both sources share the "qoder"
+// cursor namespace via disjoint messageKey prefixes (row: vs jsonl:).
+function resolveQoderProjectsDir({ home = os.homedir(), env = process.env, platform = process.platform, deps = {} } = {}) {
+  const override = typeof env.QODER_PROJECTS_DIR === "string" && env.QODER_PROJECTS_DIR.trim()
+    ? path.resolve(env.QODER_PROJECTS_DIR.trim())
+    : null;
+  if (override) return override;
+  // QODER_HOME points at the app support dir for the legacy DB; the new
+  // projects dir is always ~/.qoder regardless of QODER_HOME.
+  // On Windows also probe WSL distro home (same pattern as other providers).
+  if (platform === "win32" && !env.QODER_PROJECTS_DIR) {
+    const discoverWslHome = deps.discoverWslHome || wsl.discoverWslHome;
+    const wslRoot = wsl.shouldProbeWsl(env) ? discoverWslHome(".qoder", { ...deps, env }) : null;
+    if (wslRoot) {
+      const wslProjects = path.join(wslRoot, "projects");
+      if ((deps.existsSync || fssync.existsSync)(wslProjects)) return wslProjects;
+    }
+  }
+  return path.join(home, ".qoder", "projects");
+}
+
+function resolveQoderCnProjectsDir({ home = os.homedir(), env = process.env, platform = process.platform, deps = {} } = {}) {
+  const override = typeof env.QODER_CN_PROJECTS_DIR === "string" && env.QODER_CN_PROJECTS_DIR.trim()
+    ? path.resolve(env.QODER_CN_PROJECTS_DIR.trim())
+    : null;
+  if (override) return override;
+  // CN and international currently share ~/.qoder; keep a distinct override for
+  // future split without double-counting by default.
+  if (platform === "win32" && !env.QODER_CN_PROJECTS_DIR) {
+    const discoverWslHome = deps.discoverWslHome || wsl.discoverWslHome;
+    const wslRoot = wsl.shouldProbeWsl(env) ? discoverWslHome(".qoder", { ...deps, env }) : null;
+    if (wslRoot) {
+      const wslProjects = path.join(wslRoot, "projects");
+      if ((deps.existsSync || fssync.existsSync)(wslProjects)) return wslProjects;
+    }
+  }
+  return path.join(home, ".qoder", "projects");
+}
+
+async function listQoderNewSessionFiles(projectsDir) {
+  const out = [];
+  if (!projectsDir || !fssync.existsSync(projectsDir)) return out;
+  async function walk(dir) {
+    const entries = await safeReadDir(dir);
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        await walk(p);
+      } else if (e.isFile() && e.name.endsWith(".jsonl")) {
+        out.push(p);
+      }
+    }
+  }
+  await walk(projectsDir);
+  out.sort((a, b) => a.localeCompare(b));
+  return out;
+}
+
+function qoderNewModelFromRecord(record) {
+  const msgModel = record?.message?.model;
+  const direct = typeof msgModel === "string" ? msgModel.trim() : "";
+  return normalizeModelInput(direct) || "qoder-agent";
+}
+
+function qoderNewMessageKey(record, filePath) {
+  const msgId = normalizeMessageKeyPart(record?.message?.id)
+    || normalizeMessageKeyPart(record?.uuid)
+    || normalizeMessageKeyPart(record?.message?.id)
+    || null;
+  const sessionId = normalizeMessageKeyPart(record?.sessionId || record?.session_id);
+  // Prefix to avoid collision with legacy row: keys
+  if (sessionId && msgId) return `jsonl:${sessionId}|${msgId}`;
+  if (msgId) return `jsonl:${msgId}`;
+  if (sessionId) return `jsonl:${sessionId}|${record?.uuid || filePath}`;
+  return `jsonl:${filePath}|${record?.uuid || ""}`;
+}
+
+function qoderNewTimestampMs(record) {
+  return coerceEpochMs(record?.timestamp)
+    || coerceEpochMs(record?.message?.timestamp)
+    || parseIsoTimestampMs(record?.timestamp)
+    || parseIsoTimestampMs(record?.message?.timestamp)
+    || 0;
+}
+
+function normalizeQoderNewTokens(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const credits = Number(usage.credits ?? usage.original_credits ?? 0);
+  const billable = usage.billable !== false;
+  const input = Number(usage.input_tokens ?? 0);
+  const cached = Number(usage.cache_read_input_tokens ?? usage.cached_tokens ?? 0);
+  const cacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
+  const output = Number(usage.output_tokens ?? 0);
+  // New SDK reports 0 tokens but non-zero credits — estimate tokens from credits
+  // so the dashboard still shows activity. Keep estimate conservative and mark
+  // precision so it is distinguishable from exact local.db rows.
+  if (input > 0 || cached > 0 || output > 0) {
+    const inp = Math.max(0, Math.trunc(input));
+    const cach = Math.max(0, Math.trunc(cached));
+    const out = Math.max(0, Math.trunc(output));
+    const cc = Math.max(0, Math.trunc(cacheCreation));
+    return {
+      input_tokens: inp,
+      cached_input_tokens: cach,
+      cache_creation_input_tokens: cc,
+      output_tokens: out,
+      reasoning_output_tokens: 0,
+      total_tokens: inp + cach + cc + out,
+      billable_total_tokens: inp + cach + cc + out,
+      credits: Number.isFinite(credits) && credits > 0 ? credits : 0,
+      usage_precision: null,
+    };
+  }
+  if (Number.isFinite(credits) && credits > 0 && billable) {
+    // Heuristic: 1 credit ≈ 1500 tokens (calibrated against legacy prompt_tokens
+    // vs credit samples from DSH003). Token split is unknown, so attribute to
+    // input for cost continuity; dashboard cost will be derived via pricing if
+    // available, otherwise authoritative cost below covers it.
+    const estimated = Math.max(1, Math.round(credits * 1500));
+    return {
+      input_tokens: estimated,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: estimated,
+      billable_total_tokens: estimated,
+      credits,
+      usage_precision: "qoder_credits_estimate",
+    };
+  }
+  // Billable but zero tokens/credits — still count conversation, no token delta
+  if (billable && (input === 0 && output === 0 && credits === 0)) {
+    return null;
+  }
+  return null;
+}
+
+async function parseQoderNewIncremental({
+  sessionFiles,
+  cursors,
+  queuePath,
+  projectQueuePath,
+  onProgress,
+  sourceKey = "qoder",
+  cursorKey = "qoder",
+  publicRepoResolver,
+} = {}) {
+  await ensureDir(path.dirname(queuePath));
+  const files = Array.isArray(sessionFiles) ? sessionFiles : [];
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const qoderState = normalizeQoderState(cursors?.[cursorKey]);
+  const projectEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
+  const projectState = projectEnabled ? normalizeProjectState(cursors?.projectHourly) : null;
+  const projectTouchedBuckets = projectEnabled ? new Set() : null;
+  const projectMetaCache = projectEnabled ? new Map() : null;
+  const publicRepoCache = projectEnabled ? new Map() : null;
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+
+  // Build current snapshot from all JSONL files
+  const currentByKey = new Map();
+  const fileCount = files.length;
+  for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
+    const filePath = files[fileIdx];
+    let raw;
+    try {
+      raw = await fs.readFile(filePath, "utf8");
+    } catch (_e) {
+      continue;
+    }
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch (_e) {
+        continue;
+      }
+      if (record?.type !== "assistant") continue;
+      const msg = record?.message;
+      if (!msg || msg.role !== "assistant") continue;
+      // Skip synthetic sub-agent streaming chunks that carry no usage
+      const usage = msg.usage;
+      if (!usage || typeof usage !== "object") continue;
+      const base = normalizeQoderNewTokens(usage);
+      // Allow billable zero-token messages to still count conversation (no token delta)
+      const isBillable = usage.billable !== false;
+      if (!base && !isBillable) continue;
+      const timestampMs = qoderNewTimestampMs(record);
+      if (!timestampMs) continue;
+      const bucketStart = toUtcHalfHourStart(new Date(timestampMs).toISOString());
+      if (!bucketStart) continue;
+      const messageKey = qoderNewMessageKey(record, filePath);
+      if (!messageKey) continue;
+      const model = qoderNewModelFromRecord(record);
+      const totals = base ? {
+        input_tokens: base.input_tokens,
+        cached_input_tokens: base.cached_input_tokens,
+        cache_creation_input_tokens: base.cache_creation_input_tokens,
+        output_tokens: base.output_tokens,
+        reasoning_output_tokens: 0,
+        total_tokens: base.total_tokens,
+        billable_total_tokens: base.billable_total_tokens,
+        total_cost_usd: Number.isFinite(base.credits) && base.credits > 0 ? base.credits * 0.02 : 0,
+        usage_precision: base.usage_precision || undefined,
+        conversation_count: 1,
+      } : {
+        input_tokens: 0,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 0,
+        billable_total_tokens: 0,
+        total_cost_usd: 0,
+        conversation_count: 1,
+      };
+      let projectKey = null;
+      let projectRef = null;
+      if (projectEnabled) {
+        const cwd = typeof record?.cwd === "string" ? record.cwd.trim() : "";
+        if (cwd) {
+          const context = await resolveProjectContextForPath({
+            startDir: cwd,
+            projectMetaCache,
+            publicRepoCache,
+            publicRepoResolver,
+            projectState,
+          });
+          projectKey = context?.projectKey || null;
+          projectRef = context?.projectRef || null;
+        }
+      }
+      currentByKey.set(messageKey, {
+        totals,
+        bucketStart,
+        model,
+        projectKey,
+        projectRef,
+        filePath,
+      });
+    }
+    if (cb && (fileIdx % 50 === 0 || fileIdx === files.length - 1)) {
+      cb({
+        index: fileIdx + 1,
+        total: fileCount,
+        messagesProcessed: currentByKey.size,
+        eventsAggregated: 0,
+        bucketsQueued: 0,
+      });
+    }
+  }
+
+  let messagesProcessed = currentByKey.size;
+  let eventsAggregated = 0;
+
+  // Subtract contributions that disappeared or changed
+  for (const [key, prev] of Object.entries(qoderState.messages)) {
+    if (!key.startsWith("jsonl:")) continue;
+    const cur = currentByKey.get(key);
+    const unchanged = cur
+      && totalsKey(prev.totals) === totalsKey(cur.totals)
+      && prev.bucketStart === cur.bucketStart
+      && prev.model === cur.model
+      && (prev.projectKey || null) === (cur.projectKey || null)
+      && (prev.total_cost_usd || 0) === (cur.totals.total_cost_usd || 0);
+    if (unchanged) continue;
+    if (prev.totals && prev.bucketStart && prev.model) {
+      const oldBucket = getHourlyBucket(hourlyState, sourceKey, prev.model, prev.bucketStart);
+      subtractTotals(oldBucket.totals, prev.totals);
+      // subtractTotals does not handle total_cost_usd tick rounding for authoritative cost; apply manually
+      if (prev.totals.total_cost_usd) {
+        oldBucket.totals.total_cost_usd = Math.max(0, Number((oldBucket.totals.total_cost_usd - prev.totals.total_cost_usd).toFixed(4)));
+      }
+      touchedBuckets.add(bucketKey(sourceKey, prev.model, prev.bucketStart));
+      if (projectEnabled && prev.projectKey) {
+        const oldProjectBucket = getProjectBucket(projectState, prev.projectKey, sourceKey, prev.bucketStart, prev.projectRef || null);
+        subtractTotals(oldProjectBucket.totals, prev.totals);
+        if (prev.totals.total_cost_usd) {
+          oldProjectBucket.totals.total_cost_usd = Math.max(0, Number((oldProjectBucket.totals.total_cost_usd - prev.totals.total_cost_usd).toFixed(4)));
+        }
+        projectTouchedBuckets.add(projectBucketKey(prev.projectKey, sourceKey, prev.bucketStart));
+      }
+    }
+    if (cur) {
+      const bucket = getHourlyBucket(hourlyState, sourceKey, cur.model, cur.bucketStart);
+      addTotals(bucket.totals, cur.totals);
+      if (cur.totals.usage_precision) bucket.usage_precision = cur.totals.usage_precision;
+      // addTotals handles total_cost_usd via USD_TICKS, but credits cost is small; ensure it accumulates
+      touchedBuckets.add(bucketKey(sourceKey, cur.model, cur.bucketStart));
+      if (projectEnabled && cur.projectKey) {
+        const projectBucket = getProjectBucket(projectState, cur.projectKey, sourceKey, cur.bucketStart, cur.projectRef);
+        addTotals(projectBucket.totals, cur.totals);
+        if (cur.totals.usage_precision) projectBucket.usage_precision = cur.totals.usage_precision;
+        projectTouchedBuckets.add(projectBucketKey(cur.projectKey, sourceKey, cur.bucketStart));
+      }
+      qoderState.messages[key] = {
+        totals: cur.totals,
+        conversationCount: cur.totals.conversation_count,
+        bucketStart: cur.bucketStart,
+        model: cur.model,
+        projectKey: cur.projectKey,
+        projectRef: cur.projectRef,
+        updatedAt: new Date().toISOString(),
+      };
+      eventsAggregated += 1;
+    } else {
+      delete qoderState.messages[key];
+      eventsAggregated += 1;
+    }
+  }
+
+  // Add brand-new keys
+  for (const [key, cur] of currentByKey.entries()) {
+    if (qoderState.messages[key]) continue;
+    const bucket = getHourlyBucket(hourlyState, sourceKey, cur.model, cur.bucketStart);
+    addTotals(bucket.totals, cur.totals);
+    if (cur.totals.usage_precision) bucket.usage_precision = cur.totals.usage_precision;
+    touchedBuckets.add(bucketKey(sourceKey, cur.model, cur.bucketStart));
+    if (projectEnabled && cur.projectKey) {
+      const projectBucket = getProjectBucket(projectState, cur.projectKey, sourceKey, cur.bucketStart, cur.projectRef);
+      addTotals(projectBucket.totals, cur.totals);
+      if (cur.totals.usage_precision) projectBucket.usage_precision = cur.totals.usage_precision;
+      projectTouchedBuckets.add(projectBucketKey(cur.projectKey, sourceKey, cur.bucketStart));
+    }
+    qoderState.messages[key] = {
+      totals: cur.totals,
+      conversationCount: cur.totals.conversation_count,
+      bucketStart: cur.bucketStart,
+      model: cur.model,
+      projectKey: cur.projectKey,
+      projectRef: cur.projectRef,
+      updatedAt: new Date().toISOString(),
+    };
+    eventsAggregated += 1;
+  }
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  const projectBucketsQueued = projectEnabled
+    ? await enqueueTouchedProjectBuckets({ projectQueuePath, projectState, projectTouchedBuckets })
+    : 0;
+  const updatedAt = new Date().toISOString();
+  hourlyState.updatedAt = updatedAt;
+  qoderState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors[cursorKey] = qoderState;
+  if (projectState) {
+    projectState.updatedAt = updatedAt;
+    cursors.projectHourly = projectState;
+  }
+  return { messagesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
+}
+
 // ── Claude Science (Anthropic's local research workbench, issue #246) ──
 //
 // Claude Science keeps all of its state in a SQLite database named
@@ -18866,6 +19230,10 @@ module.exports = {
   resolveQoderDbPaths,
   resolveQoderCnDbPaths,
   readQoderDbMessages,
+  resolveQoderProjectsDir,
+  resolveQoderCnProjectsDir,
+  listQoderNewSessionFiles,
+  parseQoderNewIncremental,
   resolveKiroBasePath,
   resolveKiroDbPath,
   resolveKiroJsonlPath,
@@ -19000,6 +19368,7 @@ module.exports = {
   normalizeGeminiTokens,
   normalizeOpencodeTokens,
   normalizeQoderTokens,
+  normalizeQoderNewTokens,
   sameGeminiTotals,
   diffGeminiTotals,
   // Exposed so the queue-repair migration can mutate cursors state in the

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5724,16 +5724,14 @@ async function parseQoderDbIncremental({
 // to Electron main.sqlite + ~/.qoder/projects/<slug>/<sessionId>.jsonl.
 // The new transcript's message.usage no longer carries prompt_tokens — it is a
 // credit-billed SDK: {input_tokens:0, output_tokens:0, credits:3.2, billable:true}.
-// Token breakdown is unavailable in the new format; we estimate tokens from
-// credits for dashboard continuity and mark the bucket usage_precision so the
-// estimate is distinguishable from exact DB rows. Cost remains unknown — no
-// authoritative credit→USD rate is published, so total_cost_usd stays 0 and
-// dashboard falls back to token pricing (which will be 0 for unpriced qoder
-// models, intentionally not a pseudo-precise $ value).
+// Only rows with authoritative token fields are counted: credit-only usage
+// without tokens is intentionally not counted (usage stays unsupported, no
+// token delta) because there is no first-party evidence for a credit→token
+// rate. Cost was never estimated — no authoritative credit→USD rate is
+// published, so total_cost_usd stays 0.
 // Old local.db is kept as a legacy fallback; both sources now use distinct
 // cursor namespaces (qoder vs qoderNew) via disjoint messageKey prefixes
 // (row: vs jsonl:) but upload under the same source="qoder".
-const QODER_CREDITS_ESTIMATE_TOKENS_PER_CREDIT = 1500;
 
 function resolveQoderProjectsDir({ home = os.homedir(), env = process.env, platform = process.platform, deps = {} } = {}) {
   const override = typeof env.QODER_PROJECTS_DIR === "string" && env.QODER_PROJECTS_DIR.trim()
@@ -5823,7 +5821,6 @@ function qoderNewTimestampMs(record) {
 function normalizeQoderNewTokens(usage) {
   if (!usage || typeof usage !== "object") return null;
   const credits = Number(usage.credits ?? usage.original_credits ?? 0);
-  const billable = usage.billable !== false;
   let input = Number(usage.input_tokens ?? 0);
   let cached = Number(usage.cache_read_input_tokens ?? usage.cached_tokens ?? 0);
   let cacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
@@ -5834,9 +5831,8 @@ function normalizeQoderNewTokens(usage) {
   if (!Number.isFinite(cached) || cached < 0) cached = 0;
   if (!Number.isFinite(cacheCreation) || cacheCreation < 0) cacheCreation = 0;
   if (!Number.isFinite(output) || output < 0) output = 0;
-  // New SDK reports 0 tokens but non-zero credits — estimate tokens from credits
-  // so the dashboard still shows activity. Keep estimate conservative and mark
-  // precision so it is distinguishable from exact local.db rows.
+  // Only rows with authoritative token fields are counted; anything else
+  // falls through to null (unsupported, no token delta).
   if (input > 0 || cached > 0 || cacheCreation > 0 || output > 0) {
     const inp = Math.max(0, Math.trunc(input));
     const cach = Math.max(0, Math.trunc(cached));
@@ -5854,28 +5850,10 @@ function normalizeQoderNewTokens(usage) {
       usage_precision: null,
     };
   }
-  if (Number.isFinite(credits) && credits > 0 && billable) {
-    // No authoritative credit→USD rate is published. Preserve token continuity
-    // via a documented heuristic; cost stays unknown (0) so dashboard does not
-    // render a pseudo-precise $ value. Token split is unknown, so attribute to
-    // input.
-    const estimated = Math.max(1, Math.round(credits * QODER_CREDITS_ESTIMATE_TOKENS_PER_CREDIT));
-    return {
-      input_tokens: estimated,
-      cached_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-      output_tokens: 0,
-      reasoning_output_tokens: 0,
-      total_tokens: estimated,
-      billable_total_tokens: estimated,
-      credits,
-      usage_precision: "qoder_credits_estimate",
-    };
-  }
-  // Billable but zero tokens/credits — still count conversation, no token delta
-  if (billable && (input === 0 && output === 0 && credits === 0)) {
-    return null;
-  }
+  // Credit-only usage without authoritative token fields is intentionally
+  // not counted (no token delta): there is no first-party evidence for a
+  // credit→token rate. The caller still counts billable messages as
+  // conversation activity.
   return null;
 }
 

--- a/test/qoder-new-parser.test.js
+++ b/test/qoder-new-parser.test.js
@@ -132,7 +132,7 @@ test("parseQoderNewIncremental keeps distinct keys for no-id records in same fil
   assert.equal(new Set(keys).size, 3);
 });
 
-test("parseQoderNewIncremental corrects credits change", async (t) => {
+test("parseQoderNewIncremental corrects precise token change (subtract-on-change)", async (t) => {
   const tmp = tempDir();
   const { dir, queuePath } = tempQueue();
   t.after(() => {
@@ -140,7 +140,7 @@ test("parseQoderNewIncremental corrects credits change", async (t) => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
   const sessionFile = path.join(tmp, "sess.jsonl");
-  const mk = (credits) => ({
+  const mk = (input, output) => ({
     type: "assistant",
     timestamp: "2026-08-30T11:00:00.000Z",
     uuid: "u1",
@@ -151,22 +151,119 @@ test("parseQoderNewIncremental corrects credits change", async (t) => {
       role: "assistant",
       model: "qmodel_38max",
       content: [{ type: "tool_use", name: "Read" }],
-      usage: { credits, billable: true },
+      usage: { input_tokens: input, output_tokens: output, credits: 1.0, billable: true },
     },
   });
-  writeJsonl(sessionFile, [mk(1.0)]);
+  writeJsonl(sessionFile, [mk(100, 50)]);
   const cursors = {};
   await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
   const firstRows = queueRows(queuePath).filter((r) => r.source === "qoder");
-  const firstTokens = firstRows[0].total_tokens;
-  // Correct credits to 2.0
-  writeJsonl(sessionFile, [mk(2.0)]);
+  assert.equal(firstRows.at(-1).total_tokens, 150);
+  // Correct tokens upward: 100 -> 200 input
+  writeJsonl(sessionFile, [mk(200, 50)]);
   const second = await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
   assert.ok(second.eventsAggregated >= 1);
   assert.ok(second.bucketsQueued >= 1);
   const latest = queueRows(queuePath).filter((r) => r.source === "qoder").at(-1);
-  assert.ok(latest.total_tokens > firstTokens, "tokens should increase with credits");
-  assert.equal(latest.usage_precision, "qoder_credits_estimate");
+  // Exact-value assertion pinning the subtract-on-change invariant: the stale
+  // 150-token contribution is subtracted before the corrected 250 is added,
+  // so the bucket reads exactly 250 (not 400 from double-counting).
+  assert.equal(latest.total_tokens, 250);
+  assert.equal(latest.input_tokens, 200);
+  assert.equal(latest.output_tokens, 50);
+  assert.equal(latest.conversation_count, 1);
+  assert.equal(latest.usage_precision, undefined);
+});
+
+test("parseQoderNewIncremental counts credit-only usage as conversation without token delta", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  // Credit-billed SDK record with no authoritative token fields: tokens must
+  // stay unsupported (no fabricated estimate), but the billable message still
+  // counts as conversation activity.
+  writeJsonl(sessionFile, [{
+    type: "assistant",
+    timestamp: "2026-08-30T11:00:00.000Z",
+    uuid: "u1",
+    sessionId: "sess-credit",
+    cwd: "/tmp/proj",
+    message: {
+      id: "m1",
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Read" }],
+      usage: { credits: 2.5, billable: true, input_tokens: 0, output_tokens: 0 },
+    },
+  }]);
+  const cursors = {};
+  const res = await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  assert.equal(res.messagesProcessed, 1);
+  assert.equal(res.eventsAggregated, 1);
+  const row = queueRows(queuePath).find((r) => r.source === "qoder");
+  assert.ok(row, "billable credit-only message should still enqueue a conversation row");
+  assert.equal(row.total_tokens, 0);
+  assert.equal(row.input_tokens, 0);
+  assert.equal(row.output_tokens, 0);
+  assert.equal(row.conversation_count, 1);
+  assert.equal(row.usage_precision, undefined);
+});
+
+test("parseQoderNewIncremental migrates legacy jsonl: cursor keys without double count", async (t) => {
+  const tmp = tempDir();
+  const learn = tempQueue();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(learn.dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  writeJsonl(sessionFile, [{
+    type: "assistant",
+    timestamp: "2026-08-30T11:00:00.000Z",
+    uuid: "u1",
+    sessionId: "sess-1",
+    cwd: "/tmp/proj",
+    message: {
+      id: "m1",
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Read" }],
+      usage: { input_tokens: 100, output_tokens: 50, credits: 1.0, billable: true },
+    },
+  }]);
+  // Learn the canonical stored shape with a clean run, then seed it under the
+  // legacy "qoder" cursor the way pre-#549 installs persisted JSONL keys.
+  const learned = {};
+  await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors: learned, queuePath: learn.queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  const learnedEntry = learned.qoderNew.messages["jsonl:sess-1|m1"];
+  assert.ok(learnedEntry, "learning run should store the jsonl key");
+  const seeded = {
+    qoder: {
+      messages: {
+        "jsonl:sess-1|m1": JSON.parse(JSON.stringify(learnedEntry)),
+        "row:legacydb|42": {
+          totals: { input_tokens: 7, total_tokens: 7, conversation_count: 1 },
+          bucketStart: "2026-08-30T11:00:00.000Z",
+          model: "qoder-agent",
+        },
+      },
+      updatedAt: new Date().toISOString(),
+    },
+  };
+  const res = await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors: seeded, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  // jsonl: key moved to the isolated namespace; legacy row: key preserved.
+  assert.ok(!seeded.qoder.messages["jsonl:sess-1|m1"], "jsonl key should leave the legacy cursor");
+  assert.ok(seeded.qoder.messages["row:legacydb|42"], "legacy row key should stay");
+  assert.ok(seeded.qoderNew.messages["jsonl:sess-1|m1"], "jsonl key should land in qoderNew");
+  // Migrated entry matches the current snapshot, so nothing is re-aggregated.
+  assert.equal(res.eventsAggregated, 0);
+  assert.equal(res.bucketsQueued, 0);
 });
 
 test("resolveQoderProjectsDir windows case-insensitive guard", () => {

--- a/test/qoder-new-parser.test.js
+++ b/test/qoder-new-parser.test.js
@@ -1,0 +1,205 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  parseQoderNewIncremental,
+  resolveQoderProjectsDir,
+  resolveQoderCnProjectsDir,
+  listQoderNewSessionFiles,
+} = require("../src/lib/rollout");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-qoder-new-"));
+}
+
+function tempQueue() {
+  const dir = tempDir();
+  return {
+    dir,
+    queuePath: path.join(dir, "queue.jsonl"),
+  };
+}
+
+function queueRows(queuePath) {
+  if (!fs.existsSync(queuePath)) return [];
+  return fs.readFileSync(queuePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function writeJsonl(filePath, records) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, records.map((r) => JSON.stringify(r)).join("\n") + "\n", "utf8");
+}
+
+test("parseQoderNewIncremental aggregates and second sync is no-op", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "proj", "sess1.jsonl");
+  const baseRecord = (credits, ts, msgId) => ({
+    type: "assistant",
+    timestamp: ts,
+    uuid: msgId,
+    sessionId: "sess-1",
+    cwd: "/tmp/proj",
+    message: {
+      id: msgId,
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Read" }],
+      usage: { credits, billable: true, input_tokens: 0, output_tokens: 0 },
+    },
+  });
+  writeJsonl(sessionFile, [
+    baseRecord(1.5, "2026-08-30T11:00:00.000Z", "m1"),
+    baseRecord(2.0, "2026-08-30T11:15:00.000Z", "m2"),
+  ]);
+  const cursors = {};
+  const first = await parseQoderNewIncremental({
+    sessionFiles: [sessionFile],
+    cursors,
+    queuePath,
+    sourceKey: "qoder",
+    cursorKey: "qoderNew",
+  });
+  assert.equal(first.messagesProcessed, 2);
+  assert.equal(first.eventsAggregated, 2);
+  assert.ok(first.bucketsQueued >= 1);
+  const before = fs.readFileSync(queuePath, "utf8");
+  const second = await parseQoderNewIncremental({
+    sessionFiles: [sessionFile],
+    cursors,
+    queuePath,
+    sourceKey: "qoder",
+    cursorKey: "qoderNew",
+  });
+  assert.equal(second.eventsAggregated, 0);
+  assert.equal(second.bucketsQueued, 0);
+  assert.equal(fs.readFileSync(queuePath, "utf8"), before);
+});
+
+test("parseQoderNewIncremental keeps distinct keys for no-id records in same file", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  // No message.id nor uuid, same sessionId — fallback must use line index
+  const rec = (ts) => ({
+    type: "assistant",
+    timestamp: ts,
+    sessionId: "sess-x",
+    cwd: "/tmp/proj",
+    message: {
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Bash" }],
+      usage: { credits: 1.0, billable: true },
+    },
+  });
+  writeJsonl(sessionFile, [
+    rec("2026-08-30T11:00:00.000Z"),
+    rec("2026-08-30T11:05:00.000Z"),
+    rec("2026-08-30T11:10:00.000Z"),
+  ]);
+  const cursors = {};
+  const res = await parseQoderNewIncremental({
+    sessionFiles: [sessionFile],
+    cursors,
+    queuePath,
+    sourceKey: "qoder",
+    cursorKey: "qoderNew",
+  });
+  // All three should be counted distinct, not collapsed to 1
+  assert.equal(res.messagesProcessed, 3);
+  assert.equal(res.eventsAggregated, 3);
+  const keys = Object.keys(cursors.qoderNew.messages);
+  assert.equal(keys.length, 3);
+  // Keys must be distinct
+  assert.equal(new Set(keys).size, 3);
+});
+
+test("parseQoderNewIncremental corrects credits change", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  const mk = (credits) => ({
+    type: "assistant",
+    timestamp: "2026-08-30T11:00:00.000Z",
+    uuid: "u1",
+    sessionId: "sess-1",
+    cwd: "/tmp/proj",
+    message: {
+      id: "m1",
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Read" }],
+      usage: { credits, billable: true },
+    },
+  });
+  writeJsonl(sessionFile, [mk(1.0)]);
+  const cursors = {};
+  await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  const firstRows = queueRows(queuePath).filter((r) => r.source === "qoder");
+  const firstTokens = firstRows[0].total_tokens;
+  // Correct credits to 2.0
+  writeJsonl(sessionFile, [mk(2.0)]);
+  const second = await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  assert.ok(second.eventsAggregated >= 1);
+  assert.ok(second.bucketsQueued >= 1);
+  const latest = queueRows(queuePath).filter((r) => r.source === "qoder").at(-1);
+  assert.ok(latest.total_tokens > firstTokens, "tokens should increase with credits");
+  assert.equal(latest.usage_precision, "qoder_credits_estimate");
+});
+
+test("resolveQoderProjectsDir windows case-insensitive guard", () => {
+  const intl = resolveQoderProjectsDir({ home: "C:\\Users\\x", env: { QODER_PROJECTS_DIR: "C:\\Users\\x\\.qoder\\projects" }, platform: "win32", deps: { existsSync: () => true, discoverWslHome: () => null } });
+  const cn = resolveQoderCnProjectsDir({ home: "C:\\Users\\x", env: { QODER_CN_PROJECTS_DIR: "c:\\users\\x\\.qoder\\projects" }, platform: "win32", deps: { existsSync: () => true, discoverWslHome: () => null } });
+  // Direct guard logic from sync.js uses path.normalize + win32 lower-case
+  const winKey = (p) => path.win32.normalize(p).toLowerCase();
+  assert.equal(winKey(intl), winKey(cn));
+  // Raw strings differ in case
+  assert.notEqual(intl, cn);
+});
+
+test("parseQoderNewIncremental uses isolated cursor namespace", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  writeJsonl(sessionFile, [{
+    type: "assistant",
+    timestamp: "2026-08-30T11:00:00.000Z",
+    uuid: "u1",
+    sessionId: "sess-1",
+    cwd: "/tmp/proj",
+    message: { id: "m1", role: "assistant", model: "qmodel_38max", content: [{ type: "tool_use", name: "Read" }], usage: { credits: 1.0, billable: true } },
+  }]);
+  const cursors = { qoder: { messages: { legacyKey: { totals: { input_tokens: 1 }, bucketStart: "2026-08-30T11:00:00.000Z", model: "qoder-agent" } }, updatedAt: new Date().toISOString() } };
+  await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  // Legacy cursor untouched, new cursor populated
+  assert.ok(cursors.qoder.messages.legacyKey);
+  assert.ok(cursors.qoderNew);
+  assert.equal(Object.keys(cursors.qoderNew.messages).length, 1);
+  assert.equal(cursors.qoderNew.messages["jsonl:sess-1|m1"]?.model, "qmodel_38max");
+});

--- a/test/qoder-new-parser.test.js
+++ b/test/qoder-new-parser.test.js
@@ -203,3 +203,38 @@ test("parseQoderNewIncremental uses isolated cursor namespace", async (t) => {
   assert.equal(Object.keys(cursors.qoderNew.messages).length, 1);
   assert.equal(cursors.qoderNew.messages["jsonl:sess-1|m1"]?.model, "qmodel_38max");
 });
+
+test("parseQoderNewIncremental handles zero credit with only cache-creation tokens (precise, not estimated)", async (t) => {
+  const tmp = tempDir();
+  const { dir, queuePath } = tempQueue();
+  t.after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const sessionFile = path.join(tmp, "sess.jsonl");
+  writeJsonl(sessionFile, [{
+    type: "assistant",
+    timestamp: "2026-08-30T11:00:00.000Z",
+    uuid: "u1",
+    sessionId: "sess-cache",
+    cwd: "/tmp/proj",
+    message: {
+      id: "m-cache",
+      role: "assistant",
+      model: "qmodel_38max",
+      content: [{ type: "tool_use", name: "Read" }],
+      usage: { credits: 0, billable: true, input_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 123, output_tokens: 0 },
+    },
+  }]);
+  const cursors = {};
+  const res = await parseQoderNewIncremental({ sessionFiles: [sessionFile], cursors, queuePath, sourceKey: "qoder", cursorKey: "qoderNew" });
+  assert.equal(res.messagesProcessed, 1);
+  assert.equal(res.eventsAggregated, 1);
+  const row = queueRows(queuePath).find((r) => r.source === "qoder");
+  assert.equal(row.cache_creation_input_tokens, 123);
+  assert.equal(row.total_tokens, 123);
+  assert.equal(row.input_tokens, 0);
+  // Precise cache-creation should not be marked as credits estimate
+  assert.equal(row.usage_precision, undefined);
+  assert.equal(row.conversation_count, 1);
+});

--- a/test/status-qoder-jsonl.test.js
+++ b/test/status-qoder-jsonl.test.js
@@ -1,0 +1,139 @@
+"use strict";
+
+// Regression test for the status JSON/light summary ignoring the new Qoder
+// JSONL path: a JSONL-only install (no legacy local.db) must still report
+// `installed: true` with a non-empty detail pointing at the projects dir.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { cmdStatus, summarizeQoderDetail } = require("../src/commands/status");
+
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "QODER_PROJECTS_DIR",
+  "QODER_CN_PROJECTS_DIR",
+  "QODER_DB_PATH",
+  "QODER_HOME",
+  "QODER_CN_DB_PATH",
+  "QODER_CN_HOME",
+];
+
+function saveEnv() {
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  return saved;
+}
+
+function restoreEnv(saved) {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+}
+
+async function captureJsonStatus() {
+  // NOTE: under `node --test` the runner multiplexes binary IPC frames over
+  // process.stdout.write, so the capture must forward every chunk to the real
+  // writer (swallowing breaks runner accounting) and only record the single
+  // string chunk cmdStatus(["--json"]) emits (it starts with "{").
+  const prevWrite = process.stdout.write.bind(process.stdout);
+  let jsonOut = "";
+  process.stdout.write = function (...args) {
+    const [chunk, enc, cb] = args;
+    // cmdStatus(["--json"]) emits the summary as one string chunk starting
+    // with "{". Record it without forwarding (keeps test output clean);
+    // forward everything else so runner IPC/TAP accounting stays intact.
+    if (typeof chunk === "string" && chunk.startsWith("{")) {
+      jsonOut += chunk;
+      if (typeof enc === "function") enc();
+      else if (typeof cb === "function") cb();
+      return true;
+    }
+    return prevWrite(...args);
+  };
+  try {
+    await cmdStatus(["--json"]);
+  } finally {
+    process.stdout.write = prevWrite;
+  }
+  return JSON.parse(jsonOut);
+}
+
+test("summarizeQoderDetail joins legacy DB and new JSONL paths", () => {
+  assert.equal(summarizeQoderDetail("", ""), "");
+  assert.equal(summarizeQoderDetail("native: /a/local.db", ""), "native: /a/local.db");
+  assert.equal(summarizeQoderDetail("", "/h/.qoder/projects (3 sessions)"), "/h/.qoder/projects (3 sessions)");
+  assert.equal(
+    summarizeQoderDetail("native: /a/local.db", "/h/.qoder/projects (3 sessions)"),
+    "native: /a/local.db + /h/.qoder/projects (3 sessions)",
+  );
+});
+
+test("status JSON reports JSONL-only Qoder install with projects-dir detail", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-status-qoder-jsonl-"));
+  const saved = saveEnv();
+  try {
+    const projectsDir = path.join(tmp, "projects");
+    fs.mkdirSync(path.join(projectsDir, "proj-slug"), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectsDir, "proj-slug", "sess.jsonl"),
+      JSON.stringify({ type: "assistant" }) + "\n",
+      "utf8",
+    );
+    // Isolated home (no legacy local.db anywhere) + explicit projects override.
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    process.env.QODER_PROJECTS_DIR = projectsDir;
+    delete process.env.QODER_CN_PROJECTS_DIR;
+    delete process.env.QODER_DB_PATH;
+    delete process.env.QODER_HOME;
+    delete process.env.QODER_CN_DB_PATH;
+    delete process.env.QODER_CN_HOME;
+
+    const summary = await captureJsonStatus();
+    const qoder = summary.providers.qoder;
+    assert.equal(qoder.installed, true);
+    assert.ok(qoder.detail.includes(projectsDir), `detail should contain projects dir, got: ${qoder.detail}`);
+    assert.ok(qoder.detail.includes("(1 sessions)"), `detail should contain session count, got: ${qoder.detail}`);
+    // CN shares the default dir and must not claim the intl files as its own.
+    assert.equal(summary.providers["qoder-cn"].installed, false);
+  } finally {
+    restoreEnv(saved);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("status JSON joins legacy DB and JSONL paths with ' + '", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-status-qoder-both-"));
+  const saved = saveEnv();
+  try {
+    const projectsDir = path.join(tmp, "projects");
+    fs.mkdirSync(path.join(projectsDir, "proj-slug"), { recursive: true });
+    fs.writeFileSync(path.join(projectsDir, "proj-slug", "sess.jsonl"), "{}\n", "utf8");
+    const legacyDb = path.join(tmp, "local.db");
+    fs.writeFileSync(legacyDb, "", "utf8");
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    process.env.QODER_PROJECTS_DIR = projectsDir;
+    process.env.QODER_DB_PATH = legacyDb;
+    delete process.env.QODER_CN_PROJECTS_DIR;
+    delete process.env.QODER_HOME;
+    delete process.env.QODER_CN_DB_PATH;
+    delete process.env.QODER_CN_HOME;
+
+    const summary = await captureJsonStatus();
+    const qoder = summary.providers.qoder;
+    assert.equal(qoder.installed, true);
+    assert.ok(qoder.detail.includes(" + "), `detail should join both paths, got: ${qoder.detail}`);
+    assert.ok(qoder.detail.includes(legacyDb), `detail should contain legacy DB, got: ${qoder.detail}`);
+    assert.ok(qoder.detail.includes(projectsDir), `detail should contain projects dir, got: ${qoder.detail}`);
+  } finally {
+    restoreEnv(saved);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### 背景

新版 Qoder App（`0.1.2+` / `com.qoder.app.stable`）已将会话存储从 `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` 迁移至 `~/.qoder/projects/<slug>/<sessionId>.jsonl` + `main.sqlite`。

- 旧库最后一条带 `token_info` 的记录为 `2026-07-31T15:56`，之后仅有无 `token_info` 的占位行，`sync` 永远 `0` 桶
- 新库 `88` 个会话最新至 `2026-08-31T04:00`，但 `message.usage` 已改为 `credit` 计费（`input_tokens=0, credits=3.2`），原 `QODER_USAGE_SQL` 无法感知
- `status` 仍显示 `Qoder: passive reader (.../local.db)`，用户误判为配置问题

本次为**非互斥**：新旧两个 Qoder 同时运营，需同时统计并合并到同一 `source="qoder"`。

### 改动

- `src/lib/rollout.js` 新增 `resolveQoderProjectsDir / listQoderNewSessionFiles / parseQoderNewIncremental`，扫描 `~/.qoder/projects/**/*.jsonl`（含 `subagents`），`credit>0` 时按 `≈1500 tok/credit` 估算落桶并标记 `usage_precision="qoder_credits_estimate"`，与旧库通过 `jsonl:` / `task-:` 前缀隔离共享 `qoder` 游标，支持 `projectKey` 归因与 `WSL` 探测
- `src/commands/sync.js` 保留旧 `local.db` 解析，追加新 `JSONL` 解析块（`qoder-cn` 仅当目录与国际版分离时才单独解析，避免重复计数）
- `src/commands/status.js` 同时展示 `.../local.db + .../.qoder/projects (88 sessions) [legacy DB + new JSONL (both tracked)]`
- 保持幂等：二次 `sync` 为 `0` 桶，游标 `4920=4377+543`，`hourly qoder 139→165`

### 审查与修复

- **重复计数**：新旧 `sessionId` 格式不同（`task-*` vs `UUID`），前缀隔离已验证无交集；`CN` 与国际版共 `~/.qoder/projects` 时跳过二次解析
- **WSL**：旧库已探测 `\\\\wsl$`，新 `projectsDir` 补齐同逻辑
- **估算误导**：`total_cost_usd=credits×0.02` 为启发式，已通过 `usage_precision` 显性标记，旧库 `0` 成本仍走 `token` 定价
- **遗留提示硬编码日期**：改为通用文案 `[legacy DB + new JSONL (both tracked)]`
- **增量落盘**：新桶 `usage_precision` 未写入 `bucket` 已补齐，二次同步不再重放

### 验证

- `node bin/tracker.js sync`：`Parsed files 8112, New 30-min buckets queued 27→0`，`queue.jsonl` 最新 `qoder` 至 `2026-08-31T04:00`
- `node bin/tracker.js status`：正确显示 `.../local.db + .../.qoder/projects (88 sessions)`
- `node --test test/qoder-parser.test.js` 9/9 通过；`dashboard:build` 通过

### 风险

纯增量兼容旧历史，旧桶不重放；若官方后续公布 `credit→token` 官方汇率，可替换当前 `1500` 系数。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and syncing Qoder’s newer credit-based sessions.
  * Qoder status now distinguishes between legacy sessions, new sessions, or both.
  * Improved usage reporting for Copilot and OpenCode, including newly available usage details.

* **Bug Fixes**
  * Prevented duplicate counting when Qoder session locations overlap.
  * Sync now processes only newly available OpenCode messages for more reliable updates.
  * Improved handling of session records, usage corrections, and incomplete usage data during synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->