### PR TITLE
fix: support ZCode team coding plan quota queries

### DIFF
--- a/src/lib/zcode-limits.js
+++ b/src/lib/zcode-limits.js
@@ -95,7 +95,24 @@ function loadZcodeProviderAvailability({ home, env } = {}) {
   }
 }
 
-function loadZcodeSelectedPlanProviderKeys({ home, env } = {}) {
+function parseZcodeTeamContext(selection, family) {
+  if (family !== "bigmodel" && family !== "zai") return null;
+  const prefix = `team-plan:builtin:${family}-coding-plan:`;
+  if (!selection.startsWith(prefix)) return null;
+  const parts = selection.slice(prefix.length).split(":");
+  // ZCode 3.10.x stores product:organization:project. Older project-only
+  // selections do not identify an organization, so do not guess its scope.
+  if (parts.length !== 3) return null;
+  try {
+    const [productId, organizationId, projectId] = parts.map((part) => decodeURIComponent(part.trim()).trim());
+    if (!productId || !organizationId || !projectId) return null;
+    return { organizationId, projectId };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function loadZcodeSelectedPlans({ home, env } = {}) {
   const zcodeHome = resolveZcodeHome({ home, env });
   const settingPath = path.join(zcodeHome, "v2", "setting.json");
   if (!fs.existsSync(settingPath)) return [];
@@ -109,12 +126,17 @@ function loadZcodeSelectedPlanProviderKeys({ home, env } = {}) {
     for (const key of domains) {
       const raw = typeof selected[key] === "string" ? selected[key].trim() : "";
       const match = raw.match(/builtin:(?:bigmodel|zai)-(?:start|coding)-plan/);
-      if (match && !out.includes(match[0])) out.push(match[0]);
+      if (!match || out.some((plan) => plan.providerKey === match[0])) continue;
+      out.push({ providerKey: match[0], teamContext: parseZcodeTeamContext(raw, key) });
     }
     return out;
   } catch (_error) {
     return [];
   }
+}
+
+function loadZcodeSelectedPlanProviderKeys(options = {}) {
+  return loadZcodeSelectedPlans(options).map((plan) => plan.providerKey);
 }
 
 function resolveZcodeCredentialsPath({ home, env } = {}) {
@@ -262,7 +284,8 @@ function loadZcodeAuthCandidates({ home, env } = {}) {
     ];
     const availability = loadZcodeProviderAvailability({ home, env });
     const hasAvailability = Object.keys(availability).length > 0;
-    const selectedCandidates = loadZcodeSelectedPlanProviderKeys({ home, env })
+    const selectedPlans = loadZcodeSelectedPlans({ home, env });
+    const selectedCandidates = selectedPlans.map((plan) => plan.providerKey)
       .filter((key) => defaultCandidates.includes(key));
     const availableCandidates = defaultCandidates.filter((key) => availability?.[key]?.status === "available");
     const candidates = [
@@ -279,6 +302,7 @@ function loadZcodeAuthCandidates({ home, env } = {}) {
       const apiKey = typeof provider?.options?.apiKey === "string" ? provider.options.apiKey.trim() : "";
       const billingBaseUrl = resolveZcodeProviderBillingBaseUrl(key, provider, env);
       const quotaUrl = resolveZcodeProviderQuotaUrl(key, provider, env);
+      const teamContext = selectedPlans.find((plan) => plan.providerKey === key)?.teamContext;
       const credentialApiKey = resolveZcodeCredentialAuth(key, { home, env });
       const authEntries = [
         credentialApiKey ? { apiKey: credentialApiKey, authSource: "credential:zcodejwttoken" } : null,
@@ -296,6 +320,7 @@ function loadZcodeAuthCandidates({ home, env } = {}) {
           baseUrl: provider?.options?.baseURL || null,
           billingBaseUrl,
           quotaUrl,
+          ...(teamContext ? { teamContext } : {}),
           availability: availability?.[key]?.status || null,
         });
       }
@@ -465,13 +490,21 @@ async function fetchZcodeBilling(apiKey, { fetchImpl = fetch, baseUrl, env, home
   return res.json();
 }
 
-async function fetchZcodeCodingPlanQuota(apiKey, { fetchImpl = fetch, quotaUrl } = {}) {
+async function fetchZcodeCodingPlanQuota(apiKey, { fetchImpl = fetch, quotaUrl, teamContext } = {}) {
+  const headers = {
+    authorization: apiKey,
+    Accept: "application/json",
+  };
+  if (teamContext?.organizationId && teamContext?.projectId) {
+    const url = new URL(quotaUrl);
+    url.searchParams.set("type", "2");
+    quotaUrl = url.toString();
+    headers["bigmodel-organization"] = teamContext.organizationId;
+    headers["bigmodel-project"] = teamContext.projectId;
+  }
   const res = await fetchImpl(quotaUrl, {
     method: "GET",
-    headers: {
-      authorization: apiKey,
-      Accept: "application/json",
-    },
+    headers,
   });
   if (res.status === 401 || res.status === 403) {
     throw new Error("Not authenticated with ZCode coding plan. Run `zcode` in Terminal to log in.");
@@ -715,6 +748,7 @@ async function fetchZcodeLimits({ home, env, fetchImpl = fetch, nowMs = Date.now
         ? await fetchZcodeCodingPlanQuota(auth.apiKey, {
             fetchImpl,
             quotaUrl: auth.quotaUrl,
+            teamContext: auth.teamContext,
           })
         : await fetchZcodeBilling(auth.apiKey, {
             fetchImpl,

--- a/src/lib/zcode-limits.js
+++ b/src/lib/zcode-limits.js
@@ -95,6 +95,11 @@ function loadZcodeProviderAvailability({ home, env } = {}) {
   }
 }
 
+/**
+ * Decode routing identifiers from a complete team selection for the given family.
+ * Returns null for personal, malformed, or legacy project-only selections.
+ * @returns {{ organizationId: string, projectId: string } | null}
+ */
 function parseZcodeTeamContext(selection, family) {
   if (family !== "bigmodel" && family !== "zai") return null;
   const prefix = `team-plan:builtin:${family}-coding-plan:`;
@@ -112,6 +117,10 @@ function parseZcodeTeamContext(selection, family) {
   }
 }
 
+/**
+ * Read selected plans in active-family order, retaining each plan's team scope.
+ * Only the provider key and decoded organization/project identifiers are retained.
+ */
 function loadZcodeSelectedPlans({ home, env } = {}) {
   const zcodeHome = resolveZcodeHome({ home, env });
   const settingPath = path.join(zcodeHome, "v2", "setting.json");
@@ -135,6 +144,7 @@ function loadZcodeSelectedPlans({ home, env } = {}) {
   }
 }
 
+/** Return the ordered provider keys without exposing the internal team context. */
 function loadZcodeSelectedPlanProviderKeys(options = {}) {
   return loadZcodeSelectedPlans(options).map((plan) => plan.providerKey);
 }
@@ -268,6 +278,10 @@ function resolveZcodeProviderQuotaUrl(providerKey, provider, env = process.env) 
   return `${origin.replace(/\/$/, "")}${ZCODE_MONITOR_QUOTA_PATH}`;
 }
 
+/**
+ * Build quota/billing candidates from enabled providers and their existing keys.
+ * Selected plans take precedence; team scope stays attached to its own provider.
+ */
 function loadZcodeAuthCandidates({ home, env } = {}) {
   const zcodeHome = resolveZcodeHome({ home, env });
   const configPath = path.join(zcodeHome, "v2", "config.json");
@@ -490,6 +504,11 @@ async function fetchZcodeBilling(apiKey, { fetchImpl = fetch, baseUrl, env, home
   return res.json();
 }
 
+/**
+ * Fetch quota using the existing provider key and optional team routing metadata.
+ * Organization/project IDs select the subscription at the resolved provider URL;
+ * they do not choose the destination or include the contents of the settings file.
+ */
 async function fetchZcodeCodingPlanQuota(apiKey, { fetchImpl = fetch, quotaUrl, teamContext } = {}) {
   const headers = {
     authorization: apiKey,
@@ -730,6 +749,10 @@ function zcodeLogFallbackResult(logRecord, errors = []) {
   };
 }
 
+/**
+ * Return normalized quota windows, trying eligible providers and recent billing logs.
+ * Credentials and internal team routing identifiers are omitted from the result.
+ */
 async function fetchZcodeLimits({ home, env, fetchImpl = fetch, nowMs = Date.now() } = {}) {
   if (!isZcodeInstalled({ home, env })) {
     return { configured: false };

--- a/test/zcode-limits.test.js
+++ b/test/zcode-limits.test.js
@@ -167,6 +167,7 @@ function writeZcodeBalanceLog(v2, timestamp, { providerId = "builtin:zai-start-p
   );
 }
 
+/** Run a quota scenario with synthetic provider keys in a temporary ZCode home. */
 function withZcodePlanSettings(settings, run) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-zcode-team-plan-"));
   const v2 = path.join(tmp, ".zcode", "v2");

--- a/test/zcode-limits.test.js
+++ b/test/zcode-limits.test.js
@@ -197,6 +197,7 @@ describe("ZCode team-plan quotas", () => {
         const result = await fetchZcodeLimits({
           home,
           env: {},
+          /** Emulate a server that exposes the fixture only with the full team scope. */
           fetchImpl: async (url, options) => {
             requests.push({ url, headers: options.headers });
             // The server accepts the same key, but needs the team scope to find its plan.
@@ -236,6 +237,7 @@ describe("ZCode team-plan quotas", () => {
       const result = await fetchZcodeLimits({
         home,
         env: { TOKENTRACKER_ZCODE_MONITOR_QUOTA_URL: "https://quota.example.test/limit?locale=en&type=1" },
+        /** Check decoded routing headers and preserved query parameters before responding. */
         fetchImpl: async (url, options) => {
           assert.equal(url, "https://quota.example.test/limit?locale=en&type=2");
           assert.equal(options.headers["bigmodel-organization"], "org:example");
@@ -259,6 +261,7 @@ describe("ZCode team-plan quotas", () => {
       const result = await fetchZcodeLimits({
         home,
         env: {},
+        /** Capture the personal request so its complete URL and headers can be compared. */
         fetchImpl: async (url, options) => {
           requests.push({ url, headers: options.headers });
           return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
@@ -280,6 +283,7 @@ describe("ZCode team-plan quotas", () => {
       },
     }, async (home, v2) => {
       const requests = [];
+      /** Capture both reads across the settings change while keeping the quota response stable. */
       const fetchImpl = async (url, options) => {
         requests.push({ url, headers: options.headers });
         return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
@@ -313,6 +317,7 @@ describe("ZCode team-plan quotas", () => {
         const result = await fetchZcodeLimits({
           home,
           env: {},
+          /** Reject invented team scope when a stored selection cannot identify both IDs. */
           fetchImpl: async (url, options) => {
             assert.equal(new URL(url).searchParams.has("type"), false);
             assert.equal(options.headers["bigmodel-organization"], undefined);

--- a/test/zcode-limits.test.js
+++ b/test/zcode-limits.test.js
@@ -167,6 +167,164 @@ function writeZcodeBalanceLog(v2, timestamp, { providerId = "builtin:zai-start-p
   );
 }
 
+function withZcodePlanSettings(settings, run) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-zcode-team-plan-"));
+  const v2 = path.join(tmp, ".zcode", "v2");
+  fs.mkdirSync(v2, { recursive: true });
+  fs.writeFileSync(path.join(v2, "config.json"), JSON.stringify({
+    provider: Object.fromEntries(["bigmodel", "zai"].map((family) => [
+      `builtin:${family}-coding-plan`,
+      { enabled: true, options: { apiKey: `${family}-key` } },
+    ])),
+  }));
+  fs.writeFileSync(path.join(v2, "setting.json"), JSON.stringify(settings));
+  return Promise.resolve().then(() => run(tmp, v2)).finally(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+}
+
+describe("ZCode team-plan quotas", () => {
+  for (const [family, origin] of [["bigmodel", "https://bigmodel.cn"], ["zai", "https://api.z.ai"]]) {
+    it(`queries the selected ${family} team instead of the personal coding plan`, async () => {
+      await withZcodePlanSettings({
+        providerFamilyDomain: family,
+        modelProviderFamilySelectedKeys: {
+          [family]: `team-plan:builtin:${family}-coding-plan:product-max:org-example:proj-example`,
+        },
+      }, async (home) => {
+        const requests = [];
+        const result = await fetchZcodeLimits({
+          home,
+          env: {},
+          fetchImpl: async (url, options) => {
+            requests.push({ url, headers: options.headers });
+            // The server accepts the same key, but needs the team scope to find its plan.
+            const teamRequest = new URL(url).searchParams.get("type") === "2"
+              && options.headers["bigmodel-organization"] === "org-example"
+              && options.headers["bigmodel-project"] === "proj-example";
+            return { ok: true, status: 200, async json() {
+              return teamRequest
+                ? realLiteCodingPlanQuotaBody()
+                : { code: 500, success: false, msg: "当前用户不存在coding plan" };
+            } };
+          },
+        });
+        assert.equal(result.error, null);
+        assert.equal(result.provider_key, `builtin:${family}-coding-plan`);
+        assert.equal(result.primary_window.used_percent, 14);
+        assert.deepEqual(requests, [{
+          url: `${origin}/api/monitor/usage/quota/limit?type=2`,
+          headers: {
+            authorization: `${family}-key`,
+            Accept: "application/json",
+            "bigmodel-organization": "org-example",
+            "bigmodel-project": "proj-example",
+          },
+        }]);
+      });
+    });
+  }
+
+  it("decodes team identifiers and preserves quota URL override parameters", async () => {
+    await withZcodePlanSettings({
+      providerFamilyDomain: "bigmodel",
+      modelProviderFamilySelectedKeys: {
+        bigmodel: "team-plan:builtin:bigmodel-coding-plan:product-max:org%3Aexample:proj%2Fexample",
+      },
+    }, async (home) => {
+      const result = await fetchZcodeLimits({
+        home,
+        env: { TOKENTRACKER_ZCODE_MONITOR_QUOTA_URL: "https://quota.example.test/limit?locale=en&type=1" },
+        fetchImpl: async (url, options) => {
+          assert.equal(url, "https://quota.example.test/limit?locale=en&type=2");
+          assert.equal(options.headers["bigmodel-organization"], "org:example");
+          assert.equal(options.headers["bigmodel-project"], "proj/example");
+          return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
+        },
+      });
+      assert.equal(result.error, null);
+    });
+  });
+
+  it("keeps another family's team scope off personal-plan requests", async () => {
+    await withZcodePlanSettings({
+      providerFamilyDomain: "bigmodel",
+      modelProviderFamilySelectedKeys: {
+        bigmodel: "coding-plan:builtin:bigmodel-coding-plan",
+        zai: "team-plan:builtin:zai-coding-plan:product-max:org-overseas:proj-overseas",
+      },
+    }, async (home) => {
+      const requests = [];
+      const result = await fetchZcodeLimits({
+        home,
+        env: {},
+        fetchImpl: async (url, options) => {
+          requests.push({ url, headers: options.headers });
+          return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
+        },
+      });
+      assert.equal(result.error, null);
+      assert.deepEqual(requests, [{
+        url: "https://bigmodel.cn/api/monitor/usage/quota/limit",
+        headers: { authorization: "bigmodel-key", Accept: "application/json" },
+      }]);
+    });
+  });
+
+  it("does not retain team scope after switching back to a personal plan", async () => {
+    await withZcodePlanSettings({
+      providerFamilyDomain: "bigmodel",
+      modelProviderFamilySelectedKeys: {
+        bigmodel: "team-plan:builtin:bigmodel-coding-plan:product-max:org-example:proj-example",
+      },
+    }, async (home, v2) => {
+      const requests = [];
+      const fetchImpl = async (url, options) => {
+        requests.push({ url, headers: options.headers });
+        return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
+      };
+      await fetchZcodeLimits({ home, env: {}, fetchImpl });
+      fs.writeFileSync(path.join(v2, "setting.json"), JSON.stringify({
+        providerFamilyDomain: "bigmodel",
+        modelProviderFamilySelectedKeys: { bigmodel: "coding-plan:builtin:bigmodel-coding-plan" },
+      }));
+      await fetchZcodeLimits({ home, env: {}, fetchImpl });
+      assert.equal(new URL(requests[0].url).searchParams.get("type"), "2");
+      assert.deepEqual(requests[1], {
+        url: "https://bigmodel.cn/api/monitor/usage/quota/limit",
+        headers: { authorization: "bigmodel-key", Accept: "application/json" },
+      });
+    });
+  });
+
+  it("does not guess team scope from incomplete or malformed selections", async () => {
+    for (const selected of [
+      "team-plan:builtin:bigmodel-coding-plan:product-max:proj-legacy",
+      "team-plan:builtin:bigmodel-coding-plan:product-max::proj-example",
+      "team-plan:builtin:bigmodel-coding-plan:product-max:org-example:",
+      "team-plan:builtin:bigmodel-coding-plan:product-max:%20:proj-example",
+      "team-plan:builtin:bigmodel-coding-plan:product-max:org%ZZ:proj-example",
+    ]) {
+      await withZcodePlanSettings({
+        providerFamilyDomain: "bigmodel",
+        modelProviderFamilySelectedKeys: { bigmodel: selected },
+      }, async (home) => {
+        const result = await fetchZcodeLimits({
+          home,
+          env: {},
+          fetchImpl: async (url, options) => {
+            assert.equal(new URL(url).searchParams.has("type"), false);
+            assert.equal(options.headers["bigmodel-organization"], undefined);
+            assert.equal(options.headers["bigmodel-project"], undefined);
+            return { ok: true, status: 200, async json() { return realLiteCodingPlanQuotaBody(); } };
+          },
+        });
+        assert.equal(result.error, null);
+      });
+    }
+  });
+});
+
 describe("deriveZcodePlanLabel", () => {
   it("extracts the human tier from the raw plan id", () => {
     assert.equal(deriveZcodePlanLabel("zcode-v3-start-plan-0615"), "Start");


### PR DESCRIPTION
## Summary

ZCode team-plan users can see `ZCode coding plan API error: code=500 msg=当前用户不存在coding plan` despite having an active subscription. TokenTracker extracts the built-in provider from the selected team connection but drops its organization and project, so the quota endpoint looks for a personal subscription.

Preserve the organization/project from ZCode's `team-plan:builtin:<family>-coding-plan:<product>:<organization>:<project>` selection and send `type=2`, `bigmodel-organization`, and `bigmodel-project` with the existing API key. This applies to BigModel and Z.ai while preserving personal-plan requests, provider ordering, and URL overrides.

## Validation

- Added six regression cases covering both regions, encoded identifiers, URL query preservation, personal/team isolation, switching back to personal, and incomplete selections. Four cases fail against the original implementation.
- `node --test test/zcode-limits.test.js`: 36 passed.
- `npm test`: 2,517 passed, 2 skipped, 0 failed (macOS, Node 26.7.0).
- Read-only verification on macOS with ZCode 3.10.2: the original request returns HTTP 200 with business code 500; the patched `fetchZcodeLimits` returns the active plan and its quota windows using the same stored key.
- Dashboard production build, architecture guardrails, and version validation passed.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] User-facing strings continue through the existing error/plan rendering; no new UI copy
- [x] Commits follow conventional style
- [x] PR description explains why

<details>
<summary><strong>Risk layer addendum</strong> — quota authentication context</summary>

The existing provider API key is reused. Team scope is read from the selected provider family's local settings and carried internally to that provider's quota request.

**CodeQL `js/file-access-to-http` review:** The reported flow is the intentional transfer of the selected organization and project IDs from `setting.json` into the provider's `bigmodel-organization` / `bigmodel-project` headers. The complete file, other settings, and team context are not exposed in the dashboard response. IDs do not influence the destination: the existing quota URL resolver uses the official provider endpoint or an explicit environment override. Regression tests assert the exact outbound headers and isolate personal plans and provider families. The [CodeQL query guidance](https://codeql.github.com/codeql-query-help/javascript/js-file-access-to-http/) calls for checking this flow's intended use; the same-key live verification confirms that these routing fields are necessary to retrieve the selected team's entitlement.

| Boundary | Expected behavior |
| --- | --- |
| Complete BigModel or Z.ai team selection | Query `type=2` with the matching organization and project |
| Personal selection or switch back to personal | Keep the personal URL and headers |
| Another provider family's team selection | Keep its scope isolated from personal requests |
| Incomplete, legacy project-only, or malformed selection | Retain previous behavior without inventing missing organization/project values |

Legacy project-only connection strings remain outside this fix because they lack the organization ID required for a scoped quota request.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ZCode team plans when checking coding-plan quotas.
  * Team-plan quota requests now include the relevant organization and project context.
  * Personal plans and other providers continue to work without team-specific context.

* **Bug Fixes**
  * Improved handling when switching between team and personal plans.
  * Added validation for incomplete or malformed plan selections.
  * Corrected quota requests for team plans with encoded organization and project identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->