### PR TITLE
fix(windows): publish account usage in background

### DIFF
--- a/TokenTrackerWin.Tests/LocalSyncPublisherTests.cs
+++ b/TokenTrackerWin.Tests/LocalSyncPublisherTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace TokenTrackerWin;
+
+public sealed class LocalSyncPublisherTests
+{
+    [Fact]
+    public async Task AuthenticatesThenPublishesExactBackgroundPayload()
+    {
+        const string baseUrl = "http://127.0.0.1:17680";
+        var requests = new List<CapturedRequest>();
+        using var client = new HttpClient(new ScriptedHandler(async (request, cancellationToken) =>
+        {
+            var body = request.Content is null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            var localAuth = request.Headers.TryGetValues(
+                "x-tokentracker-local-auth", out var values)
+                ? values.SingleOrDefault()
+                : null;
+            requests.Add(new CapturedRequest(request.Method, request.RequestUri!, localAuth, body));
+            return JsonResponse(requests.Count == 1
+                ? "{\"token\":\"local-secret\"}"
+                : "{\"ok\":true}");
+        }));
+
+        var publisher = new LocalSyncPublisher(client, baseUrl);
+        await publisher.PublishAsync();
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal(HttpMethod.Get, requests[0].Method);
+        Assert.Equal(baseUrl + "/api/local-auth", requests[0].Uri.ToString());
+        Assert.Null(requests[0].LocalAuth);
+        Assert.Equal(HttpMethod.Post, requests[1].Method);
+        Assert.Equal(baseUrl + "/functions/tokentracker-local-sync", requests[1].Uri.ToString());
+        Assert.Equal("local-secret", requests[1].LocalAuth);
+        Assert.Equal(
+            "{\"auto\":true,\"background\":true,\"allLocalSources\":true,\"publishAccount\":true,\"nativeOnlyWsl\":true}",
+            requests[1].Body);
+
+        using var document = JsonDocument.Parse(requests[1].Body);
+        var payload = document.RootElement;
+        Assert.Equal(5, payload.EnumerateObject().Count());
+        Assert.True(payload.GetProperty("auto").GetBoolean());
+        Assert.True(payload.GetProperty("background").GetBoolean());
+        Assert.True(payload.GetProperty("allLocalSources").GetBoolean());
+        Assert.True(payload.GetProperty("publishAccount").GetBoolean());
+        Assert.True(payload.GetProperty("nativeOnlyWsl").GetBoolean());
+    }
+
+    [Fact]
+    public async Task RejectsNonSuccessAuthResponseWithoutEchoingResponseBody()
+    {
+        var calls = 0;
+        using var client = new HttpClient(new ScriptedHandler((_, _) =>
+        {
+            calls++;
+            return Task.FromResult(JsonResponse(
+                "{\"error\":\"local-secret\"}",
+                HttpStatusCode.ServiceUnavailable));
+        }));
+
+        var publisher = new LocalSyncPublisher(client, "http://127.0.0.1:17680");
+        var error = await Assert.ThrowsAsync<HttpRequestException>(
+            () => publisher.PublishAsync());
+
+        Assert.Equal(1, calls);
+        Assert.DoesNotContain("local-secret", error.Message);
+    }
+
+    [Fact]
+    public async Task RejectsMissingAuthTokenWithoutEchoingResponseBody()
+    {
+        using var client = new HttpClient(new ScriptedHandler((_, _) =>
+            Task.FromResult(JsonResponse("{\"error\":\"local-secret\"}"))));
+
+        var publisher = new LocalSyncPublisher(client, "http://127.0.0.1:17680");
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => publisher.PublishAsync());
+
+        Assert.Equal("Local auth response did not include a token.", error.Message);
+        Assert.DoesNotContain("local-secret", error.Message);
+    }
+
+    [Fact]
+    public async Task PropagatesCancellationDuringPost()
+    {
+        var postStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        using var client = new HttpClient(new ScriptedHandler(async (request, cancellationToken) =>
+        {
+            calls++;
+            if (calls == 1) return JsonResponse("{\"token\":\"local-secret\"}");
+
+            postStarted.SetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("unreachable");
+        }));
+
+        var publisher = new LocalSyncPublisher(client, "http://127.0.0.1:17680");
+        using var cancellation = new CancellationTokenSource();
+        var publishTask = publisher.PublishAsync(cancellation.Token);
+        await postStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => publishTask);
+        Assert.Equal(2, calls);
+    }
+
+    private static HttpResponseMessage JsonResponse(
+        string body,
+        HttpStatusCode status = HttpStatusCode.OK)
+        => new(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed record CapturedRequest(
+        HttpMethod Method,
+        Uri Uri,
+        string? LocalAuth,
+        string Body);
+
+    private sealed class ScriptedHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> script)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => script(request, cancellationToken);
+    }
+}

