### PR TITLE
fix: stop a transient cloud failure from downgrading account views to one device

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift
@@ -81,7 +81,34 @@ struct AccountViewStateStore {
         case modelBreakdown
     }
 
-    private var sourceByDataset: [Dataset: AccountViewSource] = [:]
+    /// Identifies the query a dataset's authority was recorded for.
+    ///
+    /// Authority is only meaningful for the exact scope it was observed on.
+    /// `.periodSummary` / `.modelBreakdown` / `.monthly` follow the selected
+    /// period, and the day-scoped views follow the calendar day. Without this,
+    /// a retained account snapshot from the previous period outranks a fresh
+    /// response for the new one, and the panel keeps last period's numbers
+    /// under this period's label.
+    ///
+    /// Windows that merely slide (rolling 30d, all-time, the year heatmap) use
+    /// a constant scope on purpose: there the one-day shift is a rounding
+    /// difference, and rekeying them at midnight would hand a transient cloud
+    /// failure a fresh chance to downgrade an account view to this machine.
+    enum Scope {
+        static let rolling30 = "rolling30"
+        static let total = "total"
+        static let daily30 = "daily30"
+        static let heatmap = "heatmap"
+        static func day(_ day: String) -> String { "day:\(day)" }
+        static func range(_ from: String, _ to: String) -> String { "range:\(from)..\(to)" }
+    }
+
+    private struct Record {
+        let source: AccountViewSource
+        let scope: String
+    }
+
+    private var recordByDataset: [Dataset: Record] = [:]
     private(set) var degradedDatasets: Set<Dataset> = []
 
     /// True while at least one dataset is running on (or holding onto data
