### PR TITLE
perf(opencode): shard message cursor state

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1149,17 +1149,13 @@ async function cmdSync(argv, context = {}) {
       });
 
       const parseOpencodeForInstall = async (options) => {
-        const { storageDir, dbDir, cursors } = options;
+        const { dbDir, cursors, messageFiles } = options;
         let filesResult = { filesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-        if (storageDir) {
-          const storagePath = path.join(storageDir, "storage");
-          const messageFiles = await listOpencodeMessageFiles(storagePath);
-          if (messageFiles.length > 0) {
-            filesResult = await parseOpencodeIncremental({
-              ...options,
-              messageFiles,
-            });
-          }
+        if (messageFiles.length > 0) {
+          filesResult = await parseOpencodeIncremental({
+            ...options,
+            messageFiles,
+          });
         }
 
         let dbResult = { messagesProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -1175,6 +1171,7 @@ async function cmdSync(argv, context = {}) {
               dbMessages: dbRead.messages,
               dbCursor: dbRead.cursor,
               dbPath,
+              opencodeCursorStore: cursorStore,
             });
           }
         }
@@ -1190,26 +1187,57 @@ async function cmdSync(argv, context = {}) {
         native: storagePaths.native || dbPaths.native,
         wsl: storagePaths.wsl || dbPaths.wsl,
       };
+      const installKeys = Object.keys(opencodePaths).filter((key) => opencodePaths[key]);
+      const messageFilesByInstall = {};
+      for (const key of installKeys) {
+        messageFilesByInstall[key] = storagePaths[key]
+          ? await listOpencodeMessageFiles(path.join(storagePaths[key], "storage"))
+          : [];
+      }
+      const storedOpencode = cursors.opencode;
+      const storedNamespaced = Boolean(
+        storedOpencode &&
+        typeof storedOpencode === "object" &&
+        (storedOpencode.native !== undefined || storedOpencode.wsl !== undefined),
+      );
+      if (
+        storedNamespaced !== (installKeys.length > 1) ||
+        Object.values(messageFilesByInstall).some((files) => files.length > 0)
+      ) {
+        await cursorStore.materializeAllOpencodeState();
+      }
 
-      const multiResult = await multiInstallParse({
-        paths: opencodePaths,
-        parserFn: parseOpencodeForInstall,
-        providerName: "opencode",
-        cursors,
-        queuePath,
-        projectQueuePath,
-        getParams: (p, key) => ({ storageDir: storagePaths[key], dbDir: dbPaths[key] }),
-        onProgress: (p) => {
-          if (!progress?.enabled) return;
-          const pct = p.total > 0 ? p.index / p.total : 1;
-          progress.update(
-            `Parsing Opencode (${p.install || "default"}) ${renderBar(pct)} ${formatNumber(
-              p.index,
-            )}/${formatNumber(p.total)} | buckets ${formatNumber(p.bucketsQueued)}`,
-          );
-        },
-        source: "opencode",
-      });
+      let multiResult;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          multiResult = await multiInstallParse({
+            paths: opencodePaths,
+            parserFn: parseOpencodeForInstall,
+            providerName: "opencode",
+            cursors,
+            queuePath,
+            projectQueuePath,
+            getParams: (_p, key) => ({
+              dbDir: dbPaths[key],
+              messageFiles: messageFilesByInstall[key] || [],
+              opencodeCursorNamespace: installKeys.length > 1 ? key : "flat",
+            }),
+            onProgress: (p) => {
+              if (!progress?.enabled) return;
+              const pct = p.total > 0 ? p.index / p.total : 1;
+              progress.update(
+                `Parsing Opencode (${p.install || "default"}) ${renderBar(pct)} ${formatNumber(
+                  p.index,
+                )}/${formatNumber(p.total)} | buckets ${formatNumber(p.bucketsQueued)}`,
+              );
+            },
+            source: "opencode",
+          });
+          break;
+        } catch (error) {
+          if (!isCursorStoreRetry(error) || attempt > 0) throw error;
+        }
+      }
 
       opencodeResult = {
         filesProcessed: multiResult.recordsProcessed,

--- a/src/lib/cursor-store.js
+++ b/src/lib/cursor-store.js
@@ -15,6 +15,9 @@ const STORE_DIRNAME = "cursor-store-v2";
 const MANIFEST_FILENAME = "manifest.json";
 const GENERATIONS_DIRNAME = "generations";
 const DEFERRED_CODEX_AUDIT_FILENAME = "deferred-codex-audit.json";
+const SHARDED_CORE_FILENAME = "core-v3.json";
+const OPENCODE_MESSAGES_DIRNAME = "opencode-messages";
+const OPENCODE_FINGERPRINTS_DIRNAME = "opencode-fingerprints";
 const DEFAULT_ACTIVATION_BYTES = 16 * 1024 * 1024;
 const PROJECT_ABSENT_CONTEXT_RESCAN_MS = 24 * 60 * 60 * 1000;
 const CURSOR_STORE_RETRY_CODE = "TOKENTRACKER_CURSOR_STORE_RETRY";
@@ -66,26 +69,9 @@ async function openCursorStore({
       return opened;
     }
 
-    manifest = await migrateLegacyCursorState({
-      cursorsPath,
-      storeRoot,
-      legacyFingerprint,
-      previousManifest: manifest,
-      codexRoots: normalizedCodexRoots,
-      failureInjector,
-    });
-    migratedDuringOpen = true;
-    const recovered = await openManifestGeneration({
-      cursorsPath,
-      storeRoot,
-      manifest,
-      codexRoots: normalizedCodexRoots,
-      failureInjector,
-    });
-    if (recovered) {
-      recovered.requiresCommit = true;
-      return recovered;
-    }
+    throw cursorStoreCorruption(
+      `No valid cursor store generation in ${storeRoot}`,
+    );
   }
 
   const legacySize = Number(legacyFingerprint?.size || 0);
@@ -136,7 +122,10 @@ async function readCursorStateSummary({ trackerDir, cursorsPath } = {}) {
       );
     }
     const opened = await readGeneration({ storeRoot, generationId: manifest.current }) ||
-      await readGeneration({ storeRoot, generationId: manifest.previous });
+      await readGeneration({
+        storeRoot,
+        generationId: manifest.rollback || manifest.previous,
+      });
     if (opened) {
       return {
         cursors: opened.core,
@@ -145,6 +134,7 @@ async function readCursorStateSummary({ trackerDir, cursorsPath } = {}) {
         fileCount: Number(opened.metadata?.counts?.totalFiles || 0),
         codexFileCount: Number(opened.metadata?.counts?.codexFiles || 0),
         codexEventCount: Number(opened.metadata?.counts?.codexEvents || 0),
+        opencodeMessageCount: Number(opened.metadata?.counts?.opencodeMessages || 0),
       };
     }
   }