--- a/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
+++ b/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <Compile Include="../TokenTrackerWin/ChildProcessProxy.cs" Link="ChildProcessProxy.cs" />
+    <Compile Include="../TokenTrackerWin/LocalSyncPublisher.cs" Link="LocalSyncPublisher.cs" />
     <Compile Include="../TokenTrackerWin/ResumableDownloader.cs" Link="ResumableDownloader.cs" />
   </ItemGroup>
 

--- a/TokenTrackerWin/LocalSyncPublisher.cs
+++ b/TokenTrackerWin/LocalSyncPublisher.cs
@@ -1,0 +1,77 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+namespace TokenTrackerWin;
+
+/// <summary>
+/// Performs the authenticated loopback exchange used by native background sync.
+/// Keeping this protocol separate from the process lifecycle makes the request
+/// ordering, flags, and cancellation behavior independently testable.
+/// </summary>
+internal sealed class LocalSyncPublisher
+{
+    private const string LocalAuthHeader = "x-tokentracker-local-auth";
+    private const string BackgroundSyncBody =
+        "{\"auto\":true,\"background\":true,\"allLocalSources\":true,\"publishAccount\":true,\"nativeOnlyWsl\":true}";
+
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public LocalSyncPublisher(HttpClient httpClient, string baseUrl)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new ArgumentException("A loopback base URL is required.", nameof(baseUrl));
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    public async Task PublishAsync(CancellationToken cancellationToken = default)
+    {
+        using var authResponse = await _httpClient.GetAsync(
+            _baseUrl + "/api/local-auth",
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        authResponse.EnsureSuccessStatusCode();
+
+        var authPayload = await authResponse.Content.ReadAsStringAsync(cancellationToken);
+        var localAuthToken = ReadLocalAuthToken(authPayload);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            _baseUrl + "/functions/tokentracker-local-sync");
+        request.Headers.TryAddWithoutValidation(LocalAuthHeader, localAuthToken);
+        request.Content = new StringContent(BackgroundSyncBody, Encoding.UTF8, "application/json");
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        // The local API writes its response after the sync child exits. Consume
+        // it so PublishAsync does not complete before that child is finished.
+        await response.Content.ReadAsStringAsync(cancellationToken);
+    }
+
+    private static string ReadLocalAuthToken(string payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            if (document.RootElement.ValueKind == JsonValueKind.Object &&
+                document.RootElement.TryGetProperty("token", out var tokenElement) &&
+                tokenElement.ValueKind == JsonValueKind.String)
+            {
+                var token = tokenElement.GetString();
+                if (!string.IsNullOrWhiteSpace(token)) return token;
+            }
+        }
+        catch (JsonException)
+        {
+            // Convert malformed auth responses to the same safe protocol error
+            // without echoing a response body that could contain credentials.
+        }
+
+        throw new InvalidOperationException("Local auth response did not include a token.");
+    }
+}

--- a/TokenTrackerWin/ServerManager.cs
+++ b/TokenTrackerWin/ServerManager.cs
@@ -39,6 +39,8 @@ internal sealed class ServerManager : IDisposable
 
     private Process? _serverProcess;
     private Process? _syncProcess;
