### PR TITLE
feat: attribute Codex usage per turn model

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -169,10 +169,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
-  // Three durable capability tiers: sol (flagship) / terra (balanced default) /
+  // Three durable capability tiers: sol (flagship and public alias) / terra (balanced) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -304,11 +304,11 @@ function getModelPricing(model: string) {
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
-  // fallback (which defaults to the balanced terra tier).
+  // fallback (the public gpt-5.6 alias points to the flagship sol tier).
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
-  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.4-pro")) return MODEL_PRICING["gpt-5.4-pro"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -145,10 +145,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
-  // Three durable capability tiers: sol (flagship) / terra (balanced default) /
+  // Three durable capability tiers: sol (flagship and public alias) / terra (balanced) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -280,11 +280,11 @@ function getModelPricing(model: string) {
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
-  // fallback (which defaults to the balanced terra tier).
+  // fallback (the public gpt-5.6 alias points to the flagship sol tier).
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
-  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.4-pro")) return MODEL_PRICING["gpt-5.4-pro"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -170,10 +170,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
-  // Three durable capability tiers: sol (flagship) / terra (balanced default) /
+  // Three durable capability tiers: sol (flagship and public alias) / terra (balanced) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -305,11 +305,11 @@ function getModelPricing(model: string) {
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
-  // fallback (which defaults to the balanced terra tier).
+  // fallback (the public gpt-5.6 alias points to the flagship sol tier).
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
-  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.4-pro")) return MODEL_PRICING["gpt-5.4-pro"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -142,10 +142,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
-  // Three durable capability tiers: sol (flagship) / terra (balanced default) /
+  // Three durable capability tiers: sol (flagship and public alias) / terra (balanced) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -277,11 +277,11 @@ function getModelPricing(model: string) {
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
-  // fallback (which defaults to the balanced terra tier).
+  // fallback (the public gpt-5.6 alias points to the flagship sol tier).
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
-  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.4-pro")) return MODEL_PRICING["gpt-5.4-pro"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -184,10 +184,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
-  // Three durable capability tiers: sol (flagship) / terra (balanced default) /
+  // Three durable capability tiers: sol (flagship and public alias) / terra (balanced) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -319,11 +319,11 @@ function getModelPricing(model: string) {
   if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
-  // fallback (which defaults to the balanced terra tier).
+  // fallback (the public gpt-5.6 alias points to the flagship sol tier).
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
-  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.4-pro")) return MODEL_PRICING["gpt-5.4-pro"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -1421,6 +1421,8 @@ sessions.badge.first_pass,ui,SessionsPage,SessionsPage,badge_first_pass,"First-p
 sessions.badge.reported_cost,ui,SessionsPage,SessionsPage,badge_reported_cost,"Reported cost",,active
 sessions.badge.reported_usage,ui,SessionsPage,SessionsPage,badge_reported_usage,"Reported usage",,active
 sessions.badge.partial_usage,ui,SessionsPage,SessionsPage,badge_partial_usage,"Partial usage",,active
+sessions.badge.partial_cost,ui,SessionsPage,SessionsPage,badge_partial_cost,"Partial cost","Tokens are fully observed but at least one model in the session has no public rate.",active
+sessions.cost.partial_title,ui,SessionsPage,SessionsPage,cost_partial_title,"Lower bound - some models in this session have no public rate, so their tokens cost $0 here.","Tooltip on the greater-or-equal cost marker.",active
 sessions.grok.token_breakdown,ui,SessionsPage,SessionsPage,grok_token_breakdown,"Input {{input}} · Cache read {{cacheRead}} · Cache write {{cacheWrite}} · Output {{output}} · Reasoning {{reasoning}}",,active
 sessions.grok.runtime_breakdown,ui,SessionsPage,SessionsPage,grok_runtime_breakdown,"Model calls {{calls}} · API {{seconds}}s · Tools {{tools}} · Errors {{errors}}",,active
 sessions.grok.context_breakdown,ui,SessionsPage,SessionsPage,grok_context_breakdown,"Context {{used}} / {{window}} ({{percent}}%)",,active

--- a/dashboard/src/content/i18n/de/core.json
+++ b/dashboard/src/content/i18n/de/core.json
@@ -521,7 +521,7 @@
   "sessions.badge.reported_usage": "Gemeldete Nutzung",
   "sessions.badge.partial_usage": "Unvollständige Nutzung",
   "sessions.badge.partial_cost": "Teilkosten",
-  "sessions.cost.partial_title": "Untergrenze - fur einige Modelle dieser Sitzung gibt es keinen offentlichen Tarif, ihre Tokens zahlen hier $0.",
+  "sessions.cost.partial_title": "Untergrenze — für einige Modelle dieser Sitzung gibt es keinen öffentlichen Tarif, ihre Tokens zählen hier $0.",
   "sessions.grok.token_breakdown": "Eingabe {{input}} · Cache-Lesen {{cacheRead}} · Cache-Schreiben {{cacheWrite}} · Ausgabe {{output}} · Reasoning {{reasoning}}",
   "sessions.grok.runtime_breakdown": "Modellaufrufe {{calls}} · API {{seconds}} s · Tools {{tools}} · Fehler {{errors}}",
   "sessions.grok.context_breakdown": "Kontext {{used}} / {{window}} ({{percent}} %)",

--- a/dashboard/src/content/i18n/de/core.json
+++ b/dashboard/src/content/i18n/de/core.json
@@ -520,6 +520,8 @@
   "sessions.badge.reported_cost": "Gemeldete Kosten",
   "sessions.badge.reported_usage": "Gemeldete Nutzung",
   "sessions.badge.partial_usage": "Unvollständige Nutzung",
+  "sessions.badge.partial_cost": "Teilkosten",
+  "sessions.cost.partial_title": "Untergrenze - fur einige Modelle dieser Sitzung gibt es keinen offentlichen Tarif, ihre Tokens zahlen hier $0.",
   "sessions.grok.token_breakdown": "Eingabe {{input}} · Cache-Lesen {{cacheRead}} · Cache-Schreiben {{cacheWrite}} · Ausgabe {{output}} · Reasoning {{reasoning}}",
   "sessions.grok.runtime_breakdown": "Modellaufrufe {{calls}} · API {{seconds}} s · Tools {{tools}} · Fehler {{errors}}",
   "sessions.grok.context_breakdown": "Kontext {{used}} / {{window}} ({{percent}} %)",

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -523,6 +523,8 @@
   "sessions.badge.reported_cost": "報告済みコスト",
   "sessions.badge.reported_usage": "報告済み使用量",
   "sessions.badge.partial_usage": "不完全な使用量",
+  "sessions.badge.partial_cost": "コスト不完全",
+  "sessions.cost.partial_title": "下限値 — このセッションの一部のモデルには公開レートがないため、そのトークンは $0 として計上されます。",
   "sessions.grok.token_breakdown": "入力 {{input}} · キャッシュ読取 {{cacheRead}} · キャッシュ書込 {{cacheWrite}} · 出力 {{output}} · 推論 {{reasoning}}",
   "sessions.grok.runtime_breakdown": "モデル呼出 {{calls}} 回 · API {{seconds}} 秒 · ツール {{tools}} 回 · エラー {{errors}} 件",
   "sessions.grok.context_breakdown": "コンテキスト {{used}} / {{window}}（{{percent}}%）",

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -523,6 +523,8 @@
   "sessions.badge.reported_cost": "보고된 비용",
   "sessions.badge.reported_usage": "보고된 사용량",
   "sessions.badge.partial_usage": "불완전한 사용량",
+  "sessions.badge.partial_cost": "비용 불완전",
+  "sessions.cost.partial_title": "하한값 — 이 세션의 일부 모델은 공개 요금이 없어 해당 토큰은 $0으로 계산됩니다.",
   "sessions.grok.token_breakdown": "입력 {{input}} · 캐시 읽기 {{cacheRead}} · 캐시 쓰기 {{cacheWrite}} · 출력 {{output}} · 추론 {{reasoning}}",
   "sessions.grok.runtime_breakdown": "모델 호출 {{calls}}회 · API {{seconds}}초 · 도구 {{tools}}회 · 오류 {{errors}}개",
   "sessions.grok.context_breakdown": "컨텍스트 {{used}} / {{window}} ({{percent}}%)",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -530,6 +530,8 @@
   "sessions.badge.reported_cost": "官方費用",
   "sessions.badge.reported_usage": "官方用量",
   "sessions.badge.partial_usage": "用量不完整",
+  "sessions.badge.partial_cost": "成本不完整",
+  "sessions.cost.partial_title": "下限值 — 本工作階段中部分模型沒有公開費率，其 token 在此以 $0 計。",
   "sessions.grok.token_breakdown": "輸入 {{input}} · 快取讀取 {{cacheRead}} · 快取寫入 {{cacheWrite}} · 輸出 {{output}} · 推理 {{reasoning}}",
   "sessions.grok.runtime_breakdown": "模型呼叫 {{calls}} 次 · API {{seconds}} 秒 · 工具呼叫 {{tools}} 次 · 錯誤 {{errors}} 個",
   "sessions.grok.context_breakdown": "上下文 {{used}} / {{window}}（{{percent}}%）",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -598,6 +598,8 @@
   "sessions.badge.reported_cost": "官方费用",
   "sessions.badge.reported_usage": "官方用量",
   "sessions.badge.partial_usage": "用量不完整",
+  "sessions.badge.partial_cost": "成本不完整",
+  "sessions.cost.partial_title": "下限值 — 本会话中部分模型没有公开费率，其 token 在此按 $0 计。",
   "sessions.grok.token_breakdown": "输入 {{input}} · 缓存读取 {{cacheRead}} · 缓存写入 {{cacheWrite}} · 输出 {{output}} · 推理 {{reasoning}}",
   "sessions.grok.runtime_breakdown": "模型调用 {{calls}} 次 · API {{seconds}} 秒 · 工具调用 {{tools}} 次 · 错误 {{errors}} 个",
   "sessions.grok.context_breakdown": "上下文 {{used}} / {{window}}（{{percent}}%）",

--- a/dashboard/src/lib/sessions-api.ts
+++ b/dashboard/src/lib/sessions-api.ts
@@ -7,6 +7,28 @@ const SLUG = "tokentracker-sessions";
 
 export type SessionSource = "claude" | "codex" | "grok";
 