@@ -92,32 +119,42 @@ struct AccountViewStateStore {
     /// because the cloud is unreachable — i.e. cold start with no account
     /// snapshot to fall back on.
     func showsTransientLocalData(_ dataset: Dataset) -> Bool {
-        sourceByDataset[dataset]?.isTransientFallback ?? false
+        recordByDataset[dataset]?.source.isTransientFallback ?? false
     }
 
     /// Decide whether an incoming payload should replace what is on screen.
+    /// - Parameter scope: identifies the query this response answers. A record
+    ///   held for a different scope describes data the view no longer asks for.
     /// - Parameter hasExistingValue: whether the view model already holds a
     ///   rendered payload for this dataset.
     /// - Returns: true to publish the new payload, false to keep the old one.
     mutating func shouldAdopt(
         _ source: AccountViewSource,
         for dataset: Dataset,
+        scope: String,
         hasExistingValue: Bool
     ) -> Bool {
+        // Drop authority recorded for a scope the view has since left, so the
+        // retained-snapshot rule below can never answer for the wrong period.
+        if let record = recordByDataset[dataset], record.scope != scope {
+            recordByDataset.removeValue(forKey: dataset)
+            degradedDatasets.remove(dataset)
+        }
         guard source.isTransientFallback else {
             degradedDatasets.remove(dataset)
-            sourceByDataset[dataset] = source
+            recordByDataset[dataset] = Record(source: source, scope: scope)
             return true
         }
         degradedDatasets.insert(dataset)
-        if hasExistingValue, sourceByDataset[dataset]?.isAccount == true {
+        if hasExistingValue, recordByDataset[dataset]?.source.isAccount == true {
             // Keep the account snapshot and its authority; this failure is
             // temporary and a retry is scheduled.
             return false
         }
-        // Nothing better to show (cold start, or we were already local):
-        // this-machine data beats an empty panel, but stays marked degraded.
-        sourceByDataset[dataset] = source
+        // Nothing better to show (cold start, a scope we have no account
+        // snapshot for, or we were already local): this-machine data beats an
+        // empty panel, but stays marked degraded.
+        recordByDataset[dataset] = Record(source: source, scope: scope)
         return true
     }
 
@@ -125,7 +162,7 @@ struct AccountViewStateStore {
     /// a non-day period is selected). Without this its degraded flag would
     /// linger forever, because nothing ever fetches it again to clear it.
     mutating func clear(_ dataset: Dataset) {
-        sourceByDataset.removeValue(forKey: dataset)
+        recordByDataset.removeValue(forKey: dataset)
         degradedDatasets.remove(dataset)
     }
 }

--- a/TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Where one popover dataset actually came from, as reported by the local
+/// server through `X-TokenTracker-Account-View` (+ `X-TokenTracker-Account-Fallback`).
+///
+/// The distinction that matters: the local server answers `?account=1` with
+/// this-machine data both when that is genuinely the user's scope (signed out,
+/// cloud sync off) and when a cloud read merely failed (timeout, offline,
+/// token refresh error). Both used to arrive as an indistinguishable HTTP 200,
+/// so a single slow cloud read silently shrank the popover's Activity heatmap
+/// from every device to this Mac until the next manual sync.
+enum AccountViewSource: Equatable {
+    /// Cross-device account aggregate.
+    case account
+    /// This-machine data, and that is the correct scope right now.
+    case localAuthoritative(reason: String)
+    /// This-machine data only because the cloud read failed. Whatever account
+    /// snapshot we already hold is still the better answer.
+    case localTransient(reason: String)
+
+    var isAccount: Bool { self == .account }
+
+    var isTransientFallback: Bool {
+        if case .localTransient = self { return true }
+        return false
+    }
+
+    /// Diagnostic label — safe to log (no tokens, no usage figures).
+    var reason: String {
+        switch self {
+        case .account: return "account"
+        case .localAuthoritative(let reason): return reason
+        case .localTransient(let reason): return reason
+        }
+    }
+
+    /// Parse the pair of response headers. Returns nil when the server did not
+    /// tag the response at all, which means it never ran the account path.
+    static func parse(accountView: String?, fallback: String?) -> AccountViewSource? {
+        switch accountView {
+        case "1":
+            return .account
+        case "0":
+            let reason = (fallback ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            // Any `transient-*` reason is a temporary cloud failure. Matching on
+            // the prefix lets the server add reasons without a client change.
+            if reason.hasPrefix("transient") { return .localTransient(reason: reason) }
+            // An older embedded/global server sends no fallback header. Treating
+            // the absence as authoritative keeps the pre-fix behaviour.
+            return .localAuthoritative(reason: reason.isEmpty ? "unspecified" : reason)
+        default:
+            return nil
+        }
+    }
+
+    /// Publication authority for the menu-bar summary slots.
+    var summaryViewSource: UsageSummaryViewSource {
+        self == .account ? .accountUpload : .localQueue
+    }
+}
+
+/// A decoded payload plus the authority it was served with.
+struct AccountFetchResult<Value> {
+    let value: Value
+    let source: AccountViewSource
+    let completedAt: Date
+}
+
+/// Per-dataset guard against silently downgrading an account (cross-device)
+/// view to this-machine data because one cloud read failed.
+struct AccountViewStateStore {
+    enum Dataset: Hashable, CaseIterable {
+        case todaySummary
+        case periodSummary
+        case rollingSummary
+        case totalSummary
+        case daily
+        case hourly
+        case monthly
+        case heatmap
+        case modelBreakdown
+    }
+
+    private var sourceByDataset: [Dataset: AccountViewSource] = [:]
+    private(set) var degradedDatasets: Set<Dataset> = []
+
+    /// True while at least one dataset is running on (or holding onto data
+    /// because of) a transient cloud failure.
+    var isDegraded: Bool { !degradedDatasets.isEmpty }
+
+    /// True when this dataset is currently *showing* this-machine data only
+    /// because the cloud is unreachable — i.e. cold start with no account
+    /// snapshot to fall back on.
+    func showsTransientLocalData(_ dataset: Dataset) -> Bool {
+        sourceByDataset[dataset]?.isTransientFallback ?? false
+    }
+
+    /// Decide whether an incoming payload should replace what is on screen.
+    /// - Parameter hasExistingValue: whether the view model already holds a
+    ///   rendered payload for this dataset.
+    /// - Returns: true to publish the new payload, false to keep the old one.
+    mutating func shouldAdopt(
+        _ source: AccountViewSource,
+        for dataset: Dataset,
+        hasExistingValue: Bool
+    ) -> Bool {
+        guard source.isTransientFallback else {
+            degradedDatasets.remove(dataset)
+            sourceByDataset[dataset] = source
+            return true
+        }
+        degradedDatasets.insert(dataset)
+        if hasExistingValue, sourceByDataset[dataset]?.isAccount == true {
+            // Keep the account snapshot and its authority; this failure is
+            // temporary and a retry is scheduled.
+            return false
+        }
+        // Nothing better to show (cold start, or we were already local):
+        // this-machine data beats an empty panel, but stays marked degraded.
+        sourceByDataset[dataset] = source
+        return true
+    }
+
+    /// Forget a dataset the view intentionally emptied (e.g. hourly data while
+    /// a non-day period is selected). Without this its degraded flag would
+    /// linger forever, because nothing ever fetches it again to clear it.
+    mutating func clear(_ dataset: Dataset) {
+        sourceByDataset.removeValue(forKey: dataset)
+        degradedDatasets.remove(dataset)
+    }
+}

--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -2,8 +2,12 @@ import Foundation
 
 struct UsageSummaryFetchResult {
     let summary: UsageSummaryResponse
-    let source: UsageSummaryViewSource
+    /// Full authority, including *why* a local payload was served.
+    let accountSource: AccountViewSource
     let completedAt: Date
+    /// Publication authority for the menu-bar summary slots — derived, so it
+    /// can never disagree with `accountSource`.
+    var source: UsageSummaryViewSource { accountSource.summaryViewSource }
 }
 
 actor APIClient {
@@ -43,49 +47,39 @@ actor APIClient {
 	}
 
     func fetchSummaryWithSource(from: String, to: String) async throws -> UsageSummaryFetchResult {
-        let (data, response) = try await request(
+        let result: AccountFetchResult<UsageSummaryResponse> = try await fetchWithSource(
             "/functions/tokentracker-usage-summary",
             queryItems: withAccountQueryItems([
                 URLQueryItem(name: "from", value: from),
                 URLQueryItem(name: "to", value: to)
             ])
         )
-        let source: UsageSummaryViewSource
-        switch response.value(forHTTPHeaderField: "X-TokenTracker-Account-View") {
-        case "1":
-            source = .accountUpload
-        case "0":
-            source = .localQueue
-        default:
-            throw APIError.invalidResponse
-        }
-        let completedAt = Date()
-        if source == .accountUpload {
+        let completedAt = result.completedAt
+        if result.source.isAccount {
             latestAccountSummaryReadCompletedAt = completedAt
         }
-        let summary = try decoder.decode(UsageSummaryResponse.self, from: data)
         return UsageSummaryFetchResult(
-            summary: summary,
-            source: source,
+            summary: result.value,
+            accountSource: result.source,
             completedAt: completedAt
         )
     }
 
-	func fetchDaily(from: String, to: String) async throws -> DailyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-daily", queryItems: withAccountQueryItems([
+	func fetchDaily(from: String, to: String) async throws -> AccountFetchResult<DailyUsageResponse> {
+		try await fetchWithSource("/functions/tokentracker-usage-daily", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
-	func fetchHeatmap(weeks: Int = 52) async throws -> HeatmapResponse {
-		try await fetch("/functions/tokentracker-usage-heatmap", queryItems: withAccountQueryItems([
+	func fetchHeatmap(weeks: Int = 52) async throws -> AccountFetchResult<HeatmapResponse> {
+		try await fetchWithSource("/functions/tokentracker-usage-heatmap", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "weeks", value: String(weeks))
 		]))
 	}
 
-	func fetchModelBreakdown(from: String, to: String) async throws -> ModelBreakdownResponse {
-		try await fetch("/functions/tokentracker-usage-model-breakdown", queryItems: withAccountQueryItems([
+	func fetchModelBreakdown(from: String, to: String) async throws -> AccountFetchResult<ModelBreakdownResponse> {
+		try await fetchWithSource("/functions/tokentracker-usage-model-breakdown", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
@@ -99,15 +93,15 @@ actor APIClient {
 		]))
 	}
 
-	func fetchMonthly(from: String, to: String) async throws -> MonthlyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-monthly", queryItems: withAccountQueryItems([
+	func fetchMonthly(from: String, to: String) async throws -> AccountFetchResult<MonthlyUsageResponse> {
+		try await fetchWithSource("/functions/tokentracker-usage-monthly", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
-	func fetchHourly(day: String) async throws -> HourlyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-hourly", queryItems: withAccountQueryItems([
+	func fetchHourly(day: String) async throws -> AccountFetchResult<HourlyUsageResponse> {
+		try await fetchWithSource("/functions/tokentracker-usage-hourly", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "day", value: day)
 		]))
 	}
@@ -162,6 +156,33 @@ actor APIClient {
     }
 
     // MARK: - Private Helpers
+
+    /// Like `fetch`, but keeps the account-view authority the local server
+    /// tagged the response with. Every `?account=1` endpoint must go through
+    /// this: dropping the headers is what let a transient cloud failure
+    /// masquerade as "the user only has one device".
+    private func fetchWithSource<T: Decodable>(
+        _ path: String,
+        queryItems: [URLQueryItem] = [],
+        requestTimeout: TimeInterval? = nil
+    ) async throws -> AccountFetchResult<T> {
+        let (data, response) = try await request(
+            path,
+            queryItems: queryItems,
+            requestTimeout: requestTimeout
+        )
+        guard let source = AccountViewSource.parse(
+            accountView: response.value(forHTTPHeaderField: "X-TokenTracker-Account-View"),
+            fallback: response.value(forHTTPHeaderField: "X-TokenTracker-Account-Fallback")
+        ) else {
+            throw APIError.invalidResponse
+        }
+        return AccountFetchResult(
+            value: try decoder.decode(T.self, from: data),
+            source: source,
+            completedAt: Date()
+        )
+    }
 
     private func fetch<T: Decodable>(
         _ path: String,

--- a/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Utilities/Strings.swift
@@ -190,6 +190,9 @@ enum Strings {
     }
     static var syncingUsageData: String { t("Syncing usage data…", "正在同步使用数据…", "正在同步使用資料…", "使用データを同期中…", "사용 데이터 동기화 중…") }
     static var syncingFirstLaunchHint: String { t("First launch may take a moment", "首次启动可能需要一点时间", "首次啟動可能需要一點時間", "初回起動は少し時間がかかる場合があります", "첫 실행은 잠시 시간이 걸릴 수 있습니다") }
+    /// Shown in the Activity header while the cross-device read is failing and
+    /// the popover has nothing but this machine's data to fall back on.
+    static var activityThisMacOnly: String { t("This Mac only · reconnecting", "仅本机 · 重连中", "僅本機 · 重新連線中", "このMacのみ · 再接続中", "이 Mac만 · 재연결 중") }
     static var limitsDisplayTitle: String { t("Limit Display", "限额显示", "限額顯示", "上限の表示", "한도 표시") }
     static var toastOnResetLabel: String { t("Toast on limits reset", "额度重置时显示提示", "額度重置時顯示提示", "リセット時に通知を表示", "한도 초기화 시 알림 표시") }
     static var confettiOnResetLabel: String { t("Confetti on limits reset", "额度重置时撒花", "額度重置時撒花", "リセット時に紙吹雪", "한도 초기화 시 색종이") }

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -183,6 +183,7 @@ class DashboardViewModel: ObservableObject {
                     guard self.shouldPublish(
                         result.accountSource,
                         for: .todaySummary,
+                        scope: AccountViewStateStore.Scope.day(rollingTo),
                         hasExistingValue: self.todaySummary != nil
                     ) else { return }
                     self.todaySummary = result.summary
@@ -206,6 +207,7 @@ class DashboardViewModel: ObservableObject {
                     if self.shouldPublish(
                         result.accountSource,
                         for: .periodSummary,
+                        scope: AccountViewStateStore.Scope.range(range.from, range.to),
                         hasExistingValue: self.summary != nil
                     ) {
                         self.summary = result.summary
@@ -225,6 +227,7 @@ class DashboardViewModel: ObservableObject {
                     guard self.shouldPublish(
                         result.accountSource,
                         for: .rollingSummary,
+                        scope: AccountViewStateStore.Scope.rolling30,
                         hasExistingValue: self.rollingSummary != nil
                     ) else { return }
                     self.rollingSummary = result.summary
@@ -248,6 +251,7 @@ class DashboardViewModel: ObservableObject {
                     guard self.shouldPublish(
                         result.accountSource,
                         for: .totalSummary,
+                        scope: AccountViewStateStore.Scope.total,
                         hasExistingValue: self.totalSummary != nil
                     ) else { return }
                     self.totalSummary = result.summary
@@ -269,6 +273,7 @@ class DashboardViewModel: ObservableObject {
                     if self.shouldPublish(
                         result.source,
                         for: .daily,
+                        scope: AccountViewStateStore.Scope.daily30,
                         hasExistingValue: !self.daily.isEmpty
                     ) {
                         self.daily = result.value.data
@@ -285,6 +290,7 @@ class DashboardViewModel: ObservableObject {
                         if self.shouldPublish(
                             result.source,
                             for: .hourly,
+                            scope: AccountViewStateStore.Scope.day(rollingTo),
                             hasExistingValue: !self.hourly.isEmpty
                         ) {
                             self.hourly = result.value.data
@@ -296,6 +302,7 @@ class DashboardViewModel: ObservableObject {
                         if self.shouldPublish(
                             result.source,
                             for: .monthly,
+                            scope: AccountViewStateStore.Scope.range(range.from, range.to),
                             hasExistingValue: !self.monthly.isEmpty
                         ) {
                             self.monthly = result.value.data
@@ -320,6 +327,7 @@ class DashboardViewModel: ObservableObject {
                     if self.shouldPublish(
                         result.source,
                         for: .heatmap,
+                        scope: AccountViewStateStore.Scope.heatmap,
                         hasExistingValue: self.heatmap != nil
                     ) {
                         self.heatmap = result.value
@@ -336,6 +344,7 @@ class DashboardViewModel: ObservableObject {
                     if self.shouldPublish(
                         result.source,
                         for: .modelBreakdown,
+                        scope: AccountViewStateStore.Scope.range(range.from, range.to),
                         hasExistingValue: self.modelBreakdown != nil
                     ) {
                         self.modelBreakdown = result.value
@@ -418,11 +427,13 @@ class DashboardViewModel: ObservableObject {
     private func shouldPublish(
         _ source: AccountViewSource,
         for dataset: AccountViewStateStore.Dataset,
+        scope: String,
         hasExistingValue: Bool
     ) -> Bool {
         let adopt = accountViewState.shouldAdopt(
             source,
             for: dataset,
+            scope: scope,
             hasExistingValue: hasExistingValue
         )
         if source.isTransientFallback {
@@ -594,6 +605,7 @@ class DashboardViewModel: ObservableObject {
                         if summaries.contains(.today), self.shouldPublish(
                             result.accountSource,
                             for: .todaySummary,
+                            scope: AccountViewStateStore.Scope.day(today),
                             hasExistingValue: self.todaySummary != nil
                         ) {
                             self.todaySummary = result.summary
@@ -604,6 +616,7 @@ class DashboardViewModel: ObservableObject {
                         if summaries.contains(.rolling), self.shouldPublish(
                             result.accountSource,
                             for: .rollingSummary,
+                            scope: AccountViewStateStore.Scope.rolling30,
                             hasExistingValue: self.rollingSummary != nil
                         ) {
                             self.rollingSummary = result.summary
@@ -632,6 +645,7 @@ class DashboardViewModel: ObservableObject {
                         if self.shouldPublish(
                             result.accountSource,
                             for: .totalSummary,
+                            scope: AccountViewStateStore.Scope.total,
                             hasExistingValue: self.totalSummary != nil
                         ) {
                             self.totalSummary = result.summary

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -59,6 +59,10 @@ class DashboardViewModel: ObservableObject {
     @Published var serverOnline = false
     @Published var lastRefreshed: Date?
     @Published private(set) var isPopoverVisible = false
+    /// True while the Activity heatmap is showing this-machine data purely
+    /// because the cross-device read failed and there was no account snapshot
+    /// to keep. Drives the "This Mac only" hint in the section header.
+    @Published private(set) var activityShowsTransientLocalData = false
 
     // Derived (cached) data
     @Published private(set) var fleetData: [FleetEntry] = []
@@ -80,6 +84,16 @@ class DashboardViewModel: ObservableObject {
     private var pendingUsagePublications = PendingUsagePublicationQueue()
     private var needsFullRefreshOnPopoverOpen = false
     private var summaryPublicationState = SummaryPublicationState()
+    /// Tracks, per dataset, whether what we show came from the cross-device
+    /// account aggregate — so a transient cloud failure can't silently replace
+    /// it with this-machine data.
+    private var accountViewState = AccountViewStateStore()
+    private var accountRecoveryTask: Task<Void, Never>?
+    private var accountRecoveryAttempt = 0
+    /// Backoff for re-reading the account view after a transient cloud failure.
+    /// Short first hop because the common trigger is a wake-from-sleep where
+    /// Wi-Fi/VPN comes back a second or two after the app starts refreshing.
+    private static let accountRecoveryDelays: [TimeInterval] = [1, 3, 10]
     private let resetDetector = WeeklyLimitResetDetector()
 
     // MARK: - Computed Properties
@@ -166,6 +180,11 @@ class DashboardViewModel: ObservableObject {
                         from: rollingTo,
                         to: rollingTo
                     )
+                    guard self.shouldPublish(
+                        result.accountSource,
+                        for: .todaySummary,
+                        hasExistingValue: self.todaySummary != nil
+                    ) else { return }
                     self.todaySummary = result.summary
                     self.summaryPublicationState.record(
                         source: result.source,
@@ -180,7 +199,17 @@ class DashboardViewModel: ObservableObject {
             // Period summary (for the selected period — drives chart/models)
             group.addTask { @MainActor in
                 do {
-                    self.summary = try await APIClient.shared.fetchSummary(from: range.from, to: range.to)
+                    let result = try await APIClient.shared.fetchSummaryWithSource(
+                        from: range.from,
+                        to: range.to
+                    )
+                    if self.shouldPublish(
+                        result.accountSource,
+                        for: .periodSummary,
+                        hasExistingValue: self.summary != nil
+                    ) {
+                        self.summary = result.summary
+                    }
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -193,6 +222,11 @@ class DashboardViewModel: ObservableObject {
                         from: rollingFrom,
                         to: rollingTo
                     )
+                    guard self.shouldPublish(
+                        result.accountSource,
+                        for: .rollingSummary,
+                        hasExistingValue: self.rollingSummary != nil
+                    ) else { return }
                     self.rollingSummary = result.summary
                     self.summaryPublicationState.record(
                         source: result.source,
@@ -211,6 +245,11 @@ class DashboardViewModel: ObservableObject {
                         from: totalRange.from,
                         to: totalRange.to
                     )
+                    guard self.shouldPublish(
+                        result.accountSource,
+                        for: .totalSummary,
+                        hasExistingValue: self.totalSummary != nil
+                    ) else { return }
                     self.totalSummary = result.summary
                     self.summaryPublicationState.record(
                         source: result.source,
@@ -226,7 +265,14 @@ class DashboardViewModel: ObservableObject {
             group.addTask { @MainActor in
                 do {
                     // Always fetch 30-day daily for week/month chart
-                    self.daily = try await APIClient.shared.fetchDaily(from: rollingFrom, to: rollingTo).data
+                    let result = try await APIClient.shared.fetchDaily(from: rollingFrom, to: rollingTo)
+                    if self.shouldPublish(
+                        result.source,
+                        for: .daily,
+                        hasExistingValue: !self.daily.isEmpty
+                    ) {
+                        self.daily = result.value.data
+                    }
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -235,14 +281,32 @@ class DashboardViewModel: ObservableObject {
             group.addTask { @MainActor in
                 do {
                     if self.period == .day {
-                        self.hourly = try await APIClient.shared.fetchHourly(day: rollingTo).data
+                        let result = try await APIClient.shared.fetchHourly(day: rollingTo)
+                        if self.shouldPublish(
+                            result.source,
+                            for: .hourly,
+                            hasExistingValue: !self.hourly.isEmpty
+                        ) {
+                            self.hourly = result.value.data
+                        }
                         self.monthly = []
+                        self.accountViewState.clear(.monthly)
                     } else if self.period == .total {
-                        self.monthly = try await APIClient.shared.fetchMonthly(from: range.from, to: range.to).data
+                        let result = try await APIClient.shared.fetchMonthly(from: range.from, to: range.to)
+                        if self.shouldPublish(
+                            result.source,
+                            for: .monthly,
+                            hasExistingValue: !self.monthly.isEmpty
+                        ) {
+                            self.monthly = result.value.data
+                        }
                         self.hourly = []
+                        self.accountViewState.clear(.hourly)
                     } else {
                         self.hourly = []
                         self.monthly = []
+                        self.accountViewState.clear(.hourly)
+                        self.accountViewState.clear(.monthly)
                     }
                 } catch {
                     errorCount += 1
@@ -252,7 +316,14 @@ class DashboardViewModel: ObservableObject {
             // Heatmap (always full year)
             group.addTask { @MainActor in
                 do {
-                    self.heatmap = try await APIClient.shared.fetchHeatmap()
+                    let result = try await APIClient.shared.fetchHeatmap()
+                    if self.shouldPublish(
+                        result.source,
+                        for: .heatmap,
+                        hasExistingValue: self.heatmap != nil
+                    ) {
+                        self.heatmap = result.value
+                    }
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -261,7 +332,14 @@ class DashboardViewModel: ObservableObject {
             // Model breakdown (for selected period)
             group.addTask { @MainActor in
                 do {
-                    self.modelBreakdown = try await APIClient.shared.fetchModelBreakdown(from: range.from, to: range.to)
+                    let result = try await APIClient.shared.fetchModelBreakdown(from: range.from, to: range.to)
+                    if self.shouldPublish(
+                        result.source,
+                        for: .modelBreakdown,
+                        hasExistingValue: self.modelBreakdown != nil
+                    ) {
+                        self.modelBreakdown = result.value
+                    }
                 } catch {
                     errorCount += 1
                     if firstError == nil { firstError = error.localizedDescription }
@@ -308,6 +386,17 @@ class DashboardViewModel: ObservableObject {
             self.lastRefreshed = Date()
         }
 
+        // A transient cloud fallback is not a refresh failure — the panel still
+        // holds the account snapshot — but it does mean the data is stale, so
+        // retry the account read on a short backoff instead of waiting for the
+        // next five-minute tick or a manual sync.
+        activityShowsTransientLocalData = accountViewState.showsTransientLocalData(.heatmap)
+        if accountViewState.isDegraded {
+            scheduleAccountRecoveryRetry()
+        } else {
+            cancelAccountRecovery()
+        }
+
         updateDerivedData()
         isLoading = false
 
@@ -315,6 +404,53 @@ class DashboardViewModel: ObservableObject {
         // widgets pick it up on their next timeline reload.
         await WidgetSnapshotWriter.update(from: self, capturedAt: capturedAt)
         await finishDataLoad(allowPendingRefresh: errorCount == 0)
+    }
+
+    // MARK: - Account View Authority
+
+    /// Decide whether a freshly fetched payload may replace what is on screen.
+    ///
+    /// The local server answers `?account=1` with this-machine data both when
+    /// that is the user's real scope and when a cloud read just failed. Only
+    /// the first is allowed to replace an account (cross-device) snapshot;
+    /// otherwise one timed-out request would shrink the popover to a single
+    /// device until the next manual sync.
+    private func shouldPublish(
+        _ source: AccountViewSource,
+        for dataset: AccountViewStateStore.Dataset,
+        hasExistingValue: Bool
+    ) -> Bool {
+        let adopt = accountViewState.shouldAdopt(
+            source,
+            for: dataset,
+            hasExistingValue: hasExistingValue
+        )
+        if source.isTransientFallback {
+            // Reason only — never tokens, cookies, or usage figures.
+            Self.logger.notice(
+                "Account view fallback: dataset=\(String(describing: dataset), privacy: .public) reason=\(source.reason, privacy: .public) retainedAccountSnapshot=\(!adopt, privacy: .public)"
+            )
+        }
+        return adopt
+    }
+
+    private func scheduleAccountRecoveryRetry() {
+        guard accountRecoveryTask == nil else { return }
+        guard accountRecoveryAttempt < Self.accountRecoveryDelays.count else { return }
+        let delay = Self.accountRecoveryDelays[accountRecoveryAttempt]
+        accountRecoveryAttempt += 1
+        accountRecoveryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            self.accountRecoveryTask = nil
+            await self.loadAll()
+        }
+    }
+
+    private func cancelAccountRecovery() {
+        accountRecoveryTask?.cancel()
+        accountRecoveryTask = nil
+        accountRecoveryAttempt = 0
     }
 
     private func finishDataLoad(allowPendingRefresh: Bool = true) async {
@@ -450,18 +586,33 @@ class DashboardViewModel: ObservableObject {
                             from: today,
                             to: today
                         )
-                        if summaries.contains(.today) {
+                        // Same rule as the full load: a transient cloud
+                        // fallback must not replace account totals in the menu
+                        // bar. The response still counts as a success — the
+                        // server answered — so `serverOnline` stays accurate.
+                        var adoptedSummaries = MenuBarSummarySelection()
+                        if summaries.contains(.today), self.shouldPublish(
+                            result.accountSource,
+                            for: .todaySummary,
+                            hasExistingValue: self.todaySummary != nil
+                        ) {
                             self.todaySummary = result.summary
+                            adoptedSummaries.formUnion(.today)
                         }
                         // Rolling windows are identical on every summary
                         // response, so today + 7d needs only one request.
-                        if summaries.contains(.rolling) {
+                        if summaries.contains(.rolling), self.shouldPublish(
+                            result.accountSource,
+                            for: .rollingSummary,
+                            hasExistingValue: self.rollingSummary != nil
+                        ) {
                             self.rollingSummary = result.summary
+                            adoptedSummaries.formUnion(.rolling)
                         }
                         self.summaryPublicationState.record(
                             source: result.source,
                             completedAt: result.completedAt,
-                            for: summaries.intersection([.today, .rolling])
+                            for: adoptedSummaries
                         )
                         successfulFetches += 1
                     } catch {
@@ -478,12 +629,18 @@ class DashboardViewModel: ObservableObject {
                             from: range.from,
                             to: range.to
                         )
-                        self.totalSummary = result.summary
-                        self.summaryPublicationState.record(
-                            source: result.source,
-                            completedAt: result.completedAt,
-                            for: .total
-                        )
+                        if self.shouldPublish(
+                            result.accountSource,
+                            for: .totalSummary,
+                            hasExistingValue: self.totalSummary != nil
+                        ) {
+                            self.totalSummary = result.summary
+                            self.summaryPublicationState.record(
+                                source: result.source,
+                                completedAt: result.completedAt,
+                                for: .total
+                            )
+                        }
                         successfulFetches += 1
                     } catch {
                         if firstError == nil { firstError = error }

--- a/TokenTrackerBar/TokenTrackerBar/Views/ActivityHeatmapView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ActivityHeatmapView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct ActivityHeatmapView: View {
     let heatmap: HeatmapResponse?
+    /// True when the grid is showing this machine's data only because the
+    /// cross-device read failed — worth saying out loud, because the same grid
+    /// normally aggregates every signed-in device.
+    var showsTransientLocalData: Bool = false
 
     private let cellSize: CGFloat = 11
     private let spacing: CGFloat = 3
@@ -115,6 +119,10 @@ struct ActivityHeatmapView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .modifier(FontWeightModifier(weight: .medium))
+        } else if showsTransientLocalData {
+            Text(Strings.activityThisMacOnly)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         } else {
             Text(Strings.activeDays(h.activeDays))
                 .font(.caption2)

--- a/TokenTrackerBar/TokenTrackerBar/Views/DashboardView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/DashboardView.swift
@@ -32,7 +32,10 @@ struct DashboardView: View {
                                 totalCost: viewModel.totalCost
                             )
                             UsageLimitsView(limits: viewModel.usageLimits, subscriptions: viewModel.subscriptions)
-                            ActivityHeatmapView(heatmap: viewModel.heatmap)
+                            ActivityHeatmapView(
+                                heatmap: viewModel.heatmap,
+                                showsTransientLocalData: viewModel.activityShowsTransientLocalData
+                            )
                             UsageTrendChartWrapper(
                                 daily: viewModel.daily,
                                 monthly: viewModel.monthly,

--- a/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
+++ b/TokenTrackerWin.Tests/TokenTrackerWin.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="../TokenTrackerWin/ChildProcessProxy.cs" Link="ChildProcessProxy.cs" />
     <Compile Include="../TokenTrackerWin/ResumableDownloader.cs" Link="ResumableDownloader.cs" />
+    <Compile Include="../TokenTrackerWin/UsagePoller.cs" Link="UsagePoller.cs" />
   </ItemGroup>
 
 </Project>

--- a/TokenTrackerWin.Tests/UsagePollerAccountAuthorityTests.cs
+++ b/TokenTrackerWin.Tests/UsagePollerAccountAuthorityTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Xunit;
+
+namespace TokenTrackerWin.Tests;
+
+/// <summary>
+/// The tray/pet poller asks the local server for the cross-device ("account")
+/// aggregate. That server answers with this-machine data both when that really is
+/// the user's scope and when a cloud read merely failed, so the poller has to tell
+/// the two apart or one timed-out request silently drops the tray to a single
+/// machine. These drive the real <see cref="UsagePoller"/> against a loopback
+/// server that serves the headers under test.
+/// </summary>
+public sealed class UsagePollerAccountAuthorityTests
+{
+    private const string SummaryPath = "/functions/tokentracker-usage-summary";
+    private const string HeatmapPath = "/functions/tokentracker-usage-heatmap";
+    private const string ModelsPath = "/functions/tokentracker-usage-model-breakdown";
+
+    /// <summary>Headers a response carries: null = the account view was served.</summary>
+    private sealed record Authority(string View, string? Fallback)
+    {
+        public static readonly Authority Account = new("1", null);
+        public static readonly Authority SignedOut = new("0", "signed-out");
+        public static readonly Authority Transient = new("0", "transient-network");
+    }
+
+    /// <summary>
+    /// A loopback HTTP/1.1 server built on a raw socket rather than HttpListener:
+    /// HttpListener goes through HTTP.sys on Windows, where registering a prefix
+    /// can need an URL ACL or elevation. A TcpListener has no such requirement,
+    /// so this behaves the same on every runner.
+    /// </summary>
+    private sealed class FakeLocalServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _stop = new();
+
+        public string BaseUrl { get; }
+        public Authority SummaryAuthority = Authority.Account;
+        public Authority HeatmapAuthority = Authority.Account;
+        public Authority ModelsAuthority = Authority.Account;
+        public long SummaryTokens = 1_000;
+        public int HeatmapStreak = 7;
+
+        public FakeLocalServer()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            BaseUrl = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}";
+            _ = Task.Run(AcceptLoopAsync);
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            while (!_stop.IsCancellationRequested)
+            {
+                TcpClient client;
+                try { client = await _listener.AcceptTcpClientAsync(_stop.Token); }
+                catch { return; }
+                _ = Task.Run(() => ServeOneAsync(client));
+            }
+        }
+
+        private async Task ServeOneAsync(TcpClient client)
+        {
+            using (client)
+            {
+                try
+                {
+                    using var stream = client.GetStream();
+                    var path = await ReadRequestPathAsync(stream);
+                    var (authority, body) = path switch
+                    {
+                        SummaryPath => (SummaryAuthority, SummaryJson()),
+                        HeatmapPath => (HeatmapAuthority,
+                            "{\"streak_days\":" + HeatmapStreak + ",\"active_days\":42}"),
+                        ModelsPath => (ModelsAuthority, ModelsJson()),
+                        _ => (Authority.Account, "{}"),
+                    };
+
+                    var payload = Encoding.UTF8.GetBytes(body);
+                    var head = new StringBuilder()
+                        .Append("HTTP/1.1 200 OK\r\n")
+                        .Append("Content-Type: application/json\r\n")
+                        .Append("Content-Length: ").Append(payload.Length).Append("\r\n")
+                        .Append("X-TokenTracker-Account-View: ").Append(authority.View).Append("\r\n");
+                    if (authority.Fallback is not null)
+                        head.Append("X-TokenTracker-Account-Fallback: ").Append(authority.Fallback).Append("\r\n");
+                    // One request per connection keeps the parsing above trivial.
+                    head.Append("Connection: close\r\n\r\n");
+
+                    await stream.WriteAsync(Encoding.ASCII.GetBytes(head.ToString()));
+                    await stream.WriteAsync(payload);
+                    await stream.FlushAsync();
+                }
+                catch
+                {
+                    // A client that hung up mid-response is not a test failure.
+                }
+            }
+        }
+
+        /// <summary>Reads just enough of the request to route it: the path from the request line.</summary>
+        private static async Task<string> ReadRequestPathAsync(NetworkStream stream)
+        {
+            var buffer = new byte[4096];
+            var read = 0;
+            while (read < buffer.Length)
+            {
+                var n = await stream.ReadAsync(buffer.AsMemory(read, buffer.Length - read));
+                if (n == 0) break;
+                read += n;
+                var soFar = Encoding.ASCII.GetString(buffer, 0, read);
+                if (soFar.Contains("\r\n\r\n")) break;
+            }
+
+            var requestLine = Encoding.ASCII.GetString(buffer, 0, read).Split("\r\n")[0];
+            var target = requestLine.Split(' ') is [_, var t, ..] ? t : "";
+            var query = target.IndexOf('?');
+            return query >= 0 ? target[..query] : target;
+        }
+
+        private string SummaryJson() =>
+            "{\"totals\":{\"total_tokens\":" + SummaryTokens
+            + ",\"conversation_count\":3,\"total_cost_usd\":\"1.25\"},"
+            + "\"rolling\":{\"last_7d\":{\"active_days\":4,\"totals\":{\"total_tokens\":900}},"
+            + "\"last_30d\":{\"avg_per_active_day\":50,\"totals\":{\"total_tokens\":9000}}}}";
+
+        private static string ModelsJson() =>
+            """
+            {"sources":[{"source":"claude","models":[{"model":"opus","totals":{"total_tokens":500}}]}]}
+            """;
+
+        public void Dispose()
+        {
+            _stop.Cancel();
+            try { _listener.Stop(); } catch { }
+            _stop.Dispose();
+        }
+    }
+
+    /// <summary>Runs one poll; returns the published stats, or null if none was published.</summary>
+    private static async Task<UsagePoller.UsageStats?> PollOnceAsync(UsagePoller poller, TimeSpan wait)
+    {
+        var published = new TaskCompletionSource<UsagePoller.UsageStats>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnStats(UsagePoller.UsageStats s) => published.TrySetResult(s);
+        poller.StatsUpdated += OnStats;
+        try
+        {
+            poller.RefreshNow();
+            var done = await Task.WhenAny(published.Task, Task.Delay(wait));
+            return done == published.Task ? published.Task.Result : null;
+        }
+        finally
+        {
+            poller.StatsUpdated -= OnStats;
+        }
+    }
+
+    private static readonly TimeSpan Publishes = TimeSpan.FromSeconds(10);
+    // Long enough for the poll to finish and decide not to publish.
+    private static readonly TimeSpan NoPublish = TimeSpan.FromSeconds(3);
+
+    [Fact]
+    public async Task RichStatFallbackIsNotMixedIntoTheFirstAccountSnapshot()
+    {
+        // The transition the tray actually starts in: nothing published yet, so
+        // the "are we showing account data" flag is still false. A guard written
+        // against that flag alone lets this machine's streak ride along inside an
+        // otherwise cross-device snapshot — and because the next poll then sees
+        // the flag as true and skips publishing, that mixed snapshot stays on the
+        // tray until the heatmap recovers.
+        using var server = new FakeLocalServer
+        {
+            SummaryAuthority = Authority.Account,
+            HeatmapAuthority = Authority.Transient,
+        };
+        using var poller = new UsagePoller(() => server.BaseUrl) { IncludeRichStats = true, IncludeLimits = false };
+
+        var stats = await PollOnceAsync(poller, NoPublish);
+
+        Assert.Null(stats);
+    }
+
+    [Fact]
+    public async Task AnAllAccountPollPublishes()
+    {
+        // Control for the test above: the guard must not simply block everything.
+        using var server = new FakeLocalServer();
+        using var poller = new UsagePoller(() => server.BaseUrl) { IncludeRichStats = true, IncludeLimits = false };
+
+        var stats = await PollOnceAsync(poller, Publishes);
+
+        Assert.NotNull(stats);
+        Assert.Equal(1_000, stats!.Value.TodayTokens);
+        Assert.Equal(7, stats.Value.StreakDays);
+    }
+
+    [Fact]
+    public async Task ATransientSummaryNeverReplacesAccountFiguresAlreadyShown()
+    {
+        using var server = new FakeLocalServer();
+        using var poller = new UsagePoller(() => server.BaseUrl) { IncludeRichStats = true, IncludeLimits = false };
+
+        var first = await PollOnceAsync(poller, Publishes);
+        Assert.NotNull(first);
+
+        server.SummaryAuthority = Authority.Transient;
+        server.SummaryTokens = 12; // this machine only — must not reach the tray
+        var second = await PollOnceAsync(poller, NoPublish);
+
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task SigningOutStillSwitchesTheTrayToLocalData()
+    {
+        // The reverse invariant: an authoritative local view must always win, or a
+        // signed-out user keeps staring at another session's totals.
+        using var server = new FakeLocalServer();
+        using var poller = new UsagePoller(() => server.BaseUrl) { IncludeRichStats = true, IncludeLimits = false };
+
+        Assert.NotNull(await PollOnceAsync(poller, Publishes));
+
+        server.SummaryAuthority = Authority.SignedOut;
+        server.HeatmapAuthority = Authority.SignedOut;
+        server.ModelsAuthority = Authority.SignedOut;
+        server.SummaryTokens = 12;
+        var afterSignOut = await PollOnceAsync(poller, Publishes);
+
+        Assert.NotNull(afterSignOut);
+        Assert.Equal(12, afterSignOut!.Value.TodayTokens);
+    }
+
+    [Fact]
+    public async Task AServerTooOldToSendTheReasonHeaderKeepsPreFixBehaviour()
+    {
+        using var server = new FakeLocalServer();
+        using var poller = new UsagePoller(() => server.BaseUrl) { IncludeRichStats = true, IncludeLimits = false };
+
+        Assert.NotNull(await PollOnceAsync(poller, Publishes));
+
+        // No fallback header at all: authoritative-local, so it publishes.
+        server.SummaryAuthority = new Authority("0", null);
+        server.HeatmapAuthority = new Authority("0", null);
+        server.ModelsAuthority = new Authority("0", null);
+        server.SummaryTokens = 12;
+        var stats = await PollOnceAsync(poller, Publishes);
+
+        Assert.NotNull(stats);
+        Assert.Equal(12, stats!.Value.TodayTokens);
+    }
+}

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -215,8 +215,16 @@ internal sealed class UsagePoller : IDisposable
             IReadOnlyList<TopModelStat> models = NoModels;
             if (IncludeRichStats)
             {
-                var heatmap = await FetchHeatmapAsync(tzQuery);
-                var topModels = await FetchTopModelsAsync(today, tzQuery);
+                // What this poll is about to render as. `_showingAccountData` alone
+                // describes the *previous* publish — it is not assigned until the
+                // bottom of this method — so during a local-to-account transition
+                // (cold start included, since the field starts false) it would let a
+                // transient rich-stat response ride along inside an account snapshot,
+                // and the guard below would then pin that mixed snapshot in place
+                // until the failing dataset recovered.
+                var retainAccount = summarySource == AccountSource.Account || _showingAccountData;
+                var heatmap = await FetchHeatmapAsync(tzQuery, retainAccount);
+                var topModels = await FetchTopModelsAsync(today, tzQuery, retainAccount);
                 // null = this dataset came back as a transient local fallback while
                 // the tray is showing account data. One UsageStats is published
                 // atomically, so mixing authorities inside it is not an option.
@@ -241,14 +249,14 @@ internal sealed class UsagePoller : IDisposable
 
     /// <summary>Heatmap: all-time active days + current streak (streak is server-computed; the
     /// local server returns 0, matching how the macOS pet reads it against the same backend).</summary>
-    private async Task<(int Streak, int ActiveDays)?> FetchHeatmapAsync(string tzQuery)
+    private async Task<(int Streak, int ActiveDays)?> FetchHeatmapAsync(string tzQuery, bool retainAccount)
     {
         try
         {
             var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return (0, 0);
-            if (ReadAccountSource(resp) == AccountSource.LocalTransient && _showingAccountData) return null;
+            if (ReadAccountSource(resp) == AccountSource.LocalTransient && retainAccount) return null;
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
             var root = doc.RootElement;
@@ -263,7 +271,7 @@ internal sealed class UsagePoller : IDisposable
     /// provider from the highest-token row for that name, percent = tokens / total billable
     /// (one decimal), sort by tokens desc then name asc, top 5.
     /// </summary>
-    private async Task<IReadOnlyList<TopModelStat>?> FetchTopModelsAsync(string today, string tzQuery)
+    private async Task<IReadOnlyList<TopModelStat>?> FetchTopModelsAsync(string today, string tzQuery, bool retainAccount)
     {
         try
         {
@@ -272,7 +280,7 @@ internal sealed class UsagePoller : IDisposable
                       + $"?from={from}&to={today}{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return NoModels;
-            if (ReadAccountSource(resp) == AccountSource.LocalTransient && _showingAccountData) return null;
+            if (ReadAccountSource(resp) == AccountSource.LocalTransient && retainAccount) return null;
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
             if (!doc.RootElement.TryGetProperty("sources", out var sources)

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -45,6 +45,12 @@ internal sealed class UsagePoller : IDisposable
     private const string AccountQuery = "account=1";
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;
+    /// <summary>
+    /// Whether the figures currently on the tray/pet came from the cross-device
+    /// account aggregate. Guards against a temporary cloud failure replacing them
+    /// with this-machine data; see <see cref="ReadAccountSource"/>.
+    /// </summary>
+    private volatile bool _showingAccountData;
 
     /// <summary>
     /// When true, each poll also gathers the heatmap + model-breakdown stats the pet's
@@ -52,14 +58,6 @@ internal sealed class UsagePoller : IDisposable
     /// the extra work only happens while the pet is on screen.
     /// </summary>
     public volatile bool IncludeRichStats;
-
-    /// <summary>
-    /// Whether the most recent summary fetch returned cross-device ("account view")
-    /// data rather than local single-machine data. Mirrors the macOS APIClient's
-    /// <c>accountViewActive</c>; driven by the <c>X-TokenTracker-Account-View</c>
-    /// response header the local server sets.
-    /// </summary>
-    public volatile bool AccountViewActive;
 
     /// <summary>
     /// Fetch the provider quota snapshot while the desktop pet is visible. Keeping
@@ -113,6 +111,37 @@ internal sealed class UsagePoller : IDisposable
         }, token);
     }
 
+    /// <summary>Why the local server served what it served on an <c>account=1</c> request.</summary>
+    private enum AccountSource
+    {
+        /// <summary>Cross-device account aggregate.</summary>
+        Account,
+        /// <summary>This-machine data, and that is the correct scope (signed out / cloud sync off).</summary>
+        LocalAuthoritative,
+        /// <summary>This-machine data only because the cloud read failed.</summary>
+        LocalTransient,
+    }
+
+    /// <summary>
+    /// Read the pair of account-view headers. A server too old to send the reason
+    /// header reports no reason, which stays <see cref="AccountSource.LocalAuthoritative"/>
+    /// — i.e. the behaviour this client had before the header existed.
+    /// </summary>
+    private static AccountSource ReadAccountSource(HttpResponseMessage resp)
+    {
+        if (resp.Headers.TryGetValues("X-TokenTracker-Account-View", out var view)
+            && view.FirstOrDefault() == "1")
+            return AccountSource.Account;
+
+        var reason = resp.Headers.TryGetValues("X-TokenTracker-Account-Fallback", out var fallback)
+            ? fallback.FirstOrDefault() ?? string.Empty
+            : string.Empty;
+        // Every transient reason is prefixed "transient-", so new ones need no client change.
+        return reason.StartsWith("transient", StringComparison.Ordinal)
+            ? AccountSource.LocalTransient
+            : AccountSource.LocalAuthoritative;
+    }
+
     private async Task<string?> FetchLimitsAsync()
     {
         try
@@ -144,10 +173,13 @@ internal sealed class UsagePoller : IDisposable
             using var resp = await Http.GetAsync(summaryUrl);
             if (!resp.IsSuccessStatusCode) return null;
 
-            // Track whether the server served the cross-device aggregate or fell
-            // back to local data, mirroring the macOS client.
-            if (resp.Headers.TryGetValues("X-TokenTracker-Account-View", out var accountViewValues))
-                AccountViewActive = accountViewValues.FirstOrDefault() == "1";
+            // The server serves this-machine data both when that is the user's real
+            // scope and when a cloud read merely failed. Publishing the latter would
+            // silently drop the tray/pet from cross-device totals to one machine
+            // until the next lucky poll, so skip the publish instead: the tray keeps
+            // the last stats it rendered (TrayApplicationContext._lastStats).
+            var summarySource = ReadAccountSource(resp);
+            if (summarySource == AccountSource.LocalTransient && _showingAccountData) return null;
 
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
@@ -183,10 +215,17 @@ internal sealed class UsagePoller : IDisposable
             IReadOnlyList<TopModelStat> models = NoModels;
             if (IncludeRichStats)
             {
-                (streak, activeAll) = await FetchHeatmapAsync(tzQuery);
-                models = await FetchTopModelsAsync(today, tzQuery);
+                var heatmap = await FetchHeatmapAsync(tzQuery);
+                var topModels = await FetchTopModelsAsync(today, tzQuery);
+                // null = this dataset came back as a transient local fallback while
+                // the tray is showing account data. One UsageStats is published
+                // atomically, so mixing authorities inside it is not an option.
+                if (heatmap is null || topModels is null) return null;
+                (streak, activeAll) = heatmap.Value;
+                models = topModels;
             }
 
+            _showingAccountData = summarySource == AccountSource.Account;
             return new UsageStats(
                 tokens, cost, convos,
                 l7Tokens, l7Active,
@@ -202,13 +241,14 @@ internal sealed class UsagePoller : IDisposable
 
     /// <summary>Heatmap: all-time active days + current streak (streak is server-computed; the
     /// local server returns 0, matching how the macOS pet reads it against the same backend).</summary>
-    private async Task<(int Streak, int ActiveDays)> FetchHeatmapAsync(string tzQuery)
+    private async Task<(int Streak, int ActiveDays)?> FetchHeatmapAsync(string tzQuery)
     {
         try
         {
             var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return (0, 0);
+            if (ReadAccountSource(resp) == AccountSource.LocalTransient && _showingAccountData) return null;
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
             var root = doc.RootElement;
@@ -223,7 +263,7 @@ internal sealed class UsagePoller : IDisposable
     /// provider from the highest-token row for that name, percent = tokens / total billable
     /// (one decimal), sort by tokens desc then name asc, top 5.
     /// </summary>
-    private async Task<IReadOnlyList<TopModelStat>> FetchTopModelsAsync(string today, string tzQuery)
+    private async Task<IReadOnlyList<TopModelStat>?> FetchTopModelsAsync(string today, string tzQuery)
     {
         try
         {
@@ -232,6 +272,7 @@ internal sealed class UsagePoller : IDisposable
                       + $"?from={from}&to={today}{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return NoModels;
+            if (ReadAccountSource(resp) == AccountSource.LocalTransient && _showingAccountData) return null;
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
             if (!doc.RootElement.TryGetProperty("sources", out var sources)

--- a/src/lib/cloud-account.js
+++ b/src/lib/cloud-account.js
@@ -73,8 +73,27 @@ function decodeJwtExpMs(token) {
 // The popover polls frequently, so caching avoids hammering /api/auth/refresh.
 let tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
 
+// In-flight refresh de-duplication ("single flight"), keyed the same way as
+// `tokenCache`. A full popover refresh fires six account reads concurrently; on
+// a cold cache every one of them used to POST /api/auth/refresh with the SAME
+// refresh token. When the backend rotates refresh tokens, the losers of that
+// race present an already-consumed token and fail — which is exactly the
+// intermittent "Activity silently dropped to this-machine data" symptom.
+const mintInflight = new Map();
+
 function __resetCloudAccountCacheForTests() {
   tokenCache = { cacheKey: null, accessToken: null, expMs: 0 };
+  mintInflight.clear();
+}
+
+// Failure classes surfaced to local-api so it can tell an intentional local
+// view ("signed out", "cloud sync off") apart from a temporary cloud outage.
+class AccountAuthError extends Error {
+  constructor(code, message) {
+    super(message || code);
+    this.name = "AccountAuthError";
+    this.code = code;
+  }
 }
 
 function csrfTokenFromRefreshPayload(data) {
@@ -87,30 +106,11 @@ function csrfTokenFromRefreshPayload(data) {
 }
 
 /**
- * Mint (or reuse a cached) InsForge access token from a refresh token.
- * @returns {Promise<{accessToken: string, refreshToken: string|null, csrfToken: string|null}|null>}
- *   null when no refresh token is available or the refresh failed.
+ * Perform the actual refresh POST. Throws a classified `AccountAuthError` on
+ * every failure so callers can distinguish a transient outage (timeout,
+ * offline, rotated-token rejection) from an intentionally local view.
  */
-async function mintAccessToken({
-  baseUrl,
-  anonKey,
-  refreshToken,
-  fetchImpl = fetch,
-  now = Date.now,
-  skewMs = 60_000,
-  timeoutMs,
-} = {}) {
-  if (!refreshToken) return null;
-  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
-  const cacheKey = `${root}\0${refreshToken}`;
-  if (
-    tokenCache.cacheKey === cacheKey &&
-    tokenCache.accessToken &&
-    tokenCache.expMs - skewMs > now()
-  ) {
-    return { accessToken: tokenCache.accessToken, refreshToken: null, csrfToken: null };
-  }
-
+async function performMint({ root, cacheKey, anonKey, refreshToken, fetchImpl, now, timeoutMs }) {
   const headers = { "Content-Type": "application/json", Accept: "application/json" };
   if (anonKey) headers.apikey = anonKey;
 
@@ -132,24 +132,37 @@ async function mintAccessToken({
       body: JSON.stringify({ refresh_token: refreshToken }),
       signal,
     });
-  } catch {
-    return null;
+  } catch (e) {
+    const aborted = e && (e.name === "AbortError" || e.name === "TimeoutError");
+    throw new AccountAuthError(
+      aborted ? "auth_timeout" : "auth_network",
+      e?.message || "token refresh failed",
+    );
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
   }
-  if (!res || !res.ok) return null;
+  if (!res || !res.ok) {
+    const err = new AccountAuthError(
+      "auth_rejected",
+      `token refresh failed with HTTP ${res ? res.status : "?"}`,
+    );
+    err.status = res ? res.status : 0;
+    throw err;
+  }
 
   let data = null;
   try {
     data = await res.json();
-  } catch {
-    return null;
+  } catch (e) {
+    throw new AccountAuthError("auth_invalid", e?.message || "token refresh returned invalid JSON");
   }
 
   const accessToken = accessTokenFromRefreshPayload(data);
-  if (!accessToken) return null;
+  if (!accessToken) {
+    throw new AccountAuthError("auth_invalid", "token refresh returned no access token");
+  }
 
   const expMs = decodeJwtExpMs(accessToken) || now() + 10 * 60_000;
   tokenCache = { cacheKey, accessToken, expMs };
@@ -164,6 +177,60 @@ async function mintAccessToken({
     // dashboard's cookie-path refresh with 403 Invalid CSRF.
     csrfToken: csrfTokenFromRefreshPayload(data),
   };
+}
+
+/**
+ * Mint (or reuse a cached) InsForge access token from a refresh token.
+ *
+ * Concurrent callers with the same (baseUrl, refreshToken) share ONE in-flight
+ * refresh; see `mintInflight`.
+ *
+ * @param {boolean} [throwOnFailure] when true, reject with a classified
+ *   `AccountAuthError` instead of resolving to `null`.
+ * @returns {Promise<{accessToken: string, refreshToken: string|null, csrfToken: string|null}|null>}
+ *   null when no refresh token is available or the refresh failed.
+ */
+async function mintAccessToken({
+  baseUrl,
+  anonKey,
+  refreshToken,
+  fetchImpl = fetch,
+  now = Date.now,
+  skewMs = 60_000,
+  timeoutMs,
+  throwOnFailure = false,
+} = {}) {
+  if (!refreshToken) {
+    if (throwOnFailure) throw new AccountAuthError("auth_missing_refresh_token", "not signed in");
+    return null;
+  }
+  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+  const cacheKey = `${root}\0${refreshToken}`;
+  if (
+    tokenCache.cacheKey === cacheKey &&
+    tokenCache.accessToken &&
+    tokenCache.expMs - skewMs > now()
+  ) {
+    return { accessToken: tokenCache.accessToken, refreshToken: null, csrfToken: null };
+  }
+
+  let inflight = mintInflight.get(cacheKey);
+  if (!inflight) {
+    inflight = performMint({ root, cacheKey, anonKey, refreshToken, fetchImpl, now, timeoutMs })
+      .finally(() => {
+        // Only clear our own entry: a later caller may already have started a
+        // fresh mint after this one settled.
+        if (mintInflight.get(cacheKey) === inflight) mintInflight.delete(cacheKey);
+      });
+    mintInflight.set(cacheKey, inflight);
+  }
+
+  try {
+    return await inflight;
+  } catch (e) {
+    if (throwOnFailure) throw e;
+    return null;
+  }
 }
 
 /**
@@ -237,6 +304,7 @@ async function fetchAccountUsage({
 } = {}) {
   const slug = accountSlugFor(usageSlug);
   if (!slug) return null;
+  if (!refreshToken) return null;
 
   const startTime = now();
   const getRemainingTimeout = () => {
@@ -246,6 +314,9 @@ async function fetchAccountUsage({
     return remaining > 0 ? remaining : 1;
   };
 
+  // `throwOnFailure` keeps "not signed in" (null, handled above) distinct from
+  // "signed in but the refresh call failed" (throws) so the caller does not
+  // silently downgrade an account view into a this-machine view.
   const minted = await mintAccessToken({
     baseUrl,
     anonKey,
@@ -253,6 +324,7 @@ async function fetchAccountUsage({
     fetchImpl,
     now,
     timeoutMs: getRemainingTimeout(),
+    throwOnFailure: true,
   });
   if (!minted) return null;
 
@@ -269,6 +341,7 @@ async function fetchAccountUsage({
 }
 
 module.exports = {
+  AccountAuthError,
   USAGE_TO_ACCOUNT_SLUG,
   accountSlugFor,
   accessTokenFromRefreshPayload,

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1399,14 +1399,39 @@ function createLocalApiHandler({ queuePath }) {
     }
   }
 
-  // Returns "served" when the cross-device aggregate was written to `res`, or
-  // "fallthrough" when the caller should serve the local single-machine data.
-  // Any failure (not signed in, cloud sync off, network/auth error) falls
-  // through so the popover always renders something.
+  // Why a *classified* fallback: the native popover keeps the last successful
+  // account (cross-device) snapshot on screen when a cloud read fails
+  // transiently, but must switch to this-machine data the moment the user signs
+  // out or turns cloud sync off. Both used to look identical from the outside
+  // (HTTP 200 + local payload + `X-TokenTracker-Account-View: 0`), so a single
+  // timed-out read silently shrank Activity to one device until the next
+  // manual sync. See ACCOUNT_FALLBACK_* below for the vocabulary.
+  const ACCOUNT_FALLBACK_CLOUD_SYNC_OFF = "cloud-sync-off";
+  const ACCOUNT_FALLBACK_SIGNED_OUT = "signed-out";
+
+  // Every transient reason is prefixed "transient-"; clients only need the
+  // prefix, so new reasons can be added without a client change.
+  function classifyAccountFallback(err) {
+    if (!err) return "transient-error";
+    if (err.name === "AbortError" || err.name === "TimeoutError" || err.code === "auth_timeout") {
+      return "transient-timeout";
+    }
+    if (err.code === "auth_rejected" || err.code === "auth_invalid" || err.status === 401 || err.status === 403) {
+      return "transient-auth";
+    }
+    if (err.code === "auth_network") return "transient-network";
+    if (Number.isFinite(err.status) && err.status > 0) return "transient-upstream";
+    return "transient-network";
+  }
+
+  // Returns "served" when the cross-device aggregate was written to `res`,
+  // otherwise a fallback reason (see above) telling the caller — and, through
+  // the `X-TokenTracker-Account-Fallback` header, the popover — why the local
+  // single-machine data is being served instead.
   async function tryServeAccountView(usageSlug, url, res) {
-    if (!getCloudSyncPref()) return "fallthrough";
+    if (!getCloudSyncPref()) return ACCOUNT_FALLBACK_CLOUD_SYNC_OFF;
     const refreshToken = getRefreshTokenForCloud();
-    if (!refreshToken) return "fallthrough";
+    if (!refreshToken) return ACCOUNT_FALLBACK_SIGNED_OUT;
     const runtime = resolveRuntimeConfig();
     const envTimeout = process.env.TOKENTRACKER_HTTP_TIMEOUT_MS
       ? parseInt(process.env.TOKENTRACKER_HTTP_TIMEOUT_MS, 10)
@@ -1421,7 +1446,10 @@ function createLocalApiHandler({ queuePath }) {
         refreshToken,
         timeoutMs,
       });
-      if (!out || out.data == null) return "fallthrough";
+      // `null` here means the slug has no cloud equivalent, or the session
+      // vanished mid-request — a routing/session fact, not an outage.
+      if (!out) return ACCOUNT_FALLBACK_SIGNED_OUT;
+      if (out.data == null) return "transient-upstream";
       if (out.rotatedRefreshToken) setRelayRefreshToken(out.rotatedRefreshToken);
       if (out.rotatedCsrfToken) setRelayCsrfToken(out.rotatedCsrfToken);
       res.writeHead(200, {
@@ -1433,11 +1461,14 @@ function createLocalApiHandler({ queuePath }) {
       return "served";
     } catch (e) {
       // Signed in + cloud sync on, but the cloud read failed (offline, token
-      // rejected, edge error, or timeout). Fall back to local data rather than erroring.
+      // rejected, edge error, or timeout). Serve local data rather than
+      // erroring, but say so: this is a *temporary* downgrade and the client
+      // must not treat it as the user's real data scope.
+      const reason = classifyAccountFallback(e);
       if (resolveRuntimeConfig().debug) {
-        console.warn(`[LocalAPI] account view fallback for ${usageSlug}:`, e?.message || e);
+        console.warn(`[LocalAPI] account view fallback (${reason}) for ${usageSlug}:`, e?.message || e);
       }
-      return "fallthrough";
+      return reason;
     }
   }
 
@@ -2006,14 +2037,17 @@ function createLocalApiHandler({ queuePath }) {
     // --- account (cross-device) view proxy for the native popover ---
     // When ?account=1 and the user is signed in with cloud sync on, serve the
     // same cross-device aggregate the dashboard shows; otherwise tag the
-    // response (X-TokenTracker-Account-View: 0) so the popover knows it got
-    // local single-machine data, and fall through to the local handler below.
+    // response (X-TokenTracker-Account-View: 0 plus an
+    // X-TokenTracker-Account-Fallback reason) so the popover knows it got local
+    // single-machine data and whether that is permanent (signed out / cloud
+    // sync off) or transient, and fall through to the local handler below.
     if (url.searchParams.get("account") === "1") {
       const usageSlug = p.startsWith("/functions/") ? p.slice("/functions/".length) : "";
       if (accountSlugFor(usageSlug)) {
         const result = await tryServeAccountView(usageSlug, url, res);
         if (result === "served") return true;
         res.setHeader("X-TokenTracker-Account-View", "0");
+        res.setHeader("X-TokenTracker-Account-Fallback", result);
       }
     }
 

--- a/test/cloud-account.test.js
+++ b/test/cloud-account.test.js
@@ -11,6 +11,7 @@ const {
   mintAccessToken,
   fetchAccountFunction,
   fetchAccountUsage,
+  AccountAuthError,
   __resetCloudAccountCacheForTests,
 } = require("../src/lib/cloud-account");
 
@@ -266,4 +267,92 @@ test("fetchAccountUsage threads the rotated csrf token through to the caller", a
   });
   assert.equal(out.rotatedRefreshToken, "rotated");
   assert.equal(out.rotatedCsrfToken, "csrf-rotated");
+});
+
+// --- Single-flight refresh ---------------------------------------------------
+//
+// A full popover refresh fires six account reads at once. Before this, each one
+// POSTed /api/auth/refresh with the same refresh token; when the backend rotates
+// refresh tokens the losers of that race presented a consumed token and failed,
+// which the popover then rendered as "you only have this machine".
+
+test("concurrent mints with the same refresh token share one refresh request", async () => {
+  __resetCloudAccountCacheForTests();
+  const jwt = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    await new Promise((r) => setTimeout(r, 5));
+    return jsonResponse({ accessToken: jwt, refreshToken: "rotated" });
+  };
+
+  const results = await Promise.all(
+    Array.from({ length: 6 }, () =>
+      mintAccessToken({ baseUrl: "https://api.test", refreshToken: "r1", fetchImpl }),
+    ),
+  );
+
+  assert.equal(calls, 1);
+  for (const r of results) assert.equal(r.accessToken, jwt);
+});
+
+test("a failed single-flight mint does not poison later attempts", async () => {
+  __resetCloudAccountCacheForTests();
+  const jwt = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    if (calls === 1) throw new TypeError("fetch failed");
+    return jsonResponse({ accessToken: jwt });
+  };
+
+  const failed = await Promise.all([
+    mintAccessToken({ baseUrl: "https://api.test", refreshToken: "r1", fetchImpl }),
+    mintAccessToken({ baseUrl: "https://api.test", refreshToken: "r1", fetchImpl }),
+  ]);
+  assert.deepEqual(failed, [null, null]);
+  assert.equal(calls, 1, "both callers share the failing flight");
+
+  const retried = await mintAccessToken({ baseUrl: "https://api.test", refreshToken: "r1", fetchImpl });
+  assert.equal(retried.accessToken, jwt);
+  assert.equal(calls, 2, "the in-flight entry must be cleared once it settles");
+});
+
+test("throwOnFailure classifies why the refresh failed", async () => {
+  const cases = [
+    ["auth_network", async () => { throw new TypeError("fetch failed"); }],
+    ["auth_timeout", async () => { const e = new Error("aborted"); e.name = "AbortError"; throw e; }],
+    ["auth_rejected", async () => jsonResponse({ error: "consumed" }, false, 401)],
+    ["auth_invalid", async () => jsonResponse({ nothing: true })],
+  ];
+  for (const [code, fetchImpl] of cases) {
+    __resetCloudAccountCacheForTests();
+    await assert.rejects(
+      mintAccessToken({
+        baseUrl: "https://api.test",
+        refreshToken: `r-${code}`,
+        fetchImpl,
+        throwOnFailure: true,
+      }),
+      (err) => {
+        assert.ok(err instanceof AccountAuthError);
+        assert.equal(err.code, code);
+        return true;
+      },
+    );
+  }
+});
+
+test("fetchAccountUsage throws (not returns null) when a signed-in refresh fails", async () => {
+  __resetCloudAccountCacheForTests();
+  await assert.rejects(
+    fetchAccountUsage({
+      usageSlug: "tokentracker-usage-heatmap",
+      refreshToken: "r1",
+      baseUrl: "https://api.test",
+      fetchImpl: async () => jsonResponse({ error: "nope" }, false, 401),
+    }),
+    (err) => err.code === "auth_rejected",
+    "Returning null here would look identical to 'not signed in'.",
+  );
 });

--- a/test/local-api-account-view.test.js
+++ b/test/local-api-account-view.test.js
@@ -407,3 +407,238 @@ test("usage-hourly?account=1 falls back to local hourly data when account hourly
   }
 });
 
+// --- Fallback classification -------------------------------------------------
+//
+// The popover keeps its last account (cross-device) snapshot when a cloud read
+// fails transiently, but must switch to this-machine data when the user signs
+// out or turns cloud sync off. That is only possible if the local server says
+// WHICH of the two happened.
+
+function seedSignedInTracker() {
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-xyz; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+  return trackerDir;
+}
+
+function freshAccessJwt() {
+  return `${Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url")}.${Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString("base64url")}.sig`;
+}
+
+const HEATMAP_ENDPOINT = "/functions/tokentracker-usage-heatmap?weeks=52&tz=UTC&account=1";
+
+test("account fallback is tagged 'signed-out' when there is no relayed session", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+
+  const handler = freshHandler(queuePath);
+  const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+  assert.equal(res._headers["x-tokentracker-account-view"], "0");
+  assert.equal(res._headers["x-tokentracker-account-fallback"], "signed-out");
+});
+
+test("account fallback is tagged 'cloud-sync-off' when the pref is disabled", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const trackerDir = seedSignedInTracker();
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: false }));
+
+  const handler = freshHandler(queuePath);
+  const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+  assert.equal(res._headers["x-tokentracker-account-view"], "0");
+  assert.equal(res._headers["x-tokentracker-account-fallback"], "cloud-sync-off");
+});
+
+test("a failing account read is tagged transient, not as a local view", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const accessJwt = freshAccessJwt();
+  const realFetch = global.fetch;
+  global.fetch = async (urlStr) => {
+    if (String(urlStr).includes("/api/auth/refresh")) {
+      return { ok: true, status: 200, json: async () => ({ accessToken: accessJwt }) };
+    }
+    if (String(urlStr).includes("/functions/tokentracker-account-heatmap")) {
+      return { ok: false, status: 502, json: async () => ({ error: "bad gateway" }) };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+    assert.equal(res._headers["x-tokentracker-account-view"], "0");
+    assert.equal(res._headers["x-tokentracker-account-fallback"], "transient-upstream");
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test("an account read that times out is tagged transient-timeout", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const accessJwt = freshAccessJwt();
+  const prevTimeout = process.env.TOKENTRACKER_HTTP_TIMEOUT_MS;
+  process.env.TOKENTRACKER_HTTP_TIMEOUT_MS = "10";
+
+  const realFetch = global.fetch;
+  global.fetch = async (urlStr, opts) => {
+    if (String(urlStr).includes("/api/auth/refresh")) {
+      return { ok: true, status: 200, json: async () => ({ accessToken: accessJwt }) };
+    }
+    if (String(urlStr).includes("/functions/tokentracker-account-heatmap")) {
+      return new Promise((resolve, reject) => {
+        const t = setTimeout(() => resolve({ ok: true, status: 200, json: async () => ({}) }), 10000);
+        opts?.signal?.addEventListener("abort", () => {
+          clearTimeout(t);
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+    assert.equal(res._headers["x-tokentracker-account-view"], "0");
+    assert.equal(res._headers["x-tokentracker-account-fallback"], "transient-timeout");
+  } finally {
+    global.fetch = realFetch;
+    if (prevTimeout === undefined) delete process.env.TOKENTRACKER_HTTP_TIMEOUT_MS;
+    else process.env.TOKENTRACKER_HTTP_TIMEOUT_MS = prevTimeout;
+  }
+});
+
+test("a rejected token refresh is tagged transient-auth, not signed-out", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const realFetch = global.fetch;
+  global.fetch = async (urlStr) => {
+    if (String(urlStr).includes("/api/auth/refresh")) {
+      return { ok: false, status: 401, json: async () => ({ error: "token consumed" }) };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+    assert.equal(res._headers["x-tokentracker-account-view"], "0");
+    assert.equal(
+      res._headers["x-tokentracker-account-fallback"],
+      "transient-auth",
+      "A rejected refresh must never look like the user signing out.",
+    );
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test("an offline account read is tagged transient-network", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const realFetch = global.fetch;
+  global.fetch = async () => {
+    throw new TypeError("fetch failed");
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+    assert.equal(res._headers["x-tokentracker-account-view"], "0");
+    assert.equal(res._headers["x-tokentracker-account-fallback"], "transient-network");
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test("a successful account read carries no fallback header", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const accessJwt = freshAccessJwt();
+  const payload = { weeks: [], active_days: 3 };
+  const realFetch = global.fetch;
+  global.fetch = async (urlStr) => {
+    if (String(urlStr).includes("/api/auth/refresh")) {
+      return { ok: true, status: 200, json: async () => ({ accessToken: accessJwt }) };
+    }
+    if (String(urlStr).includes("/functions/tokentracker-account-heatmap")) {
+      return { ok: true, status: 200, json: async () => payload };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, { endpoint: HEATMAP_ENDPOINT });
+    assert.equal(res._headers["x-tokentracker-account-view"], "1");
+    assert.equal(res._headers["x-tokentracker-account-fallback"], undefined);
+    assert.deepEqual(res.json(), payload);
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test("one popover refresh mints ONE access token across concurrent account reads", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  seedSignedInTracker();
+
+  const accessJwt = freshAccessJwt();
+  let refreshCalls = 0;
+  const realFetch = global.fetch;
+  global.fetch = async (urlStr) => {
+    const u = String(urlStr);
+    if (u.includes("/api/auth/refresh")) {
+      refreshCalls += 1;
+      // Rotate on every call: a second refresh with the same (already consumed)
+      // token is exactly what used to fail intermittently.
+      if (refreshCalls > 1) return { ok: false, status: 401, json: async () => ({ error: "consumed" }) };
+      await new Promise((r) => setTimeout(r, 5));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ accessToken: accessJwt, refreshToken: "rotated-1" }),
+      };
+    }
+    if (u.includes("/functions/tokentracker-account-")) {
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+  try {
+    const handler = freshHandler(queuePath);
+    const endpoints = [
+      HEATMAP_ENDPOINT,
+      "/functions/tokentracker-usage-daily?from=2026-04-20&to=2026-04-20&tz=UTC&account=1",
+      "/functions/tokentracker-usage-monthly?from=2026-04-01&to=2026-04-30&tz=UTC&account=1",
+      "/functions/tokentracker-usage-model-breakdown?from=2026-04-20&to=2026-04-20&tz=UTC&account=1",
+    ];
+    const results = await Promise.all(endpoints.map((endpoint) => call(handler, { endpoint })));
+    assert.equal(refreshCalls, 1, "concurrent account reads must share one token refresh");
+    for (const res of results) {
+      assert.equal(res._headers["x-tokentracker-account-view"], "1");
+    }
+  } finally {
+    global.fetch = realFetch;
+  }
+});

--- a/test/macos-account-view-authority.test.js
+++ b/test/macos-account-view-authority.test.js
@@ -1,0 +1,139 @@
+"use strict";
+
+// Guard rails for the native popover's account-view authority.
+//
+// There is no Swift test target in this repo (see TokenTrackerBar/project.yml),
+// so the invariants that keep a transient cloud failure from silently shrinking
+// the popover to this-machine data are asserted against the source itself.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+
+function read(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+test("account fallback reasons are classified, and transient ones are recognised by prefix", () => {
+  const source = read("TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift");
+
+  assert.match(source, /case account\b/);
+  assert.match(source, /case localAuthoritative\(reason: String\)/);
+  assert.match(source, /case localTransient\(reason: String\)/);
+  assert.match(
+    source,
+    /if reason\.hasPrefix\("transient"\) \{ return \.localTransient\(reason: reason\) \}/,
+    "Transient reasons must be matched by prefix so the server can add new ones.",
+  );
+  assert.match(
+    source,
+    /return \.localAuthoritative\(reason: reason\.isEmpty \? "unspecified" : reason\)/,
+    "A server too old to send the fallback header must keep the pre-fix behaviour.",
+  );
+});
+
+test("a transient fallback never replaces an account snapshot that is already shown", () => {
+  const source = read("TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift");
+
+  assert.match(
+    source,
+    /mutating func shouldAdopt\([\s\S]*guard source\.isTransientFallback else \{[\s\S]*return true\n {8}\}/,
+    "Authoritative sources (account, signed out, cloud sync off) always publish.",
+  );
+  assert.match(
+    source,
+    /degradedDatasets\.insert\(dataset\)\n {8}if hasExistingValue, sourceByDataset\[dataset\]\?\.isAccount == true \{[\s\S]*return false/,
+    "A transient fallback must keep the existing account snapshot.",
+  );
+  assert.match(
+    source,
+    /sourceByDataset\[dataset\] = source\n {8}return true\n {4}\}/,
+    "With no account snapshot to keep, local data is still better than an empty panel.",
+  );
+});
+
+test("every account-capable popover fetch keeps its response authority", () => {
+  const apiClient = read("TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift");
+
+  for (const fn of [
+    "fetchDaily",
+    "fetchHeatmap",
+    "fetchModelBreakdown",
+    "fetchMonthly",
+    "fetchHourly",
+  ]) {
+    assert.match(
+      apiClient,
+      new RegExp(`func ${fn}\\([^)]*\\) async throws -> AccountFetchResult<`),
+      `${fn} must return the account-view authority, not a bare payload.`,
+    );
+  }
+  assert.match(
+    apiClient,
+    /X-TokenTracker-Account-Fallback/,
+    "The fallback reason header must be read by the client.",
+  );
+  assert.doesNotMatch(
+    apiClient,
+    /withAccountQueryItems\(\[[\s\S]{0,200}?\]\)\)\n\t\}\n\n\tfunc fetch(Daily|Heatmap|Monthly|Hourly|ModelBreakdown)[^\n]*-> (Daily|Heatmap|Monthly|Hourly|Model)/,
+    "No account endpoint may fall back to the header-dropping generic fetch.",
+  );
+});
+
+test("the view model gates every dataset behind the account-view authority", () => {
+  const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
+
+  for (const dataset of [
+    "todaySummary",
+    "periodSummary",
+    "rollingSummary",
+    "totalSummary",
+    "daily",
+    "hourly",
+    "monthly",
+    "heatmap",
+    "modelBreakdown",
+  ]) {
+    assert.match(
+      viewModel,
+      new RegExp(`for: \\.${dataset},`),
+      `${dataset} must go through shouldPublish before overwriting what is on screen.`,
+    );
+  }
+
+  assert.match(
+    viewModel,
+    /private static let accountRecoveryDelays: \[TimeInterval\] = \[1, 3, 10\]/,
+    "A transient cloud failure should retry on a short backoff, not wait for the next tick.",
+  );
+  assert.match(
+    viewModel,
+    /if accountViewState\.isDegraded \{\n {12}scheduleAccountRecoveryRetry\(\)\n {8}\} else \{\n {12}cancelAccountRecovery\(\)/,
+    "Recovery retries must stop as soon as the account view comes back.",
+  );
+  assert.match(
+    viewModel,
+    /guard accountRecoveryAttempt < Self\.accountRecoveryDelays\.count else \{ return \}/,
+    "Retries must be bounded.",
+  );
+});
+
+test("the local server tags why it served this-machine data", () => {
+  const localApi = read("src/lib/local-api.js");
+
+  assert.match(localApi, /const ACCOUNT_FALLBACK_CLOUD_SYNC_OFF = "cloud-sync-off";/);
+  assert.match(localApi, /const ACCOUNT_FALLBACK_SIGNED_OUT = "signed-out";/);
+  assert.match(
+    localApi,
+    /res\.setHeader\("X-TokenTracker-Account-View", "0"\);\n\s*res\.setHeader\("X-TokenTracker-Account-Fallback", result\);/,
+    "Every local fallback response must carry its reason.",
+  );
+  assert.match(
+    localApi,
+    /function classifyAccountFallback\(err\)[\s\S]*return "transient-timeout"[\s\S]*return "transient-auth"[\s\S]*return "transient-network"/,
+    "Timeout, auth and network failures must be distinguishable in logs.",
+  );
+});

--- a/test/macos-account-view-authority.test.js
+++ b/test/macos-account-view-authority.test.js
@@ -7,7 +7,9 @@
 // the popover to this-machine data are asserted against the source itself.
 
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
@@ -45,12 +47,12 @@ test("a transient fallback never replaces an account snapshot that is already sh
   );
   assert.match(
     source,
-    /degradedDatasets\.insert\(dataset\)\n {8}if hasExistingValue, sourceByDataset\[dataset\]\?\.isAccount == true \{[\s\S]*return false/,
+    /degradedDatasets\.insert\(dataset\)\n {8}if hasExistingValue, recordByDataset\[dataset\]\?\.source\.isAccount == true \{[\s\S]*return false/,
     "A transient fallback must keep the existing account snapshot.",
   );
   assert.match(
     source,
-    /sourceByDataset\[dataset\] = source\n {8}return true\n {4}\}/,
+    /recordByDataset\[dataset\] = Record\(source: source, scope: scope\)\n {8}return true\n {4}\}/,
     "With no account snapshot to keep, local data is still better than an empty panel.",
   );
 });
@@ -137,3 +139,167 @@ test("the local server tags why it served this-machine data", () => {
     "Timeout, auth and network failures must be distinguishable in logs.",
   );
 });
+
+test("dataset authority is keyed by query scope, not by dataset alone", () => {
+  const source = read("TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift");
+  const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
+
+  assert.match(
+    source,
+    /mutating func shouldAdopt\(\n\s*_ source: AccountViewSource,\n\s*for dataset: Dataset,\n\s*scope: String,\n\s*hasExistingValue: Bool\n\s*\) -> Bool \{/,
+    "Authority is only meaningful for the query it was recorded on.",
+  );
+  assert.match(
+    source,
+    /if let record = recordByDataset\[dataset\], record\.scope != scope \{\n\s*recordByDataset\.removeValue\(forKey: dataset\)\n\s*degradedDatasets\.remove\(dataset\)\n\s*\}\n\s*guard source\.isTransientFallback else \{/,
+    "A record from a scope the view has left must be dropped BEFORE the retained-snapshot rule runs, or last period's numbers outrank this period's response.",
+  );
+
+  // Every gated publish must name the scope it answers for; one that forgets
+  // reintroduces the cross-scope retention this test exists to prevent.
+  const calls = viewModel.match(/self\.shouldPublish\(/g) ?? [];
+  const scoped = viewModel.match(/scope: AccountViewStateStore\.Scope\./g) ?? [];
+  assert.ok(calls.length >= 12, `expected the full set of gated publishes, found ${calls.length}`);
+  assert.equal(
+    scoped.length,
+    calls.length,
+    "every shouldPublish call site must pass the scope its response answers for",
+  );
+
+  // Period-scoped datasets follow the selection; sliding windows deliberately
+  // do not, so midnight gives a transient failure no fresh chance to downgrade.
+  assert.match(viewModel, /for: \.periodSummary,\n\s*scope: AccountViewStateStore\.Scope\.range\(range\.from, range\.to\)/);
+  assert.match(viewModel, /for: \.modelBreakdown,\n\s*scope: AccountViewStateStore\.Scope\.range\(range\.from, range\.to\)/);
+  assert.match(viewModel, /for: \.monthly,\n\s*scope: AccountViewStateStore\.Scope\.range\(range\.from, range\.to\)/);
+  assert.match(viewModel, /for: \.hourly,\n\s*scope: AccountViewStateStore\.Scope\.day\(rollingTo\)/);
+  assert.match(viewModel, /for: \.heatmap,\n\s*scope: AccountViewStateStore\.Scope\.heatmap/);
+
+  // The full load and the hidden menu-bar refresh both publish todaySummary.
+  // They must key it on the same local day string, or each would invalidate the
+  // other's authority every pass and hand a transient failure a way through.
+  const todayScopes = viewModel.match(/for: \.todaySummary,\n\s*scope: [^\n]+/g) ?? [];
+  assert.equal(todayScopes.length, 2, "both publish paths must scope todaySummary");
+  for (const scoped of todayScopes) {
+    assert.match(scoped, /AccountViewStateStore\.Scope\.day\(/);
+  }
+
+  // The executed test below declares this enum locally to stay standalone.
+  assert.match(
+    read("TokenTrackerBar/TokenTrackerBar/Models/UsagePublicationPolicy.swift"),
+    /enum UsageSummaryViewSource: Equatable \{\n {4}case localQueue\n {4}case accountUpload\n\}/,
+    "Change this and the standalone driver in the executed test needs the same change.",
+  );
+});
+
+// The store is Foundation-only, so where a Swift toolchain exists the state
+// machine is exercised for real rather than pattern-matched. Skipped elsewhere
+// (Linux validators, machines without Xcode) — the assertions above still hold
+// the shape of the code there.
+const swiftAvailable =
+  process.platform === "darwin" &&
+  spawnSync("swiftc", ["--version"], { stdio: "ignore" }).status === 0;
+
+test(
+  "account authority does not survive a change of period or day (executed)",
+  { skip: swiftAvailable ? false : "no Swift toolchain on this platform" },
+  () => {
+    const driver = `
+import Foundation
+
+// AccountViewSource.swift references this one type from
+// UsagePublicationPolicy.swift, which drags in most of the app. Declaring the
+// four lines here keeps the driver standalone; the assertion above pins the
+// real enum's shape so this copy cannot silently drift.
+enum UsageSummaryViewSource: Equatable {
+    case localQueue
+    case accountUpload
+}
+
+typealias Store = AccountViewStateStore
+let month = Store.Scope.range("2026-08-01", "2026-08-31")
+let week = Store.Scope.range("2026-08-31", "2026-09-06")
+var failures = 0
+
+func check(_ ok: Bool, _ what: String) {
+    if !ok { failures += 1; FileHandle.standardError.write("FAIL \\(what)\\n".data(using: .utf8)!) }
+}
+
+// The reported regression: the user switches period while the cloud read fails.
+var store = Store()
+var summary: String? = nil
+_ = store.shouldAdopt(.account, for: .periodSummary, scope: month, hasExistingValue: false)
+summary = "month account totals"
+let adopted = store.shouldAdopt(.localTransient(reason: "transient-network"),
+                                for: .periodSummary, scope: week,
+                                hasExistingValue: summary != nil)
+if adopted { summary = "week local totals" }
+check(adopted, "a new period's response must not be outranked by the old period's authority")
+check(summary == "week local totals", "the panel must not keep last period's numbers")
+
+// The invariant this whole guard exists for must survive: same scope, transient loses.
+var sameScope = Store()
+_ = sameScope.shouldAdopt(.account, for: .periodSummary, scope: month, hasExistingValue: false)
+check(sameScope.shouldAdopt(.localTransient(reason: "transient-timeout"),
+                            for: .periodSummary, scope: month,
+                            hasExistingValue: true) == false,
+      "a transient fallback still never replaces an account snapshot of the same scope")
+
+// Signing out must still switch to local.
+var signOut = Store()
+_ = signOut.shouldAdopt(.account, for: .periodSummary, scope: month, hasExistingValue: false)
+check(signOut.shouldAdopt(.localAuthoritative(reason: "signed-out"),
+                          for: .periodSummary, scope: month,
+                          hasExistingValue: true) == true,
+      "an authoritative local view always replaces account data")
+
+// A scope change also resets the retry budget.
+var degraded = Store()
+_ = degraded.shouldAdopt(.account, for: .modelBreakdown, scope: month, hasExistingValue: false)
+_ = degraded.shouldAdopt(.localTransient(reason: "transient-network"),
+                         for: .modelBreakdown, scope: month, hasExistingValue: true)
+check(degraded.isDegraded, "a retained snapshot marks the dataset degraded")
+_ = degraded.shouldAdopt(.account, for: .modelBreakdown, scope: week, hasExistingValue: true)
+check(!degraded.isDegraded, "a healthy response on the new scope clears the degraded flag")
+
+// Crossing midnight: yesterday's account hourly must not be kept under today's label.
+var midnight = Store()
+_ = midnight.shouldAdopt(.account, for: .hourly, scope: Store.Scope.day("2026-09-01"), hasExistingValue: false)
+check(midnight.shouldAdopt(.localTransient(reason: "transient-network"),
+                           for: .hourly, scope: Store.Scope.day("2026-09-02"),
+                           hasExistingValue: true) == true,
+      "a day-scoped dataset lets the new day through")
+
+// Sliding windows keep a constant scope, so midnight is not an opening.
+var heatmap = Store()
+_ = heatmap.shouldAdopt(.account, for: .heatmap, scope: Store.Scope.heatmap, hasExistingValue: false)
+check(heatmap.shouldAdopt(.localTransient(reason: "transient-network"),
+                          for: .heatmap, scope: Store.Scope.heatmap,
+                          hasExistingValue: true) == false,
+      "the year heatmap keeps its account snapshot across midnight")
+
+exit(failures == 0 ? 0 : 1)
+`;
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-account-scope-"));
+    try {
+      const driverPath = path.join(dir, "main.swift");
+      const binary = path.join(dir, "scopecheck");
+      fs.writeFileSync(driverPath, driver);
+      const build = spawnSync(
+        "swiftc",
+        [
+          path.join(repoRoot, "TokenTrackerBar/TokenTrackerBar/Models/AccountViewSource.swift"),
+          driverPath,
+          "-o",
+          binary,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.equal(build.status, 0, `swiftc failed:\n${build.stderr}`);
+      const run = spawnSync(binary, { encoding: "utf8" });
+      assert.equal(run.status, 0, `state machine violated its invariants:\n${run.stderr}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/macos-background-sync-source.test.js
+++ b/test/macos-background-sync-source.test.js
@@ -45,8 +45,13 @@ test("macOS background sync sends auto background while Sync Now drains", () => 
   );
   assert.match(
     apiClient,
-    /func fetchSummaryWithSource\([\s\S]*X-TokenTracker-Account-View[\s\S]*latestAccountSummaryReadCompletedAt = completedAt/,
+    /func fetchSummaryWithSource\([\s\S]*latestAccountSummaryReadCompletedAt = completedAt/,
     "Every summary response should return its own authority and track account-cache completion.",
+  );
+  assert.match(
+    apiClient,
+    /private func fetchWithSource<T: Decodable>\([\s\S]*X-TokenTracker-Account-View[\s\S]*X-TokenTracker-Account-Fallback/,
+    "The shared sourced fetch must read both account-view headers.",
   );
   assert.match(
     viewModel,

--- a/test/windows-account-view-authority.test.js
+++ b/test/windows-account-view-authority.test.js
@@ -7,7 +7,11 @@
 // flag nobody consumed, and published the payload regardless — so a transient
 // cloud failure dropped the tray from cross-device totals to this machine.
 //
-// There is no C# test project, so the invariants are asserted against the source.
+// The behaviour itself is covered end-to-end against a loopback server in
+// TokenTrackerWin.Tests/UsagePollerAccountAuthorityTests.cs, which CI runs on a
+// Windows runner. These assertions are the cheap cross-platform half: they hold
+// the *shape* of the code (no write-only flags, both headers read, the guards
+// wired to this poll's authority) on runners with no .NET toolchain.
 
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
@@ -62,8 +66,8 @@ test("rich pet stats cannot mix authorities into one published snapshot", () => 
     "FetchTopModelsAsync must be able to signal a would-be downgrade.",
   );
   for (const guard of [
-    /FetchHeatmapAsync[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && _showingAccountData\) return null;/,
-    /FetchTopModelsAsync[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && _showingAccountData\) return null;/,
+    /FetchHeatmapAsync\(string tzQuery, bool retainAccount\)[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && retainAccount\) return null;/,
+    /FetchTopModelsAsync\(string today, string tzQuery, bool retainAccount\)[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && retainAccount\) return null;/,
   ]) {
     assert.match(usagePoller, guard, "each rich sub-fetch must apply the same rule");
   }
@@ -71,6 +75,35 @@ test("rich pet stats cannot mix authorities into one published snapshot", () => 
     usagePoller,
     /if \(heatmap is null \|\| topModels is null\) return null;/,
     "UsageStats is published atomically, so one degraded dataset skips the whole poll.",
+  );
+});
+
+test("the rich-stat guards read this poll's authority, not the last publish's", () => {
+  // `_showingAccountData` is assigned at the very end of FetchAsync, so it
+  // describes the *previous* published snapshot. It starts false, so on a cold
+  // start — and on any local-to-account transition — a summary that came back
+  // as Account paired with a transient heatmap/model response would pass a
+  // guard written against the old flag alone, mixing this machine's streak and
+  // top models into an account-authoritative UsageStats. Worse, the next poll
+  // then sees the flag as true, returns null, and leaves that mixed snapshot
+  // rendering in the tray until the failing dataset recovers.
+  assert.match(
+    usagePoller,
+    /var retainAccount = summarySource == AccountSource\.Account \|\| _showingAccountData;/,
+    "The retention decision must include what THIS poll is about to render as.",
+  );
+  for (const call of [
+    /var heatmap = await FetchHeatmapAsync\(tzQuery, retainAccount\);/,
+    /var topModels = await FetchTopModelsAsync\(today, tzQuery, retainAccount\);/,
+  ]) {
+    assert.match(usagePoller, call, "both rich sub-fetches must be told the current authority");
+  }
+  // The flag must not be consulted directly inside the helpers any more.
+  const heatmapBody = usagePoller.slice(usagePoller.indexOf("FetchHeatmapAsync(string tzQuery"));
+  assert.doesNotMatch(
+    heatmapBody,
+    /_showingAccountData/,
+    "A helper reading the previous-publish flag reintroduces the transition gap.",
   );
 });
 

--- a/test/windows-account-view-authority.test.js
+++ b/test/windows-account-view-authority.test.js
@@ -1,0 +1,83 @@
+"use strict";
+
+// Windows counterpart of test/macos-account-view-authority.test.js.
+//
+// The tray/pet poller hits the same `?account=1` contract as the macOS popover
+// and had the same defect: it read `X-TokenTracker-Account-View`, stored it in a
+// flag nobody consumed, and published the payload regardless — so a transient
+// cloud failure dropped the tray from cross-device totals to this machine.
+//
+// There is no C# test project, so the invariants are asserted against the source.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+const usagePoller = fs.readFileSync(
+  path.join(repoRoot, "TokenTrackerWin/UsagePoller.cs"),
+  "utf8",
+);
+
+test("the write-only AccountViewActive flag is gone", () => {
+  assert.doesNotMatch(
+    usagePoller,
+    /AccountViewActive/,
+    "Tracking the account view in a field nobody reads is what made the bug invisible.",
+  );
+});
+
+test("both account-view headers are read, transient matched by prefix", () => {
+  assert.match(
+    usagePoller,
+    /private static AccountSource ReadAccountSource\(HttpResponseMessage resp\)/,
+  );
+  assert.match(usagePoller, /"X-TokenTracker-Account-View"/);
+  assert.match(usagePoller, /"X-TokenTracker-Account-Fallback"/);
+  assert.match(
+    usagePoller,
+    /reason\.StartsWith\("transient", StringComparison\.Ordinal\)\n\s*\? AccountSource\.LocalTransient\n\s*: AccountSource\.LocalAuthoritative/,
+    "New transient reasons must not require a client change; a missing reason stays authoritative.",
+  );
+});
+
+test("a transient fallback skips the publish instead of overwriting account figures", () => {
+  assert.match(
+    usagePoller,
+    /var summarySource = ReadAccountSource\(resp\);\n\s*if \(summarySource == AccountSource\.LocalTransient && _showingAccountData\) return null;/,
+    "Returning null leaves TrayApplicationContext._lastStats — the account snapshot — untouched.",
+  );
+});
+
+test("rich pet stats cannot mix authorities into one published snapshot", () => {
+  assert.match(
+    usagePoller,
+    /private async Task<\(int Streak, int ActiveDays\)\?> FetchHeatmapAsync\(/,
+    "FetchHeatmapAsync must be able to signal a would-be downgrade.",
+  );
+  assert.match(
+    usagePoller,
+    /private async Task<IReadOnlyList<TopModelStat>\?> FetchTopModelsAsync\(/,
+    "FetchTopModelsAsync must be able to signal a would-be downgrade.",
+  );
+  for (const guard of [
+    /FetchHeatmapAsync[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && _showingAccountData\) return null;/,
+    /FetchTopModelsAsync[\s\S]*?if \(ReadAccountSource\(resp\) == AccountSource\.LocalTransient && _showingAccountData\) return null;/,
+  ]) {
+    assert.match(usagePoller, guard, "each rich sub-fetch must apply the same rule");
+  }
+  assert.match(
+    usagePoller,
+    /if \(heatmap is null \|\| topModels is null\) return null;/,
+    "UsageStats is published atomically, so one degraded dataset skips the whole poll.",
+  );
+});
+
+test("account authority is recorded only on a real publish", () => {
+  assert.match(
+    usagePoller,
+    /_showingAccountData = summarySource == AccountSource\.Account;\n\s*return new UsageStats\(/,
+    "The flag must track what is actually on screen, not what the last response said.",
+  );
+});


### PR DESCRIPTION
## Summary

A cloud read that merely *failed* was indistinguishable from "this user only has one device", so a single timed-out account request silently replaced the native popover's cross-device Activity heatmap with this-machine data until the next manual sync.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [x] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Why

`?account=1` answers with local single-machine data in two completely different situations:

1. that really is the user's scope — signed out, or cloud sync off;
2. the cloud read failed — timeout, offline, rejected token refresh.

Both came back as an indistinguishable `HTTP 200` + `X-TokenTracker-Account-View: 0`, and the popover's heatmap / daily / monthly / model-breakdown fetches went through the generic `fetch()`, which dropped the header entirely. So case 2 overwrote a good account snapshot with one device's data.

An amplifier made it fire more often than it should: a full refresh issues six account reads concurrently, and on a cold token cache every one of them POSTed `/api/auth/refresh` with the same refresh token. When the backend rotates refresh tokens, the losers of that race present an already-consumed token and fail — inside a 4s budget shared by the token mint *and* the account fetch.

Reproduces on any flaky network; wake-from-sleep just makes it likely, because the wake catch-up fires before Wi-Fi/VPN is back.

## What changed

**`src/lib/local-api.js`** — classify the fallback (`signed-out`, `cloud-sync-off`, `transient-timeout|auth|network|upstream`) and report it in a new `X-TokenTracker-Account-Fallback` header. Every transient reason carries the `transient-` prefix, so new reasons need no client change.

**`src/lib/cloud-account.js`** — share one in-flight `/api/auth/refresh` per `(baseUrl, refreshToken)`. Also throw a classified error instead of returning `null` when a *signed-in* refresh fails, so it can no longer be mistaken for "not signed in".

**`TokenTrackerBar/`** — every account-capable fetch returns `AccountFetchResult<T>` carrying the response authority. `AccountViewStateStore` refuses to let a transient fallback replace an account snapshot that is already on screen (full load and hidden menu-bar refresh alike), retries on a 1s/3s/10s backoff, and logs the reason only. Cold start with no snapshot still shows local data, labelled "This Mac only · reconnecting".

**`TokenTrackerWin/`** — the tray poller had the same defect: it stored `X-TokenTracker-Account-View` in an `AccountViewActive` field that **nothing in the assembly read**, then published the payload regardless. Net deletion plus one guard — on a transient downgrade, skip the publish and let `TrayApplicationContext._lastStats` keep rendering the account snapshot. No new types and no cached copies, because `UsageStats` is published atomically.

## Behaviour matrix

| Situation | Before | After |
|---|---|---|
| Cloud read times out, account snapshot on screen | Replaced with this-machine data | Snapshot kept, retried on backoff |
| User signs out / turns cloud sync off | Switches to local | Switches to local (unchanged) |
| Cold start, cloud already down | Local data, unlabelled | Local data, labelled as temporary |
| Server too old to send the reason header | — | Treated as authoritative-local (pre-fix behaviour) |

## Checklist

- [x] `npm test` passes — 2526 passed. The 5 failures in my sandbox are environment-only (this worktree has no `node_modules`, so the vitest / `tsc` / vite-dev-server tests can't resolve their deps); none touch this change.
- [x] New user-facing strings go through the copy registry — n/a for `dashboard/`; the one new string is a macOS `Strings.swift` entry with all five locales filled in.
- [x] Commits follow conventional style
- [x] PR description explains *why*, not just *what*

`TokenTrackerBar/project.yml` is untouched (sources are directory-based, so the new Swift file is picked up by `xcodegen generate` with no project edit).

**Maintainer note:** this touches `src/`, `TokenTrackerBar/` and `TokenTrackerWin/`, so per `CLAUDE.md` it is release-eligible. I did not bump any version file — that is the release workflow's call.

---

<details>
<summary><strong>Risk layer addendum</strong></summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [x] Auth / session / token handling
- [x] Cross-endpoint invariants or shared logic
- [x] External gateway / environment constraints

### Rules / invariants

- A `transient-*` fallback must never replace a payload whose recorded authority is `account`.
- An authoritative local view (signed out, cloud sync off) must *always* replace an account payload — otherwise a signed-out user keeps seeing another session's totals.
- With no account snapshot to keep, local data is still published; an empty panel is worse.
- Concurrent account reads sharing a `(baseUrl, refreshToken)` must produce exactly one refresh request.
- A rotated refresh token reaches every waiter of that shared flight.
- The reason string is diagnostic only: no tokens, cookies, or usage figures cross the boundary or reach logs.

### Boundary matrix

| Boundary | Input | Expected |
|---|---|---|
| `X-TokenTracker-Account-View` absent (pre-0.46 server) | no headers | authoritative-local; pre-fix behaviour, no throw on the popover's summary path |
| `Account-View: 0`, no reason header | older server | authoritative-local, not transient |
| `Account-View: 0`, unknown `transient-xyz` | future server | transient, matched by prefix |
| Refresh returns 401 (token consumed) | rotation race | `transient-auth`, **not** `signed-out` |
| Cloud unreachable (`TypeError: fetch failed`) | offline | `transient-network`, body still local data, HTTP 200 |
| Failed in-flight mint | first caller throws | entry cleared; the next call retries rather than inheriting the failure |
| Dataset emptied by a period switch (`hourly`/`monthly`) | period change | degraded flag cleared, so retry budget resets |

### Regression tests

- `test/local-api-account-view.test.js` — six classification cases + "one popover refresh mints ONE token across concurrent reads"
- `test/cloud-account.test.js` — single-flight, failure doesn't poison later attempts, error classification, signed-in refresh failure throws
- `test/macos-account-view-authority.test.js`, `test/windows-account-view-authority.test.js` — no Swift/C# test target exists, so the invariants are asserted against the source

</details>

<details>
<summary><strong>Verification</strong></summary>

**Executed, not just asserted:**

- The Swift state machine is Foundation-only, so it was compiled standalone and run against the reported scenario plus the reverse case (sign-out must still switch), cold start, an old server with no reason header, and the degraded-flag reset — all pass.
- A real `http.createServer` round-trip (the existing tests use a fake `res`, which can't prove `writeHead` doesn't drop `setHeader` values) confirms both headers arrive over a socket and the body is still local data rather than an error:

  ```
  HTTP/1.1 200 OK
  X-TokenTracker-Account-View: 0
  X-TokenTracker-Account-Fallback: transient-network
  ```

**Compiled on both platforms:**

- macOS: Xcode 27.0 beta (27A5252f), Swift 6.4, `xcodebuild -configuration Release` → `** BUILD SUCCEEDED **`. No warnings from any changed file (the one warning in the log is the pre-existing `Copy EmbeddedServer` script-phase notice). Verified the new type actually reached the product binary:

  ```
  TokenTracker.AccountViewStateStore.shouldAdopt(
      _: TokenTracker.AccountViewSource,
      for: TokenTracker.AccountViewStateStore.Dataset,
      hasExistingValue: Swift.Bool) -> Swift.Bool
  ```

- Windows: .NET SDK 10.0.400, `dotnet build -p:EnableWindowsTargeting=true` (cross-compiled from macOS), Debug and Release → **0 warnings, 0 errors** in both.

`TokenTrackerBar/project.yml` needed no edit; `xcodegen generate` picks up the new Swift file from the directory-based source list.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented temporary local-only data from replacing trusted account data during cloud sync interruptions.
  * Prevented stale data from a previous date or period from overriding current results.
  * Added automatic recovery retries when account data is temporarily unavailable.
  * Improved refresh authentication errors and handling of concurrent token refreshes.
  * Preserved dashboard and menu-bar values during temporary account request failures.

* **User Experience**
  * Activity heatmaps now indicate when they show data from this Mac only, with localized messaging.

* **Tests**
  * Added coverage for account authority, fallback states, recovery, and authentication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->