+    private CancellationTokenSource? _backgroundSyncCts;
+    private bool _syncInFlight;
     private readonly object _syncLock = new();
     private readonly JobObject _job = new();
     private CancellationTokenSource? _healthCts;
@@ -48,6 +50,14 @@ internal sealed class ServerManager : IDisposable
     // app then thinks startup failed even though the server is up. UseProxy=false = direct.
     private static readonly HttpClient Http =
         new(new HttpClientHandler { UseProxy = false }) { Timeout = TimeSpan.FromSeconds(3) };
+
+    // The local API owns its configured network timeouts (which may be
+    // unbounded) and its 120s sync-child timeout. Do not impose a finite
+    // native timeout that could release the single-flight slot while the
+    // server is still publishing; shutdown cancels this request and kills the
+    // server/child process instead.
+    private static readonly HttpClient LocalSyncHttp =
+        new(new HttpClientHandler { UseProxy = false }) { Timeout = Timeout.InfiniteTimeSpan };
 
     /// <summary>Raised on the thread-pool when the running state flips. UI must marshal to the UI thread.</summary>
     public event Action<ServerStatus>? StatusChanged;
@@ -90,31 +100,43 @@ internal sealed class ServerManager : IDisposable
     /// <summary>Run a one-shot `tracker sync` against the resolved runtime.</summary>
     public void TriggerSync()
     {
-        StartSync(auto: false);
+        StartDirectSync();
     }
 
     /// <summary>Run a quiet, non-overlapping background sync for live tray totals.</summary>
     public void TriggerBackgroundSync()
     {
-        StartSync(auto: true);
+        CancellationTokenSource cts;
+        lock (_syncLock)
+        {
+            if (_syncInFlight) return;
+
+            cts = new CancellationTokenSource();
+            _backgroundSyncCts = cts;
+            _syncInFlight = true;
+            SyncStarted?.Invoke();
+        }
+
+        // Keep the timer/UI thread free while the local API runs the sync child.
+        _ = RunBackgroundSyncAsync(cts);
     }
 
-    private bool StartSync(bool auto)
+    private bool StartDirectSync()
     {
         var runtime = FindEmbeddedServer() ?? FindDevServer() ?? FindRepoDevServer();
         if (runtime is null) return false;
 
         lock (_syncLock)
         {
-            if (_syncProcess is { HasExited: false }) return false;
+            if (_syncInFlight) return false;
 
-            var args = auto
-                ? new[] { "sync", "--auto", "--background" }
-                : new[] { "sync" };
+            var args = new[] { "sync" };
             var proc = StartTrackerProcess(
-                runtime.Value.NodePath, runtime.Value.EntryPath, auto, args);
+                runtime.Value.NodePath, runtime.Value.EntryPath,
+                false, args);
             if (proc is null) return false;
 
+            _syncInFlight = true;
             _syncProcess = proc;
             proc.EnableRaisingEvents = true;
             proc.Exited += (_, _) =>
@@ -124,12 +146,40 @@ internal sealed class ServerManager : IDisposable
                 lock (_syncLock)
                 {
                     if (ReferenceEquals(_syncProcess, proc)) _syncProcess = null;
+                    _syncInFlight = false;
                 }
                 try { proc.Dispose(); } catch { }
                 SyncCompleted?.Invoke();
             };
             SyncStarted?.Invoke();
             return true;
+        }
+    }
+
+    private async Task RunBackgroundSyncAsync(CancellationTokenSource cts)
+    {
+        try
+        {
+            await new LocalSyncPublisher(LocalSyncHttp, BaseUrl).PublishAsync(cts.Token);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            Log("background sync cancelled");
+        }
+        catch (Exception ex)
+        {
+            // Never include the local-auth response/header in diagnostics.
+            Log($"background sync failed ({ex.GetType().Name})");
+        }
+        finally
+        {
+            lock (_syncLock)
+            {
+                if (ReferenceEquals(_backgroundSyncCts, cts)) _backgroundSyncCts = null;
+                _syncInFlight = false;
+            }
+            cts.Dispose();
+            SyncCompleted?.Invoke();
         }
     }
 
