### PR TITLE
fix(linux): open external links in the system browser

### DIFF
--- a/TokenTrackerLinux/src-tauri/src/external.rs
+++ b/TokenTrackerLinux/src-tauri/src/external.rs
@@ -1,0 +1,88 @@
+//! Routing for links that should leave the app window.
+//!
+//! The dashboard renders external links as `target="_blank"` (service status
+//! cards, leaderboard profiles, GitHub links). WebKitGTK's default `create`
+//! handler returns no webview, so without an explicit handler those clicks are
+//! a silent no-op — the macOS (`WKUIDelegate.createWebViewWith`) and Windows
+//! (`CoreWebView2.NewWindowRequested`) clients both hand the URL to the system
+//! browser instead, and this is the Linux counterpart.
+
+use std::process::Command;
+
+use tauri::Url;
+
+/// URLs the dashboard is allowed to load inside the app window.
+///
+/// Only `http`/`https` can escape to the browser: the loading screen is served
+/// over Tauri's own `tauri://` scheme and the dashboard over the loopback
+/// server, and any other scheme (`about:`, `blob:`, `data:`) is webview
+/// bookkeeping that must not be handed to `xdg-open`.
+pub fn is_internal_url(url: &Url) -> bool {
+    if !matches!(url.scheme(), "http" | "https") {
+        return true;
+    }
+    match url.host_str() {
+        Some(host) => {
+            host == "127.0.0.1"
+                || host == "localhost"
+                || host == "::1"
+                || host == "[::1]"
+                || host.ends_with(".localhost")
+        }
+        // Tauri's custom protocol has no host on some WebKit versions.
+        None => true,
+    }
+}
+
+/// Hand an external URL to the system browser. Returns whether it was opened.
+pub fn open_in_browser(url: &Url) -> bool {
+    if is_internal_url(url) {
+        return false;
+    }
+    match Command::new("xdg-open").arg(url.as_str()).spawn() {
+        Ok(_) => true,
+        Err(error) => {
+            eprintln!("[TokenTracker] failed to open {url} in the system browser: {error}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(raw: &str) -> Url {
+        Url::parse(raw).expect("valid url")
+    }
+
+    #[test]
+    fn keeps_app_and_loopback_urls_inside_the_window() {
+        for internal in [
+            "http://127.0.0.1:17680/dashboard",
+            "http://localhost:17680/",
+            "https://127.0.0.1:17680/",
+            "http://tauri.localhost/index.html",
+            "tauri://localhost/index.html",
+            "about:blank",
+            "blob:http://127.0.0.1:17680/1234",
+        ] {
+            assert!(is_internal_url(&url(internal)), "{internal}");
+        }
+    }
+
+    #[test]
+    fn sends_provider_status_pages_to_the_browser() {
+        for external in [
+            "https://status.anthropic.com/",
+            "https://status.openai.com/",
+            "https://status.cursor.com/",
+            "http://example.com/",
+            // A loopback-looking host that is not loopback.
+            "https://127.0.0.1.evil.com/",
+            "https://localhost.evil.com/",
+        ] {
+            assert!(!is_internal_url(&url(external)), "{external}");
+        }
+    }
+}

--- a/TokenTrackerLinux/src-tauri/src/lib.rs
+++ b/TokenTrackerLinux/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod external;
 pub mod oauth;
 pub mod paths;
 pub mod server;

--- a/TokenTrackerLinux/src-tauri/src/main.rs
+++ b/TokenTrackerLinux/src-tauri/src/main.rs
@@ -1,4 +1,4 @@
-use tokentracker_linux::{oauth, paths, server, tray};
+use tokentracker_linux::{external, oauth, paths, server, tray};
 
 use std::sync::Mutex;
 
@@ -277,6 +277,22 @@ fn main() {
                 tauri::WebviewUrl::App("index.html".into()),
             )
             .initialization_script(NATIVE_OAUTH_BRIDGE)
+            // `target="_blank"` links (provider status pages, leaderboard
+            // profiles) belong in the system browser. WebKitGTK opens nothing
+            // at all unless this handler is installed.
+            .on_new_window(|url, _features| {
+                external::open_in_browser(&url);
+                tauri::webview::NewWindowResponse::Deny
+            })
+            // The app window has no browser chrome, so a top-level navigation
+            // off the dashboard would strand the user with no way back.
+            .on_navigation(|url| {
+                if external::is_internal_url(url) {
+                    return true;
+                }
+                external::open_in_browser(url);
+                false
+            })
             .title("TokenTracker")
             .inner_size(1180.0, 820.0)
             .min_inner_size(960.0, 640.0)

--- a/TokenTrackerLinux/src-tauri/tests/external.rs
+++ b/TokenTrackerLinux/src-tauri/tests/external.rs
@@ -1,0 +1,37 @@
+use tauri::Url;
+use tokentracker_linux::external::is_internal_url;
+
+fn url(raw: &str) -> Url {
+    Url::parse(raw).expect("valid url")
+}
+
+/// The dashboard is served from the loopback port the bundled server picked, so
+/// the check must not be pinned to a single port, and the loading screen is
+/// served over Tauri's own scheme before that port exists.
+#[test]
+fn dashboard_navigation_stays_in_the_window() {
+    for internal in [
+        "http://127.0.0.1:17680/dashboard",
+        "http://127.0.0.1:41235/status",
+        "http://localhost:17680/",
+        "tauri://localhost/index.html",
+        "http://tauri.localhost/index.html",
+    ] {
+        assert!(is_internal_url(&url(internal)), "{internal}");
+    }
+}
+
+/// Every provider card on the Service Status page is a `target="_blank"` link
+/// to a third-party status page; those must leave for the system browser.
+#[test]
+fn provider_status_pages_leave_the_window() {
+    for external in [
+        "https://status.anthropic.com/",
+        "https://status.openai.com/",
+        "https://status.cursor.com/",
+        "https://www.githubstatus.com/",
+        "https://github.com/xiufengsun/TokenTracker",
+    ] {
+        assert!(!is_internal_url(&url(external)), "{external}");
+    }
+}


### PR DESCRIPTION
## Problem

On the Linux client, clicking an external link inside the app window does nothing at all — no popup, no browser, no error. Most visible on the **Service Status** page, where every provider card is a link to that provider's status page, but it affects every `target="_blank"` link in the dashboard (leaderboard profiles, the sidebar GitHub link, docs links).

Cause: wry only connects WebKitGTK's `create` signal when a new-window handler is registered (`wry/src/webkitgtk/mod.rs`), and the Tauri window in `main.rs` registered none. WebKitGTK's default `create` returns no webview, so the click is silently dropped.

The other two desktop clients already handle this explicitly:

- macOS — `WKUIDelegate.createWebViewWith` → `NSWorkspace.shared.open` (`DashboardWindowController.swift:507`)
- Windows — `CoreWebView2.NewWindowRequested` → `OpenInBrowser` (`DashboardWindow.cs:364`)

## Fix

New `src-tauri/src/external.rs`:

- `is_internal_url()` — loopback hosts, `*.localhost`, and non-`http(s)` schemes (`tauri://`, `about:`, `blob:`) stay in the window. Port-agnostic, since the bundled server picks its port dynamically. Lookalike hosts such as `https://127.0.0.1.evil.com/` are treated as external.
- `open_in_browser()` — hands the URL to `xdg-open`, matching how `oauth.rs` already launches the browser.

Wired into the window builder:

- `.on_new_window(...)` → open externally, `NewWindowResponse::Deny`. This is the reported bug.
- `.on_navigation(...)` → mirrors the Windows navigation guard. The app window has no browser chrome, so a top-level navigation off the dashboard would otherwise strand the user with no way back.

## Testing

- `cargo test` — all suites pass, including the new `tests/external.rs` and the unit tests in `external.rs`.
- `cargo fmt --check` clean.
- Ran the app on Fedora / GNOME Wayland and clicked through the Service Status cards: each opens the provider's status page in the default browser and the app window stays put.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - External links now open in the system browser on Linux.
  - Internal dashboard links, loopback addresses, and supported application URLs remain inside the app.
  - Links opened in new windows and navigation away from the dashboard are routed appropriately.

- **Bug Fixes**
  - Prevents third-party pages and potentially misleading domains from opening within the app.

- **Tests**
  - Added coverage for internal dashboard navigation, provider status pages, and external domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->