@@ -188,6 +178,12 @@ class LegacyCursorStore {
 
   async materializeAllCodexState() {}
 
+  async loadOpencodeMessagesForBatch() {
+    return null;
+  }
+
+  async materializeAllOpencodeState() {}
+
   async canSkipCodexDay() {
     return false;
   }
@@ -211,7 +207,7 @@ class V2CursorStore {
     storeRoot,
     manifest,
     generation,
-    fallbackGenerationId,
+    fallbackGenerationIds,
     codexRoots,
     failureInjector,
   }) {
@@ -221,7 +217,9 @@ class V2CursorStore {
     this.manifest = manifest;
     this.generation = generation.metadata;
     this.generationDir = generation.directory;
-    this.fallbackGenerationId = fallbackGenerationId;
+    this.fallbackGenerationIds = Array.isArray(fallbackGenerationIds)
+      ? [...fallbackGenerationIds]
+      : [];
     this.codexRoots = codexRoots;
     this.cursors = generation.core;
     this.failureInjector = failureInjector;
@@ -233,9 +231,18 @@ class V2CursorStore {
     this.loadedEventSets = new Map();
     this.pendingEventKeys = new Map();
     this.skipValidationCache = new Map();
+    this.loadedOpencodeMessageShards = new Map();
+    this.loadedOpencodeFingerprintShards = new Map();
+    this.opencodeFingerprintIndexes = new Map();
+    this.materializedOpencodeNamespaces = new Set();
     this.fileShardLoadCount = 0;
+    this.opencodeMessageShardLoadCount = 0;
+    this.opencodeFingerprintShardLoadCount = 0;
     this.materializedCodexHashes = false;
     this.requiresCommit = generation.metadata.id !== manifest.current;
+
+    this.normalizeGenerationMetadata();
+    this.stageInlineOpencodeMessages();
 
     if (!this.cursors.files || typeof this.cursors.files !== "object") {
       this.cursors.files = {};
@@ -263,6 +270,30 @@ class V2CursorStore {
 
   get currentCorePath() {
     return path.join(this.generationDir, this.generation?.coreFile || "core.json");
+  }
+
+  normalizeGenerationMetadata() {
+    if (!this.generation.opencodeMessages) this.generation.opencodeMessages = {};
+    if (!this.generation.opencodeFingerprints) this.generation.opencodeFingerprints = {};
+  }
+
+  stageInlineOpencodeMessages() {
+    const states = opencodeNamespaceStates(this.cursors.opencode);
+    const messageCount = Array.from(states.values()).reduce(
+      (sum, state) => sum + Object.keys(state.messages || {}).length,
+      0,
+    );
+    if (messageCount === 0) return;
+    if (
+      Object.keys(this.generation.opencodeMessages).length > 0 ||
+      Object.keys(this.generation.opencodeFingerprints).length > 0
+    ) {
+      throw cursorStoreCorruption("OpenCode messages exist in both core and shards");
+    }
+    for (const namespace of states.keys()) {
+      this.materializedOpencodeNamespaces.add(namespace);
+    }
+    this.requiresCommit = true;
   }
 
   async loadCodexFilesForPaths(paths, cursors = this.cursors) {
@@ -363,6 +394,210 @@ class V2CursorStore {
         }
         cursors.codexHashes = hashes;
         this.materializedCodexHashes = true;
+        return { restarted: attempt > 0 };
+      } catch (error) {
+        if (!isCursorStoreRetry(error) || attempt > 0) throw error;
+      }
+    }
+    return { restarted: false };
+  }
+
+  async loadOpencodeMessagesForBatch({
+    namespace = "flat",
+    messageKeys = [],
+    fingerprints = [],
+  } = {}) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const loaded = await this.loadOpencodeMessagesForBatchUnchecked({
+          namespace,
+          messageKeys,
+          fingerprints,
+        });
+        if (loaded) loaded.restarted = attempt > 0;
+        return loaded;
+      } catch (error) {
+        if (
+          !isCursorStoreRetry(error) ||
+          normalizeOpencodeNamespace(namespace) !== "flat" ||
+          attempt > 0
+        ) {
+          throw error;
+        }
+      }
+    }
+    return null;
+  }
+
+  async loadOpencodeMessagesForBatchUnchecked({
+    namespace,
+    messageKeys,
+    fingerprints,
+  }) {
+    const normalizedNamespace = normalizeOpencodeNamespace(namespace);
+    const activeRoot = this.cursors.opencode;
+    const activeRootIsFlat = Boolean(
+      activeRoot &&
+      typeof activeRoot === "object" &&
+      activeRoot.native === undefined &&
+      activeRoot.wsl === undefined,
+    );
+    const state = normalizedNamespace !== "flat" && activeRootIsFlat
+      ? activeRoot
+      : opencodeStateForNamespace(this.cursors, normalizedNamespace, true);
+    if (!state || this.materializedOpencodeNamespaces.has(normalizedNamespace)) return null;
+    const messages = state.messages && typeof state.messages === "object"
+      ? state.messages
+      : (state.messages = {});
+    const managed = hasOpencodeNamespaceShards({
+      namespace: normalizedNamespace,
+      metadata: this.generation,
+      loadedMessages: this.loadedOpencodeMessageShards,
+      loadedFingerprints: this.loadedOpencodeFingerprintShards,
+    });
+    if (!managed && Object.keys(messages).length > 0) return null;
+    if (!managed && this.generation.coreFile !== SHARDED_CORE_FILENAME) return null;
+
+    const wantedMessageKeys = Array.from(new Set(
+      Array.from(messageKeys || []).filter((key) => typeof key === "string" && key.length > 0),
+    ));
+    for (const shardKey of new Set(wantedMessageKeys.map((key) => (
+      opencodeMessageShardKey(key, normalizedNamespace)
+    )))) {
+      const alreadyLoaded = this.loadedOpencodeMessageShards.has(shardKey);
+      const data = await this.loadOpencodeMessageShard(shardKey);
+      if (!alreadyLoaded) Object.assign(messages, data);
+    }
+
+    const wantedFingerprints = new Set(
+      Array.from(fingerprints || []).filter((value) => (
+        typeof value === "string" && value.length > 0
+      )),
+    );
+    for (const messageKey of wantedMessageKeys) {
+      const previousFingerprint = messages[messageKey]?.fingerprint;
+      if (typeof previousFingerprint === "string" && previousFingerprint.length > 0) {
+        wantedFingerprints.add(previousFingerprint);
+      }
+    }
+    for (const shardKey of new Set(Array.from(wantedFingerprints, (fingerprint) => (
+      opencodeFingerprintShardKey(fingerprint, normalizedNamespace)
+    )))) {
+      await this.loadOpencodeFingerprintShard(shardKey, normalizedNamespace);
+    }
+
+    if (!this.opencodeFingerprintIndexes.has(normalizedNamespace)) {
+      this.opencodeFingerprintIndexes.set(normalizedNamespace, new Map());
+    }
+    return {
+      fingerprintIndex: this.opencodeFingerprintIndexes.get(normalizedNamespace),
+      restarted: false,
+    };
+  }
+
+  async loadOpencodeMessageShard(shardKey) {
+    try {
+      return await this.loadOpencodeMessageShardUnchecked(shardKey);
+    } catch (error) {
+      if (
+        error?.code !== "TOKENTRACKER_CURSOR_STORE_CORRUPT" ||
+        !this.activateFallbackGeneration(this.cursors)
+      ) {
+        throw error;
+      }
+      throw cursorStoreRetry(error);
+    }
+  }
+
+  async loadOpencodeMessageShardUnchecked(shardKey) {
+    if (this.loadedOpencodeMessageShards.has(shardKey)) {
+      return this.loadedOpencodeMessageShards.get(shardKey).data;
+    }
+    const metadata = this.generation.opencodeMessages[shardKey] || null;
+    const data = await readJsonObjectShard({
+      generationDir: this.generationDir,
+      metadata,
+      label: `OpenCode message shard ${metadata?.file || shardKey}`,
+    });
+    this.loadedOpencodeMessageShards.set(shardKey, { data });
+    this.opencodeMessageShardLoadCount += 1;
+    return data;
+  }
+
+  async loadOpencodeFingerprintShard(shardKey, namespace) {
+    try {
+      return await this.loadOpencodeFingerprintShardUnchecked(shardKey, namespace);
+    } catch (error) {
+      if (
+        error?.code !== "TOKENTRACKER_CURSOR_STORE_CORRUPT" ||
+        !this.activateFallbackGeneration(this.cursors)
+      ) {
+        throw error;
+      }
+      throw cursorStoreRetry(error);
+    }
+  }
+
+  async loadOpencodeFingerprintShardUnchecked(shardKey, namespace) {
+    const alreadyLoaded = this.loadedOpencodeFingerprintShards.has(shardKey);
+    if (!alreadyLoaded) {
+      const metadata = this.generation.opencodeFingerprints[shardKey] || null;
+      const data = await readJsonObjectShard({
+        generationDir: this.generationDir,
+        metadata,
+        label: `OpenCode fingerprint shard ${metadata?.file || shardKey}`,
+        validate: (value) => Array.isArray(value) && value.every((item) => (
+          typeof item === "string" && item.length > 0
+        )),
+      });
+      this.loadedOpencodeFingerprintShards.set(shardKey, { data });
+      this.opencodeFingerprintShardLoadCount += 1;
+    }
+    if (!this.opencodeFingerprintIndexes.has(namespace)) {
+      this.opencodeFingerprintIndexes.set(namespace, new Map());
+    }
+    const index = this.opencodeFingerprintIndexes.get(namespace);
+    if (!alreadyLoaded) {
+      for (const [fingerprint, owners] of Object.entries(
+        this.loadedOpencodeFingerprintShards.get(shardKey).data,
+      )) {
+        index.set(fingerprint, new Set(owners));
+      }
+    }
+    return index;
+  }
+
+  async materializeAllOpencodeState() {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const namespaces = opencodeNamespacesForStore({
+          state: this.cursors.opencode,
+          metadata: this.generation,
+          loadedMessages: this.loadedOpencodeMessageShards,
+          loadedFingerprints: this.loadedOpencodeFingerprintShards,
+        });
+        for (const namespace of namespaces) {
+          const state = opencodeStateForNamespace(this.cursors, namespace, true);
+          if (!state.messages || typeof state.messages !== "object") state.messages = {};
+          for (const shardKey of opencodeShardKeysForNamespace(
+            namespace,
+            this.generation.opencodeMessages,
+            this.loadedOpencodeMessageShards,
+          )) {
+            Object.assign(
+              state.messages,
+              await this.loadOpencodeMessageShard(shardKey),
+            );
+          }
+          for (const shardKey of opencodeShardKeysForNamespace(
+            namespace,
+            this.generation.opencodeFingerprints,
+            this.loadedOpencodeFingerprintShards,
+          )) {
+            await this.loadOpencodeFingerprintShard(shardKey, namespace);
+          }
+          this.materializedOpencodeNamespaces.add(namespace);
+        }
         return { restarted: attempt > 0 };
       } catch (error) {
         if (!isCursorStoreRetry(error) || attempt > 0) throw error;
@@ -490,14 +725,13 @@ class V2CursorStore {
   }
 
   activateFallbackGeneration(cursors = this.cursors) {
-    const generationId = this.fallbackGenerationId;
-    this.fallbackGenerationId = null;
-    if (!generationId) return false;
-
-    const fallback = readGenerationSync({
-      storeRoot: this.storeRoot,
-      generationId,
-    });
+    let fallback = null;
+    while (!fallback && this.fallbackGenerationIds.length > 0) {
+      fallback = readGenerationSync({
+        storeRoot: this.storeRoot,
+        generationId: this.fallbackGenerationIds.shift(),
+      });
+    }
     if (!fallback) return false;
 
     const fallbackCore = cloneJson(fallback.core);
@@ -511,9 +745,111 @@ class V2CursorStore {
     this.loadedEventSets.clear();
     this.pendingEventKeys.clear();
     this.skipValidationCache.clear();
+    this.loadedOpencodeMessageShards.clear();
+    this.loadedOpencodeFingerprintShards.clear();
+    this.opencodeFingerprintIndexes.clear();
+    this.materializedOpencodeNamespaces.clear();
     this.materializedCodexHashes = false;
     this.requiresCommit = true;
+    this.normalizeGenerationMetadata();
+    this.stageInlineOpencodeMessages();
     return true;
+  }
+
+  async commitOpencodeShards({ cursors, generationDir, metadata }) {
+    const states = opencodeNamespaceStates(cursors.opencode);
+    const currentNamespaces = new Set(states.keys());
+
+    for (const shardMap of [metadata.opencodeMessages, metadata.opencodeFingerprints]) {
+      for (const [shardKey, entry] of Object.entries(shardMap)) {
+        if (currentNamespaces.has(opencodeShardNamespace(shardKey))) continue;
+        if (entry?.file) await fs.unlink(path.join(generationDir, entry.file)).catch(() => {});
+        delete shardMap[shardKey];
+      }
+    }
+
+    for (const [namespace, state] of states) {
+      const messages = state.messages && typeof state.messages === "object"
+        ? state.messages
+        : {};
+      const managed = hasOpencodeNamespaceShards({
+        namespace,
+        metadata: this.generation,
+        loadedMessages: this.loadedOpencodeMessageShards,
+        loadedFingerprints: this.loadedOpencodeFingerprintShards,
+      });
+      const materialized = this.materializedOpencodeNamespaces.has(namespace) ||
+        (!managed && Object.keys(messages).length > 0);
+
+      if (materialized) {
+        await removeOpencodeNamespaceShards({ generationDir, metadata, namespace });
+        const partitioned = partitionOpencodeMessages(messages, namespace);
+        for (const [shardKey, data] of partitioned.messageShards) {
+          await writeOpencodeShard({
+            generationDir,
+            metadataMap: metadata.opencodeMessages,
+            directory: OPENCODE_MESSAGES_DIRNAME,
+            shardKey,
+            data,
+          });
+        }
+        for (const [shardKey, data] of partitioned.fingerprintShards) {
+          await writeOpencodeShard({
+            generationDir,
+            metadataMap: metadata.opencodeFingerprints,
+            directory: OPENCODE_FINGERPRINTS_DIRNAME,
+            shardKey,
+            data,
+          });
+        }
+        continue;
+      }
+
+      const dirtyMessageShards = new Set([
+        ...opencodeShardKeysForNamespace(
+          namespace,
+          {},
+          this.loadedOpencodeMessageShards,
+        ),
+        ...Object.keys(messages).map((key) => opencodeMessageShardKey(key, namespace)),
+      ]);
+      for (const shardKey of dirtyMessageShards) {
+        const data = {};
+        for (const [messageKey, entry] of Object.entries(messages)) {
+          if (opencodeMessageShardKey(messageKey, namespace) === shardKey) {
+            data[messageKey] = entry;
+          }
+        }
+        await writeOpencodeShard({
+          generationDir,
+          metadataMap: metadata.opencodeMessages,
+          directory: OPENCODE_MESSAGES_DIRNAME,
+          shardKey,
+          data,
+        });
+      }
+
+      const fingerprintIndex = this.opencodeFingerprintIndexes.get(namespace) || new Map();
+      for (const shardKey of opencodeShardKeysForNamespace(
+        namespace,
+        {},
+        this.loadedOpencodeFingerprintShards,
+      )) {
+        const data = {};
+        for (const [fingerprint, owners] of fingerprintIndex) {
+          if (opencodeFingerprintShardKey(fingerprint, namespace) === shardKey) {
+            data[fingerprint] = Array.from(owners);
+          }
+        }
+        await writeOpencodeShard({
+          generationDir,
+          metadataMap: metadata.opencodeFingerprints,
+          directory: OPENCODE_FINGERPRINTS_DIRNAME,
+          shardKey,
+          data,
+        });
+      }
+    }
   }
 
   async commit(cursors = this.cursors) {
@@ -523,15 +859,19 @@ class V2CursorStore {
     try {
       await ensureDir(path.join(generationDir, "codex-files"));
       await ensureDir(path.join(generationDir, "codex-events"));
+      await ensureDir(path.join(generationDir, OPENCODE_MESSAGES_DIRNAME));
+      await ensureDir(path.join(generationDir, OPENCODE_FINGERPRINTS_DIRNAME));
 
       const nextMetadata = {
         version: STORE_VERSION,
         id: generationId,
         createdAt: new Date().toISOString(),
-        coreFile: "core.json",
+        coreFile: SHARDED_CORE_FILENAME,
         codexFiles: cloneJson(this.generation?.codexFiles || {}),
         codexEvents: cloneJson(this.generation?.codexEvents || {}),
-        counts: { nonCodexFiles: 0, codexFiles: 0, totalFiles: 0, codexEvents: 0 },
+        opencodeMessages: cloneJson(this.generation?.opencodeMessages || {}),
+        opencodeFingerprints: cloneJson(this.generation?.opencodeFingerprints || {}),
+        counts: {},
       };
 
       await cloneGenerationFiles({
@@ -604,9 +944,16 @@ class V2CursorStore {
         }
       }
 
+      await this.commitOpencodeShards({
+        cursors,
+        generationDir,
+        metadata: nextMetadata,
+      });
+
       const core = {
         ...cursors,
         files: coreFiles,
+        opencode: cloneOpencodeCoreState(cursors.opencode),
       };
       delete core.codexHashes;
       await fs.writeFile(
@@ -624,10 +971,16 @@ class V2CursorStore {
 
       await maybeInjectFailure(this.failureInjector, "beforeManifestSwap");
 
+      const compatibleGeneration = this.generation?.coreFile === "core.json"
+        ? this.generation.id
+        : this.manifest?.previous || null;
       const nextManifest = {
         version: STORE_VERSION,
         current: generationId,
-        previous: this.generation?.id || null,
+        rollback: this.generation?.id || null,
+        // Older v2 readers reject core-v3.json and fall back to this frozen,
+        // fully-inline checkpoint instead of opening an empty message index.
+        previous: compatibleGeneration,
         legacyFingerprint: this.manifest?.legacyFingerprint || null,
         updatedAt: new Date().toISOString(),
       };
@@ -642,10 +995,16 @@ class V2CursorStore {
       this.loadedEventSets.clear();
       this.pendingEventKeys.clear();
       this.skipValidationCache.clear();
+      this.loadedOpencodeMessageShards.clear();
+      this.loadedOpencodeFingerprintShards.clear();
+      this.opencodeFingerprintIndexes.clear();
+      this.materializedOpencodeNamespaces.clear();
       this.materializedCodexHashes = false;
+      this.fallbackGenerationIds = [nextManifest.rollback].filter(Boolean);
       this.requiresCommit = false;
       await cleanupGenerations(this.storeRoot, new Set([
         nextManifest.current,
+        nextManifest.rollback,
         nextManifest.previous,
       ].filter(Boolean)));
     } catch (error) {
@@ -779,9 +1138,10 @@ async function openManifestGeneration({
 }) {
   const generationIds = Array.from(new Set([
     manifest.current,
-    manifest.previous,
+    manifest.rollback || manifest.previous,
   ].filter(Boolean)));
-  for (const generationId of generationIds) {
+  for (let index = 0; index < generationIds.length; index += 1) {
+    const generationId = generationIds[index];
     const generation = await readGeneration({ storeRoot, generationId });
     if (!generation) continue;
     return new V2CursorStore({
@@ -789,10 +1149,7 @@ async function openManifestGeneration({
       storeRoot,
       manifest,
       generation,
-      fallbackGenerationId:
-        generationId === manifest.current && manifest.previous !== generationId
-          ? manifest.previous
-          : null,
+      fallbackGenerationIds: generationIds.slice(index + 1),
       codexRoots,
       failureInjector,
     });
@@ -848,13 +1205,14 @@ function isCursorStateRoot(value) {
 }
 
 function isGenerationMetadata(metadata, generationId) {
+  const shardedOpencode = metadata?.coreFile === SHARDED_CORE_FILENAME;
   if (
     !metadata ||
     typeof metadata !== "object" ||
     Array.isArray(metadata) ||
     metadata.version !== STORE_VERSION ||
     metadata.id !== generationId ||
-    metadata.coreFile !== "core.json" ||
+    (metadata.coreFile !== "core.json" && !shardedOpencode) ||
     !metadata.codexFiles ||
     typeof metadata.codexFiles !== "object" ||
     Array.isArray(metadata.codexFiles) ||
@@ -867,10 +1225,25 @@ function isGenerationMetadata(metadata, generationId) {
   ) {
     return false;
   }
+  if (
+    shardedOpencode &&
+    (!metadata.opencodeMessages ||
+      typeof metadata.opencodeMessages !== "object" ||
+      Array.isArray(metadata.opencodeMessages) ||
+      !metadata.opencodeFingerprints ||
+      typeof metadata.opencodeFingerprints !== "object" ||
+      Array.isArray(metadata.opencodeFingerprints))
+  ) {
+    return false;
+  }
 
   return (
     validShardMetadataMap(metadata.codexFiles, "codex-files") &&
-    validShardMetadataMap(metadata.codexEvents, "codex-events")
+    validShardMetadataMap(metadata.codexEvents, "codex-events") &&
+    (!shardedOpencode || (
+      validShardMetadataMap(metadata.opencodeMessages, OPENCODE_MESSAGES_DIRNAME) &&
+      validShardMetadataMap(metadata.opencodeFingerprints, OPENCODE_FINGERPRINTS_DIRNAME)
+    ))
   );
 }
 
@@ -898,10 +1271,7 @@ function validShardMetadataMap(shards, expectedDirectory) {
 }
 
 async function generationReferencesExist(directory, metadata) {
-  for (const [expectedDirectory, shards] of [
-    ["codex-files", metadata.codexFiles],
-    ["codex-events", metadata.codexEvents],
-  ]) {
+  for (const [expectedDirectory, shards] of generationShardMaps(metadata)) {
     const expectedNames = Object.values(shards)
       .map((entry) => normalizeShardReference(entry.file, expectedDirectory).name);
     if (expectedNames.length === 0) continue;
@@ -921,10 +1291,7 @@ async function generationReferencesExist(directory, metadata) {
 }
 
 function generationReferencesExistSync(directory, metadata) {
-  for (const [expectedDirectory, shards] of [
-    ["codex-files", metadata.codexFiles],
-    ["codex-events", metadata.codexEvents],
-  ]) {
+  for (const [expectedDirectory, shards] of generationShardMaps(metadata)) {
     const expectedNames = Object.values(shards)
       .map((entry) => normalizeShardReference(entry.file, expectedDirectory).name);
     if (expectedNames.length === 0) continue;
@@ -959,17 +1326,31 @@ function normalizeShardReference(relativeFile, expectedDirectory) {
   return { directory: expectedDirectory, name: parts[1] };
 }
 
+function generationShardMaps(metadata) {
+  return [
+    ["codex-files", metadata.codexFiles || {}],
+    ["codex-events", metadata.codexEvents || {}],
+    [OPENCODE_MESSAGES_DIRNAME, metadata.opencodeMessages || {}],
+    [OPENCODE_FINGERPRINTS_DIRNAME, metadata.opencodeFingerprints || {}],
+  ];
+}
+
 function sameGenerationCounts(left, right) {
-  return ["nonCodexFiles", "codexFiles", "totalFiles", "codexEvents"]
-    .every((key) => Number(left?.[key]) === Number(right?.[key]));
+  return [
+    "nonCodexFiles",
+    "codexFiles",
+    "totalFiles",
+    "codexEvents",
+    "opencodeMessages",
+    "opencodeFingerprints",
+  ].every((key) => Number(left?.[key] || 0) === Number(right?.[key] || 0));
 }
 
 async function cloneGenerationFiles({ fromDirectory, toDirectory, metadata }) {
-  for (const entry of Object.values(metadata.codexFiles || {})) {
-    if (entry?.file) await cloneOrCopy(fromDirectory, toDirectory, entry.file);
-  }
-  for (const entry of Object.values(metadata.codexEvents || {})) {
-    if (entry?.file) await cloneOrCopy(fromDirectory, toDirectory, entry.file);
+  for (const [, shards] of generationShardMaps(metadata)) {
+    for (const entry of Object.values(shards)) {
+      if (entry?.file) await cloneOrCopy(fromDirectory, toDirectory, entry.file);
+    }
   }
 }
 
@@ -1099,6 +1480,196 @@ function assertShardIntegrity(raw, metadata, label) {
   }
 }
 
+async function readJsonObjectShard({
+  generationDir,
+  metadata,
+  label,
+  validate = (value) => value && typeof value === "object" && !Array.isArray(value),
+}) {
+  if (!metadata?.file) return {};
+  let raw;
+  try {
+    raw = await fs.readFile(path.join(generationDir, metadata.file), "utf8");
+  } catch (error) {
+    throw cursorStoreCorruption(`Unable to read ${label}`, error);
+  }
+  assertShardIntegrity(raw, metadata, label);
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (error) {
+    throw cursorStoreCorruption(`Invalid ${label}`, error);
+  }
+  if (
+    !data ||
+    typeof data !== "object" ||
+    Array.isArray(data) ||
+    Object.keys(data).length !== metadata.count ||
+    Object.values(data).some((value) => !validate(value))
+  ) {
+    throw cursorStoreCorruption(`Invalid ${label}`);
+  }
+  return data;
+}
+
+async function writeOpencodeShard({
+  generationDir,
+  metadataMap,
+  directory,
+  shardKey,
+  data,
+}) {
+  const previousFile = metadataMap[shardKey]?.file;
+  if (previousFile) await fs.unlink(path.join(generationDir, previousFile)).catch(() => {});
+  if (Object.keys(data).length === 0) {
+    delete metadataMap[shardKey];
+    return;
+  }
+  const relativeFile = path.join(directory, `${shardKey}.json`);
+  const serialized = `${JSON.stringify(data)}\n`;
+  await fs.writeFile(path.join(generationDir, relativeFile), serialized, "utf8");
+  metadataMap[shardKey] = {
+    file: relativeFile,
+    count: Object.keys(data).length,
+    ...buildShardIntegrity(serialized),
+  };
+}
+
+async function removeOpencodeNamespaceShards({ generationDir, metadata, namespace }) {
+  for (const shardMap of [metadata.opencodeMessages, metadata.opencodeFingerprints]) {
+    for (const [shardKey, entry] of Object.entries(shardMap)) {
+      if (opencodeShardNamespace(shardKey) !== namespace) continue;
+      if (entry?.file) await fs.unlink(path.join(generationDir, entry.file)).catch(() => {});
+      delete shardMap[shardKey];
+    }
+  }
+}
+
+function normalizeOpencodeNamespace(value) {
+  return value === "native" || value === "wsl" ? value : "flat";
+}
+
+function opencodeNamespaceStates(state) {
+  const out = new Map();
+  if (!state || typeof state !== "object" || Array.isArray(state)) return out;
+  if (state.native !== undefined || state.wsl !== undefined) {
+    for (const namespace of ["native", "wsl"]) {
+      const child = state[namespace];
+      if (child && typeof child === "object" && !Array.isArray(child)) {
+        out.set(namespace, child);
+      }
+    }
+  } else {
+    out.set("flat", state);
+  }
+  return out;
+}
+
+function opencodeStateForNamespace(cursors, namespace, create = false) {
+  if (!cursors.opencode || typeof cursors.opencode !== "object" || Array.isArray(cursors.opencode)) {
+    if (!create) return null;
+    cursors.opencode = namespace === "flat" ? {} : { native: {}, wsl: {} };
+  }
+  const root = cursors.opencode;
+  const namespaced = root.native !== undefined || root.wsl !== undefined;
+  if (namespace === "flat") return namespaced ? null : root;
+  if (!namespaced) return null;
+  if (!root[namespace] || typeof root[namespace] !== "object" || Array.isArray(root[namespace])) {
+    if (!create) return null;
+    root[namespace] = {};
+  }
+  return root[namespace];
+}
+
+function opencodeShardHash(value) {
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 2);
+}
+
+function opencodeMessageShardKey(messageKey, namespace = "flat") {
+  return `${normalizeOpencodeNamespace(namespace)}-${opencodeShardHash(messageKey)}`;
+}
+
+function opencodeFingerprintShardKey(fingerprint, namespace = "flat") {
+  return `${normalizeOpencodeNamespace(namespace)}-${opencodeShardHash(fingerprint)}`;
+}
+
+function opencodeShardNamespace(shardKey) {
+  const namespace = typeof shardKey === "string" ? shardKey.split("-", 1)[0] : "";
+  return namespace === "native" || namespace === "wsl" ? namespace : "flat";
+}
+
+function opencodeShardKeysForNamespace(namespace, metadataMap, loadedMap) {
+  return Array.from(new Set([
+    ...Object.keys(metadataMap || {}),
+    ...Array.from(loadedMap?.keys?.() || []),
+  ].filter((shardKey) => opencodeShardNamespace(shardKey) === namespace)));
+}
+
+function hasOpencodeNamespaceShards({
+  namespace,
+  metadata,
+  loadedMessages,
+  loadedFingerprints,
+}) {
+  return (
+    opencodeShardKeysForNamespace(namespace, metadata.opencodeMessages, loadedMessages).length > 0 ||
+    opencodeShardKeysForNamespace(namespace, metadata.opencodeFingerprints, loadedFingerprints).length > 0
+  );
+}
+
+function opencodeNamespacesForStore({
+  state,
+  metadata,
+  loadedMessages,
+  loadedFingerprints,
+}) {
+  const namespaces = new Set(opencodeNamespaceStates(state).keys());
+  for (const shardKey of [
+    ...Object.keys(metadata.opencodeMessages || {}),
+    ...Object.keys(metadata.opencodeFingerprints || {}),
+    ...Array.from(loadedMessages.keys()),
+    ...Array.from(loadedFingerprints.keys()),
+  ]) {
+    namespaces.add(opencodeShardNamespace(shardKey));
+  }
+  return namespaces;
+}
+
+function partitionOpencodeMessages(messages, namespace) {
+  const messageShards = new Map();
+  const fingerprintShards = new Map();
+  for (const messageKey in messages || {}) {
+    const entry = messages[messageKey];
+    const messageShard = opencodeMessageShardKey(messageKey, namespace);
+    if (!messageShards.has(messageShard)) messageShards.set(messageShard, {});
+    messageShards.get(messageShard)[messageKey] = entry;
+    const fingerprint = typeof entry?.fingerprint === "string" ? entry.fingerprint : null;
+    if (!fingerprint || entry?.dedupedForkCopy === true) continue;
+    const fingerprintShard = opencodeFingerprintShardKey(fingerprint, namespace);
+    if (!fingerprintShards.has(fingerprintShard)) fingerprintShards.set(fingerprintShard, {});
+    const shard = fingerprintShards.get(fingerprintShard);
+    if (!shard[fingerprint]) shard[fingerprint] = [];
+    shard[fingerprint].push(messageKey);
+  }
+  return { messageShards, fingerprintShards };
+}
+
+function cloneOpencodeCoreState(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state)) return state;
+  if (state.native !== undefined || state.wsl !== undefined) {
+    const clone = { ...state };
+    for (const namespace of ["native", "wsl"]) {
+      if (!state[namespace] || typeof state[namespace] !== "object") continue;
+      clone[namespace] = { ...state[namespace] };
+      delete clone[namespace].messages;
+    }
+    return clone;
+  }
+  const clone = { ...state };
+  delete clone.messages;
+  return clone;
+}
+
 async function validateProjectSummary(summary, nowMs) {
   if (!summary || typeof summary !== "object") return false;
   const absentFreshUntil = Number(summary.absentFreshUntil);
@@ -1176,11 +1747,17 @@ function calculateGenerationCounts(metadata, coreFiles) {
     .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
   const codexEvents = Object.values(metadata.codexEvents || {})
     .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
+  const opencodeMessages = Object.values(metadata.opencodeMessages || {})
+    .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
+  const opencodeFingerprints = Object.values(metadata.opencodeFingerprints || {})
+    .reduce((sum, entry) => sum + Number(entry?.count || 0), 0);
   return {
     nonCodexFiles,
     codexFiles,
     totalFiles: nonCodexFiles + codexFiles,
     codexEvents,
+    opencodeMessages,
+    opencodeFingerprints,
   };
 }
 
@@ -1332,6 +1909,8 @@ module.exports = {
   STORE_VERSION,
   codexEventShardKey,
   codexFileShardKey,
+  opencodeFingerprintShardKey,
+  opencodeMessageShardKey,
   isCodexSessionCursorPath,
   isCursorStoreRetry,
   openCursorStore,

--- a/src/lib/multi-install-parser.js
+++ b/src/lib/multi-install-parser.js
@@ -47,7 +47,9 @@ async function multiInstallParse({ paths, parserFn, providerName, cursors, getPa
       eventsAggregated += result.eventsAggregated || 0;
       bucketsQueued += result.bucketsQueued || 0;
     } catch (parseErr) {
-      cursors[providerName] = ns;
+      if (parseErr?.code !== "TOKENTRACKER_CURSOR_STORE_RETRY") {
+        cursors[providerName] = ns;
+      }
       throw parseErr;
     }
   }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3376,10 +3376,9 @@ function deriveOpencodeMessageFingerprint({ msg, totals, source }) {
   return crypto.createHash("sha256").update(raw).digest("base64url").slice(0, 22);
 }
 
-// `fingerprint -> messageKey` for counted messages in this cursor namespace.
-// Rebuilt per parse run. Pre-#426 entries are fingerprinted as they are read;
-// the first claims ownership and later cross-session matches are retracted from
-// persisted buckets once. Tombstoned copies never claim ownership themselves.
+// `fingerprint -> Set<messageKey>` for counted messages in this cursor namespace.
+// Same-session duplicates are all retained as owners; the first session remains
+// canonical for cross-session fork copies. Tombstoned copies never claim ownership.
 function buildOpencodeFingerprintIndex(messageIndex, wantedFingerprints = null) {
   const byFingerprint = new Map();
   if (!messageIndex || typeof messageIndex !== "object") return byFingerprint;
@@ -3387,12 +3386,9 @@ function buildOpencodeFingerprintIndex(messageIndex, wantedFingerprints = null) 
     const entry = messageIndex[key];
     if (entry?.dedupedForkCopy === true) continue;
     const fingerprint = entry && typeof entry.fingerprint === "string" ? entry.fingerprint : null;
-    if (
-      fingerprint &&
-      (!wantedFingerprints || wantedFingerprints.has(fingerprint)) &&
-      !byFingerprint.has(fingerprint)
-    ) {
-      byFingerprint.set(fingerprint, key);
+    if (fingerprint && (!wantedFingerprints || wantedFingerprints.has(fingerprint))) {
+      if (!byFingerprint.has(fingerprint)) byFingerprint.set(fingerprint, new Set());
+      byFingerprint.get(fingerprint).add(key);
     }
   }
   return byFingerprint;
@@ -3410,12 +3406,16 @@ function opencodeMessageKeySession(messageKey) {
 // must not delete usage.
 function isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey) {
   if (!fingerprint || !fingerprintIndex) return false;
-  const owner = fingerprintIndex.get(fingerprint);
-  if (!owner || owner === messageKey) return false;
-  const ownerSession = opencodeMessageKeySession(owner);
+  const owners = fingerprintIndex.get(fingerprint);
+  if (!owners) return false;
   const session = opencodeMessageKeySession(messageKey);
-  if (!ownerSession || !session) return false;
-  return ownerSession !== session;
+  if (!session) return false;
+  for (const owner of owners instanceof Set ? owners : [owners]) {
+    const ownerSession = opencodeMessageKeySession(owner);
+    if (!ownerSession) continue;
+    return owner !== messageKey && ownerSession !== session;
+  }
+  return false;
 }
 
 function normalizeOpencodeAttribution(raw) {
@@ -3493,8 +3493,16 @@ function recordOpencodeMessage({
     prevDeduped === Boolean(dedupedForkCopy)
   ) return;
 
-  if (fingerprintIndex && prevFingerprint && prevFingerprint !== nextFingerprint) {
-    if (fingerprintIndex.get(prevFingerprint) === messageKey) {
+  if (
+    fingerprintIndex &&
+    prevFingerprint &&
+    (prevFingerprint !== nextFingerprint || dedupedForkCopy)
+  ) {
+    const owners = fingerprintIndex.get(prevFingerprint);
+    if (owners instanceof Set) {
+      owners.delete(messageKey);
+      if (owners.size === 0) fingerprintIndex.delete(prevFingerprint);
+    } else if (owners === messageKey) {
       fingerprintIndex.delete(prevFingerprint);
     }
   }
@@ -3503,13 +3511,12 @@ function recordOpencodeMessage({
   if (nextAttribution) entry.attribution = encodeOpencodeAttribution(nextAttribution);
   if (dedupedForkCopy) entry.dedupedForkCopy = true;
   messageIndex[messageKey] = entry;
-  if (
-    fingerprintIndex &&
-    nextFingerprint &&
-    !dedupedForkCopy &&
-    !fingerprintIndex.has(nextFingerprint)
-  ) {
-    fingerprintIndex.set(nextFingerprint, messageKey);
+  if (fingerprintIndex && nextFingerprint && !dedupedForkCopy) {
+    if (!fingerprintIndex.has(nextFingerprint)) {
+      fingerprintIndex.set(nextFingerprint, new Set());
+    }
+    const owners = fingerprintIndex.get(nextFingerprint);
+    if (owners instanceof Set) owners.add(messageKey);
   }
 }
 
@@ -5104,6 +5111,8 @@ async function parseOpencodeDbIncremental({
   source,
   cursorKey,
   publicRepoResolver,
+  opencodeCursorStore,
+  opencodeCursorNamespace = "flat",
 }) {
   await ensureDir(path.dirname(queuePath));
   let messagesProcessed = 0;
@@ -5119,22 +5128,35 @@ async function parseOpencodeDbIncremental({
   const projectMetaCache = projectEnabled ? new Map() : null;
   const publicRepoCache = projectEnabled ? new Map() : null;
   const cursorNamespace = typeof cursorKey === "string" && cursorKey.length > 0 ? cursorKey : "opencode";
-  const opencodeState = normalizeOpencodeState(cursors?.[cursorNamespace]);
-  const messageIndex = opencodeState.messages;
   const touchedBuckets = new Set();
   const defaultSource = normalizeSourceInput(source) || "opencode";
+  const candidateMessageKeys = new Set();
   const candidateFingerprints = new Set();
   for (const entry of messages) {
+    const msgForKey = { ...entry?.data };
+    if (entry?.id && !msgForKey.id) msgForKey.id = entry.id;
+    if (entry?.sessionID && !msgForKey.sessionID) msgForKey.sessionID = entry.sessionID;
+    const messageKey = deriveOpencodeMessageKey(msgForKey, null);
+    if (messageKey) candidateMessageKeys.add(messageKey);
     const totals = normalizeOpencodeTokens(entry?.data?.tokens);
     const fingerprint = totals
       ? deriveOpencodeMessageFingerprint({ msg: entry.data, totals, source: defaultSource })
       : null;
     if (fingerprint) candidateFingerprints.add(fingerprint);
   }
-  // A hook-triggered sync normally carries one changed row. Restrict the
-  // historical fingerprint map to fingerprints that can actually match this
-  // batch instead of duplicating the whole long-lived message index in memory.
-  const fingerprintIndex = buildOpencodeFingerprintIndex(messageIndex, candidateFingerprints);
+  const loaded = cursorNamespace === "opencode" && opencodeCursorStore
+    ? await opencodeCursorStore.loadOpencodeMessagesForBatch({
+        namespace: opencodeCursorNamespace,
+        messageKeys: candidateMessageKeys,
+        fingerprints: candidateFingerprints,
+      })
+    : null;
+  const opencodeState = normalizeOpencodeState(cursors?.[cursorNamespace]);
+  const messageIndex = opencodeState.messages;
+  // Direct parser callers and the legacy single-file store retain the in-memory
+  // fallback; cursor-store generations provide the bounded reverse index.
+  const fingerprintIndex = loaded?.fingerprintIndex ||
+    buildOpencodeFingerprintIndex(messageIndex, candidateFingerprints);
 
   for (let idx = 0; idx < messages.length; idx++) {
     const entry = messages[idx];

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3413,7 +3413,8 @@ function isOpencodeForkCopy(fingerprintIndex, fingerprint, messageKey) {
   for (const owner of owners instanceof Set ? owners : [owners]) {
     const ownerSession = opencodeMessageKeySession(owner);
     if (!ownerSession) continue;
-    return owner !== messageKey && ownerSession !== session;
+    if (owner === messageKey) return false;
+    if (ownerSession !== session) return true;
   }
   return false;
 }

--- a/test/cursor-store.test.js
+++ b/test/cursor-store.test.js
@@ -6,9 +6,12 @@ const { test } = require("node:test");
 
 const {
   STORE_DIRNAME,
+  opencodeFingerprintShardKey,
+  opencodeMessageShardKey,
   openCursorStore,
   readCursorStateSummary,
 } = require("../src/lib/cursor-store");
+const { multiInstallParse } = require("../src/lib/multi-install-parser");
 const { purgeProjectUsage } = require("../src/lib/project-usage-purge");
 
 async function withCursorFixture(fn) {
@@ -394,14 +397,8 @@ test("a corrupt current generation falls back to the previous generation", async
     await migrated.commit();
 
     const manifestPath = path.join(trackerDir, STORE_DIRNAME, "manifest.json");
-    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
-    const corePath = path.join(
-      trackerDir,
-      STORE_DIRNAME,
-      "generations",
-      manifest.current,
-      "core.json",
-    );
+    const current = await readCurrentGeneration(trackerDir);
+    const corePath = path.join(current.directory, current.metadata.coreFile);
     await fs.writeFile(corePath, "{broken", "utf8");
 
     const recovered = await openCursorStore({ trackerDir, cursorsPath });
@@ -580,6 +577,188 @@ test("state summaries prefer a later legacy write over stale v2 state", async ()
     assert.equal(summary.legacyDrift, true);
     assert.equal(summary.cursors.files[day17File].offset, 77);
     assert.equal(summary.codexEventCount, legacy.codexHashes.length);
+  });
+});
+
+test("OpenCode messages migrate out of core and load by message and fingerprint shard", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, legacy }) => {
+    const prepared = structuredClone(legacy);
+    const totals = (input) => ({
+      input_tokens: input,
+      output_tokens: 1,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: input + 1,
+    });
+    prepared.opencode = {
+      messages: {
+        "session-a|message-a": {
+          lastTotals: totals(10),
+          fingerprint: "fingerprint-a",
+          updatedAt: "2026-08-30T00:00:00.000Z",
+        },
+        "session-a|message-b": {
+          lastTotals: totals(20),
+          fingerprint: "fingerprint-a",
+          updatedAt: "2026-08-30T00:00:00.000Z",
+        },
+        "session-b|message-c": {
+          lastTotals: totals(30),
+          fingerprint: "fingerprint-c",
+          updatedAt: "2026-08-30T00:00:00.000Z",
+        },
+      },
+      dbCursor: { version: 1 },
+    };
+    await fs.writeFile(cursorsPath, `${JSON.stringify(prepared)}\n`, "utf8");
+
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    assert.equal(Object.keys(migrated.cursors.opencode.messages).length, 3);
+    await migrated.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const core = JSON.parse(
+      await fs.readFile(path.join(current.directory, current.metadata.coreFile), "utf8"),
+    );
+    assert.equal(current.metadata.coreFile, "core-v3.json");
+    assert.equal(core.opencode.messages, undefined);
+    assert.equal(current.metadata.counts.opencodeMessages, 3);
+    assert.equal(current.metadata.counts.opencodeFingerprints, 2);
+
+    const compatible = await readGenerationFixture(trackerDir, current.manifest.previous);
+    assert.equal(compatible.metadata.coreFile, "core.json");
+    const compatibleCore = JSON.parse(
+      await fs.readFile(path.join(compatible.directory, compatible.metadata.coreFile), "utf8"),
+    );
+    assert.equal(Object.keys(compatibleCore.opencode.messages).length, 3);
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    assert.equal(reopened.cursors.opencode.messages, undefined);
+    const loaded = await reopened.loadOpencodeMessagesForBatch({
+      messageKeys: ["session-a|message-a"],
+      fingerprints: ["fingerprint-a"],
+    });
+    assert.equal(reopened.cursors.opencode.messages["session-a|message-a"].lastTotals.input_tokens, 10);
+    assert.deepEqual(
+      Array.from(loaded.fingerprintIndex.get("fingerprint-a")).sort(),
+      ["session-a|message-a", "session-a|message-b"],
+    );
+    assert.equal(reopened.opencodeMessageShardLoadCount, 1);
+    assert.equal(reopened.opencodeFingerprintShardLoadCount, 1);
+    assert.ok(current.metadata.opencodeMessages[opencodeMessageShardKey("session-a|message-a")]);
+    assert.ok(current.metadata.opencodeFingerprints[opencodeFingerprintShardKey("fingerprint-a")]);
+  });
+});
+
+test("OpenCode shards stay isolated while multi-install parsing selects each namespace", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, legacy }) => {
+    const entry = (input, fingerprint) => ({
+      lastTotals: { input_tokens: input, total_tokens: input },
+      fingerprint,
+    });
+    const prepared = structuredClone(legacy);
+    prepared.opencode = {
+      native: { messages: { "native-session|message": entry(10, "native-fingerprint") } },
+      wsl: { messages: { "wsl-session|message": entry(20, "wsl-fingerprint") } },
+    };
+    await fs.writeFile(cursorsPath, `${JSON.stringify(prepared)}\n`, "utf8");
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.commit();
+
+    const store = await openCursorStore({ trackerDir, cursorsPath });
+    await multiInstallParse({
+      paths: { native: "/native", wsl: "/wsl" },
+      providerName: "opencode",
+      cursors: store.cursors,
+      getParams: (_path, namespace) => ({ namespace }),
+      parserFn: async ({ namespace, cursors }) => {
+        const messageKey = `${namespace}-session|message`;
+        const loaded = await store.loadOpencodeMessagesForBatch({
+          namespace,
+          messageKeys: [messageKey],
+          fingerprints: [`${namespace}-fingerprint`],
+        });
+        assert.equal(cursors.opencode.messages[messageKey].lastTotals.input_tokens, namespace === "native" ? 10 : 20);
+        assert.deepEqual(Array.from(loaded.fingerprintIndex.get(`${namespace}-fingerprint`)), [messageKey]);
+        return { recordsProcessed: 1 };
+      },
+    });
+    assert.equal(store.cursors.opencode.native.messages["wsl-session|message"], undefined);
+    assert.equal(store.cursors.opencode.wsl.messages["native-session|message"], undefined);
+    await store.commit();
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    await reopened.loadOpencodeMessagesForBatch({
+      namespace: "wsl",
+      messageKeys: ["wsl-session|message"],
+      fingerprints: ["wsl-fingerprint"],
+    });
+    assert.equal(reopened.cursors.opencode.wsl.messages["wsl-session|message"].lastTotals.input_tokens, 20);
+  });
+});
+
+test("invalid current and fallback generations fail closed instead of remigrating frozen legacy state", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, originalLegacyRaw }) => {
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.commit();
+    const second = await openCursorStore({ trackerDir, cursorsPath });
+    await second.commit();
+    const current = await readCurrentGeneration(trackerDir);
+    const rollback = await readGenerationFixture(trackerDir, current.manifest.rollback);
+    const compatible = await readGenerationFixture(trackerDir, current.manifest.previous);
+    assert.equal(compatible.metadata.coreFile, "core.json");
+    await fs.writeFile(path.join(current.directory, current.metadata.coreFile), "{broken", "utf8");
+    await fs.writeFile(path.join(rollback.directory, rollback.metadata.coreFile), "{broken", "utf8");
+
+    await assert.rejects(
+      openCursorStore({ trackerDir, cursorsPath }),
+      (error) => error?.code === "TOKENTRACKER_CURSOR_STORE_CORRUPT",
+    );
+    assert.equal(await fs.readFile(cursorsPath, "utf8"), originalLegacyRaw);
+  });
+});
+
+test("a corrupt OpenCode shard lazily falls back to the rollback generation", async () => {
+  await withCursorFixture(async ({ trackerDir, cursorsPath, legacy }) => {
+    const prepared = structuredClone(legacy);
+    prepared.opencode = {
+      messages: {
+        "session-a|message-a": {
+          lastTotals: { input_tokens: 10, total_tokens: 10 },
+          fingerprint: "fingerprint-a",
+        },
+      },
+    };
+    await fs.writeFile(cursorsPath, `${JSON.stringify(prepared)}\n`, "utf8");
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.commit();
+
+    const updating = await openCursorStore({ trackerDir, cursorsPath });
+    await updating.loadOpencodeMessagesForBatch({
+      messageKeys: ["session-a|message-a"],
+      fingerprints: ["fingerprint-a"],
+    });
+    updating.cursors.opencode.messages["session-a|message-a"].lastTotals.input_tokens = 20;
+    await updating.commit();
+
+    const current = await readCurrentGeneration(trackerDir);
+    const shard = current.metadata.opencodeMessages[
+      opencodeMessageShardKey("session-a|message-a")
+    ];
+    const shardPath = path.join(current.directory, shard.file);
+    const raw = await fs.readFile(shardPath, "utf8");
+    await fs.writeFile(shardPath, corruptShardWithoutChangingLength(raw), "utf8");
+
+    const recovered = await openCursorStore({ trackerDir, cursorsPath });
+    const result = await recovered.loadOpencodeMessagesForBatch({
+      messageKeys: ["session-a|message-a"],
+      fingerprints: ["fingerprint-a"],
+    });
+    assert.equal(result.restarted, true);
+    assert.equal(
+      recovered.cursors.opencode.messages["session-a|message-a"].lastTotals.input_tokens,
+      10,
+    );
   });
 });
 

--- a/test/multi-install-parser.test.js
+++ b/test/multi-install-parser.test.js
@@ -107,6 +107,29 @@ test("multiInstallParse partial parse failure propagates error", async () => {
   assert.deepEqual(cursors.hermes.native, { done: true }, "first install's cursor state should be preserved");
 });
 
+test("cursor-store retry preserves the activated fallback namespaces", async () => {
+  const cursors = { opencode: { native: { old: true }, wsl: { old: true } } };
+  await assert.rejects(
+    () => multiInstallParse({
+      paths: { native: "/a", wsl: "/b" },
+      parserFn: async ({ cursors: current }) => {
+        current.opencode = { native: { fallback: true }, wsl: { fallback: true } };
+        const error = new Error("retry");
+        error.code = "TOKENTRACKER_CURSOR_STORE_RETRY";
+        throw error;
+      },
+      providerName: "opencode",
+      cursors,
+      getParams: () => ({}),
+    }),
+    (error) => error?.code === "TOKENTRACKER_CURSOR_STORE_RETRY",
+  );
+  assert.deepEqual(cursors.opencode, {
+    native: { fallback: true },
+    wsl: { fallback: true },
+  });
+});
+
 test("multiInstallParse empty install produces correct partial result", async () => {
   const cursors = { hourly: { buckets: {} } };
 

--- a/test/opencode-fork-dedup.test.js
+++ b/test/opencode-fork-dedup.test.js
@@ -407,6 +407,35 @@ test("parseOpencodeDbIncremental never drops a same-session duplicate (fork alwa
   });
 });
 
+test("fork dedup scans past same-session fingerprint owners", async () => {
+  await withTmp(async (tmp) => {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = newCursors();
+    const base = Date.parse(HOUR);
+    const owner = msg({ id: "msg_1", sessionID: "ses_same", created: base + 1000, input: 100 });
+    await parseOpencodeDbIncremental({
+      dbMessages: [owner],
+      cursors,
+      queuePath,
+      source: "opencode",
+    });
+
+    const ownerEntry = cursors.opencode.messages["ses_same|msg_1"];
+    cursors.opencode.messages["ses_other|msg_2"] = { ...ownerEntry };
+    const fork = msg({ id: "msg_3", sessionID: "ses_same", created: base + 1000, input: 100 });
+    const result = await parseOpencodeDbIncremental({
+      dbMessages: [fork],
+      cursors,
+      queuePath,
+      source: "opencode",
+    });
+
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal((await queueTotals(queuePath)).input_tokens, 100);
+    assert.equal(cursors.opencode.messages["ses_same|msg_3"].dedupedForkCopy, true);
+  });
+});
+
 test("fingerprint ownership keeps alternate same-session owners after a correction", async () => {
   await withTmp(async (tmp) => {
     const queuePath = path.join(tmp, "queue.jsonl");

--- a/test/opencode-fork-dedup.test.js
+++ b/test/opencode-fork-dedup.test.js
@@ -19,6 +19,7 @@ const path = require("node:path");
 const fs = require("node:fs/promises");
 const { test } = require("node:test");
 
+const { openCursorStore } = require("../src/lib/cursor-store");
 const { parseOpencodeIncremental, parseOpencodeDbIncremental } = require("../src/lib/rollout");
 
 const HOUR = "2026-08-06T10:00:00.000Z";
@@ -145,6 +146,77 @@ test("parseOpencodeDbIncremental counts a fork-copied prefix once and keeps the 
     assert.equal(again.eventsAggregated, 0);
     assert.equal(again.bucketsQueued, 0);
     assert.deepEqual(await queueTotals(queuePath), totals);
+  });
+});
+
+test("sharded OpenCode cursors load only the batch state and preserve fork dedup", async () => {
+  await withTmp(async (tmp) => {
+    const trackerDir = path.join(tmp, "tracker");
+    const cursorsPath = path.join(trackerDir, "cursors.json");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = newCursors();
+    const base = Date.parse(HOUR);
+    const parent = msg({
+      id: "msg_parent",
+      sessionID: "ses_parent",
+      created: base + 1000,
+      input: 4000,
+      output: 40,
+    });
+    const fork = msg({
+      id: "msg_fork",
+      sessionID: "ses_fork",
+      created: base + 1000,
+      input: 4000,
+      output: 40,
+    });
+
+    await parseOpencodeDbIncremental({
+      dbMessages: [parent],
+      cursors,
+      queuePath,
+      source: "opencode",
+    });
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(cursorsPath, `${JSON.stringify(cursors)}\n`, "utf8");
+    const migrated = await openCursorStore({ trackerDir, cursorsPath, forceV2: true });
+    await migrated.commit();
+
+    const store = await openCursorStore({ trackerDir, cursorsPath });
+    const result = await parseOpencodeDbIncremental({
+      dbMessages: [fork],
+      cursors: store.cursors,
+      queuePath,
+      source: "opencode",
+      opencodeCursorStore: store,
+    });
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal((await queueTotals(queuePath)).input_tokens, 4000);
+    assert.equal(store.opencodeMessageShardLoadCount, 1);
+    assert.equal(store.opencodeFingerprintShardLoadCount, 1);
+    assert.equal(store.cursors.opencode.messages["ses_fork|msg_fork"].dedupedForkCopy, true);
+    const beforeCommit = await parseOpencodeDbIncremental({
+      dbMessages: [fork],
+      cursors: store.cursors,
+      queuePath,
+      source: "opencode",
+      opencodeCursorStore: store,
+    });
+    assert.equal(beforeCommit.eventsAggregated, 0);
+    assert.equal(store.cursors.opencode.messages["ses_fork|msg_fork"].dedupedForkCopy, true);
+    await store.commit();
+
+    const reopened = await openCursorStore({ trackerDir, cursorsPath });
+    const again = await parseOpencodeDbIncremental({
+      dbMessages: [fork],
+      cursors: reopened.cursors,
+      queuePath,
+      source: "opencode",
+      opencodeCursorStore: reopened,
+    });
+    assert.equal(again.eventsAggregated, 0);
+    assert.equal(again.bucketsQueued, 0);
+    assert.equal((await queueTotals(queuePath)).input_tokens, 4000);
   });
 });
 
@@ -332,6 +404,35 @@ test("parseOpencodeDbIncremental never drops a same-session duplicate (fork alwa
     assert.equal(res.eventsAggregated, 2);
     const totals = await queueTotals(queuePath);
     assert.equal(totals.input_tokens, 1800);
+  });
+});
+
+test("fingerprint ownership keeps alternate same-session owners after a correction", async () => {
+  await withTmp(async (tmp) => {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = newCursors();
+    const base = Date.parse(HOUR);
+    const first = msg({ id: "msg_1", sessionID: "ses_same", created: base + 1000, input: 100 });
+    const second = msg({ id: "msg_2", sessionID: "ses_same", created: base + 1000, input: 100 });
+    await parseOpencodeDbIncremental({
+      dbMessages: [first, second],
+      cursors,
+      queuePath,
+      source: "opencode",
+    });
+
+    const corrected = msg({ id: "msg_1", sessionID: "ses_same", created: base + 1000, input: 200 });
+    const fork = msg({ id: "msg_fork", sessionID: "ses_other", created: base + 1000, input: 100 });
+    const result = await parseOpencodeDbIncremental({
+      dbMessages: [corrected, fork],
+      cursors,
+      queuePath,
+      source: "opencode",
+    });
+
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal((await queueTotals(queuePath)).input_tokens, 300);
+    assert.equal(cursors.opencode.messages["ses_other|msg_fork"].dedupedForkCopy, true);
   });
 });
 


### PR DESCRIPTION
## Summary

- move canonical OpenCode message cursors out of the eagerly parsed cursor core into 256 hash shards
- add a separately sharded fingerprint-to-owner-set index so fork dedup loads only fingerprints relevant to the incremental DB batch
- preserve native/WSL cursor isolation, legacy JSON-storage behavior, crash-safe generation rollback, and an inline downgrade checkpoint for older v2 readers
- fail closed when both runtime generations are invalid instead of remigrating stale frozen cursor state
- retain every same-session fingerprint owner so correcting one message cannot make a later fork copy count again

## Why

The current cursor generation still eagerly parses and rewrites all OpenCode message history during routine sync, even though the SQLite reader normally returns one boundary/changed row.

Measured on the current 179,660-message store:

- `core.json`: 61.05 MB
- OpenCode message state: 57.1 MB
- JSON parse: 203 ms
- JSON stringify: 129 ms
- process RSS after parse/stringify: 389 MB
- routine incremental SQLite batch: 1 message

The existing candidate filter reduced the temporary fingerprint `Map`, but `buildOpencodeFingerprintIndex()` still scanned all 179,660 messages and the core still had to parse them first.

## Design

Routine DB sync now loads only:

1. message-key shards touched by the batch
2. fingerprint-owner shards for current and previous fingerprints

The existing parser still owns signed corrections, attribution moves, and tombstones. Legacy JSON message storage materializes full state because it requires historical traversal.

Sharded generations use `core-v3.json`, which older v2 binaries reject. The manifest retains a frozen inline `core.json` checkpoint as `previous`, while current code uses `rollback` for runtime recovery. This prevents an older binary from opening an apparently valid core with an empty message index.

## Validation

68 focused tests passed sequentially:

- `test/cursor-store.test.js`: 22 passed
- `test/opencode-fork-dedup.test.js`: 12 passed
- `test/multi-install-parser.test.js`: 11 passed
- `test/opencode2-parser.test.js`: 15 passed
- `test/kilo-parser.test.js`: 6 passed
- `test/mimo-parser.test.js`: 2 passed
- syntax checks for all four changed source files
- `git diff --check`

The focused tests cover two-run idempotence, bounded one-shard loading, native/WSL isolation, corruption rollback, downgrade compatibility, fork repair, in-place correction, and alternate same-session fingerprint ownership.

## Deferred locally

The full repository suite and real 179,660-message after-migration RSS/timing benchmark were not run locally to avoid further memory pressure. GitHub CI will run the full suite on this PR. The baseline above is measured; no unmeasured after-result is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode synchronization across multiple installations.
  * Preserved cursor state during recoverable sync retries.
  * Improved recovery from corrupted or incomplete sync data.
  * Fixed fork-copy deduplication so valid same-session messages are retained.

* **Performance**
  * OpenCode message and fingerprint data now loads on demand, reducing unnecessary processing.
  * Improved synchronization reliability when processing large message histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->