### PR TITLE
fix(macos): keep limit-reset baseline when a reading has no reset_at

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/WeeklyLimitResetDetector.swift
@@ -93,15 +93,19 @@ struct WeeklyLimitResetDetector {
 
         for reading in readings {
             let key = reading.windowKey
+            // A reading without a reset timestamp (e.g. Claude's 5h window sitting idle
+            // after rollover reports 0% / null) carries no window identity, so it must
+            // not touch the baseline: overwriting the percent with 0 here would make the
+            // next real reading fail the minDrop check and silently lose the celebration.
+            guard let curReset = reading.resetAt else { continue }
             let prevPercent = snapshot.lastPercent[key]
             let prevReset = snapshot.lastResetAt[key]
             updated.lastPercent[key] = reading.usedPercent
-            if let resetAt = reading.resetAt { updated.lastResetAt[key] = resetAt }   // keep last value when missing
+            updated.lastResetAt[key] = curReset
 
-            // Need a full prior baseline (percent + reset time) and a current reset
-            // time. First observation, or a window without a reset timestamp, only
+            // Need a full prior baseline (percent + reset time). First observation only
             // records a baseline — never celebrates.
-            guard let prevPercent, let prevReset, let curReset = reading.resetAt else { continue }
+            guard let prevPercent, let prevReset else { continue }
             // The window must have actually rolled over: its reset_at advanced to a
             // new period, not merely a percentage that dipped.
             guard curReset > prevReset + resetAdvanceTolerance else { continue }

--- a/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/WeeklyLimitResetDetectorTests.swift
@@ -58,6 +58,20 @@ final class WeeklyLimitResetDetectorTests: XCTestCase {
         XCTAssertTrue(events.isEmpty)
     }
 
+    func testIdleReadingWithoutResetTimeKeepsBaseline() {
+        // Claude 5h after rollover with no active session reports 0% and no reset_at.
+        // That reading must not overwrite the baseline, otherwise the next real reading
+        // (new reset_at, low usage) sees prevPercent == 0 and never celebrates.
+        let (_, baseline) = detector.evaluate(readings: reading(60, resetAt: 5000), snapshot: .init(), now: 1000)
+        let (idleEvents, idle) = detector.evaluate(readings: reading(0, resetAt: nil), snapshot: baseline, now: 1500)
+        XCTAssertTrue(idleEvents.isEmpty)
+        XCTAssertEqual(idle.lastPercent["codex.primary"], 60, "nil reset_at must not clobber the percent baseline")
+
+        let (events, _) = detector.evaluate(readings: reading(3, resetAt: 9000), snapshot: idle, now: 2000)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.previousPercent, 60)
+    }
+
     func testSlidingResetWithoutUsageDropDoesNotFire() {
         // Kiro-style: reset_at slides forward every poll, but usage stayed high.
         // The minDrop guard prevents a false celebration.


### PR DESCRIPTION
## Summary

Skip limit-window readings that carry no `reset_at` before touching the persisted baseline, so Claude's idle `0% / null` reading after rollover no longer wipes the percent needed to celebrate the next reset. Closes #564.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes — all pass except `installLocalTrackerApp replaces stale installed runtime…`, which needs a prebuilt `dashboard/dist` locally and is unrelated (no JS touched here)
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` — n/a, no strings
- [x] Commits follow conventional style
- [x] PR description explains *why*, not just *what*

## Why

`WeeklyLimitResetDetector.evaluate` wrote `lastPercent[key] = usedPercent` for every reading, including ones with `resetAt == nil`. Claude's 5h window sitting idle after rollover reports `utilization: 0, resets_at: null`, so the baseline became 0; the next real reading (new `resets_at`, low usage) then failed the `minDrop` check and the toast/confetti never fired. Kimi returns a `reset_at` even for an empty window, which is why it celebrated every rollover while Claude almost never did (snapshot evidence in #564).

## Behaviour

- Reading with `resetAt == nil` → baseline untouched, no event (it still never celebrates by itself, as before).
- Reading with `resetAt` → baseline updated and rollover detection unchanged.

## Test

Added `testIdleReadingWithoutResetTimeKeepsBaseline`: 60% → (0%, nil) → (3%, new reset) fires with `previousPercent == 60`. No Xcode on this machine, so the detector struct was compiled standalone with `swiftc` and run through every scenario in `WeeklyLimitResetDetectorTests` including the new one (all pass); CI should run the real XCTest target.
