### PR TITLE
fix(sync): forward runtime anon key to account ingest

### DIFF
--- a/src/commands/device-login.js
+++ b/src/commands/device-login.js
@@ -4,7 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs/promises");
 
-const { readJson, writeJson } = require("../lib/fs");
+const { readJson, updateJsonLocked } = require("../lib/fs");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
 const { resolveRuntimeConfig } = require("../lib/runtime-config");
 
@@ -139,20 +139,15 @@ async function cmdDeviceLogin(argv = [], options = {}) {
       if (!result.deviceToken) {
         throw new Error("device login approved but server did not return a device token");
       }
-      const next = {
-        ...config,
-        // `config` was read BEFORE getOrCreateMachineId persisted the
-        // machineId — spreading it alone would clobber the freshly-written
-        // machineId on disk and the next caller would mint a different one
-        // (device identity drift, the exact bug this field exists to fix).
+      await updateJsonLocked(configPath, async (current) => ({
+        ...current,
         ...(machineId ? { machineId } : {}),
         baseUrl,
         user_id: result.user_id,
         deviceToken: result.deviceToken,
-        deviceId: result.deviceId || config.deviceId,
+        deviceId: result.deviceId || current.deviceId || config.deviceId,
         device_login_at: new Date().toISOString(),
-      };
-      await writeJson(configPath, next);
+      }));
       process.stdout.write(`\n✓ Approved. device token written to ${configPath}\n`);
       return;
     }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -15,6 +15,7 @@ const {
   chmod600IfPossible,
   openLock,
   inspectLock,
+  updateJsonLocked,
 } = require("../lib/fs");
 const { physicalJsonlRecords } = require("../lib/jsonl-lines");
 const {
@@ -2927,12 +2928,12 @@ async function cmdSync(argv, context = {}) {
           // migration observed. A concurrent login may replace the backend URL
           // while preserving the old key, or another writer may replace the key
           // while the legacy URL is still present.
-          const latestConfig = (await readJson(configPath)) || config;
-          const hasLegacyBaseUrl = isLegacyInsforgeBaseUrl(latestConfig.baseUrl);
-          const hasUnchangedLegacyAnonKey =
-            legacyBaseUrlMigration.hadPersistedAnonKey &&
-            latestConfig.anonKey === legacyBaseUrlMigration.persistedAnonKey;
-          if (hasLegacyBaseUrl || hasUnchangedLegacyAnonKey) {
+          await updateJsonLocked(configPath, async (latestConfig) => {
+            const hasLegacyBaseUrl = isLegacyInsforgeBaseUrl(latestConfig.baseUrl);
+            const hasUnchangedLegacyAnonKey =
+              legacyBaseUrlMigration.hadPersistedAnonKey &&
+              latestConfig.anonKey === legacyBaseUrlMigration.persistedAnonKey;
+            if (!hasLegacyBaseUrl && !hasUnchangedLegacyAnonKey) return null;
             if (hasLegacyBaseUrl) {
               latestConfig.deviceToken = successfulDeviceToken;
               delete latestConfig.baseUrl;
@@ -2940,9 +2941,8 @@ async function cmdSync(argv, context = {}) {
             if (hasUnchangedLegacyAnonKey) {
               delete latestConfig.anonKey;
             }
-            await writeJson(configPath, latestConfig);
-            await chmod600IfPossible(configPath);
-          }
+            return latestConfig;
+          });
         }
         // Record success so the exponential backoff step resets — otherwise
         // a single past failure keeps us pessimistically throttled forever.

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2835,6 +2835,9 @@ async function cmdSync(argv, context = {}) {
     progress?.stop();
 
     const runtimeConfig = config ? { ...config } : {};
+    if (legacyBaseUrlMigration) {
+      delete runtimeConfig.anonKey;
+    }
     if (legacyBaseUrlMigration?.replacementDeviceToken) {
       runtimeConfig.deviceToken = legacyBaseUrlMigration.replacementDeviceToken;
     }
@@ -2924,6 +2927,7 @@ async function cmdSync(argv, context = {}) {
           if (isLegacyInsforgeBaseUrl(latestConfig.baseUrl)) {
             latestConfig.deviceToken = successfulDeviceToken;
             delete latestConfig.baseUrl;
+            delete latestConfig.anonKey;
             await writeJson(configPath, latestConfig);
             await chmod600IfPossible(configPath);
           }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -561,6 +561,8 @@ async function cmdSync(argv, context = {}) {
       legacyBaseUrlMigration = {
         previousDeviceToken,
         replacementDeviceToken,
+        hadPersistedAnonKey: Object.prototype.hasOwnProperty.call(config, "anonKey"),
+        persistedAnonKey: config.anonKey,
       };
     }
     const codexCursorRoots = [process.env.CODEX_HOME || path.join(home, ".codex")];
@@ -2921,13 +2923,23 @@ async function cmdSync(argv, context = {}) {
         if (legacyBaseUrlMigration && uploadResult.batches > 0) {
           // device-login does not share the sync lock and may have written a
           // fresh current-backend config while the scan/upload was running.
-          // Re-read before committing, merge only while the legacy marker still
-          // exists, and never clobber a concurrently completed login.
+          // Re-read before committing and only remove the anonymous key this
+          // migration observed. A concurrent login may replace the backend URL
+          // while preserving the old key, or another writer may replace the key
+          // while the legacy URL is still present.
           const latestConfig = (await readJson(configPath)) || config;
-          if (isLegacyInsforgeBaseUrl(latestConfig.baseUrl)) {
-            latestConfig.deviceToken = successfulDeviceToken;
-            delete latestConfig.baseUrl;
-            delete latestConfig.anonKey;
+          const hasLegacyBaseUrl = isLegacyInsforgeBaseUrl(latestConfig.baseUrl);
+          const hasUnchangedLegacyAnonKey =
+            legacyBaseUrlMigration.hadPersistedAnonKey &&
+            latestConfig.anonKey === legacyBaseUrlMigration.persistedAnonKey;
+          if (hasLegacyBaseUrl || hasUnchangedLegacyAnonKey) {
+            if (hasLegacyBaseUrl) {
+              latestConfig.deviceToken = successfulDeviceToken;
+              delete latestConfig.baseUrl;
+            }
+            if (hasUnchangedLegacyAnonKey) {
+              delete latestConfig.anonKey;
+            }
             await writeJson(configPath, latestConfig);
             await chmod600IfPossible(configPath);
           }

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2888,6 +2888,7 @@ async function cmdSync(argv, context = {}) {
         const drainWithToken = (deviceToken) =>
           drainQueueToCloud({
             baseUrl: runtime.baseUrl,
+            anonKey: runtime.anonKey,
             deviceToken,
             queuePath,
             queueStatePath,
@@ -3613,7 +3614,7 @@ const AUTO_RETRY_MAX_DELAY_MS = 2 * 60 * 60 * 1000;
 const INGEST_SLUG = "tokentracker-ingest";
 const MAX_INGEST_BUCKETS = 500;
 
-async function drainQueueToCloud({ baseUrl, deviceToken, queuePath, queueStatePath, maxBatches = 5, batchSize = 200 }) {
+async function drainQueueToCloud({ baseUrl, anonKey, deviceToken, queuePath, queueStatePath, maxBatches = 5, batchSize = 200 }) {
   const state = (await readJson(queueStatePath)) || { offset: 0 };
   let offset = Number(state.offset || 0);
   let inserted = 0;
@@ -3632,7 +3633,6 @@ async function drainQueueToCloud({ baseUrl, deviceToken, queuePath, queueStatePa
     if (result.buckets.length === 0 && result.sessionStates.length === 0) break;
 
     const root = baseUrl.replace(/\/$/, "");
-    const anonKey = process.env.TOKENTRACKER_INSFORGE_ANON_KEY || "";
     const headers = {
       "Content-Type": "application/json",
       Accept: "application/json",

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -413,6 +413,35 @@ async function openLock(
   }
 }
 
+async function updateJsonLocked(
+  filePath,
+  update,
+  { timeoutMs = 30_000, retryMs = 10 } = {},
+) {
+  const lockPath = `${filePath}.lock`;
+  const deadline = Date.now() + timeoutMs;
+  let lock = null;
+  while (!lock) {
+    lock = await openLock(lockPath, { quietIfLocked: true });
+    if (lock) break;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting to update JSON file: ${filePath}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, retryMs));
+  }
+
+  try {
+    const current = (await readJson(filePath)) || {};
+    const next = await update(current);
+    if (next == null) return current;
+    await writeJson(filePath, next);
+    await chmod600IfPossible(filePath);
+    return next;
+  } finally {
+    await lock.release();
+  }
+}
+
 module.exports = {
   ensureDir,
   writeFileAtomic,
@@ -422,4 +451,5 @@ module.exports = {
   chmod600IfPossible,
   openLock,
   inspectLock,
+  updateJsonLocked,
 };

--- a/test/device-login.test.js
+++ b/test/device-login.test.js
@@ -35,6 +35,7 @@ test("pollOnce maps approved device token fields from server response", async ()
 
 test("cmdDeviceLogin persists the approved device token used by sync", async () => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "device-login-"));
+  const configPath = path.join(home, ".tokentracker", "tracker", "config.json");
   const calls = [];
   const originalFetch = global.fetch;
   const originalStdoutWrite = process.stdout.write;
@@ -56,6 +57,16 @@ test("cmdDeviceLogin persists the approved device token used by sync", async () 
         },
       };
     }
+    const currentConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        ...currentConfig,
+        anonKey: "current-anon-key",
+        concurrentSetting: "preserved",
+      }),
+      "utf8",
+    );
     return {
       ok: true,
       status: 200,
@@ -73,13 +84,13 @@ test("cmdDeviceLogin persists the approved device token used by sync", async () 
 
   try {
     await cmdDeviceLogin(["--base-url", "https://example.invalid"], { home, sleep: async () => {} });
-    const config = JSON.parse(
-      await fs.readFile(path.join(home, ".tokentracker", "tracker", "config.json"), "utf8"),
-    );
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
     assert.equal(config.user_id, "user-1");
     assert.equal(config.deviceToken, "device-token-1");
     assert.equal(config.deviceId, "device-1");
     assert.equal(config.baseUrl, "https://example.invalid");
+    assert.equal(config.anonKey, "current-anon-key");
+    assert.equal(config.concurrentSetting, "preserved");
     assert.equal(calls.length, 2);
     // Machine-anchored device identity: authorize must carry the SAME
     // machineId that was persisted to config.json, so the server can anchor

--- a/test/fs-lock.test.js
+++ b/test/fs-lock.test.js
@@ -5,7 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { openLock } = require("../src/lib/fs");
+const { openLock, updateJsonLocked } = require("../src/lib/fs");
 const { acquireSyncLock } = require("../src/commands/sync");
 
 async function withLockPath(fn) {
@@ -30,6 +30,49 @@ test("sync lock records its live owner and releases its own lease", async () => 
     assert.equal(await openLock(lockPath, { quietIfLocked: true }), null);
     await lock.release();
     await assert.rejects(fs.stat(lockPath), { code: "ENOENT" });
+  });
+});
+
+test("locked JSON updates serialize their read-modify-write transactions", async () => {
+  await withLockPath(async (lockPath) => {
+    const filePath = path.join(path.dirname(lockPath), "config.json");
+    await fs.writeFile(filePath, JSON.stringify({ existing: true }), "utf8");
+
+    let releaseFirst;
+    const firstMayFinish = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    let signalFirstRead;
+    const firstHasRead = new Promise((resolve) => {
+      signalFirstRead = resolve;
+    });
+
+    const first = updateJsonLocked(filePath, async (current) => {
+      signalFirstRead();
+      await firstMayFinish;
+      return { ...current, first: true };
+    });
+    await firstHasRead;
+    const second = updateJsonLocked(filePath, async (current) => ({
+      ...current,
+      second: true,
+    }));
+    let secondSettled = false;
+    void second.finally(() => {
+      secondSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(secondSettled, false, "the second transaction must wait for the first lock");
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    assert.deepEqual(JSON.parse(await fs.readFile(filePath, "utf8")), {
+      existing: true,
+      first: true,
+      second: true,
+    });
   });
 });
 

--- a/test/legacy-baseurl-migration.test.js
+++ b/test/legacy-baseurl-migration.test.js
@@ -259,6 +259,134 @@ test("sync preserves the legacy device token and replays the queue to the curren
   });
 });
 
+test("sync preserves an anon key replaced while legacy migration is uploading", async () => {
+  await withTempHome(async (home) => {
+    const trackerDir = await writeTrackerState(home, {});
+    await cmdSync(["--auto"]);
+
+    const queue = sampleQueueLine();
+    const configPath = path.join(trackerDir, "config.json");
+    await writeTrackerState(home, {
+      config: {
+        baseUrl: LEGACY_BASE_URL,
+        anonKey: "legacy-anon-key",
+        deviceToken: "legacy-token",
+        machineId: "machine-1",
+      },
+      queue,
+      queueState: { offset: Buffer.byteLength(queue) },
+    });
+
+    global.fetch = async (url) => {
+      if (String(url).endsWith("/functions/tokentracker-ingest")) {
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({
+            baseUrl: LEGACY_BASE_URL,
+            anonKey: "current-anon-key",
+            deviceToken: "legacy-token",
+            machineId: "machine-1",
+          }),
+          "utf8",
+        );
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ inserted: 1, skipped: 0 }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => "{}",
+        json: async () => ({}),
+      };
+    };
+
+    await cmdSync(["--auto"]);
+
+    const config = await readJsonFile(configPath);
+    assert.equal(config.baseUrl, undefined);
+    assert.equal(config.anonKey, "current-anon-key");
+    assert.equal(config.deviceToken, "legacy-token");
+  });
+});
+
+test("sync removes an unchanged legacy anon key after a concurrent login updates the base URL", async () => {
+  await withTempHome(async (home) => {
+    const trackerDir = await writeTrackerState(home, {});
+    await cmdSync(["--auto"]);
+
+    const queue = sampleQueueLine();
+    const configPath = path.join(trackerDir, "config.json");
+    await writeTrackerState(home, {
+      config: {
+        baseUrl: LEGACY_BASE_URL,
+        anonKey: "legacy-anon-key",
+        deviceToken: "legacy-token",
+        machineId: "machine-1",
+      },
+      queue,
+      queueState: { offset: Buffer.byteLength(queue) },
+    });
+
+    const ingestCalls = [];
+    global.fetch = async (url, options = {}) => {
+      if (String(url).endsWith("/functions/tokentracker-ingest")) {
+        ingestCalls.push(options);
+        if (ingestCalls.length === 1) {
+          await fs.writeFile(
+            configPath,
+            JSON.stringify({
+              baseUrl: DEFAULT_BASE_URL,
+              anonKey: "legacy-anon-key",
+              deviceToken: "current-login-token",
+              user_id: "current-user",
+              machineId: "machine-1",
+            }),
+            "utf8",
+          );
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ inserted: 1, skipped: 0 }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => "{}",
+        json: async () => ({}),
+      };
+    };
+
+    await cmdSync(["--auto"]);
+    const config = await readJsonFile(configPath);
+    assert.equal(config.baseUrl, DEFAULT_BASE_URL);
+    assert.equal(config.anonKey, undefined);
+    assert.equal(config.deviceToken, "current-login-token");
+    assert.equal(config.user_id, "current-user");
+
+    const pendingRow = {
+      ...JSON.parse(queue),
+      hour_start: "2026-04-20T00:30:00.000Z",
+      model: "gpt-5.4-after-login",
+    };
+    const pendingLine = `${JSON.stringify(pendingRow)}\n`;
+    await fs.appendFile(path.join(trackerDir, "queue.jsonl"), pendingLine, "utf8");
+    await cmdSync(["--auto"]);
+
+    assert.equal(ingestCalls.length, 2);
+    assert.equal(ingestCalls[1].headers.apikey, DEFAULT_ANON_KEY);
+    assert.equal(ingestCalls[1].headers.Authorization, "Bearer current-login-token");
+  });
+});
+
 test("sync adopts a current-backend device token supplied by the signed-in local API", async () => {
   await withTempHome(async (home) => {
     const trackerDir = await writeTrackerState(home, {});

--- a/test/legacy-baseurl-migration.test.js
+++ b/test/legacy-baseurl-migration.test.js
@@ -230,17 +230,32 @@ test("sync preserves the legacy device token and replays the queue to the curren
     assert.equal(uploadThrottle.backoffStep, 0);
     assert.equal(uploadThrottle.lastError, null);
 
-    // Second run must not reset again: the guard no longer matches.
+    // Second run must not reset again, and a newly pending row must upload
+    // with the current runtime key after the legacy config key was removed.
+    const pendingRow = {
+      ...JSON.parse(queue),
+      hour_start: "2026-04-20T00:30:00.000Z",
+      model: "gpt-5.4-follow-up",
+    };
+    const pendingLine = `${JSON.stringify(pendingRow)}\n`;
+    await fs.appendFile(path.join(trackerDir, "queue.jsonl"), pendingLine, "utf8");
     await fs.writeFile(
       path.join(trackerDir, "queue.state.json"),
-      JSON.stringify({ offset: 777, updatedAt: new Date().toISOString(), note: "manual" }),
+      JSON.stringify({
+        offset: Buffer.byteLength(queue),
+        updatedAt: new Date().toISOString(),
+        note: "manual",
+      }),
       "utf8",
     );
     await cmdSync(["--auto"]);
     const after = await readJsonFile(path.join(trackerDir, "queue.state.json"));
-    assert.equal(after.offset, 777);
+    assert.equal(after.offset, Buffer.byteLength(queue) + Buffer.byteLength(pendingLine));
     assert.equal(after.note, "manual");
-    assert.equal(ingestCalls.length, 1);
+    assert.equal(ingestCalls.length, 2);
+    assert.equal(ingestCalls[1].options.headers.apikey, DEFAULT_ANON_KEY);
+    assert.equal(ingestCalls[1].options.headers.Authorization, "Bearer legacy-token");
+    assert.deepEqual(JSON.parse(ingestCalls[1].options.body).hourly, [pendingRow]);
   });
 });
 

--- a/test/legacy-baseurl-migration.test.js
+++ b/test/legacy-baseurl-migration.test.js
@@ -11,6 +11,7 @@ const {
   resolveRuntimeConfig,
   isLegacyInsforgeBaseUrl,
   DEFAULT_BASE_URL,
+  DEFAULT_ANON_KEY,
 } = require("../src/lib/runtime-config");
 
 const LEGACY_BASE_URL = "https://b46ug8xu.us-east.insforge.app";
@@ -28,6 +29,7 @@ async function withTempHome(fn) {
     TOKENTRACKER_DSH_HOME: process.env.TOKENTRACKER_DSH_HOME,
     TOKENTRACKER_DEVICE_TOKEN: process.env.TOKENTRACKER_DEVICE_TOKEN,
     TOKENTRACKER_INSFORGE_BASE_URL: process.env.TOKENTRACKER_INSFORGE_BASE_URL,
+    TOKENTRACKER_INSFORGE_ANON_KEY: process.env.TOKENTRACKER_INSFORGE_ANON_KEY,
     TOKENTRACKER_SKIP_FIRST_SYNC: process.env.TOKENTRACKER_SKIP_FIRST_SYNC,
   };
   try {
@@ -38,6 +40,7 @@ async function withTempHome(fn) {
     process.env.XDG_DATA_HOME = path.join(home, ".local", "share");
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    delete process.env.TOKENTRACKER_INSFORGE_ANON_KEY;
     delete process.env.DSH_HOME;
     delete process.env.TOKENTRACKER_DSH_HOME;
     return await fn(home);
@@ -175,6 +178,7 @@ test("sync preserves the legacy device token and replays the queue to the curren
       config: {
         installedAt: "2026-03-23T08:16:55.409Z",
         baseUrl: LEGACY_BASE_URL,
+        anonKey: "legacy-anon-key",
         deviceToken: "legacy-token",
         deviceId: "legacy-device",
         user_id: "legacy-user",
@@ -200,6 +204,7 @@ test("sync preserves the legacy device token and replays the queue to the curren
 
     const config = await readJsonFile(path.join(trackerDir, "config.json"));
     assert.equal(config.baseUrl, undefined);
+    assert.equal(config.anonKey, undefined);
     assert.equal(config.deviceToken, "legacy-token");
     assert.equal(config.deviceId, "legacy-device");
     assert.equal(config.user_id, "legacy-user");
@@ -217,6 +222,7 @@ test("sync preserves the legacy device token and replays the queue to the curren
 
     assert.equal(ingestCalls.length, 1);
     assert.equal(ingestCalls[0].url, `${DEFAULT_BASE_URL}/functions/tokentracker-ingest`);
+    assert.equal(ingestCalls[0].options.headers.apikey, DEFAULT_ANON_KEY);
     assert.equal(ingestCalls[0].options.headers.Authorization, "Bearer legacy-token");
     assert.deepEqual(JSON.parse(ingestCalls[0].options.body).hourly, [JSON.parse(queue)]);
 

--- a/test/sync-background.test.js
+++ b/test/sync-background.test.js
@@ -6,6 +6,7 @@ const { test } = require("node:test");
 
 const { cmdSync } = require("../src/commands/sync");
 const { openLock } = require("../src/lib/fs");
+const { DEFAULT_ANON_KEY } = require("../src/lib/runtime-config");
 
 function tokenCountLine({ ts, totalTokens }) {
   const usage = {
@@ -110,6 +111,7 @@ async function withTempSyncEnv(fn) {
     REASONIX_STATE_HOME: process.env.REASONIX_STATE_HOME,
     TOKENTRACKER_DEVICE_TOKEN: process.env.TOKENTRACKER_DEVICE_TOKEN,
     TOKENTRACKER_INSFORGE_BASE_URL: process.env.TOKENTRACKER_INSFORGE_BASE_URL,
+    TOKENTRACKER_INSFORGE_ANON_KEY: process.env.TOKENTRACKER_INSFORGE_ANON_KEY,
     TOKENTRACKER_OPENCLAW_HOME: process.env.TOKENTRACKER_OPENCLAW_HOME,
     TOKENTRACKER_OPENCLAW_AGENT_ID: process.env.TOKENTRACKER_OPENCLAW_AGENT_ID,
     TOKENTRACKER_OPENCLAW_PREV_SESSION_ID: process.env.TOKENTRACKER_OPENCLAW_PREV_SESSION_ID,
@@ -128,6 +130,7 @@ async function withTempSyncEnv(fn) {
     delete process.env.REASONIX_STATE_HOME;
     delete process.env.TOKENTRACKER_DEVICE_TOKEN;
     delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    delete process.env.TOKENTRACKER_INSFORGE_ANON_KEY;
     delete process.env.TOKENTRACKER_OPENCLAW_AGENT_ID;
     delete process.env.TOKENTRACKER_OPENCLAW_PREV_SESSION_ID;
     delete process.env.TOKENTRACKER_OPENCLAW_SESSION_KEY;
@@ -526,9 +529,11 @@ test("explicit account publication uploads after bounded background parsing", as
     process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
     const originalFetch = global.fetch;
     let ingestCalls = 0;
-    global.fetch = async (url) => {
+    let ingestHeaders = null;
+    global.fetch = async (url, options = {}) => {
       if (String(url).endsWith("/functions/tokentracker-ingest")) {
         ingestCalls += 1;
+        ingestHeaders = options.headers;
         return {
           ok: true,
           status: 200,
@@ -546,6 +551,7 @@ test("explicit account publication uploads after bounded background parsing", as
     }
 
     assert.equal(ingestCalls, 1);
+    assert.equal(ingestHeaders.apikey, DEFAULT_ANON_KEY);
     const queueState = JSON.parse(
       await fs.readFile(path.join(home, ".tokentracker", "tracker", "queue.state.json"), "utf8"),
     );


### PR DESCRIPTION
## What happened

A signed-in desktop user could have valid local usage in queue.jsonl while the account-backed dashboard showed zero usage for recent days.

The desktop Sync Now path resolved the current InsForge base URL, issued device token, and bundled public anonymous key through resolveRuntimeConfig(). However, drainQueueToCloud() discarded the resolved anonymous key and read only TOKENTRACKER_INSFORGE_ANON_KEY from the child process environment.

The native app does not normally set that environment override. Account-ingest requests could therefore carry the device bearer token without the required apikey header. In the reproduced v0.94.1 incident, the local queue was healthy, but publication stopped with HTTP 500 Invalid API key. Because the signed-in dashboard prefers account aggregates, unpublished recent buckets appeared as zero even though local usage existed.

A related migration case affected installs carrying the retired InsForge base URL and its persisted anonymous key. The URL recovered, but the obsolete key could still be selected for the current backend. Review also identified that migration cleanup and device-login could race while rewriting config.json, either deleting a newly replaced key or overwriting newly issued login credentials.

## Fix

- Pass runtime.anonKey into drainQueueToCloud() and use it for the apikey header on every ingest batch.
- During retired-backend migration, suppress the persisted legacy key before runtime resolution.
- Record the exact persisted key observed at migration start and remove only that unchanged value after a successful upload.
- Add a shared lock-protected JSON read-modify-write transaction using the existing crash-recoverable file lease.
- Use that transaction for both migration cleanup and device-login credential persistence, with the upload and interactive login wait outside the lock.
- Re-read and merge config while holding the lock so current anonymous keys, device tokens, user fields, machine identity, and unrelated settings survive concurrent updates.

## Verification

- Red/green regressions reproduced both key-cleanup races before the fixes.
- A serialization regression holds one JSON transaction open and proves a second writer cannot settle until the first releases the lock.
- Device-login now preserves configuration written during authorization.
- A post-migration upload verifies DEFAULT_ANON_KEY is selected and the current login token is preserved.
- Focused sync, migration, device-login, and lock tests: 51 passed, 0 failed.
- Full test suite: 2512 passed, 0 failed, 2 skipped.
- Architecture guardrails and all local CI validation commands passed.
- Dashboard production build passed.
- Remote CI passed on e4096eb1: test and validation build, CodeQL, macOS unit tests, Windows build, and Linux build.
- CodeRabbit reviewed e4096eb1 and generated no actionable comments.
- Live desktop verification on v0.94.1: the interrupted queue resumed from its committed offset, drained to 100%, upload errors cleared, and the previously empty account date range returned non-zero daily usage.