@@ -146,6 +196,14 @@ internal sealed class ServerManager : IDisposable
                 catch { /* already gone */ }
             }
             _syncProcess = null;
+        }
+
+        // Cancel an in-flight authenticated background request without waiting
+        // on the UI thread. The server process is killed below as part of the
+        // same shutdown path.
+        lock (_syncLock)
+        {
+            _backgroundSyncCts?.Cancel();
         }
 
         if (_serverProcess is { HasExited: false } p)

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1936,6 +1936,9 @@ function createLocalApiHandler({ queuePath }) {
         const publishAccount =
           background && body.publishAccount === true && getCloudSyncPref();
         const allLocalSources = background && body.allLocalSources === true;
+        if (background && body.nativeOnlyWsl === true) {
+          extraEnv.TOKENTRACKER_WSL_MODE = "native-only";
+        }
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
         }

--- a/test/local-api-background.test.js
+++ b/test/local-api-background.test.js
@@ -156,7 +156,7 @@ function installDeviceTokenFetch(fetchCalls) {
 }
 
 test("local-api forwards strict boolean auto background sync", async () => {
-  const call = await runLocalSync({ auto: true, background: true });
+  const call = await runLocalSync({ auto: true, background: true, nativeOnlyWsl: true });
   const args = call.args;
   assert.deepEqual(args.slice(-4), [
     path.join(process.cwd(), "bin/tracker.js"),
@@ -164,6 +164,7 @@ test("local-api forwards strict boolean auto background sync", async () => {
     "--auto",
     "--background",
   ]);
+  assert.equal(call.options.env.TOKENTRACKER_WSL_MODE, "native-only");
 });
 
 test("local-api treats lightweight true as background alias", async () => {
@@ -216,6 +217,33 @@ test("local-api background and lightweight require boolean true", async () => {
       "--auto",
       "--wait-for-lock",
     ]);
+  }
+});
+
+test("local-api only propagates native-only WSL for strict boolean background requests", async () => {
+  const previousWslMode = process.env.TOKENTRACKER_WSL_MODE;
+  delete process.env.TOKENTRACKER_WSL_MODE;
+
+  try {
+    const cases = [
+      {
+        body: { auto: true, background: true, nativeOnlyWsl: true },
+        expected: "native-only",
+      },
+      { body: { auto: true, background: true, nativeOnlyWsl: false }, expected: undefined },
+      { body: { auto: true, background: true, nativeOnlyWsl: "true" }, expected: undefined },
+      { body: { auto: true, background: false, nativeOnlyWsl: true }, expected: undefined },
+      { body: { auto: true, nativeOnlyWsl: true }, expected: undefined },
+      { body: { nativeOnlyWsl: true }, expected: undefined },
+    ];
+
+    for (const { body, expected } of cases) {
+      const call = await runLocalSync(body);
+      assert.equal(call.options.env.TOKENTRACKER_WSL_MODE, expected, JSON.stringify(body));
+    }
+  } finally {
+    if (previousWslMode === undefined) delete process.env.TOKENTRACKER_WSL_MODE;
+    else process.env.TOKENTRACKER_WSL_MODE = previousWslMode;
   }
 });
 

--- a/test/windows-background-sync-args.test.js
+++ b/test/windows-background-sync-args.test.js
@@ -9,8 +9,9 @@ function read(relPath) {
   return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
 }
 
-test("Windows background sync stays native-only while manual sync preserves WSL mode", () => {
+test("Windows background and manual sync keep separate execution paths", () => {
   const serverManager = read("TokenTrackerWin/ServerManager.cs");
+  const publisher = read("TokenTrackerWin/LocalSyncPublisher.cs");
   const trayContext = read("TokenTrackerWin/TrayApplicationContext.cs");
 
   assert.match(
@@ -30,32 +31,44 @@ test("Windows background sync stays native-only while manual sync preserves WSL 
   );
   assert.match(
     serverManager,
-    /public void TriggerBackgroundSync\(\)[\s\S]*StartSync\(auto: true\);/,
-    "Windows background sync should select the auto path",
+    /public void TriggerBackgroundSync\(\)[\s\S]*RunBackgroundSyncAsync\(cts\)/,
+    "Windows background sync should select the asynchronous local API path",
   );
   assert.match(
     serverManager,
-    /auto\s*\?\s*new\[\]\s*\{\s*"sync",\s*"--auto",\s*"--background"\s*\}\s*:\s*new\[\]\s*\{\s*"sync"\s*\}/,
-    "Windows background args should use sync --auto --background while manual sync remains plain sync",
+    /new LocalSyncPublisher\(\s*LocalSyncHttp,\s*BaseUrl\s*\)\.PublishAsync\(/,
+    "Windows background sync should authenticate before posting all background flags",
   );
+  assert.match(
+    publisher,
+    /\/api\/local-auth/,
+    "The extracted publisher should own the authenticated background request",
+  );
+  assert.match(publisher, /\/functions\/tokentracker-local-sync/);
+  assert.match(publisher, /nativeOnlyWsl/);
+  const backgroundMethod = serverManager.match(
+    /public void TriggerBackgroundSync\(\)[\s\S]*?\n    \}\r?\n\r?\n    private bool StartDirectSync/,
+  )?.[0];
+  assert.ok(backgroundMethod, "background sync method should remain discoverable");
   assert.doesNotMatch(
-    serverManager,
-    /new\[\]\s*\{\s*"sync",\s*"--auto"\s*\}/,
-    "Windows background sync must not retain the bare sync --auto pattern",
+    backgroundMethod,
+    /StartDirectSync\(\)/,
+    "Windows background sync must not launch a second direct tracker process",
   );
   assert.match(
     serverManager,
-    /StartTrackerProcess\(\s*runtime\.Value\.NodePath,\s*runtime\.Value\.EntryPath,\s*auto,\s*args\)/,
-    "Only the auto/background sync path should request native-only WSL isolation",
+    /public void TriggerSync\(\)[\s\S]*StartDirectSync\(\)/,
+    "Manual sync should keep the direct tracker process path",
+  );
+  assert.match(
+    serverManager,
+    /var args = new\[\] \{ "sync" \};[\s\S]*StartTrackerProcess\([\s\S]*\n\s*false,\s*args\)/,
+    "Manual sync should remain exhaustive plain sync and preserve the user's WSL mode",
   );
   assert.match(
     serverManager,
     /if \(forceNativeOnlyWslMode\)[\s\S]*psi\.Environment\["TOKENTRACKER_WSL_MODE"\]\s*=\s*"native-only";/,
-    "The Windows child launcher should override WSL mode for isolated background syncs",
+    "The child launcher should retain the explicit WSL environment hook for authorized paths",
   );
-  assert.match(
-    serverManager,
-    /StartTrackerProcess\(\s*nodePath,\s*entryPath,\s*false,\s*"serve"/,
-    "The long-lived server must not receive the background-only WSL override",
-  );
+  assert.match(serverManager, /StartTrackerProcess\(\s*nodePath,\s*entryPath,\s*false,\s*"serve"/);
 });

--- a/test/windows-background-sync-source.test.js
+++ b/test/windows-background-sync-source.test.js
@@ -9,8 +9,9 @@ function read(relPath) {
   return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
 }
 
-test("Windows high-frequency background sync uses explicit background args", () => {
+test("Windows background sync publishes through the authenticated local API", () => {
   const serverManager = read("TokenTrackerWin/ServerManager.cs");
+  const publisher = read("TokenTrackerWin/LocalSyncPublisher.cs");
   const trayContext = read("TokenTrackerWin/TrayApplicationContext.cs");
 
   assert.match(trayContext, /new\(\)\s*\{\s*Interval\s*=\s*5\s*\*\s*60\s*\*\s*1000\s*\}/);
@@ -19,10 +20,38 @@ test("Windows high-frequency background sync uses explicit background args", () 
     trayContext,
     /ServerStatus\.Running[\s\S]*_syncTimer\.Start\(\);[\s\S]*TriggerBackgroundSync\(\);/,
   );
-  assert.match(serverManager, /public void TriggerBackgroundSync\(\)[\s\S]*StartSync\(auto: true\);/);
   assert.match(
     serverManager,
-    /auto\s*\?\s*new\[\]\s*\{\s*"sync",\s*"--auto",\s*"--background"\s*\}\s*:\s*new\[\]\s*\{\s*"sync"\s*\}/,
+    /public void TriggerBackgroundSync\(\)[\s\S]*RunBackgroundSyncAsync\(cts\)/,
+    "Windows timer sync should run asynchronously through the local API",
   );
-  assert.doesNotMatch(serverManager, /new\[\]\s*\{\s*"sync",\s*"--auto"\s*\}/);
+  assert.match(
+    serverManager,
+    /new LocalSyncPublisher\(\s*LocalSyncHttp,\s*BaseUrl\s*\)\.PublishAsync\(/,
+    "ServerManager should delegate the authenticated exchange to the tested publisher",
+  );
+  assert.match(publisher, /\/api\/local-auth/);
+  assert.match(
+    publisher,
+    /HttpMethod\.Post[\s\S]*\/functions\/tokentracker-local-sync/,
+  );
+  assert.match(publisher, /x-tokentracker-local-auth/);
+  assert.match(
+    publisher,
+    /"\{\\"auto\\":true,\\"background\\":true,\\"allLocalSources\\":true,\\"publishAccount\\":true,\\"nativeOnlyWsl\\":true\}"/,
+    "Windows background sync should publish all local sources and request native-only WSL",
+  );
+  assert.match(
+    serverManager,
+    /LocalSyncHttp[\s\S]*UseProxy\s*=\s*false[\s\S]*Timeout\s*=\s*Timeout\.InfiniteTimeSpan/,
+    "Background local sync must let the server own its complete budget and cancel on shutdown",
+  );
+  assert.match(serverManager, /SyncStarted\?\.Invoke\(\)/);
+  assert.match(serverManager, /SyncCompleted\?\.Invoke\(\)/);
+  assert.match(serverManager, /public void TriggerSync\(\)[\s\S]*StartDirectSync\(\)/);
+  assert.match(
+    serverManager,
+    /var args = new\[\] \{ "sync" \};[\s\S]*StartTrackerProcess\([\s\S]*\n\s*false,\s*args\)/,
+    "Manual sync should remain the direct exhaustive plain sync path",
+  );
 });


### PR DESCRIPTION
## Summary

Keep Windows account usage current while the dashboard is hidden by routing the five-minute native background sync through the authenticated local publication endpoint.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [x] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Why

On Windows v0.94.1, the raw session files, V2 parser cursor, local queue, and local usage API could all be current while the signed-in account view remained several days behind. The native host log showed the five-minute timer repeatedly exiting successfully with:

`sync --auto --background`

That path intentionally performs local parsing only. Account publication requires `--publish-account` plus an ephemeral device token, so a tray-only Windows session never advanced its cloud upload offset. Opening the dashboard could make one bounded upload attempt, but it was not a periodic publisher and a large backlog stayed stale.

This is independent of #551: that PR fixes the ingest anon-key value after publication starts; this PR fixes the missing Windows publication trigger itself.

## What changed

- Windows background refresh now uses loopback `GET /api/local-auth` followed by an authenticated `POST /functions/tokentracker-local-sync`.
- The request asks for `auto`, `background`, `allLocalSources`, `publishAccount`, and `nativeOnlyWsl` as strict booleans.
- The local API accepts `nativeOnlyWsl` only for a real background request and passes `TOKENTRACKER_WSL_MODE=native-only` to the child.
- Manual Windows sync remains the existing direct exhaustive path, including its WSL behavior.
- Background and manual sync share a single-flight gate; shutdown cancels the request and terminates the server process tree.
- The local auth token is held only for the request and is never logged or persisted by the native client.
- `LocalSyncPublisher` is covered by executable xUnit tests rather than source-text assertions alone.

## Checklist

- [ ] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no new strings)
- [x] Commits follow conventional style (`fix(windows): ...`)
- [x] PR description explains *why*, not just *what*

## Verification

- `node --test test/windows-background-sync-source.test.js test/windows-background-sync-args.test.js test/local-api-background.test.js test/local-api-security.test.js` — 37 passed
- `npm run validate:copy` — passed (existing unused-key warnings only)
- `npm run validate:locale` — passed
- `npm run validate:ui-hardcode` — passed
- `npm run validate:guardrails` — passed
- `npm run validate:versions` — passed
- `node --test test/architecture-guardrails.test.js` — 4 passed
- `npm --prefix dashboard run build` — passed
- Full `npm test` was attempted locally on Windows/Node 25; unrelated host- and timing-dependent baseline tests fail in this environment. The changed-scope tests above are green.
- Local .NET test/build could not run because this machine has the .NET runtime but no SDK; the Windows CI job is the authoritative compile/xUnit check.

---

<details open>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

### Rules / invariants

- Local mutation still requires the per-process local-auth token.
- Cloud publication remains gated by the server-side persisted cloud-sync preference.
- Windows background scans remain native-only with respect to WSL; manual sync remains exhaustive.
- A native client timeout must not release the single-flight slot while the server child is still running, so the local endpoint owns its configured request/child budgets and app shutdown provides cancellation.
- No prompt, response, auth token, or response body is logged.

### Boundary matrix

- Signed in + cloud sync enabled: background scan mints/reuses a device token and publishes bounded batches.
- Signed out or no refresh token: local background parsing continues; no account upload occurs.
- Cloud sync disabled: the server suppresses `publishAccount` even though the native request asks for it.
- Non-boolean or foreground `nativeOnlyWsl`: ignored; no environment override is injected.
- Timer fires during manual/background sync: request is skipped by the shared single-flight gate.
- App exits during publication: CTS cancellation and server process-tree termination prevent an orphaned native operation.

</details>

<details open>
<summary><strong>Codex review context</strong></summary>

- **Delta since last Codex review:** extracted and unit-tested `LocalSyncPublisher`; replaced a too-short client timeout with server-owned lifetime plus shutdown cancellation.
- **Intended behavior / invariants:** periodic Windows account publication without changing local parsing, privacy, cloud opt-out, or manual WSL semantics.
- **Edge cases covered:** exact request order/body/header, non-success auth response, missing token, cancellation, strict boolean WSL override, disabled cloud sync, no refresh token, and overlapping native sync calls.
- **Tests run:** listed above.
- **Known gaps / out of scope:** existing backlog drains in bounded batches across timer ticks; provider-parser risks and #551's anon-key propagation are separate changes.

### Most likely regression surface

Windows native sync lifecycle, loopback local-auth exchange, shutdown cancellation, and WSL background isolation.

### Verification method

Focused Node contract tests, executable xUnit HTTP protocol tests in CI, Windows Release build in CI, and a privacy-preserving live data-flow reproduction.

### Uncovered scope

Local .NET compilation is pending CI because no SDK is installed on the reproducing machine.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background synchronization now uses an authenticated local connection and publishes comprehensive local-source updates.
  * Added native-only WSL handling for background synchronization.
  * Manual synchronization continues to use its existing direct execution behavior.

* **Bug Fixes**
  * Improved cancellation and shutdown handling for background synchronization.
  * Prevented authentication response contents from being exposed in errors.

* **Tests**
  * Added coverage for authentication, payloads, cancellation, error handling, and native-only WSL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->