+export interface SessionModelUsage {
+  model: string;
+  input_tokens: number;
+  cached_input_tokens: number;
+  cache_creation_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+  total_tokens: number;
+  long_context_input_tokens: number;
+  long_context_cached_input_tokens: number;
+  long_context_cache_creation_input_tokens: number;
+  long_context_output_tokens: number;
+  long_context_reasoning_output_tokens: number;
+  usage_events: number;
+  rerouted_usage_events: number;
+  long_context_usage_events: number;
+  selected_models: string[];
+  reroute_reasons: string[];
+  model_attribution: "selected" | "effective";
+  cost_usd: number;
+}
+
 export interface SessionRow {
   session_hash: string;
   session_id: string | null;
@@ -23,6 +45,7 @@ export interface SessionRow {
   project_key: string;
   project_ref: string | null;
   model: string;
+  model_usage: SessionModelUsage[];
   started_at: string | null;
   ended_at: string | null;
   duration_ms: number;

--- a/dashboard/src/lib/sessions-api.ts
+++ b/dashboard/src/lib/sessions-api.ts
@@ -7,6 +7,11 @@ const SLUG = "tokentracker-sessions";
 
 export type SessionSource = "claude" | "codex" | "grok";
 
+// Every field here is always present: the server densifies model_usage rows at
+// the response boundary (modelUsageForAggregation in src/lib/session-analytics.js),
+// so the sparse on-disk sidecar shape never reaches this client. Adding a field
+// here means adding it to MODEL_USAGE_SUM_FIELDS there; test/session-analytics
+// .test.js asserts the emitted key set matches for both producer paths.
 export interface SessionModelUsage {
   model: string;
   input_tokens: number;
@@ -23,6 +28,7 @@ export interface SessionModelUsage {
   usage_events: number;
   rerouted_usage_events: number;
   long_context_usage_events: number;
+  edit_turns: number;
   selected_models: string[];
   reroute_reasons: string[];
   model_attribution: "selected" | "effective";
@@ -45,7 +51,10 @@ export interface SessionRow {
   project_key: string;
   project_ref: string | null;
   model: string;
-  model_usage: SessionModelUsage[];
+  // Optional for version skew only: a desktop app whose bundled EmbeddedServer
+  // predates model_usage omits the field entirely (same skew the 404 branch in
+  // fetchSessions handles). A current server always sends a dense array.
+  model_usage?: SessionModelUsage[];
   started_at: string | null;
   ended_at: string | null;
   duration_ms: number;

--- a/dashboard/src/pages/SessionsPage.jsx
+++ b/dashboard/src/pages/SessionsPage.jsx
@@ -65,6 +65,25 @@ function overlapsRange(session, startMs) {
   return Number.isFinite(ended) ? ended >= startMs : true;
 }
 
+function modelUsageRows(session) {
+  const observed = Array.isArray(session?.model_usage)
+    ? session.model_usage.filter((row) => row && typeof row.model === "string" && row.model)
+    : [];
+  if (observed.length) return observed;
+  return [{
+    model: session?.model || copy("sessions.model.unknown"),
+    total_tokens: Number(session?.own_total_tokens || session?.total_tokens || 0),
+  }];
+}
+
+function modelUsageLabel(session) {
+  const rows = modelUsageRows(session);
+  if (rows.length === 1) return rows[0].model;
+  return rows
+    .map((row) => `${row.model} ${formatCompactNumber(Number(row.total_tokens || 0))}`)
+    .join(" · ");
+}
+
 function formatWhen(value, locale) {
   if (!value) return "—";
   const ms = Date.parse(value);
@@ -276,7 +295,7 @@ const SessionRow = React.memo(function SessionRow({
                 <span aria-hidden>·</span>
               </>
             ) : null}
-            <span className="truncate">{session.model || copy("sessions.model.unknown")}</span>
+            <span className="truncate">{modelUsageLabel(session)}</span>
             <span aria-hidden>·</span>
             <span className="tabular-nums">{formatWhen(session.started_at, locale)}</span>
             {duration ? (
@@ -329,7 +348,9 @@ const SessionRow = React.memo(function SessionRow({
           </div>
           <div className="flex w-16 flex-col-reverse">
             <dt className="text-[11px] text-oai-gray-400 dark:text-oai-gray-500">{copy("sessions.col.cost")}</dt>
-            <dd className="tabular-nums text-sm font-medium text-oai-black dark:text-white">{formatUsdCurrency(session.cost_usd, { currency, rate })}</dd>
+            <dd className="tabular-nums text-sm font-medium text-oai-black dark:text-white">
+              {session.cost_is_partial ? "≥" : ""}{formatUsdCurrency(session.cost_usd, { currency, rate })}
+            </dd>
           </div>
           <div className="hidden w-10 flex-col-reverse sm:flex">
             <dt className="text-[11px] text-oai-gray-400 dark:text-oai-gray-500">{copy("sessions.col.turns")}</dt>
@@ -367,13 +388,15 @@ function ThreadModelUsage({ sessions, selectedModel, onSelect }) {
     const byModel = new Map();
     let total = 0;
     for (const session of sessions) {
-      const model = session.model || copy("sessions.model.unknown");
-      const tokens = Number(session.own_total_tokens || session.total_tokens || 0);
-      const current = byModel.get(model) || { model, count: 0, tokens: 0 };
-      current.count += 1;
-      current.tokens += tokens;
-      total += tokens;
-      byModel.set(model, current);
+      for (const usage of modelUsageRows(session)) {
+        const model = usage.model || copy("sessions.model.unknown");
+        const tokens = Number(usage.total_tokens || 0);
+        const current = byModel.get(model) || { model, count: 0, tokens: 0 };
+        current.count += 1;
+        current.tokens += tokens;
+        total += tokens;
+        byModel.set(model, current);
+      }
     }
     return {
       groups: [...byModel.values()].sort((a, b) => b.tokens - a.tokens),
@@ -499,7 +522,8 @@ export function SessionsPage() {
       if (projectFilter !== "all" && row.project_key !== projectFilter) return false;
       if (!overlapsRange(row, startMs)) return false;
       if (!q) return true;
-      const haystack = `${row.title || ""} ${row.project_key || ""} ${row.model || ""} ${row.agent_nickname || ""} ${row.agent_role || ""} ${row.project_ref || ""} ${row.session_id || ""}`.toLowerCase();
+      const models = modelUsageRows(row).map((usage) => usage.model).join(" ");
+      const haystack = `${row.title || ""} ${row.project_key || ""} ${models} ${row.agent_nickname || ""} ${row.agent_role || ""} ${row.project_ref || ""} ${row.session_id || ""}`.toLowerCase();
       return haystack.includes(q);
     });
   }, [allSessions, sourceFilter, projectFilter, rangeFilter, deferredQuery]);
@@ -738,7 +762,7 @@ export function SessionsPage() {
                   const visibleChildren = selectedModel === "all"
                     ? children
                     : children.filter(function matchesSelectedModel(child) {
-                        return (child.model || copy("sessions.model.unknown")) === selectedModel;
+                        return modelUsageRows(child).some((usage) => usage.model === selectedModel);
                       });
 
                   return (

--- a/dashboard/src/pages/SessionsPage.jsx
+++ b/dashboard/src/pages/SessionsPage.jsx
@@ -257,18 +257,23 @@ const SessionRow = React.memo(function SessionRow({
                 {copy("sessions.badge.first_pass")}
               </span>
             ) : null}
-            {isGrok && session.usage_precision ? (
+            {(isGrok && session.usage_precision) || session.cost_is_partial ? (
               <span className={cn(
                 "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium",
                 session.usage_is_incomplete || session.cost_is_partial
                   ? "bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300"
                   : "bg-sky-50 text-sky-700 dark:bg-sky-500/10 dark:text-sky-300",
               )}>
-                {session.usage_is_incomplete || session.cost_is_partial
+                {session.usage_is_incomplete
                   ? copy("sessions.badge.partial_usage")
-                  : session.cost_source === "provider_reported"
-                    ? copy("sessions.badge.reported_cost")
-                    : copy("sessions.badge.reported_usage")}
+                  : session.cost_is_partial
+                    // Distinct from partial usage: every token is observed,
+                    // but a model in the session has no public rate, so the
+                    // cost below is a lower bound rather than an estimate.
+                    ? copy("sessions.badge.partial_cost")
+                    : session.cost_source === "provider_reported"
+                      ? copy("sessions.badge.reported_cost")
+                      : copy("sessions.badge.reported_usage")}
               </span>
             ) : null}
             {childCount ? (
@@ -348,7 +353,10 @@ const SessionRow = React.memo(function SessionRow({
           </div>
           <div className="flex w-16 flex-col-reverse">
             <dt className="text-[11px] text-oai-gray-400 dark:text-oai-gray-500">{copy("sessions.col.cost")}</dt>
-            <dd className="tabular-nums text-sm font-medium text-oai-black dark:text-white">
+            <dd
+              className="tabular-nums text-sm font-medium text-oai-black dark:text-white"
+              title={session.cost_is_partial ? copy("sessions.cost.partial_title") : undefined}
+            >
               {session.cost_is_partial ? "≥" : ""}{formatUsdCurrency(session.cost_usd, { currency, rate })}
             </dd>
           </div>

--- a/dashboard/src/pages/SessionsPage.test.jsx
+++ b/dashboard/src/pages/SessionsPage.test.jsx
@@ -210,7 +210,12 @@ describe("SessionsPage", () => {
     render(<SessionsPage />);
     expect(await screen.findByText("Mixed model work")).toBeInTheDocument();
     expect(screen.getByText(/gpt-5\.6-sol 6K.*gpt-5\.6-terra 2K/)).toBeInTheDocument();
-    expect(screen.getByText(/^≥\$/)).toBeInTheDocument();
+    // A Codex session priced from an unrated model must explain itself: the
+    // marker alone used to be the only signal and carried no label at all.
+    const partialCost = screen.getByText(/^≥\$/);
+    expect(partialCost).toBeInTheDocument();
+    expect(partialCost).toHaveAttribute("title", expect.stringContaining("Lower bound"));
+    expect(screen.getByText("Partial cost")).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole("searchbox", { name: "Search sessions" }), {
       target: { value: "terra" },

--- a/dashboard/src/pages/SessionsPage.test.jsx
+++ b/dashboard/src/pages/SessionsPage.test.jsx
@@ -186,6 +186,38 @@ describe("SessionsPage", () => {
     expect(screen.queryByText("Debug local proxy")).not.toBeInTheDocument();
   });
 
+  it("renders and searches every observed model in a mixed Codex session", async () => {
+    const mixed = {
+      ...response.sessions[1],
+      session_hash: "mixed-codex-row",
+      title: "Mixed model work",
+      model: "mixed",
+      own_total_tokens: 8_000,
+      cost_usd: 0.1,
+      cost_is_partial: true,
+      model_usage: [
+        { model: "gpt-5.6-sol", total_tokens: 6_000 },
+        { model: "gpt-5.6-terra", total_tokens: 2_000 },
+      ],
+    };
+    getSessions.mockResolvedValue({
+      ...response,
+      session_count: 1,
+      returned_count: 1,
+      sessions: [mixed],
+    });
+
+    render(<SessionsPage />);
+    expect(await screen.findByText("Mixed model work")).toBeInTheDocument();
+    expect(screen.getByText(/gpt-5\.6-sol 6K.*gpt-5\.6-terra 2K/)).toBeInTheDocument();
+    expect(screen.getByText(/^≥\$/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search sessions" }), {
+      target: { value: "terra" },
+    });
+    expect(screen.getByText("Mixed model work")).toBeInTheDocument();
+  });
+
   it("folds direct and nested subagents under their root session", async () => {
     const root = makeThreadSession({
       session_hash: "root-hash",

--- a/src/lib/codex-model-attribution.js
+++ b/src/lib/codex-model-attribution.js
@@ -13,6 +13,14 @@
 // in the UI - seconds to minutes before the switch takes effect - so usage
 // still streaming from the in-flight turn belongs to the previous model.
 // turn_context is the only signal that marks where a turn actually begins.
+//
+// session_meta is a defensive fallback, not an observed source. Codex has
+// never written a model into it - 0 of 10310 session_meta rows across 5849
+// local rollouts carry the field (codex-cli 0.151.0); the payload records
+// model_provider ("openai"), which is provenance rather than a model. The
+// fallback only fills selectedModel when nothing else has, so a future format
+// that does carry one attributes instead of falling through to "unknown". It
+// never overrides a turn_context model.
 
 function cleanString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -81,6 +89,16 @@ function applyCodexModelEvent(state, obj) {
     state.rerouted = false;
     state.rerouteReason = null;
     return { type: "turn_context", selectedModel };
+  }
+
+  // Strictly weaker than turn_context, and never allowed to overwrite it: a
+  // forked rollout replays the parent's session_meta rows after its own.
+  if (obj?.type === "session_meta" && obj.payload && typeof obj.payload === "object") {
+    const metaModel = cleanString(obj.payload.model);
+    if (!metaModel || state.selectedModel) return null;
+    state.selectedModel = metaModel;
+    state.effectiveModel = state.effectiveModel || metaModel;
+    return { type: "session_meta", selectedModel: metaModel };
   }
 
   const reroute = extractModelReroute(obj);

--- a/src/lib/codex-model-attribution.js
+++ b/src/lib/codex-model-attribution.js
@@ -1,0 +1,95 @@
+"use strict";
+
+// Codex token_count events do not carry a model id. Attribute them to the
+// latest turn selection, upgraded to the effective model when an app-server
+// model/rerouted notification is present in the persisted event stream.
+
+function cleanString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeEventName(value) {
+  return cleanString(value)?.toLowerCase().replaceAll("_", "/") || "";
+}
+
+function eventEnvelope(obj) {
+  const candidates = [
+    { name: obj?.method, data: obj?.params },
+    { name: obj?.type, data: obj?.payload },
+    { name: obj?.payload?.method, data: obj?.payload?.params },
+    { name: obj?.payload?.type, data: obj?.payload },
+    { name: obj?.payload?.msg?.method, data: obj?.payload?.msg?.params },
+    { name: obj?.payload?.msg?.type, data: obj?.payload?.msg },
+    { name: obj?.msg?.method, data: obj?.msg?.params },
+    { name: obj?.msg?.type, data: obj?.msg },
+  ];
+  return candidates.find(({ name }) => normalizeEventName(name) === "model/rerouted") || null;
+}
+
+function extractModelReroute(obj) {
+  const envelope = eventEnvelope(obj);
+  if (!envelope) return null;
+  const data = envelope.data && typeof envelope.data === "object" ? envelope.data : {};
+  const fromModel = cleanString(data.fromModel ?? data.from_model);
+  const toModel = cleanString(data.toModel ?? data.to_model);
+  if (!toModel) return null;
+  return {
+    fromModel,
+    toModel,
+    reason: cleanString(data.reason),
+    threadId: cleanString(data.threadId ?? data.thread_id),
+    turnId: cleanString(data.turnId ?? data.turn_id),
+  };
+}
+
+function createCodexModelAttributionState(value = {}) {
+  const selectedModel = cleanString(value.selectedModel ?? value.selected_model ?? value.model);
+  const effectiveModel = cleanString(value.effectiveModel ?? value.effective_model) || selectedModel;
+  return {
+    selectedModel,
+    effectiveModel,
+    turnId: cleanString(value.turnId ?? value.turn_id),
+    rerouted: Boolean(value.rerouted),
+    rerouteReason: cleanString(value.rerouteReason ?? value.reroute_reason),
+  };
+}
+
+function applyCodexModelEvent(state, obj) {
+  if (!state || typeof state !== "object") return null;
+  if (obj?.type === "turn_context" && obj.payload && typeof obj.payload === "object") {
+    const selectedModel = cleanString(obj.payload.model);
+    if (selectedModel) {
+      state.selectedModel = selectedModel;
+    }
+    state.effectiveModel = state.selectedModel || state.effectiveModel;
+    state.turnId = cleanString(obj.payload.turn_id ?? obj.payload.turnId) || state.turnId;
+    state.rerouted = false;
+    state.rerouteReason = null;
+    return { type: "turn_context", selectedModel };
+  }
+
+  const reroute = extractModelReroute(obj);
+  if (!reroute) return null;
+  state.selectedModel = reroute.fromModel || state.selectedModel || state.effectiveModel;
+  state.effectiveModel = reroute.toModel;
+  state.turnId = reroute.turnId || state.turnId;
+  state.rerouted = true;
+  state.rerouteReason = reroute.reason;
+  return { type: "model_rerouted", ...reroute };
+}
+
+function currentCodexModel(state) {
+  return cleanString(state?.effectiveModel) || cleanString(state?.selectedModel);
+}
+
+function snapshotCodexModelAttributionState(state) {
+  return createCodexModelAttributionState(state);
+}
+
+module.exports = {
+  applyCodexModelEvent,
+  createCodexModelAttributionState,
+  currentCodexModel,
+  extractModelReroute,
+  snapshotCodexModelAttributionState,
+};

--- a/src/lib/codex-model-attribution.js
+++ b/src/lib/codex-model-attribution.js
@@ -1,8 +1,18 @@
 "use strict";
 
-// Codex token_count events do not carry a model id. Attribute them to the
-// latest turn selection, upgraded to the effective model when an app-server
-// model/rerouted notification is present in the persisted event stream.
+// Codex token_count events do not carry a model id. Every usage event is
+// therefore attributed to the model named by the most recent turn_context,
+// which Codex emits at the start of each turn and which tracks mid-session
+// model switches exactly. That per-turn path is what actually runs today.
+//
+// The model/rerouted upgrade below is forward-looking: it promotes usage to
+// the effective model when the app server reports a server-side reroute.
+//
+// Deliberately NOT used for attribution: event_msg/thread_settings_applied.
+// It carries thread_settings.model, but it fires when the user picks a model
+// in the UI - seconds to minutes before the switch takes effect - so usage
+// still streaming from the in-flight turn belongs to the previous model.
+// turn_context is the only signal that marks where a turn actually begins.
 
 function cleanString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -26,6 +36,11 @@ function eventEnvelope(obj) {
   return candidates.find(({ name }) => normalizeEventName(name) === "model/rerouted") || null;
 }
 
+// Forward-looking: no model/rerouted event has been observed in any real
+// rollout (verified against 5832 local files, codex-cli 0.151.0), so the
+// envelope shapes and the fromModel/toModel field names below are inferred
+// from the app-server protocol rather than confirmed against logged data.
+// Re-verify against a real sample before relying on rerouted attribution.
 function extractModelReroute(obj) {
   const envelope = eventEnvelope(obj);
   if (!envelope) return null;

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -24,12 +24,19 @@ const {
   getExecutableName,
   buildExecStatsEntry,
 } = require("./categorizer-utils");
+const {
+  applyCodexModelEvent,
+  createCodexModelAttributionState,
+  currentCodexModel,
+  snapshotCodexModelAttributionState,
+} = require("./codex-model-attribution");
 
 const DISCOVERY_FULL_AUDIT_INTERVAL_MS = 60 * 1000;
 const MAX_DISCOVERY_INVENTORIES = 32;
 const DISCOVERY_INVENTORIES = new Map();
 const ZONED_DAY_FORMATTERS = new Map();
 const CODEX_RESUME_INVALIDATED = "TOKENTRACKER_CODEX_RESUME_INVALIDATED";
+const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
 
 // ---------------------------------------------------------------------------
 // Timezone helpers
@@ -520,6 +527,17 @@ function finalizeExecRows(map) {
     .sort((a, b) => (b.totals?.total_tokens || 0) - (a.totals?.total_tokens || 0));
 }
 
+function finalizeModelUsageRows(map) {
+  return Array.from(map.values())
+    .map((row) => ({
+      ...row,
+      selected_models: Array.from(row.selected_models).sort(),
+      reroute_reasons: Array.from(row.reroute_reasons).sort(),
+      model_attribution: row.rerouted_usage_events > 0 ? "effective" : "selected",
+    }))
+    .sort((a, b) => b.total_tokens - a.total_tokens || a.model.localeCompare(b.model));
+}
+
 // ---------------------------------------------------------------------------
 // Main parser
 // ---------------------------------------------------------------------------
@@ -537,6 +555,9 @@ async function parseCodexRolloutFile(filePath, {
   captureContentHash = false,
   contentHashState = null,
   sourceHandle = null,
+  collectBreakdowns = true,
+  collectModelUsage = false,
+  onObject = null,
 } = {}) {
   const filePaths = (Array.isArray(filePath) ? filePath : [filePath]).filter(Boolean);
   const primaryFilePath = filePaths[0] || String(filePath || "");
@@ -566,6 +587,9 @@ async function parseCodexRolloutFile(filePath, {
   let sessionId = isResuming ? resumeState.sessionId || null : null;
   let cwd = isResuming ? resumeState.cwd || null : null;
   let model = isResuming ? resumeState.model || null : null;
+  const modelAttributionState = createCodexModelAttributionState(
+    isResuming ? resumeState.modelAttributionState || { model } : {},
+  );
   let provider = isResuming ? resumeState.provider || null : null;
   let cliVersion = isResuming ? resumeState.cliVersion || null : null;
   let forkedFromId = isResuming ? resumeState.forkedFromId || null : null;
@@ -607,8 +631,54 @@ async function parseCodexRolloutFile(filePath, {
   const byExecCommand = new Map(); // sanitized executable + subcommand -> stats
   const byExecDuration = new Map(); // duration bucket -> stats
   const byExecOutput = new Map(); // output size bucket -> stats
+  const byModel = new Map(); // effective model -> observed token usage
 
   let turnCount = 0;
+
+  function recordModelUsage(delta, rawRequestUsage) {
+    if (!collectModelUsage || !delta || delta.total_tokens <= 0) return;
+    const effectiveModel = currentCodexModel(modelAttributionState) || "unknown";
+    let row = byModel.get(effectiveModel);
+    if (!row) {
+      row = {
+        model: effectiveModel,
+        ...emptyTotals(),
+        long_context_input_tokens: 0,
+        long_context_cached_input_tokens: 0,
+        long_context_cache_creation_input_tokens: 0,
+        long_context_output_tokens: 0,
+        long_context_reasoning_output_tokens: 0,
+        usage_events: 0,
+        rerouted_usage_events: 0,
+        long_context_usage_events: 0,
+        selected_models: new Set(),
+        reroute_reasons: new Set(),
+      };
+      byModel.set(effectiveModel, row);
+    }
+    addInto(row, delta);
+    row.usage_events += 1;
+    if (modelAttributionState.selectedModel) {
+      row.selected_models.add(modelAttributionState.selectedModel);
+    }
+    if (modelAttributionState.rerouted) {
+      row.rerouted_usage_events += 1;
+      if (modelAttributionState.rerouteReason) {
+        row.reroute_reasons.add(modelAttributionState.rerouteReason);
+      }
+    }
+    // OpenAI applies the long-context tier to the whole request when its raw
+    // (cache-inclusive) input exceeds 272K tokens. Preserve the exact subset
+    // so pricing can be recomputed later without rescanning private logs.
+    if (Number(rawRequestUsage?.input_tokens || 0) > OPENAI_LONG_CONTEXT_INPUT_THRESHOLD) {
+      row.long_context_usage_events += 1;
+      row.long_context_input_tokens += delta.input_tokens;
+      row.long_context_cached_input_tokens += delta.cached_input_tokens;
+      row.long_context_cache_creation_input_tokens += delta.cache_creation_input_tokens;
+      row.long_context_output_tokens += delta.output_tokens;
+      row.long_context_reasoning_output_tokens += delta.reasoning_output_tokens;
+    }
+  }
 
   function ensureTool(name) {
     if (!byTool.has(name)) {
@@ -685,6 +755,14 @@ async function parseCodexRolloutFile(filePath, {
       return;
     }
     turnCount += 1;
+
+    if (!collectBreakdowns) {
+      addInto(totals, delta);
+      pendingToolNames = [];
+      pendingSkills = [];
+      pendingExecDetails = [];
+      return;
+    }
 
     const unique = [...new Set(pendingToolNames.filter(Boolean))];
     const tools = unique.length > 0 ? unique : ["text_response"];
@@ -822,6 +900,9 @@ async function parseCodexRolloutFile(filePath, {
     contentHasher,
     sourceHandle,
   })) {
+    if (typeof onObject === "function") onObject(obj);
+    const modelEvent = applyCodexModelEvent(modelAttributionState, obj);
+    model = currentCodexModel(modelAttributionState) || model;
     const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
     if (!ts) continue;
     const inRequestedRange = isTimestampInRequestedDayRange(ts, { from, to, timeZoneContext });
@@ -849,18 +930,19 @@ async function parseCodexRolloutFile(filePath, {
     if (obj.type === "turn_context") {
       const p = obj.payload || {};
       if (typeof p.cwd === "string") cwd = p.cwd;
-      if (typeof p.model === "string") model = p.model;
       continue;
     }
 
-    if (obj.type === "response_item" && obj.payload?.type === "function_call") {
+    if (modelEvent?.type === "model_rerouted") continue;
+
+    if (collectBreakdowns && obj.type === "response_item" && obj.payload?.type === "function_call") {
       pendingToolNames.push(normalizeToolName(obj.payload));
       const skill = extractSkillNameFromFunctionCall(obj.payload, diagnostics);
       if (skill) pendingSkills.push(skill);
       continue;
     }
 
-    if (obj.type === "event_msg" && obj.payload?.type === "exec_command_end") {
+    if (collectBreakdowns && obj.type === "event_msg" && obj.payload?.type === "exec_command_end") {
       const details = getExecKeys(obj.payload);
       if (details) pendingExecDetails.push(details);
       continue;
@@ -881,6 +963,7 @@ async function parseCodexRolloutFile(filePath, {
           attributeTurn(null);
         } else {
           if (seenTokenEvents && delta?.total_tokens > 0) seenTokenEvents.add(eventKey);
+          recordModelUsage(delta, lastUsage || rawDelta);
           attributeTurn(delta);
         }
       } else {
@@ -895,7 +978,7 @@ async function parseCodexRolloutFile(filePath, {
   const result = {
     sessionId: sessionId || rolloutSessionIdFromPath(primaryFilePath) || primaryFilePath,
     cwd,
-    model: model || provider,
+    model: currentCodexModel(modelAttributionState) || model || provider,
     provider,
     version: cliVersion,
     forkedFromId,
@@ -906,6 +989,7 @@ async function parseCodexRolloutFile(filePath, {
     filePath: primaryFilePath,
     turnCount,
     totals,
+    modelUsage: finalizeModelUsageRows(byModel),
     toolBreakdown: {
       tool_rows: finalizeToolRows(byTool),
     },
@@ -926,6 +1010,7 @@ async function parseCodexRolloutFile(filePath, {
       sessionId,
       cwd,
       model,
+      modelAttributionState: snapshotCodexModelAttributionState(modelAttributionState),
       provider,
       cliVersion,
       forkedFromId,

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -36,6 +36,8 @@ const MAX_DISCOVERY_INVENTORIES = 32;
 const DISCOVERY_INVENTORIES = new Map();
 const ZONED_DAY_FORMATTERS = new Map();
 const CODEX_RESUME_INVALIDATED = "TOKENTRACKER_CODEX_RESUME_INVALIDATED";
+// See src/lib/pricing/index.js: no observed Codex request reaches this
+// threshold yet (context window 258400), so long_context_* stays at zero.
 const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
 
 // ---------------------------------------------------------------------------

--- a/src/lib/codex-rollout-parser.js
+++ b/src/lib/codex-rollout-parser.js
@@ -902,9 +902,16 @@ async function parseCodexRolloutFile(filePath, {
     contentHasher,
     sourceHandle,
   })) {
-    if (typeof onObject === "function") onObject(obj);
     const modelEvent = applyCodexModelEvent(modelAttributionState, obj);
-    model = currentCodexModel(modelAttributionState) || model;
+    const attributedModel = currentCodexModel(modelAttributionState);
+    model = attributedModel || model;
+    // onObject runs AFTER the attribution state machine, and is handed the
+    // model it just decided. A consumer sharing this pass (the delivery-signal
+    // collector, which attributes edit turns) therefore sees exactly the model
+    // recordModelUsage() bills the turn's tokens to. Letting it re-read
+    // turn_context.payload.model itself would make codex-model-attribution.js
+    // one of two authorities on the same question.
+    if (typeof onObject === "function") onObject(obj, attributedModel);
     const ts = typeof obj?.timestamp === "string" ? obj.timestamp : null;
     if (!ts) continue;
     const inRequestedRange = isTimestampInRequestedDayRange(ts, { from, to, timeZoneContext });

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -48,11 +48,11 @@
       "note": "Canonical undated alias emitted by Cursor. Pin to the same rates as claude-haiku-4-5-20251001 so local cost does not depend on which dated LiteLLM aliases are present in the current cache."
     },
     "gpt-5.6-sol": {
-      "input": 5,
-      "output": 30,
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing short-context: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it."
+      "input": 4,
+      "output": 20,
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "note": "Official GPT-5.6 Sol standard pricing: $4 input, $0.40 cached input, $5 cache write, and $20 output per MTok. Requests above 272K input are repriced from their preserved per-request long-context subset. Codex emits gpt-5.6-sol plus reasoning-effort variants caught by fuzzy matching."
     },
     "gpt-5.6-terra": {
       "input": 2,
@@ -418,7 +418,7 @@
     },
     {
       "match": "gpt-5.6",
-      "ref": "gpt-5.6-terra"
+      "ref": "gpt-5.6-sol"
     },
     {
       "match": "kiro",

--- a/src/lib/pricing/index.js
+++ b/src/lib/pricing/index.js
@@ -25,6 +25,10 @@ const PI_SUBSCRIPTION_SOURCES = new Set([
 // server (including LM Link). Secure Cloud usage has a separate billing path
 // and is not present in these logs.
 const LOCAL_INFERENCE_SOURCES = new Set(["lmstudio"]);
+// Forward-looking: unreachable for Codex today. Every observed token_count
+// reports model_context_window = 258400, below this threshold, so no request
+// can exceed it (max raw input seen locally: 238853). The long-context
+// repricing stays in place for when OpenAI ships a larger Codex window.
 const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
 const SOURCES_WITH_AUTHORITATIVE_COST = new Set(["grok"]);
 const SEED_SNAPSHOT_PATH = path.resolve(__dirname, "seed-snapshot.json");

--- a/src/lib/pricing/index.js
+++ b/src/lib/pricing/index.js
@@ -25,6 +25,7 @@ const PI_SUBSCRIPTION_SOURCES = new Set([
 // server (including LM Link). Secure Cloud usage has a separate billing path
 // and is not present in these logs.
 const LOCAL_INFERENCE_SOURCES = new Set(["lmstudio"]);
+const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
 const SOURCES_WITH_AUTHORITATIVE_COST = new Set(["grok"]);
 const SEED_SNAPSHOT_PATH = path.resolve(__dirname, "seed-snapshot.json");
 const DEEPSEEK_TIME_PRICED_MODELS = [
@@ -192,7 +193,7 @@ function computeRowCost(row) {
   const reasoningCost = reasoningIncludedInOutput
     ? 0
     : (row.reasoning_output_tokens || 0) * (pricing.output || 0);
-  return (
+  const baseCost = (
     ((row.input_tokens || 0) * (pricing.input || 0) +
       (row.output_tokens || 0) * (pricing.output || 0) +
       (row.cached_input_tokens || 0) * (pricing.cache_read || 0) +
@@ -200,6 +201,37 @@ function computeRowCost(row) {
       reasoningCost) /
     1_000_000
   );
+
+  const model = String(row?.model || "").toLowerCase();
+  const usesGpt56SolLongContextTier =
+    model === "gpt-5.6" || model.includes("gpt-5.6-sol");
+  if (!usesGpt56SolLongContextTier) return baseCost;
+
+  const bounded = (value, total) => Math.min(
+    Math.max(0, Number(value) || 0),
+    Math.max(0, Number(total) || 0),
+  );
+  // The parser records only usage from requests whose cache-inclusive input
+  // exceeded 272K. OpenAI prices the whole such request at 2x input and 1.5x
+  // output, so add the premium over the standard-rate base exactly once.
+  const longInput = bounded(row.long_context_input_tokens, row.input_tokens);
+  const longCached = bounded(row.long_context_cached_input_tokens, row.cached_input_tokens);
+  const longCacheWrite = bounded(
+    row.long_context_cache_creation_input_tokens,
+    row.cache_creation_input_tokens,
+  );
+  const longOutput = bounded(row.long_context_output_tokens, row.output_tokens);
+  const longReasoning = reasoningIncludedInOutput
+    ? 0
+    : bounded(row.long_context_reasoning_output_tokens, row.reasoning_output_tokens);
+  const longContextPremium = (
+    longInput * (pricing.input || 0) +
+    longCached * (pricing.cache_read || 0) +
+    longCacheWrite * (pricing.cache_write || 0) +
+    0.5 * longOutput * (pricing.output || 0) +
+    0.5 * longReasoning * (pricing.output || 0)
+  ) / 1_000_000;
+  return baseCost + longContextPremium;
 }
 
 // Backwards-compatible MODEL_PRICING export. Test at
@@ -219,6 +251,7 @@ module.exports = {
   resetPricingForTests,
   MODEL_PRICING,
   ZERO_PRICING,
+  OPENAI_LONG_CONTEXT_INPUT_THRESHOLD,
   // Internal hooks for tests.
   __getStateForTests: () => state,
 };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15,6 +15,12 @@ const {
   createUsageDeltaState,
   snapshotUsageBaselines,
 } = require("./codex-token-usage");
+const {
+  applyCodexModelEvent,
+  createCodexModelAttributionState,
+  currentCodexModel,
+  snapshotCodexModelAttributionState,
+} = require("./codex-model-attribution");
 const { USD_TICKS_PER_USD, normalizeGrokUsage } = require("./grok-usage");
 
 const DEFAULT_SOURCE = "codex";
@@ -435,6 +441,9 @@ async function parseRolloutIncremental({
       ? prev.tokenUsageBaselines || null
       : null;
     const lastModel = sameInode && !truncated ? prev.lastModel || null : null;
+    const modelAttributionState = sameInode && !truncated
+      ? prev.modelAttributionState || null
+      : null;
 
     const codexProjectFastPath = projectEnabled && fileSource === DEFAULT_SOURCE;
     const projectOffset = sameInode && !truncated ? Number(prev.projectOffset || 0) : 0;
@@ -506,6 +515,7 @@ async function parseRolloutIncremental({
           lastTotal,
           tokenUsageBaselines,
           lastModel,
+          modelAttributionState,
           projectState,
           projectMetaCache,
           publicRepoCache,
@@ -520,6 +530,7 @@ async function parseRolloutIncremental({
           lastTotal,
           tokenUsageBaselines,
           lastModel,
+          modelAttributionState,
           hourlyState,
           touchedBuckets,
           source: fileSource,
@@ -542,6 +553,7 @@ async function parseRolloutIncremental({
       lastTotal: result.lastTotal,
       tokenUsageBaselines: result.tokenUsageBaselines,
       lastModel: result.lastModel,
+      modelAttributionState: result.modelAttributionState,
       updatedAt: new Date().toISOString(),
     };
     if (codexProjectFastPath) {
@@ -2017,6 +2029,7 @@ async function parseRolloutFile({
   lastTotal,
   tokenUsageBaselines,
   lastModel,
+  modelAttributionState: previousModelAttributionState,
   hourlyState,
   touchedBuckets,
   source,
@@ -2042,6 +2055,7 @@ async function parseRolloutFile({
       lastTotal,
       tokenUsageBaselines,
       lastModel,
+      modelAttributionState: previousModelAttributionState,
       eventsAggregated: 0,
       projectFileContexts,
     };
@@ -2053,6 +2067,9 @@ async function parseRolloutFile({
   });
 
   let model = typeof lastModel === "string" ? lastModel : null;
+  const modelAttributionState = createCodexModelAttributionState(
+    previousModelAttributionState || { model },
+  );
   const usageDeltaState = createUsageDeltaState({
     lastTotal,
     baselines: tokenUsageBaselines,
@@ -2090,14 +2107,17 @@ async function parseRolloutFile({
     const { line } = record;
     if (!line) continue;
     const maybeTokenCount = line.includes('"token_count"');
-    const maybeTurnContext =
+    const maybeModelReroute =
       !maybeTokenCount &&
+      (line.includes('"model/rerouted"') || line.includes('"model_rerouted"'));
+    const maybeTurnContext =
+      !maybeTokenCount && !maybeModelReroute &&
       (line.includes('"turn_context"') || line.includes('"session_meta"')) &&
       (line.includes('"model"') ||
         line.includes('"cwd"') ||
         line.includes('"current_date"') ||
         line.includes('"forked_from_id"'));
-    if (!maybeTokenCount && !maybeTurnContext) {
+    if (!maybeTokenCount && !maybeTurnContext && !maybeModelReroute) {
       if (invalidRecordPolicy === "throw" || !record.terminated) {
         try {
           JSON.parse(line);
@@ -2120,6 +2140,9 @@ async function parseRolloutFile({
     }
     if (!record.terminated) committedEndOffset = scannedEndOffset;
 
+    applyCodexModelEvent(modelAttributionState, obj);
+    model = currentCodexModel(modelAttributionState) || model;
+
     if (
       (obj?.type === "turn_context" || obj?.type === "session_meta") &&
       obj?.payload &&
@@ -2130,9 +2153,6 @@ async function parseRolloutFile({
       }
       if (obj.type === "turn_context" && typeof obj.payload.current_date === "string") {
         currentDate = normalizeIsoDate(obj.payload.current_date);
-      }
-      if (typeof obj.payload.model === "string") {
-        model = obj.payload.model;
       }
       if (projectState && typeof obj.payload.cwd === "string") {
         const nextCwd = obj.payload.cwd.trim();
@@ -2167,7 +2187,9 @@ async function parseRolloutFile({
     if (totalUsage && typeof totalUsage === "object") latestTotal = totalUsage;
 
     const rawDelta = consumeUsageDelta(usageDeltaState, lastUsage, totalUsage);
-    const delta = rawDelta ? normalizeUsage(rawDelta) : null;
+    const totalOnlyResetSentinel = source === DEFAULT_SOURCE
+      && isCodexTotalOnlyResetSentinel(lastUsage, totalUsage);
+    const delta = rawDelta && !totalOnlyResetSentinel ? normalizeUsage(rawDelta) : null;
     if (!delta || isAllZeroUsage(delta)) continue;
     delta.conversation_count = 1;
 
@@ -2266,6 +2288,7 @@ async function parseRolloutFile({
     lastTotal: latestTotal,
     tokenUsageBaselines: snapshotUsageBaselines(usageDeltaState),
     lastModel: model,
+    modelAttributionState: snapshotCodexModelAttributionState(modelAttributionState),
     eventsAggregated,
     projectFileContexts,
   };
@@ -2277,6 +2300,7 @@ async function scanRolloutProjectFileContexts({
   lastTotal,
   tokenUsageBaselines,
   lastModel,
+  modelAttributionState,
   projectState,
   projectMetaCache,
   publicRepoCache,
@@ -2294,6 +2318,7 @@ async function scanRolloutProjectFileContexts({
       lastTotal,
       tokenUsageBaselines,
       lastModel,
+      modelAttributionState,
       eventsAggregated: 0,
       projectFileContexts,
     };
@@ -2370,6 +2395,7 @@ async function scanRolloutProjectFileContexts({
     lastTotal,
     tokenUsageBaselines,
     lastModel,
+    modelAttributionState,
     eventsAggregated: 0,
     projectFileContexts,
   };
@@ -4389,11 +4415,26 @@ function normalizeUsage(u) {
   // bytes twice: once at the full input rate and again at the cache_read
   // rate, producing ~6–7x cost inflation on cache-heavy Codex sessions
   // (verified against ccusage's per-day numbers on the same rollouts).
-  // We intentionally leave `total_tokens` unchanged: Codex reports
-  // total = input(inclusive of cached) + output, which numerically equals
-  // our schema's non_cached + cached + output + 0 (cache_creation=0 here).
+  // Preserve the reported total for compatibility with older Codex / Every
+  // Code shapes where output_tokens can exclude reasoning or some component
+  // fields are absent. The exact all-zero reset sentinel is rejected before
+  // normalization by isCodexTotalOnlyResetSentinel().
   out.input_tokens = Math.max(0, out.input_tokens - out.cached_input_tokens);
   return out;
+}
+
+function isCodexTotalOnlyResetSentinel(lastUsage, totalUsage) {
+  const componentTotal = (usage) => [
+    usage?.input_tokens,
+    usage?.cached_input_tokens,
+    usage?.cache_creation_input_tokens ?? usage?.cache_write_input_tokens,
+    usage?.output_tokens,
+    usage?.reasoning_output_tokens,
+  ].reduce((sum, value) => sum + Math.max(0, Number(value) || 0), 0);
+  return Number(lastUsage?.total_tokens || 0) > 0
+    && Number(totalUsage?.total_tokens || 0) === 0
+    && componentTotal(lastUsage) === 0
+    && componentTotal(totalUsage) === 0;
 }
 
 // Stable dedup key for one Claude jsonl entry. Anthropic's official protocol

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -30,7 +30,7 @@ const path = require("node:path");
 const readline = require("node:readline");
 const { listClaudeProjectFiles, listRolloutFilesDeep, claudeMessageDedupKey } = require("./rollout");
 const { parseCodexRolloutFile } = require("./codex-rollout-parser");
-const { computeRowCost } = require("./pricing");
+const { computeRowCost, getModelPricing } = require("./pricing");
 const { USD_TICKS_PER_USD, normalizeGrokUsage } = require("./grok-usage");
 const wsl = require("./wsl-probe");
 
@@ -57,9 +57,10 @@ const wsl = require("./wsl-probe");
 // their union, deduping shared records while retaining divergent tails.
 // v12 fixes Grok's mutually exclusive token columns, retains exact reported
 // cost, and adds metadata-only usage diagnostics to the local session browser.
-// v12 retains Codex parent/subagent metadata locally and derives exact child
-// token totals from observed child rollouts instead of spawn-call estimates.
-const SIDECAR_VERSION = 12;
+// v13 stores per-model Codex usage (including observed reroutes and the exact
+// long-context subset) and folds delivery signals into the token parser's
+// single pass instead of parsing every Codex file twice.
+const SIDECAR_VERSION = 13;
 const EDIT_TOOLS = new Set([
   "apply_patch",
   "edit",
@@ -116,6 +117,113 @@ function addTotals(target, delta) {
 
 function emptyTotals() {
   return tokenTotals({});
+}
+
+const MODEL_USAGE_SUM_FIELDS = [
+  "input_tokens",
+  "cached_input_tokens",
+  "cache_creation_input_tokens",
+  "output_tokens",
+  "reasoning_output_tokens",
+  "total_tokens",
+  "long_context_input_tokens",
+  "long_context_cached_input_tokens",
+  "long_context_cache_creation_input_tokens",
+  "long_context_output_tokens",
+  "long_context_reasoning_output_tokens",
+  "usage_events",
+  "rerouted_usage_events",
+  "long_context_usage_events",
+];
+
+function normalizeModelUsageRows(rows) {
+  const byModel = new Map();
+  for (const value of Array.isArray(rows) ? rows : []) {
+    const model = normalizeSessionModel(value?.model) || "unknown";
+    let row = byModel.get(model);
+    if (!row) {
+      row = {
+        model,
+        ...Object.fromEntries(MODEL_USAGE_SUM_FIELDS.map((field) => [field, 0])),
+        selected_models: new Set(),
+        reroute_reasons: new Set(),
+        model_attribution: "selected",
+      };
+      byModel.set(model, row);
+    }
+    for (const field of MODEL_USAGE_SUM_FIELDS) row[field] += finite(value?.[field]);
+    for (const selected of Array.isArray(value?.selected_models) ? value.selected_models : []) {
+      const normalized = normalizeSessionModel(selected);
+      if (normalized) row.selected_models.add(normalized);
+    }
+    for (const reason of Array.isArray(value?.reroute_reasons) ? value.reroute_reasons : []) {
+      if (typeof reason === "string" && reason.trim()) row.reroute_reasons.add(reason.trim());
+    }
+    if (value?.model_attribution === "effective" || finite(value?.rerouted_usage_events) > 0) {
+      row.model_attribution = "effective";
+    }
+  }
+  return [...byModel.values()]
+    .map((row) => ({
+      ...row,
+      selected_models: [...row.selected_models].sort(),
+      reroute_reasons: [...row.reroute_reasons].sort(),
+    }))
+    .sort((a, b) => b.total_tokens - a.total_tokens || a.model.localeCompare(b.model));
+}
+
+function repriceSessionRecord(record) {
+  const modelUsage = normalizeModelUsageRows(record?.model_usage);
+  if (modelUsage.length > 0) {
+    let hasUnpricedUsage = false;
+    for (const row of modelUsage) {
+      row.cost_usd = computeRowCost({ source: record.source, ...row });
+      if (record.source === "codex" && row.total_tokens > 0) {
+        const pricing = getModelPricing(row.model, { source: record.source });
+        if (![pricing.input, pricing.output, pricing.cache_read, pricing.cache_write]
+          .some((value) => finite(value) > 0)) {
+          hasUnpricedUsage = true;
+        }
+      }
+    }
+    record.model_usage = modelUsage;
+    record.model = modelUsage.length > 1 ? "mixed" : modelUsage[0].model;
+    record.cost_usd = modelUsage.reduce((sum, row) => sum + finite(row.cost_usd), 0);
+    record.cost_source = "model_pricing";
+    // Internal labels such as `codex-auto-review` expose token usage but not
+    // an underlying public model/rate. Keep their tokens, leave their cost at
+    // zero, and explicitly mark the session estimate as a known lower bound.
+    record.cost_is_partial = hasUnpricedUsage;
+  } else {
+    const providerCost = Number(record.provider_cost_usd);
+    record.cost_usd = record.cost_source === "provider_reported"
+      && Number.isFinite(providerCost)
+      && providerCost >= 0
+      ? providerCost
+      : computeRowCost({ source: record.source, model: record.model, ...record.tokens });
+  }
+  record.cost_per_edit = record.edit_turns > 0 ? record.cost_usd / record.edit_turns : null;
+  return record;
+}
+
+function modelUsageForAggregation(record) {
+  const rows = normalizeModelUsageRows(record?.model_usage);
+  if (rows.length > 0) {
+    return rows.map((row) => ({
+      ...row,
+      cost_usd: Number.isFinite(Number(row.cost_usd))
+        ? Number(row.cost_usd)
+        : computeRowCost({ source: record.source, ...row }),
+    }));
+  }
+  return [{
+    model: normalizeSessionModel(record?.model) || "unknown",
+    total_tokens: finite(record?.total_tokens || record?.tokens?.total_tokens),
+    cost_usd: finite(record?.cost_usd),
+    selected_models: [],
+    reroute_reasons: [],
+    model_attribution: "selected",
+  }];
 }
 
 function safeTimestamp(value) {
@@ -243,12 +351,7 @@ function finalizeRecord(record) {
   record.active_ms = Math.max(0, finite(record.active_ms));
   record.duration_ms = record.active_ms;
   record.total_tokens = finite(record.total_tokens || record.tokens?.total_tokens);
-  const providerCost = Number(record.provider_cost_usd);
-  record.cost_usd = record.cost_source === "provider_reported"
-    && Number.isFinite(providerCost)
-    && providerCost >= 0
-    ? providerCost
-    : computeRowCost({ source: record.source, model: record.model, ...record.tokens });
+  repriceSessionRecord(record);
   record.productive = record.edit_turns > 0;
   // A first-pass delivery has exactly one user turn containing an observed
   // edit and no repeated user request. The legacy one_shot field stays as an
@@ -409,8 +512,7 @@ async function scanClaudeSession(filePath) {
   });
 }
 
-async function scanCodexDeliverySignals(filePath) {
-  const filePaths = readableSessionPaths(filePath);
+function createCodexDeliverySignalCollector() {
   const bounds = emptyBounds();
   let turns = 0;
   let editTurns = 0;
@@ -436,81 +538,75 @@ async function scanCodexDeliverySignals(filePath) {
     turns += 1;
   }
 
-  const priorRecordHashes = new Set();
-  let scannedFiles = 0;
-  for (const currentFilePath of filePaths) {
-    const currentRecordHashes = new Set();
-    try {
-      const input = fs.createReadStream(currentFilePath, { encoding: "utf8" });
-      const lines = readline.createInterface({ input, crlfDelay: Infinity });
-      for await (const line of lines) {
-        if (filePaths.length > 1) {
-          const recordHash = crypto.createHash("sha256").update(line).digest("base64url");
-          if (priorRecordHashes.has(recordHash)) continue;
-          currentRecordHashes.add(recordHash);
-        }
-        let obj;
-        try { obj = JSON.parse(line); } catch { continue; }
-        updateBounds(bounds, obj.timestamp);
-        if (obj.type === "turn_context") {
-          hasTurnContext = true;
-          beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
-          continue;
-        }
-        const prompt = extractCodexPrompt(obj);
-        if (prompt) {
-          const fingerprint = promptFingerprint(prompt);
-          if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
-          lastPromptFingerprint = fingerprint;
-          if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
-          continue;
-        }
-        if (obj.type !== "response_item") continue;
-        const toolNames = extractCodexSignalTools(obj.payload);
-        if (!toolNames.length) continue;
-        if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
-        if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
-        for (const name of toolNames) {
-          if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
-          subagentCalls += 1;
-          const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
-          subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
-        }
-      }
-      scannedFiles += 1;
-    } catch (error) {
-      if (!isRecoverableSessionReadError(error)) throw error;
-    } finally {
-      for (const recordHash of currentRecordHashes) priorRecordHashes.add(recordHash);
+  function consume(obj) {
+    updateBounds(bounds, obj?.timestamp);
+    if (obj?.type === "turn_context") {
+      hasTurnContext = true;
+      beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
+      return;
+    }
+    const prompt = extractCodexPrompt(obj);
+    if (prompt) {
+      const fingerprint = promptFingerprint(prompt);
+      if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
+      lastPromptFingerprint = fingerprint;
+      if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
+      return;
+    }
+    if (obj?.type !== "response_item") return;
+    const toolNames = extractCodexSignalTools(obj.payload);
+    if (!toolNames.length) return;
+    if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
+    if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
+    for (const name of toolNames) {
+      if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
+      subagentCalls += 1;
+      const displayName = name === "multi_agent_v1__spawn_agent" ? "spawn_agent" : name;
+      subagentTypes.set(displayName, (subagentTypes.get(displayName) || 0) + 1);
     }
   }
-  if (!scannedFiles) throw new Error("all grouped Codex signal files failed during read");
-  closeTurn();
-  return {
-    bounds,
-    turns,
-    editTurns,
-    retryTurns,
-    subagentCalls,
-    subagentTypes: Object.fromEntries([...subagentTypes.entries()].sort()),
-  };
+
+  function finish() {
+    closeTurn();
+    return {
+      bounds,
+      turns,
+      editTurns,
+      retryTurns,
+      subagentCalls,
+      subagentTypes: Object.fromEntries([...subagentTypes.entries()].sort()),
+    };
+  }
+
+  return { consume, finish };
 }
 
 async function scanCodexSession(filePath) {
   const filePaths = readableSessionPaths(filePath);
   const primaryFilePath = filePaths[0] || String(filePath || "");
-  const [parsed, signals] = await Promise.all([
-    parseCodexRolloutFile(filePaths, { seenTokenEvents: new Set() }),
-    scanCodexDeliverySignals(filePaths),
-  ]);
+  const signalCollector = createCodexDeliverySignalCollector();
+  const parsed = await parseCodexRolloutFile(filePaths, {
+    seenTokenEvents: new Set(),
+    collectBreakdowns: false,
+    collectModelUsage: true,
+    onObject: signalCollector.consume,
+  });
+  const signals = signalCollector.finish();
   const parsedModel = normalizeSessionModel(parsed.model);
   const provider = normalizeSessionModel(parsed.provider);
   // Older Codex rollouts can omit turn_context.model. The shared parser then
   // falls back to model_provider (for example "openai"), which is provenance
   // rather than a model and must not become a model-table row.
-  const model = parsedModel && parsedModel.toLowerCase() !== provider?.toLowerCase()
-    ? parsedModel
-    : "unknown";
+  const observedModels = (parsed.modelUsage || [])
+    .map((row) => normalizeSessionModel(row.model))
+    .filter(Boolean);
+  const model = observedModels.length > 1
+    ? "mixed"
+    : observedModels[0] || (
+      parsedModel && parsedModel.toLowerCase() !== provider?.toLowerCase()
+        ? parsedModel
+        : "unknown"
+    );
   // Codex's own thread title from session_index.jsonl (Codex-authored
   // metadata, keyed by session id). Null when Codex never named the thread —
   // the UI then falls back to the project name.
@@ -539,6 +635,7 @@ async function scanCodexSession(filePath) {
     project_key: projectKey(parsed.cwd, primaryFilePath),
     project_ref: parsed.cwd || null,
     model,
+    model_usage: parsed.modelUsage || [],
     ...signals.bounds,
     turns: signals.turns || finite(parsed.turnCount),
     edit_turns: signals.editTurns,
@@ -1129,7 +1226,10 @@ function analyticsEntryStatKey(source, filePath) {
 
 function readSidecar(sidecarPath) {
   try {
-    return fs.readFileSync(sidecarPath, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    return fs.readFileSync(sidecarPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => repriceSessionRecord(JSON.parse(line)));
   } catch { return []; }
 }
 
@@ -1219,6 +1319,7 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
       }
     }
     if (!row) continue;
+    repriceSessionRecord(row);
     // A one-way file hash enables incremental reuse without persisting or
     // exposing the user's local session path.
     row._cache_key = cacheKey;
@@ -1290,32 +1391,72 @@ function summarizeSessions(sessions, { from = "", to = "", includeSessions = tru
     .map((row) => ({ ...row })));
   const byModel = new Map();
   const subagents = new Map();
+  const totals = {
+    sessions: 0,
+    productive_sessions: 0,
+    one_shot_sessions: 0,
+    edit_turns: 0,
+    retries: 0,
+    total_tokens: 0,
+    cost_usd: 0,
+    edit_tokens: 0,
+    edit_cost_usd: 0,
+  };
   for (const row of filtered) {
-    const key = row.model || "unknown";
-    const agg = byModel.get(key) || {
-      model: key,
-      sessions: 0,
-      productive_sessions: 0,
-      one_shot_sessions: 0,
-      edit_turns: 0,
-      retries: 0,
-      total_tokens: 0,
-      cost_usd: 0,
-      edit_tokens: 0,
-      edit_cost_usd: 0,
-    };
-    agg.sessions += 1;
-    if (row.productive) agg.productive_sessions += 1;
-    if (row.first_pass ?? row.one_shot) agg.one_shot_sessions += 1;
-    agg.edit_turns += finite(row.edit_turns);
-    agg.retries += finite(row.retry_turns);
-    agg.total_tokens += finite(row.total_tokens);
-    agg.cost_usd += finite(row.cost_usd);
+    totals.sessions += 1;
+    if (row.productive) totals.productive_sessions += 1;
+    if (row.first_pass ?? row.one_shot) totals.one_shot_sessions += 1;
+    totals.edit_turns += finite(row.edit_turns);
+    totals.retries += finite(row.retry_turns);
+    totals.total_tokens += finite(row.total_tokens);
+    totals.cost_usd += finite(row.cost_usd);
     if (row.productive) {
-      agg.edit_tokens += finite(row.total_tokens);
-      agg.edit_cost_usd += finite(row.cost_usd);
+      totals.edit_tokens += finite(row.total_tokens);
+      totals.edit_cost_usd += finite(row.cost_usd);
     }
-    byModel.set(key, agg);
+
+    const usageRows = modelUsageForAggregation(row);
+    const primaryModel = usageRows[0]?.model || "unknown";
+    for (const usage of usageRows) {
+      const key = usage.model || "unknown";
+      const agg = byModel.get(key) || {
+        model: key,
+        sessions: 0,
+        productive_sessions: 0,
+        one_shot_sessions: 0,
+        edit_turns: 0,
+        retries: 0,
+        total_tokens: 0,
+        cost_usd: 0,
+        edit_tokens: 0,
+        edit_cost_usd: 0,
+        usage_events: 0,
+        rerouted_usage_events: 0,
+        long_context_usage_events: 0,
+        model_attribution: "selected",
+      };
+      agg.sessions += 1;
+      if (row.productive) agg.productive_sessions += 1;
+      if (row.first_pass ?? row.one_shot) agg.one_shot_sessions += 1;
+      agg.total_tokens += finite(usage.total_tokens);
+      agg.cost_usd += finite(usage.cost_usd);
+      agg.usage_events += finite(usage.usage_events);
+      agg.rerouted_usage_events += finite(usage.rerouted_usage_events);
+      agg.long_context_usage_events += finite(usage.long_context_usage_events);
+      if (usage.model_attribution === "effective") agg.model_attribution = "effective";
+      // Edit/retry events do not carry a model id. Keep global metrics exact
+      // and attribute those session-level counters only to its busiest model;
+      // token and cost totals above remain fully observed for every model.
+      if (key === primaryModel) {
+        agg.edit_turns += finite(row.edit_turns);
+        agg.retries += finite(row.retry_turns);
+        if (row.productive) {
+          agg.edit_tokens += finite(usage.total_tokens);
+          agg.edit_cost_usd += finite(usage.cost_usd);
+        }
+      }
+      byModel.set(key, agg);
+    }
     if (row.source === "codex" && row.parent_session_hash) {
       const name = row.agent_role || row.agent_nickname || "subagent";
       const sub = subagents.get(name) || {
@@ -1359,10 +1500,6 @@ function summarizeSessions(sessions, { from = "", to = "", includeSessions = tru
     tokens_per_edit: row.edit_turns ? row.edit_tokens / row.edit_turns : null,
     cost_per_edit: row.edit_turns ? row.edit_cost_usd / row.edit_turns : null,
   })).sort((a, b) => b.edit_turns - a.edit_turns || b.productive_sessions - a.productive_sessions || b.sessions - a.sessions);
-  const totals = by_model.reduce((acc, row) => {
-    for (const key of ["sessions", "productive_sessions", "one_shot_sessions", "edit_turns", "retries", "total_tokens", "cost_usd", "edit_tokens", "edit_cost_usd"]) acc[key] += finite(row[key]);
-    return acc;
-  }, { sessions: 0, productive_sessions: 0, one_shot_sessions: 0, edit_turns: 0, retries: 0, total_tokens: 0, cost_usd: 0, edit_tokens: 0, edit_cost_usd: 0 });
   return {
     available: filtered.length > 0,
     // Local filesystem paths and raw session ids are required internally for
@@ -1449,6 +1586,7 @@ function toSessionBrowserRow(row) {
     // browser can show where a session ran and compose a resume command.
     project_ref: row.project_ref || null,
     model: row.model,
+    model_usage: modelUsageForAggregation(row),
     started_at: row.started_at || null,
     ended_at: row.ended_at || null,
     duration_ms: finite(row.duration_ms),
@@ -1506,6 +1644,7 @@ function mergeSessionFragments(rows) {
       byHash.set(key, {
         ...row,
         tokens: row.tokens && typeof row.tokens === "object" ? { ...row.tokens } : emptyTotals(),
+        model_usage: normalizeModelUsageRows(row.model_usage),
         _repr_tokens: finite(row.total_tokens),
       });
       continue;
@@ -1515,6 +1654,10 @@ function mergeSessionFragments(rows) {
     cur.retry_turns = finite(cur.retry_turns) + finite(row.retry_turns);
     cur.subagent_calls = finite(cur.subagent_calls) + finite(row.subagent_calls);
     addTotals(cur.tokens, row.tokens);
+    cur.model_usage = normalizeModelUsageRows([
+      ...(cur.model_usage || []),
+      ...(row.model_usage || []),
+    ]);
     cur.total_tokens = finite(cur.total_tokens) + finite(row.total_tokens);
     cur.cost_usd = finite(cur.cost_usd) + finite(row.cost_usd);
     cur.provider_cost_usd = finite(cur.provider_cost_usd) + finite(row.provider_cost_usd);
@@ -1543,11 +1686,11 @@ function mergeSessionFragments(rows) {
     if (!cur.forked_from_id && row.forked_from_id) cur.forked_from_id = row.forked_from_id;
     if (!cur.agent_nickname && row.agent_nickname) cur.agent_nickname = row.agent_nickname;
     if (!cur.agent_role && row.agent_role) cur.agent_role = row.agent_role;
-    // Representative model/project comes from the busiest fragment (most
-    // tokens) so a tiny sidechain cannot overwrite the real coding model.
+    // Representative project comes from the busiest fragment (most tokens) so
+    // a tiny sidechain cannot overwrite the real working directory. Models are
+    // merged independently above; a multi-model session is represented as mixed.
     if (finite(row.total_tokens) > finite(cur._repr_tokens)) {
       cur._repr_tokens = finite(row.total_tokens);
-      if (row.model && row.model !== "unknown") cur.model = row.model;
       // Project needs its own guard: a subagent running in a git worktree has
       // that throwaway directory as its cwd, so the busiest fragment can label
       // the whole session with a temp name like "agent-a3cb8089a11d3471a" and
@@ -1569,6 +1712,7 @@ function mergeSessionFragments(rows) {
     row.duration_ms = finite(row.active_ms);
     row.first_pass = finite(row.edit_turns) === 1 && finite(row.retry_turns) === 0;
     row.one_shot = row.first_pass;
+    repriceSessionRecord(row);
     merged.push(row);
   }
   return merged;
@@ -1714,9 +1858,12 @@ function listSessionsForBrowser(sessions, { from = "", to = "", limit = 0 } = {}
 }
 
 function sessionsToCsv(rows) {
-  const columns = ["session_hash", "source", "project_key", "model", "started_at", "ended_at", "duration_ms", "turns", "edit_turns", "retry_turns", "subagent_calls", "total_tokens", "cost_usd", "productive", "first_pass", "one_shot"];
+  const columns = ["session_hash", "source", "project_key", "model", "model_usage_json", "started_at", "ended_at", "duration_ms", "turns", "edit_turns", "retry_turns", "subagent_calls", "total_tokens", "cost_usd", "productive", "first_pass", "one_shot"];
   const escape = (value) => `"${String(value ?? "").replaceAll('"', '""')}"`;
-  return [columns.join(","), ...(rows || []).map((row) => columns.map((key) => escape(row[key])).join(","))].join("\n") + "\n";
+  const valueFor = (row, key) => key === "model_usage_json"
+    ? JSON.stringify(row.model_usage || [])
+    : row[key];
+  return [columns.join(","), ...(rows || []).map((row) => columns.map((key) => escape(valueFor(row, key))).join(","))].join("\n") + "\n";
 }
 
 module.exports = {

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -627,6 +627,12 @@ function createCodexDeliverySignalCollector() {
       beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1), model);
       return;
     }
+    // Between two turn_context rows the attributed model only moves when a
+    // model/rerouted event fires mid-turn. recordModelUsage() bills the rest of
+    // the turn's tokens to the new model, so the turn's edits have to move with
+    // them - otherwise one turn's tokens and its edit count land on two
+    // different rows and by_model.tokens_per_edit divides across models.
+    if (currentTurnOpen && model && model !== currentTurnModel) currentTurnModel = model;
     const prompt = extractCodexPrompt(obj);
     if (prompt) {
       const fingerprint = promptFingerprint(prompt);

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -134,6 +134,11 @@ const MODEL_USAGE_SUM_FIELDS = [
   "usage_events",
   "rerouted_usage_events",
   "long_context_usage_events",
+  // Not a token counter: an edit turn is a turn, and turn_context both marks
+  // where a turn begins and names its model, so an edit turn has exactly one
+  // owner. Splitting it here keeps by_model.tokens_per_edit a ratio over one
+  // population instead of this model's tokens over the whole session's turns.
+  "edit_turns",
 ];
 
 function normalizeModelUsageRows(rows) {
@@ -244,23 +249,35 @@ function repriceSessionRecord(record) {
 }
 
 function modelUsageForAggregation(record) {
+  const editTurns = finite(record?.edit_turns);
   const rows = normalizeModelUsageRows(record?.model_usage);
-  if (rows.length > 0) {
-    return rows.map((row) => ({
-      ...row,
-      cost_usd: Number.isFinite(Number(row.cost_usd))
-        ? Number(row.cost_usd)
-        : computeRowCost({ source: record.source, ...row }),
-    }));
+  if (rows.length === 0) {
+    return [{
+      model: normalizeSessionModel(record?.model) || "unknown",
+      total_tokens: finite(record?.total_tokens || record?.tokens?.total_tokens),
+      cost_usd: finite(record?.cost_usd),
+      edit_turns: editTurns,
+      selected_models: [],
+      reroute_reasons: [],
+      model_attribution: "selected",
+    }];
   }
-  return [{
-    model: normalizeSessionModel(record?.model) || "unknown",
-    total_tokens: finite(record?.total_tokens || record?.tokens?.total_tokens),
-    cost_usd: finite(record?.cost_usd),
-    selected_models: [],
-    reroute_reasons: [],
-    model_attribution: "selected",
-  }];
+  const priced = rows.map((row) => ({
+    ...row,
+    cost_usd: Number.isFinite(Number(row.cost_usd))
+      ? Number(row.cost_usd)
+      : computeRowCost({ source: record.source, ...row }),
+  }));
+  // Sum(rows.edit_turns) has to equal record.edit_turns or the by_model column
+  // stops summing to summary.edit_turns. It can fall short two ways: a sidecar
+  // written before model_usage carried edit_turns, and an edit turn whose model
+  // produced no billable delta, leaving no usage row to attach to. Fold the
+  // residual into the busiest model - normalizeModelUsageRows() sorts by
+  // total_tokens - which is the same approximation `retries` uses.
+  const assigned = priced.reduce((sum, row) => sum + finite(row.edit_turns), 0);
+  const residual = editTurns - assigned;
+  if (residual > 0) priced[0].edit_turns = finite(priced[0].edit_turns) + residual;
+  return priced;
 }
 
 function safeTimestamp(value) {
@@ -561,25 +578,36 @@ function createCodexDeliverySignalCollector() {
   let lastPromptFingerprint = null;
   let subagentCalls = 0;
   const subagentTypes = new Map();
+  // The model the open turn belongs to, as decided by codex-model-attribution.
+  // The parser hands it in rather than this collector re-reading
+  // turn_context.payload.model, so there stays exactly one authority on which
+  // model owns a turn - the same one that bills the turn's tokens.
+  let currentTurnModel = null;
+  const editTurnsByModel = new Map();
 
   function closeTurn() {
-    if (currentTurnOpen && currentHadEdit) editTurns += 1;
+    if (currentTurnOpen && currentHadEdit) {
+      editTurns += 1;
+      const key = currentTurnModel || "unknown";
+      editTurnsByModel.set(key, (editTurnsByModel.get(key) || 0) + 1);
+    }
     currentHadEdit = false;
   }
 
-  function beginTurn(key) {
+  function beginTurn(key, model) {
     if (currentTurnOpen && key && currentTurnKey === key) return;
     if (currentTurnOpen) closeTurn();
     currentTurnOpen = true;
     currentTurnKey = key || null;
+    currentTurnModel = model || null;
     turns += 1;
   }
 
-  function consume(obj) {
+  function consume(obj, model = null) {
     updateBounds(bounds, obj?.timestamp);
     if (obj?.type === "turn_context") {
       hasTurnContext = true;
-      beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1));
+      beginTurn(String(obj.payload?.turn_id || obj.timestamp || turns + 1), model);
       return;
     }
     const prompt = extractCodexPrompt(obj);
@@ -587,13 +615,13 @@ function createCodexDeliverySignalCollector() {
       const fingerprint = promptFingerprint(prompt);
       if (lastPromptFingerprint && fingerprint === lastPromptFingerprint) retryTurns += 1;
       lastPromptFingerprint = fingerprint;
-      if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1));
+      if (!hasTurnContext) beginTurn(String(obj.timestamp || turns + 1), model);
       return;
     }
     if (obj?.type !== "response_item") return;
     const toolNames = extractCodexSignalTools(obj.payload);
     if (!toolNames.length) return;
-    if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1));
+    if (!currentTurnOpen) beginTurn(String(obj.timestamp || turns + 1), model);
     if (toolNames.some((name) => EDIT_TOOLS.has(name))) currentHadEdit = true;
     for (const name of toolNames) {
       if (!CODEX_SUBAGENT_TOOLS.has(name)) continue;
@@ -609,6 +637,7 @@ function createCodexDeliverySignalCollector() {
       bounds,
       turns,
       editTurns,
+      editTurnsByModel: Object.fromEntries(editTurnsByModel),
       retryTurns,
       subagentCalls,
       subagentTypes: Object.fromEntries([...subagentTypes.entries()].sort()),
@@ -629,6 +658,16 @@ async function scanCodexSession(filePath) {
     onObject: signalCollector.consume,
   });
   const signals = signalCollector.finish();
+  // The collector keyed edit turns by the model the parser handed it, so the
+  // keys are the same raw model ids parsed.modelUsage rows carry. A model whose
+  // edit turns produced no billable delta has no row to land on;
+  // modelUsageForAggregation() folds that residual into the busiest model so
+  // the by_model column still sums to edit_turns.
+  const editTurnsByModel = signals.editTurnsByModel || {};
+  const modelUsage = (parsed.modelUsage || []).map((row) => ({
+    ...row,
+    edit_turns: finite(editTurnsByModel[row.model]),
+  }));
   const parsedModel = normalizeSessionModel(parsed.model);
   const provider = normalizeSessionModel(parsed.provider);
   // Older Codex rollouts can omit turn_context.model. The shared parser then
@@ -672,7 +711,7 @@ async function scanCodexSession(filePath) {
     project_key: projectKey(parsed.cwd, primaryFilePath),
     project_ref: parsed.cwd || null,
     model,
-    model_usage: parsed.modelUsage || [],
+    model_usage: modelUsage,
     ...signals.bounds,
     turns: signals.turns || finite(parsed.turnCount),
     edit_turns: signals.editTurns,
@@ -1455,9 +1494,9 @@ function summarizeSessions(sessions, { from = "", to = "", includeSessions = tru
     // One session contributes a row to EVERY model it used, so per-model
     // `sessions` counts "sessions that touched this model" and the column does
     // NOT sum to summary.sessions (a session that switched models mid-thread
-    // is counted once per model). Token, cost and edit_turn columns DO sum
-    // exactly - only the session headcount overlaps. Read the session total
-    // from summary.sessions / session_count, never by summing this column;
+    // is counted once per model). Token, cost, edit_turn and edit_token columns
+    // DO sum exactly - only the session headcount overlaps. Read the session
+    // total from summary.sessions / session_count, never by summing this column;
     // test/session-analytics.test.js locks both halves of that contract.
     const usageRows = modelUsageForAggregation(row);
     const primaryModel = usageRows[0]?.model || "unknown";
@@ -1488,17 +1527,23 @@ function summarizeSessions(sessions, { from = "", to = "", includeSessions = tru
       agg.rerouted_usage_events += finite(usage.rerouted_usage_events);
       agg.long_context_usage_events += finite(usage.long_context_usage_events);
       if (usage.model_attribution === "effective") agg.model_attribution = "effective";
-      // Edit/retry events do not carry a model id. Keep global metrics exact
-      // and attribute those session-level counters only to its busiest model;
-      // token and cost totals above remain fully observed for every model.
-      if (key === primaryModel) {
-        agg.edit_turns += finite(row.edit_turns);
-        agg.retries += finite(row.retry_turns);
-        if (row.productive) {
-          agg.edit_tokens += finite(usage.total_tokens);
-          agg.edit_cost_usd += finite(usage.cost_usd);
-        }
+      // Numerator and denominator of tokens_per_edit / cost_per_edit must come
+      // from the same population, so both are per model: an edit turn is a
+      // turn, and turn_context names the model that owns it. Giving one model
+      // the whole session's edit_turns but only its own slice of the tokens
+      // understated the ratio and broke sum(edit_tokens) == summary.edit_tokens.
+      agg.edit_turns += finite(usage.edit_turns);
+      if (row.productive) {
+        agg.edit_tokens += finite(usage.total_tokens);
+        agg.edit_cost_usd += finite(usage.cost_usd);
       }
+      // Retries are deliberately NOT split. A retry is detected from the user
+      // prompt, and user_message / turn_context ordering is not stable in Codex
+      // rollouts (1332 one way vs 1139 the other across 400 local files), so a
+      // per-model retry would name the wrong turn about as often as the right
+      // one. Attributing them to the busiest model keeps the column summing to
+      // summary.retries without claiming a precision the log cannot support.
+      if (key === primaryModel) agg.retries += finite(row.retry_turns);
       byModel.set(key, agg);
     }
     if (row.source === "codex" && row.parent_session_hash) {

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -248,21 +248,38 @@ function repriceSessionRecord(record) {
   return record;
 }
 
+// The model_usage wire contract is DENSE: every field dashboard/src/lib/
+// sessions-api.ts declares is present on every row. Storage is free to be
+// sparse - serializeModelUsageRow() drops zero counters, and a record with no
+// model_usage at all (every claude/grok session, plus codex sessions written
+// by an older sidecar) has nothing to trim in the first place - but neither
+// shape may leak into an API response, or the declared type describes a row
+// that does not exist. Densify here, the one point both the by_model
+// aggregation and toSessionBrowserRow() pass through.
+function denseModelUsageRow(overrides = {}) {
+  return {
+    model: "unknown",
+    ...Object.fromEntries(MODEL_USAGE_SUM_FIELDS.map((field) => [field, 0])),
+    selected_models: [],
+    reroute_reasons: [],
+    model_attribution: "selected",
+    cost_usd: 0,
+    ...overrides,
+  };
+}
+
 function modelUsageForAggregation(record) {
   const editTurns = finite(record?.edit_turns);
   const rows = normalizeModelUsageRows(record?.model_usage);
   if (rows.length === 0) {
-    return [{
+    return [denseModelUsageRow({
       model: normalizeSessionModel(record?.model) || "unknown",
       total_tokens: finite(record?.total_tokens || record?.tokens?.total_tokens),
       cost_usd: finite(record?.cost_usd),
       edit_turns: editTurns,
-      selected_models: [],
-      reroute_reasons: [],
-      model_attribution: "selected",
-    }];
+    })];
   }
-  const priced = rows.map((row) => ({
+  const priced = rows.map((row) => denseModelUsageRow({
     ...row,
     cost_usd: Number.isFinite(Number(row.cost_usd))
       ? Number(row.cost_usd)

--- a/src/lib/session-analytics.js
+++ b/src/lib/session-analytics.js
@@ -152,9 +152,16 @@ function normalizeModelUsageRows(rows) {
       byModel.set(model, row);
     }
     for (const field of MODEL_USAGE_SUM_FIELDS) row[field] += finite(value?.[field]);
-    for (const selected of Array.isArray(value?.selected_models) ? value.selected_models : []) {
-      const normalized = normalizeSessionModel(selected);
-      if (normalized) row.selected_models.add(normalized);
+    if (Array.isArray(value?.selected_models)) {
+      for (const selected of value.selected_models) {
+        const normalized = normalizeSessionModel(selected);
+        if (normalized) row.selected_models.add(normalized);
+      }
+    } else if (model !== "unknown") {
+      // serializeModelUsageRow() omits selected_models when it is just the
+      // effective model repeated. An absent field therefore means "selected
+      // == effective", which is the case for every non-rerouted row.
+      row.selected_models.add(model);
     }
     for (const reason of Array.isArray(value?.reroute_reasons) ? value.reroute_reasons : []) {
       if (typeof reason === "string" && reason.trim()) row.reroute_reasons.add(reason.trim());
@@ -170,6 +177,36 @@ function normalizeModelUsageRows(rows) {
       reroute_reasons: [...row.reroute_reasons].sort(),
     }))
     .sort((a, b) => b.total_tokens - a.total_tokens || a.model.localeCompare(b.model));
+}
+
+// The sidecar is re-read on every dashboard request, so keep it small: omit
+// the model_usage fields that normalizeModelUsageRows() reconstructs on read.
+// All four omissions are lossless - zero counters default to 0, an absent
+// selected_models re-seeds from `model`, model_attribution is derived from
+// rerouted_usage_events, and cost_usd is always recomputed by
+// repriceSessionRecord(). Worth ~19% of the file on a 6.8k-session history,
+// most of it the long_context_* counters that stay at zero (see
+// OPENAI_LONG_CONTEXT_INPUT_THRESHOLD in src/lib/pricing/index.js).
+function serializeModelUsageRow(row) {
+  const out = { model: row.model };
+  for (const field of MODEL_USAGE_SUM_FIELDS) {
+    const value = finite(row[field]);
+    if (value !== 0) out[field] = value;
+  }
+  const selected = Array.isArray(row.selected_models) ? row.selected_models : [];
+  if (!(selected.length === 1 && selected[0] === row.model)) out.selected_models = selected;
+  if (Array.isArray(row.reroute_reasons) && row.reroute_reasons.length > 0) {
+    out.reroute_reasons = row.reroute_reasons;
+  }
+  if (row.model_attribution === "effective") out.model_attribution = "effective";
+  return out;
+}
+
+function serializeSessionRecord(row) {
+  if (!Array.isArray(row?.model_usage) || row.model_usage.length === 0) {
+    return JSON.stringify(row);
+  }
+  return JSON.stringify({ ...row, model_usage: row.model_usage.map(serializeModelUsageRow) });
 }
 
 function repriceSessionRecord(record) {
@@ -1327,7 +1364,7 @@ async function buildSessionAnalyticsInternal({ home = os.homedir(), force = fals
     nextFiles[cacheKey] = { stat_key: statKey };
   }
   sessions.sort((a, b) => String(b.ended_at || "").localeCompare(String(a.ended_at || "")));
-  const content = sessions.map((row) => JSON.stringify(row)).join("\n") + (sessions.length ? "\n" : "");
+  const content = sessions.map(serializeSessionRecord).join("\n") + (sessions.length ? "\n" : "");
   await writeAtomic(sidecarPath, content);
   const generatedAt = new Date().toISOString();
   await writeAtomic(metaPath, `${JSON.stringify({
@@ -1415,6 +1452,13 @@ function summarizeSessions(sessions, { from = "", to = "", includeSessions = tru
       totals.edit_cost_usd += finite(row.cost_usd);
     }
 
+    // One session contributes a row to EVERY model it used, so per-model
+    // `sessions` counts "sessions that touched this model" and the column does
+    // NOT sum to summary.sessions (a session that switched models mid-thread
+    // is counted once per model). Token, cost and edit_turn columns DO sum
+    // exactly - only the session headcount overlaps. Read the session total
+    // from summary.sessions / session_count, never by summing this column;
+    // test/session-analytics.test.js locks both halves of that contract.
     const usageRows = modelUsageForAggregation(row);
     const primaryModel = usageRows[0]?.model || "unknown";
     for (const usage of usageRows) {

--- a/test/codex-model-attribution.test.js
+++ b/test/codex-model-attribution.test.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  applyCodexModelEvent,
+  createCodexModelAttributionState,
+  currentCodexModel,
+  extractModelReroute,
+} = require("../src/lib/codex-model-attribution");
+
+test("Codex model attribution promotes an official model/rerouted notification to the effective model", () => {
+  const state = createCodexModelAttributionState();
+  applyCodexModelEvent(state, {
+    type: "turn_context",
+    payload: { turn_id: "turn-1", model: "gpt-5.6-sol" },
+  });
+  const notification = {
+    method: "model/rerouted",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      fromModel: "gpt-5.6-sol",
+      toModel: "gpt-5.6-terra",
+      reason: "capacity",
+    },
+  };
+  assert.deepEqual(extractModelReroute(notification), {
+    threadId: "thread-1",
+    turnId: "turn-1",
+    fromModel: "gpt-5.6-sol",
+    toModel: "gpt-5.6-terra",
+    reason: "capacity",
+  });
+  applyCodexModelEvent(state, notification);
+  assert.equal(state.selectedModel, "gpt-5.6-sol");
+  assert.equal(currentCodexModel(state), "gpt-5.6-terra");
+  assert.equal(state.rerouted, true);
+  applyCodexModelEvent(state, { type: "turn_context", payload: { turn_id: "turn-2" } });
+  assert.equal(currentCodexModel(state), "gpt-5.6-sol");
+  assert.equal(state.rerouted, false);
+});
+
+test("Codex model attribution accepts persisted snake-case event envelopes", () => {
+  const state = createCodexModelAttributionState({ model: "gpt-5.6-sol" });
+  applyCodexModelEvent(state, {
+    type: "event_msg",
+    payload: {
+      type: "model_rerouted",
+      from_model: "gpt-5.6-sol",
+      to_model: "gpt-5.6-luna",
+      reason: "user_limit",
+    },
+  });
+  assert.equal(currentCodexModel(state), "gpt-5.6-luna");
+  assert.equal(state.rerouteReason, "user_limit");
+});

--- a/test/codex-model-attribution.test.js
+++ b/test/codex-model-attribution.test.js
@@ -55,3 +55,31 @@ test("Codex model attribution accepts persisted snake-case event envelopes", () 
   assert.equal(currentCodexModel(state), "gpt-5.6-luna");
   assert.equal(state.rerouteReason, "user_limit");
 });
+
+test("Codex model attribution falls back to session_meta only when nothing stronger named a model", () => {
+  // Defensive path, not an observed one: no Codex build has written a model
+  // into session_meta - 0 of 10310 session_meta rows across 5849 local
+  // rollouts carry the field, which is why this fixture has to be synthetic.
+  // It pins the precedence rule, not the format.
+  const state = createCodexModelAttributionState();
+  applyCodexModelEvent(state, { type: "session_meta", payload: { id: "s-1", model_provider: "openai" } });
+  assert.equal(currentCodexModel(state), null, "model_provider is provenance, never a model");
+
+  assert.deepEqual(
+    applyCodexModelEvent(state, { type: "session_meta", payload: { id: "s-1", model: "gpt-5.6-sol" } }),
+    { type: "session_meta", selectedModel: "gpt-5.6-sol" },
+  );
+  assert.equal(currentCodexModel(state), "gpt-5.6-sol");
+
+  // turn_context marks where a turn actually begins, so it always wins.
+  applyCodexModelEvent(state, { type: "turn_context", payload: { turn_id: "turn-1", model: "gpt-5.6-terra" } });
+  assert.equal(currentCodexModel(state), "gpt-5.6-terra");
+
+  // A forked rollout replays the parent's session_meta rows after its own;
+  // that must not drag attribution back to the parent's model.
+  assert.equal(
+    applyCodexModelEvent(state, { type: "session_meta", payload: { id: "parent", model: "gpt-5.6-sol" } }),
+    null,
+  );
+  assert.equal(currentCodexModel(state), "gpt-5.6-terra");
+});

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -129,15 +129,15 @@ test("matcher: GPT-5.6 codex tiers resolve to their real curated rates (not the 
   // LiteLLM has no gpt-5.6 yet; simulate that so curated must win.
   const litellm = { "gpt-5": { input: 1.25, output: 10, cache_read: 0.125 } };
   const cases = [
-    ["gpt-5.6-sol", 5, 30, "curated:exact"],
+    ["gpt-5.6-sol", 4, 20, "curated:exact"],
     ["gpt-5.6-terra", 2, 12, "curated:exact"],
     ["gpt-5.6-luna", 0.2, 1.2, "curated:exact"],
     // reasoning-effort variants codex appends must still land on the right tier
-    ["gpt-5.6-sol-high", 5, 30, null],
-    ["gpt-5.6-solhigh", 5, 30, "curated:fuzzy"],
+    ["gpt-5.6-sol-high", 4, 20, null],
+    ["gpt-5.6-solhigh", 4, 20, "curated:fuzzy"],
     ["gpt-5.6-terrahigh", 2, 12, "curated:fuzzy"],
-    // bare / unknown-tier falls back to the balanced terra tier, never gpt-5
-    ["gpt-5.6", 2, 12, "curated:fuzzy"],
+    // The public bare alias resolves to Sol, never the older gpt-5 entry.
+    ["gpt-5.6", 4, 20, "curated:fuzzy"],
   ];
   for (const [model, input, output, source] of cases) {
     const r = matcher.lookupPricing(model, { curated, litellm, source: "codex" });
@@ -921,6 +921,34 @@ test("index: computeRowCost on Codex row does NOT double-count reasoning", async
     Math.abs(cost - expected) < 1e-9,
     `expected ${expected}, got ${cost}`,
   );
+});
+
+test("index: computeRowCost applies GPT-5.6 Sol long-context pricing to only the observed request subset", () => {
+  const row = {
+    source: "codex",
+    model: "gpt-5.6-sol-high",
+    input_tokens: 100_000,
+    cached_input_tokens: 200_000,
+    cache_creation_input_tokens: 10_000,
+    output_tokens: 20_000,
+    reasoning_output_tokens: 5_000,
+    long_context_input_tokens: 100_000,
+    long_context_cached_input_tokens: 200_000,
+    long_context_cache_creation_input_tokens: 10_000,
+    long_context_output_tokens: 20_000,
+    long_context_reasoning_output_tokens: 5_000,
+  };
+  // Standard: .4 + .08 + .05 + .4 = .93. Long-context premium:
+  // .4 + .08 + .05 + .2 = .73. Reasoning is already inside Codex output.
+  assert.ok(Math.abs(pricing.computeRowCost(row) - 1.66) < 1e-12);
+  assert.ok(Math.abs(pricing.computeRowCost({
+    ...row,
+    long_context_input_tokens: 0,
+    long_context_cached_input_tokens: 0,
+    long_context_cache_creation_input_tokens: 0,
+    long_context_output_tokens: 0,
+    long_context_reasoning_output_tokens: 0,
+  }) - 0.93) < 1e-12);
 });
 
 test("index: computeRowCost on non-Codex source DOES bill reasoning tokens", async () => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -3996,9 +3996,50 @@ test("parseRolloutIncremental subtracts cached_input_tokens from Codex input_tok
     assert.equal(queued[0].cached_input_tokens, 950_000);
     assert.equal(queued[0].output_tokens, 10_000);
     assert.equal(queued[0].reasoning_output_tokens, 4_000);
-    // total_tokens left as reported: still equals non_cached + cached + output
-    // numerically, so downstream aggregation stays stable.
+    // The reported total already equals the normalized, mutually-exclusive parts.
     assert.equal(queued[0].total_tokens, 1_010_000);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental drops Codex total-only sentinel usage", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-total-sentinel-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-codex.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const zero = {
+      input_tokens: 0,
+      cached_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: 0,
+    };
+    const sentinel = { ...zero, total_tokens: 4_442 };
+    const valid = { ...zero, input_tokens: 100, output_tokens: 10, total_tokens: 110 };
+
+    await fs.writeFile(
+      rolloutPath,
+      [
+        buildTokenCountLine({ ts: "2026-08-04T12:58:55.420Z", last: sentinel, total: zero }),
+        buildTokenCountLine({ ts: "2026-08-04T12:59:06.736Z", last: valid, total: valid }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await parseRolloutIncremental({
+      rolloutFiles: [{ path: rolloutPath, source: "codex" }],
+      cursors,
+      queuePath,
+    });
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 100);
+    assert.equal(queued[0].output_tokens, 10);
+    assert.equal(queued[0].total_tokens, 110);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -4140,6 +4181,56 @@ test("parseRolloutIncremental keeps buckets separate per model within the same h
     assert.ok(byModel.has("gpt-4o-mini"));
     assert.equal(byModel.get("gpt-4o").total_tokens, usage1.total_tokens);
     assert.equal(byModel.get("gpt-4o-mini").total_tokens, usage2.total_tokens);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseRolloutIncremental persists selected-model state and bills an observed reroute to the effective model", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-codex-reroute-"));
+  try {
+    const rolloutPath = path.join(tmp, "rollout-reroute.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    await fs.writeFile(
+      rolloutPath,
+      `${buildTurnContextLine({ model: "gpt-5.6-sol" })}\n`,
+      "utf8",
+    );
+    await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+
+    const usage = {
+      input_tokens: 100,
+      cached_input_tokens: 0,
+      output_tokens: 20,
+      reasoning_output_tokens: 0,
+      total_tokens: 120,
+    };
+    const reroute = JSON.stringify({
+      timestamp: "2025-12-17T00:04:59.000Z",
+      method: "model/rerouted",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        fromModel: "gpt-5.6-sol",
+        toModel: "gpt-5.6-terra",
+        reason: "capacity",
+      },
+    });
+    await fs.appendFile(
+      rolloutPath,
+      `${reroute}\n${buildTokenCountLine({ ts: "2025-12-17T00:05:00.000Z", last: usage, total: usage })}\n`,
+      "utf8",
+    );
+    await parseRolloutIncremental({ rolloutFiles: [rolloutPath], cursors, queuePath });
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].model, "gpt-5.6-terra");
+    assert.equal(queued[0].total_tokens, 120);
+    const cursor = cursors.files[rolloutPath];
+    assert.equal(cursor.modelAttributionState.selectedModel, "gpt-5.6-sol");
+    assert.equal(cursor.modelAttributionState.effectiveModel, "gpt-5.6-terra");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -1153,3 +1153,75 @@ test("sidecar omits reconstructible model_usage fields without losing informatio
   assert.equal(restored.edit_turns, 1);
   assert.equal(warm[0].model_usage.find((row) => row.model === "gpt-5.6-terra").edit_turns, 0);
 });
+
+test("a mid-turn reroute moves the open turn's edits onto the model that is now billed", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-reroute-edit-"));
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const filePath = path.join(dir, "rollout-2026-07-24T08-00-00-00000000-0000-4000-8000-00000000000d.jsonl");
+  fs.writeFileSync(filePath, `${[
+    { timestamp: "2026-07-24T08:00:00Z", type: "session_meta", payload: { id: "codex-reroute-edit", cwd: dir, model_provider: "openai" } },
+    { timestamp: "2026-07-24T08:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-24T08:00:02Z", type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } },
+    { timestamp: "2026-07-24T08:00:03Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(1000, 200), total_token_usage: usage(1000, 200) } } },
+    { timestamp: "2026-07-24T08:00:04Z", method: "model/rerouted", params: { threadId: "codex-reroute-edit", turnId: "turn-1", fromModel: "gpt-5.6-sol", toModel: "gpt-5.6-terra", reason: "capacity" } },
+    { timestamp: "2026-07-24T08:00:05Z", type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } },
+    { timestamp: "2026-07-24T08:00:06Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(3000, 300), total_token_usage: usage(4000, 500) } } },
+    { timestamp: "2026-07-24T08:01:00Z", type: "turn_context", payload: { turn_id: "turn-2", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-24T08:01:01Z", type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } },
+    { timestamp: "2026-07-24T08:01:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(500, 100), total_token_usage: usage(4500, 600) } } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  assert.equal(session.model, "mixed");
+  assert.equal(session.edit_turns, 2);
+  const byModel = Object.fromEntries(session.model_usage.map((row) => [row.model, row]));
+  assert.equal(byModel["gpt-5.6-terra"].total_tokens, 3300);
+  assert.equal(byModel["gpt-5.6-sol"].total_tokens, 1800);
+
+  // turn-1 was rerouted to terra partway through, so terra pays for the rest of
+  // that turn's tokens and owns its edit. The reroute does not leak past the
+  // turn boundary: turn-2 starts a fresh turn_context back on sol.
+  assert.equal(byModel["gpt-5.6-terra"].edit_turns, 1);
+  assert.equal(byModel["gpt-5.6-sol"].edit_turns, 1);
+
+  const summary = summarizeSessions([session]);
+  assert.equal(
+    summary.by_model.reduce((acc, row) => acc + row.edit_turns, 0),
+    summary.summary.edit_turns,
+  );
+});
+
+test("a Codex session whose only model signal is session_meta attributes rather than falling to unknown", async () => {
+  // The field has never been observed in a real rollout (0 of 10310
+  // session_meta rows across 5849 local files), so the fixture is synthetic by
+  // necessity. It guards the fallback, not the format: without it a session
+  // that named a model only in its metadata bills every token to "unknown"
+  // and renders as an unpriced session.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-meta-model-"));
+  const usage = {
+    input_tokens: 100,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 20,
+    reasoning_output_tokens: 0,
+    total_tokens: 120,
+  };
+  const filePath = path.join(dir, "rollout-2026-07-25T08-00-00-00000000-0000-4000-8000-00000000000e.jsonl");
+  fs.writeFileSync(filePath, `${[
+    { timestamp: "2026-07-25T08:00:00Z", type: "session_meta", payload: { id: "codex-meta-model", cwd: dir, model_provider: "openai", model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-25T08:00:01Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage, total_token_usage: usage } } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  assert.equal(session.model, "gpt-5.6-sol");
+  assert.deepEqual(session.model_usage.map((row) => [row.model, row.total_tokens]), [["gpt-5.6-sol", 120]]);
+  assert.equal(session.model_usage[0].model_attribution, "selected");
+  assert.ok(session.cost_usd > 0, "an attributed model is priced; unknown is not");
+});

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -173,6 +173,104 @@ test("Codex session analytics does not report model providers as models", async 
   assert.notEqual(summarizeSessions([session]).by_model[0].model, "openai");
 });
 
+test("Codex session analytics marks unpriced internal model usage as a partial cost", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-codex-unpriced-"));
+  const filePath = path.join(dir, "rollout-2026-07-18T07-30-00-00000000-0000-4000-8000-000000000005.jsonl");
+  const usage = {
+    input_tokens: 100,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 20,
+    reasoning_output_tokens: 0,
+    total_tokens: 120,
+  };
+  fs.writeFileSync(filePath, `${[
+    { timestamp: "2026-07-18T07:30:00Z", type: "session_meta", payload: { id: "codex-unpriced", cwd: dir, model_provider: "openai" } },
+    { timestamp: "2026-07-18T07:30:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: dir, model: "codex-auto-review" } },
+    { timestamp: "2026-07-18T07:30:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage, total_token_usage: usage } } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  assert.equal(session.model, "codex-auto-review");
+  assert.equal(session.total_tokens, 120);
+  assert.equal(session.cost_usd, 0);
+  assert.equal(session.cost_is_partial, true);
+});
+
+test("Codex session analytics attributes one session across selected and rerouted effective models", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-codex-models-"));
+  const filePath = path.join(dir, "rollout-2026-07-18T08-00-00-00000000-0000-4000-8000-000000000003.jsonl");
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const rows = [
+    { timestamp: "2026-07-18T08:00:00Z", type: "session_meta", payload: { id: "codex-models", cwd: dir, model_provider: "openai" } },
+    { timestamp: "2026-07-18T08:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-18T08:00:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(100, 20), total_token_usage: usage(100, 20) } } },
+    { timestamp: "2026-07-18T08:01:00Z", type: "turn_context", payload: { turn_id: "turn-2", cwd: dir, model: "gpt-5.6-luna" } },
+    { timestamp: "2026-07-18T08:01:01Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(50, 10), total_token_usage: usage(150, 30) } } },
+    { timestamp: "2026-07-18T08:02:00Z", type: "turn_context", payload: { turn_id: "turn-3", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-18T08:02:01Z", method: "model/rerouted", params: { threadId: "codex-models", turnId: "turn-3", fromModel: "gpt-5.6-sol", toModel: "gpt-5.6-terra", reason: "capacity" } },
+    { timestamp: "2026-07-18T08:02:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(30, 6), total_token_usage: usage(180, 36) } } },
+  ];
+  fs.writeFileSync(filePath, `${rows.map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  assert.equal(session.model, "mixed");
+  assert.equal(session.total_tokens, 216);
+  assert.deepEqual(session.model_usage.map((row) => [row.model, row.total_tokens]), [
+    ["gpt-5.6-sol", 120],
+    ["gpt-5.6-luna", 60],
+    ["gpt-5.6-terra", 36],
+  ]);
+  const terra = session.model_usage.find((row) => row.model === "gpt-5.6-terra");
+  assert.equal(terra.model_attribution, "effective");
+  assert.equal(terra.rerouted_usage_events, 1);
+  assert.deepEqual(terra.selected_models, ["gpt-5.6-sol"]);
+  assert.deepEqual(terra.reroute_reasons, ["capacity"]);
+  assert.ok(Math.abs(session.cost_usd - 0.000954) < 1e-12);
+
+  const summary = summarizeSessions([session]);
+  assert.equal(summary.summary.sessions, 1);
+  assert.equal(summary.summary.total_tokens, 216);
+  assert.equal(summary.by_model.length, 3);
+  assert.equal(summary.by_model.reduce((sum, row) => sum + row.total_tokens, 0), 216);
+  assert.match(sessionsToCsv(summary.sessions), /gpt-5\.6-terra/);
+});
+
+test("Codex session analytics preserves the exact GPT-5.6 Sol long-context request subset", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-codex-long-"));
+  const filePath = path.join(dir, "rollout-2026-07-18T09-00-00-00000000-0000-4000-8000-000000000004.jsonl");
+  const usage = {
+    input_tokens: 300_000,
+    cached_input_tokens: 250_000,
+    cache_creation_input_tokens: 0,
+    output_tokens: 10_000,
+    reasoning_output_tokens: 2_000,
+    total_tokens: 310_000,
+  };
+  fs.writeFileSync(filePath, `${[
+    { timestamp: "2026-07-18T09:00:00Z", type: "session_meta", payload: { id: "codex-long", cwd: dir, model_provider: "openai" } },
+    { timestamp: "2026-07-18T09:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-18T09:00:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage, total_token_usage: usage } } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  const modelUsage = session.model_usage[0];
+  assert.equal(modelUsage.input_tokens, 50_000);
+  assert.equal(modelUsage.cached_input_tokens, 250_000);
+  assert.equal(modelUsage.long_context_input_tokens, 50_000);
+  assert.equal(modelUsage.long_context_cached_input_tokens, 250_000);
+  assert.equal(modelUsage.long_context_output_tokens, 10_000);
+  assert.equal(modelUsage.long_context_usage_events, 1);
+  assert.ok(Math.abs(session.cost_usd - 0.9) < 1e-12);
+});
+
 test("efficiency denominators only use sessions that contain edits", () => {
   const summary = summarizeSessions([
     {

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -910,6 +910,9 @@ test("by_model sums tokens and cost exactly while session headcount overlaps by 
     turns.forEach(([model, input, output], index) => {
       running += input + output;
       rows.push({ timestamp: `2026-07-19T08:0${index}:01Z`, type: "turn_context", payload: { turn_id: `turn-${index}`, cwd: dir, model } });
+      // Every turn edits, so edit_turns is non-zero and the edit_* columns below
+      // are actually exercised rather than reconciling 0 against 0.
+      rows.push({ timestamp: `2026-07-19T08:0${index}:01.5Z`, type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } });
       rows.push({ timestamp: `2026-07-19T08:0${index}:02Z`, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(input, output), total_token_usage: usage(running, 0) } } });
     });
     fs.writeFileSync(filePath, `${rows.map(JSON.stringify).join("\n")}\n`);
@@ -921,18 +924,104 @@ test("by_model sums tokens and cost exactly while session headcount overlaps by 
   const single = await scanCodexSession(writeSession(2, [["gpt-5.6-sol", 40, 8]]));
   const summary = summarizeSessions([mixed, single]);
 
-  // Token, cost and edit-turn columns are fully observed per model, so they
+  // Token, cost and edit columns are fully observed per model, so they
   // reconcile with the session totals to the last unit.
   const sum = (key) => summary.by_model.reduce((acc, row) => acc + row[key], 0);
   assert.equal(sum("total_tokens"), summary.summary.total_tokens);
   assert.equal(sum("edit_turns"), summary.summary.edit_turns);
+  assert.equal(sum("edit_tokens"), summary.summary.edit_tokens);
+  assert.equal(sum("retries"), summary.summary.retries);
   assert.ok(Math.abs(sum("cost_usd") - summary.summary.cost_usd) < 1e-12);
+  assert.ok(Math.abs(sum("edit_cost_usd") - summary.summary.edit_cost_usd) < 1e-12);
+  assert.ok(summary.summary.edit_turns > 0);
+  assert.ok(summary.summary.edit_tokens > 0);
 
   // The session headcount deliberately overlaps: the mixed session is counted
   // under both models, so summing this column overstates the real total.
   assert.equal(summary.summary.sessions, 2);
   assert.equal(sum("sessions"), 3);
   assert.equal(summary.session_count, 2);
+});
+
+test("per-model tokens_per_edit divides one model's tokens by that model's own edit turns", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-tokens-per-edit-"));
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const filePath = path.join(dir, "rollout-2026-07-21T08-00-00-00000000-0000-4000-8000-00000000000a.jsonl");
+  const rows = [
+    { timestamp: "2026-07-21T08:00:00Z", type: "session_meta", payload: { id: "codex-tpe", cwd: dir, model_provider: "openai" } },
+  ];
+  let running = 0;
+  // One edit turn per model, but the models spend very different amounts.
+  [["gpt-5.6-sol", 1000, 200], ["gpt-5.6-terra", 500, 100]].forEach(([model, input, output], index) => {
+    running += input + output;
+    rows.push({ timestamp: `2026-07-21T08:0${index}:01Z`, type: "turn_context", payload: { turn_id: `turn-${index}`, cwd: dir, model } });
+    rows.push({ timestamp: `2026-07-21T08:0${index}:01.5Z`, type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } });
+    rows.push({ timestamp: `2026-07-21T08:0${index}:02Z`, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(input, output), total_token_usage: usage(running, 0) } } });
+  });
+  fs.writeFileSync(filePath, `${rows.map(JSON.stringify).join("\n")}\n`);
+
+  const session = await scanCodexSession(filePath);
+  assert.equal(session.edit_turns, 2);
+  const summary = summarizeSessions([session]);
+  const byModel = Object.fromEntries(summary.by_model.map((row) => [row.model, row]));
+
+  // Each turn belongs to exactly one model, so each model owns one edit turn
+  // and its own tokens. Before per-model edit turns the busiest model divided
+  // its 1200 tokens by the whole session's 2 edit turns and reported 600.
+  assert.equal(byModel["gpt-5.6-sol"].edit_turns, 1);
+  assert.equal(byModel["gpt-5.6-terra"].edit_turns, 1);
+  assert.equal(byModel["gpt-5.6-sol"].tokens_per_edit, 1200);
+  assert.equal(byModel["gpt-5.6-terra"].tokens_per_edit, 600);
+  assert.equal(summary.summary.tokens_per_edit, 900);
+});
+
+test("a sidecar without per-model edit turns still sums to the session's edit turns", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-editturn-skew-"));
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const filePath = path.join(dir, "rollout-2026-07-22T08-00-00-00000000-0000-4000-8000-00000000000b.jsonl");
+  const rows = [
+    { timestamp: "2026-07-22T08:00:00Z", type: "session_meta", payload: { id: "codex-skew", cwd: dir, model_provider: "openai" } },
+  ];
+  let running = 0;
+  [["gpt-5.6-sol", 1000, 200], ["gpt-5.6-terra", 500, 100]].forEach(([model, input, output], index) => {
+    running += input + output;
+    rows.push({ timestamp: `2026-07-22T08:0${index}:01Z`, type: "turn_context", payload: { turn_id: `turn-${index}`, cwd: dir, model } });
+    rows.push({ timestamp: `2026-07-22T08:0${index}:01.5Z`, type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } });
+    rows.push({ timestamp: `2026-07-22T08:0${index}:02Z`, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(input, output), total_token_usage: usage(running, 0) } } });
+  });
+  fs.writeFileSync(filePath, `${rows.map(JSON.stringify).join("\n")}\n`);
+
+  // A sidecar written before model_usage carried edit_turns: the rows are
+  // otherwise intact, they just have no per-model turn counts to read.
+  const session = await scanCodexSession(filePath);
+  const stale = {
+    ...session,
+    model_usage: session.model_usage.map(({ edit_turns: _editTurns, ...row }) => row),
+  };
+  const summary = summarizeSessions([stale]);
+  const sum = (key) => summary.by_model.reduce((acc, row) => acc + row[key], 0);
+
+  // The whole residual lands on the busiest model rather than being dropped,
+  // so the column still reconciles and no edit turn goes missing.
+  assert.equal(sum("edit_turns"), summary.summary.edit_turns);
+  assert.equal(sum("edit_tokens"), summary.summary.edit_tokens);
+  const byModel = Object.fromEntries(summary.by_model.map((row) => [row.model, row]));
+  assert.equal(byModel["gpt-5.6-sol"].edit_turns, 2);
+  assert.equal(byModel["gpt-5.6-terra"].edit_turns, 0);
 });
 
 test("sidecar omits reconstructible model_usage fields without losing information", async () => {
@@ -950,6 +1039,9 @@ test("sidecar omits reconstructible model_usage fields without losing informatio
   const rows = [
     { timestamp: "2026-07-20T08:00:00Z", type: "session_meta", payload: { id: "codex-trim", cwd: home, model_provider: "openai" } },
     { timestamp: "2026-07-20T08:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: home, model: "gpt-5.6-sol" } },
+    // Only the first turn edits, so edit_turns is 1 on one row and 0 on the
+    // other - the non-zero value must survive the trim, the zero must not.
+    { timestamp: "2026-07-20T08:00:01.5Z", type: "response_item", payload: { type: "function_call", name: "apply_patch", arguments: "{}" } },
     { timestamp: "2026-07-20T08:00:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(100, 20), total_token_usage: usage(100, 20) } } },
     { timestamp: "2026-07-20T08:01:01Z", type: "turn_context", payload: { turn_id: "turn-2", cwd: home, model: "gpt-5.6-terra" } },
     { timestamp: "2026-07-20T08:01:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(50, 10), total_token_usage: usage(150, 30) } } },
@@ -961,7 +1053,8 @@ test("sidecar omits reconstructible model_usage fields without losing informatio
 
   const cold = await buildSessionAnalytics({ home, force: true });
   const sidecar = fs.readFileSync(path.join(home, ".tokentracker", "tracker", "session.queue.jsonl"), "utf8");
-  const persisted = JSON.parse(sidecar.split("\n").filter(Boolean)[0]).model_usage[0];
+  const persistedRows = JSON.parse(sidecar.split("\n").filter(Boolean)[0]).model_usage;
+  const persisted = persistedRows[0];
 
   // Zero counters, a selected_models that only repeats the model, the default
   // attribution and the recomputed cost are all dropped on write.
@@ -985,4 +1078,13 @@ test("sidecar omits reconstructible model_usage fields without losing informatio
   assert.deepEqual(restored.selected_models, ["gpt-5.6-sol"]);
   assert.equal(restored.model_attribution, "selected");
   assert.equal(restored.long_context_input_tokens, 0);
+
+  // Per-model edit turns follow the same rule: written only when non-zero,
+  // rebuilt as 0 otherwise, and unchanged across the trim.
+  const persistedSol = persistedRows.find((row) => row.model === "gpt-5.6-sol");
+  const persistedTerra = persistedRows.find((row) => row.model === "gpt-5.6-terra");
+  assert.equal(persistedSol.edit_turns, 1);
+  assert.equal(persistedTerra.edit_turns, undefined);
+  assert.equal(restored.edit_turns, 1);
+  assert.equal(warm[0].model_usage.find((row) => row.model === "gpt-5.6-terra").edit_turns, 0);
 });

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -890,3 +890,99 @@ test("Grok does not invent billable tokens from context window occupancy", async
   assert.equal(session.total_tokens, 0);
   assert.equal(listSessionsForBrowser([session]).sessions.length, 0);
 });
+
+test("by_model sums tokens and cost exactly while session headcount overlaps by design", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-bymodel-sum-"));
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const writeSession = (id, turns) => {
+    const filePath = path.join(dir, `rollout-2026-07-19T08-00-00-00000000-0000-4000-8000-00000000000${id}.jsonl`);
+    const rows = [
+      { timestamp: "2026-07-19T08:00:00Z", type: "session_meta", payload: { id: `codex-sum-${id}`, cwd: dir, model_provider: "openai" } },
+    ];
+    let running = 0;
+    turns.forEach(([model, input, output], index) => {
+      running += input + output;
+      rows.push({ timestamp: `2026-07-19T08:0${index}:01Z`, type: "turn_context", payload: { turn_id: `turn-${index}`, cwd: dir, model } });
+      rows.push({ timestamp: `2026-07-19T08:0${index}:02Z`, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(input, output), total_token_usage: usage(running, 0) } } });
+    });
+    fs.writeFileSync(filePath, `${rows.map(JSON.stringify).join("\n")}\n`);
+    return filePath;
+  };
+
+  // One session switches models mid-thread, one stays on a single model.
+  const mixed = await scanCodexSession(writeSession(1, [["gpt-5.6-sol", 100, 20], ["gpt-5.6-terra", 50, 10]]));
+  const single = await scanCodexSession(writeSession(2, [["gpt-5.6-sol", 40, 8]]));
+  const summary = summarizeSessions([mixed, single]);
+
+  // Token, cost and edit-turn columns are fully observed per model, so they
+  // reconcile with the session totals to the last unit.
+  const sum = (key) => summary.by_model.reduce((acc, row) => acc + row[key], 0);
+  assert.equal(sum("total_tokens"), summary.summary.total_tokens);
+  assert.equal(sum("edit_turns"), summary.summary.edit_turns);
+  assert.ok(Math.abs(sum("cost_usd") - summary.summary.cost_usd) < 1e-12);
+
+  // The session headcount deliberately overlaps: the mixed session is counted
+  // under both models, so summing this column overstates the real total.
+  assert.equal(summary.summary.sessions, 2);
+  assert.equal(sum("sessions"), 3);
+  assert.equal(summary.session_count, 2);
+});
+
+test("sidecar omits reconstructible model_usage fields without losing information", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-sidecar-trim-"));
+  const codexDir = path.join(home, ".codex", "sessions", "2026", "07", "20");
+  fs.mkdirSync(codexDir, { recursive: true });
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const rows = [
+    { timestamp: "2026-07-20T08:00:00Z", type: "session_meta", payload: { id: "codex-trim", cwd: home, model_provider: "openai" } },
+    { timestamp: "2026-07-20T08:00:01Z", type: "turn_context", payload: { turn_id: "turn-1", cwd: home, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-20T08:00:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(100, 20), total_token_usage: usage(100, 20) } } },
+    { timestamp: "2026-07-20T08:01:01Z", type: "turn_context", payload: { turn_id: "turn-2", cwd: home, model: "gpt-5.6-terra" } },
+    { timestamp: "2026-07-20T08:01:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(50, 10), total_token_usage: usage(150, 30) } } },
+  ];
+  fs.writeFileSync(
+    path.join(codexDir, "rollout-2026-07-20T08-00-00-00000000-0000-4000-8000-000000000004.jsonl"),
+    `${rows.map(JSON.stringify).join("\n")}\n`,
+  );
+
+  const cold = await buildSessionAnalytics({ home, force: true });
+  const sidecar = fs.readFileSync(path.join(home, ".tokentracker", "tracker", "session.queue.jsonl"), "utf8");
+  const persisted = JSON.parse(sidecar.split("\n").filter(Boolean)[0]).model_usage[0];
+
+  // Zero counters, a selected_models that only repeats the model, the default
+  // attribution and the recomputed cost are all dropped on write.
+  assert.equal(persisted.long_context_input_tokens, undefined);
+  assert.equal(persisted.long_context_usage_events, undefined);
+  assert.equal(persisted.rerouted_usage_events, undefined);
+  assert.equal(persisted.selected_models, undefined);
+  assert.equal(persisted.reroute_reasons, undefined);
+  assert.equal(persisted.model_attribution, undefined);
+  assert.equal(persisted.cost_usd, undefined);
+  assert.ok(persisted.total_tokens > 0);
+
+  // Re-reading the trimmed sidecar rebuilds every dropped field.
+  const warm = await buildSessionAnalytics({ home });
+  assert.deepEqual(
+    warm.map((row) => row.model_usage),
+    cold.map((row) => row.model_usage),
+  );
+  assert.deepEqual(warm.map((row) => row.cost_usd), cold.map((row) => row.cost_usd));
+  const restored = warm[0].model_usage.find((row) => row.model === "gpt-5.6-sol");
+  assert.deepEqual(restored.selected_models, ["gpt-5.6-sol"]);
+  assert.equal(restored.model_attribution, "selected");
+  assert.equal(restored.long_context_input_tokens, 0);
+});

--- a/test/session-analytics.test.js
+++ b/test/session-analytics.test.js
@@ -1024,6 +1024,71 @@ test("a sidecar without per-model edit turns still sums to the session's edit tu
   assert.equal(byModel["gpt-5.6-terra"].edit_turns, 0);
 });
 
+test("model_usage reaches the browser dense whatever the sidecar stored", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-dense-usage-"));
+  const usage = (input, output) => ({
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  });
+  const codexPath = path.join(dir, "rollout-2026-07-23T08-00-00-00000000-0000-4000-8000-00000000000c.jsonl");
+  fs.writeFileSync(codexPath, `${[
+    { timestamp: "2026-07-23T08:00:00Z", type: "session_meta", payload: { id: "codex-dense", cwd: dir, model_provider: "openai" } },
+    { timestamp: "2026-07-23T08:00:01Z", type: "turn_context", payload: { turn_id: "turn-0", cwd: dir, model: "gpt-5.6-sol" } },
+    { timestamp: "2026-07-23T08:00:02Z", type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage(100, 20), total_token_usage: usage(120, 0) } } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  // Claude records never carry model_usage at all, so they exercise the
+  // fallback branch that used to emit a six-field row.
+  const claudePath = path.join(dir, "claude.jsonl");
+  fs.writeFileSync(claudePath, `${[
+    { type: "user", sessionId: "dense-1", cwd: dir, timestamp: "2026-07-23T09:00:00Z", message: { content: "do the thing" } },
+    { type: "assistant", sessionId: "dense-1", cwd: dir, timestamp: "2026-07-23T09:00:01Z", message: { id: "m1", model: "claude-opus-4-8", usage: { input_tokens: 100, output_tokens: 20 }, content: [] } },
+  ].map(JSON.stringify).join("\n")}\n`);
+
+  const codex = await scanCodexSession(codexPath);
+  const claude = await scanClaudeSession(claudePath);
+  assert.equal(Array.isArray(claude.model_usage), false);
+
+  const listed = listSessionsForBrowser([codex, claude]).sessions;
+  assert.equal(listed.length, 2);
+  const keySets = listed.map((row) => {
+    assert.ok(Array.isArray(row.model_usage) && row.model_usage.length > 0);
+    return Object.keys(row.model_usage[0]).sort();
+  });
+
+  // Both producer paths must emit the identical key set, or dashboard/src/lib/
+  // sessions-api.ts is describing a row shape that only one of them sends.
+  assert.deepEqual(keySets[0], keySets[1]);
+  for (const field of [
+    "model",
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_creation_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+    "long_context_input_tokens",
+    "long_context_cached_input_tokens",
+    "long_context_cache_creation_input_tokens",
+    "long_context_output_tokens",
+    "long_context_reasoning_output_tokens",
+    "usage_events",
+    "rerouted_usage_events",
+    "long_context_usage_events",
+    "edit_turns",
+    "selected_models",
+    "reroute_reasons",
+    "model_attribution",
+    "cost_usd",
+  ]) {
+    assert.ok(keySets[0].includes(field), `model_usage row is missing ${field}`);
+  }
+});
+
 test("sidecar omits reconstructible model_usage fields without losing information", async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "tt-session-sidecar-trim-"));
   const codexDir = path.join(home, ".codex", "sessions", "2026", "07", "20");


### PR DESCRIPTION
## Summary

Codex `token_count` events carry no model id, so a session's usage was billed entirely to the last model seen in the file — this attributes every usage event to the model named by the most recent `turn_context`, which Codex emits at the start of every turn and which tracks mid-session model switches exactly.

## Scope

- [x] CLI (`src/`)
- [x] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [x] Commits follow conventional style
- [x] PR description explains *why*, not just *what*

---

## Why

A session that switched models mid-thread had **all** of its tokens attributed to whichever model happened to be selected last. On a local history of 6617 Codex sessions, **501 (7.6%)** are multi-model; at the half-hour-bucket level it is **747 of 1213 codex buckets (61.5%)**. One measured session billed 52.1M tokens entirely to `gpt-5.6-terra` when 12.8M of them belonged to `gpt-5.6-sol` — a ~$5.6 undercount in a single session.

## What changed

**Per-turn attribution.** New `src/lib/codex-model-attribution.js` tracks the selected/effective model across a rollout; `codex-rollout-parser.js` accumulates a per-model usage table, and `rollout.js` persists the attribution state across incremental syncs. Sessions now carry `model_usage[]`; multi-model sessions report as `mixed` and are priced per model.

**Pricing corrections.** GPT-5.6 Sol moves to the official $4/$20 per MTok (from $5/$30), and the bare `gpt-5.6` alias now points at sol rather than terra. All 5 edge-function copies updated; `test/edge-pricing-parity.test.js` passes.

**Partial costs are labelled.** A session whose model has no public rate (mainly `codex-auto-review` — 1733 sessions, 27.5% of local sessions) rendered a bare `≥` in the cost column with nothing explaining it, because the badge that says so was gated behind `isGrok && usage_precision`. That gate now covers any partial cost, with its own copy key (`Partial cost` is a distinct claim from `Partial usage`: every token is observed, only the rate is missing) plus a tooltip. Both keys are localized in zh / zh-TW / ja / ko / de.

**Single-pass Codex scanning.** Delivery-signal collection folds into the token parser's pass via an `onObject` callback instead of reading every rollout file twice.

**Sidecar trimmed.** `SIDECAR_VERSION` 12 → 13. The sidecar is re-read on every dashboard request and a third of it was fields `normalizeModelUsageRows()` reconstructs anyway (zero counters, a `selected_models` that repeats the model, the default attribution, a cost recomputed on read). Omitting them is lossless: 11.9 MB → 9.4 MB on a 6816-session history.

## Two paths are forward-looking, and say so in code

- **`model/rerouted` attribution** — no such event exists in any of **5832** local rollouts (codex-cli 0.151.0). Exact-key search for `"model/rerouted"` and `"model_rerouted"` returns zero files; every loose match is conversation content. The envelope shapes and `fromModel`/`toModel` names are inferred from the app-server protocol, not confirmed against logged data.
- **The 272K long-context tier** — unreachable while Codex reports `model_context_window = 258400` (max raw input observed: 238853). `long_context_*` stays at zero and the repricing never fires.

Also documented: `event_msg/thread_settings_applied` is deliberately **not** used for attribution. It carries `thread_settings.model` but fires when the user picks a model in the UI, seconds to minutes before the switch takes effect, so usage still streaming from the in-flight turn belongs to the previous model. Across 600 rollouts, 12 files / 66 usage events fall in that window. `turn_context` is the only signal that marks where a turn actually begins.

## Verification

`npm run ci:local` passes end to end (exit 0):

```
npm test                 2519 pass / 0 fail  (108 suites)
validate:copy            1536 entries ok
validate:locale          zh + zh-TW 100%
validate:ui-hardcode     ok
validate:guardrails      ok
validate:versions        all match v0.94.1
validate:bot-frames      ok
architecture-guardrails  4 pass
dashboard build          ok

dashboard vitest         675 pass / 96 files
tsc --noEmit             clean
```

Against real logs (6.6 GB, 5832 rollouts), in an isolated `HOME` so no upload happened and no local state was touched:

- Cold sidecar rebuild 22.7s → 6816 sessions; warm read 54ms, summarize 35ms.
- Cold build and warm re-read agree to the cent (**$16135.25** both), and `model_usage` round-trips field for field.
- **Sync stress test, three consecutive runs** (per the repo's data-migration rule): run 1 cold 29.9s / 394 files / 80 buckets; runs 2 and 3 both 1.5s with **0 brand-new buckets**, the only delta being the live half-hour bucket still being written.
- **Three incremental runs == one from-scratch cold sync, exactly**: 2428/2428 settled buckets identical, 20,694,070,852 tokens on both sides. No state pollution.

## Reviewer notes

- **`SIDECAR_VERSION` 12 → 13 forces a full rebuild** on first run after upgrade (~23s on a 6.6 GB history; larger histories will take longer).
- **The 5 edge functions must be deployed** after merge (account-daily / account-summary / account-model-breakdown / leaderboard-profile / leaderboard-refresh).
- **No version bump here.** This touches `src/` and `dashboard/`, so per CLAUDE.md it needs a version bump plus the full npm + DMG + Windows + Linux release; left to the release owner.
- **`by_model.sessions` deliberately overlaps.** A session contributes a row to every model it used, so summing that column overstates the total (7330 vs 6816 locally) while tokens, cost and edit turns reconcile exactly. Nothing sums it today; a comment and a test now pin both halves.
- **4.8% of tokens remain unpriced** — `codex-auto-review` (870M) and `unknown` (473M). Honest rather than silently $0, but still uncovered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session analytics now show usage, tokens, edits, and costs broken down by model, including rerouted models.
  * Added support for tracking usage from Qoder, LM Studio, and Unsloth Studio.
  * Added long-context pricing adjustments for GPT-5.6 usage.
  * Sessions with unavailable model pricing now display clear lower-bound cost indicators.
* **Bug Fixes**
  * Corrected GPT-5.6 Sol pricing and default model mapping.
  * Improved model attribution and ignored invalid zero-total usage records.
* **Localization**
  * Added partial-cost labels and explanations in German, Japanese, Korean, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->