### PR TITLE
fix(antigravity): 修复 billable 丢失导致热力图/近7日滚动为 0

### DIFF
--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -219,8 +219,12 @@ function normalizeQueueRow(row) {
   // non-zero billable usage (GitHub issue #106). Treat billing and usage as
   // orthogonal: bump billable up to total_tokens at read time so historical
   // queue.jsonl entries render correctly without requiring a file rewrite.
+  // Antigravity had the same symptom from e69e2746a (billable deleted during
+  // the O(N) refactoring, leaving 167 local rows with billable=0 until the
+  // parser fix). Apply the same read-time healing so upgraded installs show
+  // correct heatmap / rolling numbers without a queue rewrite.
   const sourceName = String(normalized.source || "").toLowerCase();
-  if (sourceName === "cursor") {
+  if (sourceName === "cursor" || sourceName === "antigravity") {
     const totalTokens = Number(normalized.total_tokens || 0);
     const billable = Number(normalized.billable_total_tokens || 0);
     if (totalTokens > 0 && billable < totalTokens) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -17435,6 +17435,7 @@ async function parseAntigravityFile({
       // Match the mainstream convention (Codebuddy / Kilocode / OMP / Hermes):
       // total_tokens = sum of every token column. No cache columns here.
       delta.total_tokens = inputDelta + outputTokens + reasoningTokens;
+      delta.billable_total_tokens = delta.total_tokens;
       delta.conversation_count = 1;
       billedPlanner = delta.total_tokens > 0;
     }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -11596,6 +11596,7 @@ test("parseAntigravityIncremental bills only newly added context per planner cal
       queued[0].total_tokens,
       queued[0].input_tokens + queued[0].output_tokens + queued[0].reasoning_output_tokens,
     );
+    assert.equal(queued[0].billable_total_tokens, queued[0].total_tokens);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
### 背景

排查Antigravity 会员额度与token消耗时发现一个真 bug：Antigravity 的 billable_total_tokens 过去 3 个月全是 0。

### 根因

- b02d7ab 新增时：delta.billable_total_tokens = delta.total_tokens 正确。
- e69e2746a 修 O(N²) 时把 delta.total_tokens 重构成局部变量，误删了 billable 那一行，之后只用 let delta = initTotals()（billable:0）打底，addTotals 里 delta.billable ?? delta.total 对 0 不回退 → 入库 167 行全 b:0, t>0。
- 同类估算型 provider（Hermes/CodeBuddy/KiloCode/OMP）都是 const delta = { total: … } 纯对象，billable 为 undefined 才会回退到 total，所以只有 Antigravity 中招。

### 修复

1. 写时 src/lib/rollout.js:17419 补回 delta.billable_total_tokens = delta.total_tokens
2. 读时 src/lib/local-api.js:222 把历史脏数据在 normalizeQueueRow 治愈（沿用 #106 对 Cursor 的做法），已升级的用户无需重写 queue.jsonl 也能立刻看到正确的热力图/滚动
3. test 补断言 billable == total

本地已就地治愈验证：queue.jsonl 167→0 行 b:0，model-breakdown 今日 b:482472==t:482472，daily/rolling 恢复非 0

### 验证

- parseAntigravityIncremental 12 项通过
- npm test 2507 pass / 2 fail（2 个失败与主分支一致，resolveCodebuddyProjectFiles 环境多文件、usage-limits-singleflight 不稳）

### 风险

仅 Antigravity 通路，历史热力图会从 0 恢复到真实深度（符合预期），排行榜会把过去 3 个月的 Antigravity 估算 Upper Bound 计入 billable（与 b02d7ab 原始意图一致）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Antigravity usage accounting so billable tokens accurately match total tokens.
  * Updated heatmap and rolling usage figures for existing Antigravity data without requiring a queue rewrite.
  * Improved per-turn billing calculations for newly added context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->