### PR TITLE
fix(linux): keep tray menu labels from rendering blank

### DIFF
--- a/TokenTrackerLinux/src-tauri/src/tray.rs
+++ b/TokenTrackerLinux/src-tauri/src/tray.rs
@@ -1,10 +1,18 @@
+use std::time::Duration;
+
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconBuilder;
-use tauri::{App, AppHandle, Manager};
+use tauri::{App, AppHandle, Manager, Runtime};
 
 const OPEN_ID: &str = "open-dashboard";
 const QUIT_ID: &str = "quit";
+const TRAY_ID: &str = "main-tray";
+
+/// How long to wait before re-publishing the menu. Long enough that the
+/// desktop's tray client has finished its initial layout exchange, short
+/// enough that a user reaching for the tray immediately still gets labels.
+const MENU_REPUBLISH_DELAY: Duration = Duration::from_millis(1500);
 const FALLBACK_TRAY_ICON: &[u8] = include_bytes!("../icons/icon.png");
 
 fn fallback_tray_icon() -> tauri::Result<Image<'static>> {
@@ -23,17 +31,56 @@ fn fallback_tray_icon() -> tauri::Result<Image<'static>> {
 ///
 /// The upside is that libappindicator opens the context menu on *left* click
 /// too, so "Open Dashboard" as the first item is the primary entry point.
+fn build_menu<R: Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> {
+    let open = MenuItem::with_id(manager, OPEN_ID, "Open Dashboard", true, None::<&str>)?;
+    let quit = MenuItem::with_id(manager, QUIT_ID, "Quit", true, None::<&str>)?;
+    Menu::with_items(manager, &[&open, &quit])
+}
+
+/// Publish a second, freshly built menu once startup has quiesced.
+///
+/// libappindicator exports the menu in two passes: the structure first, then
+/// the item properties ~50ms later as `ItemsPropertiesUpdated` plus a second
+/// `LayoutUpdated`. GNOME's AppIndicator extension cannot absorb that. Its
+/// `GetLayout` deliberately asks for `type`/`children-display` only and fetches
+/// labels separately on an idle callback, and the second `LayoutUpdated`
+/// cancels that pending fetch. The re-run then finds the item ids already
+/// known and skips re-requesting them (`dbusMenu.js`), so the labels are never
+/// fetched and the tray menu renders as blank rows.
+///
+/// Re-publishing a newly built menu gets new item ids, so the extension has to
+/// create the items afresh — and by then nothing is racing the property fetch.
+fn republish_menu(app: &AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(MENU_REPUBLISH_DELAY);
+        let _ = app.clone().run_on_main_thread(move || {
+            let Some(tray) = app.tray_by_id(TRAY_ID) else {
+                return;
+            };
+            match build_menu(&app) {
+                Ok(menu) => {
+                    if let Err(error) = tray.set_menu(Some(menu)) {
+                        eprintln!("[TokenTracker] failed to republish the tray menu: {error}");
+                    }
+                }
+                Err(error) => {
+                    eprintln!("[TokenTracker] failed to rebuild the tray menu: {error}");
+                }
+            }
+        });
+    });
+}
+
 pub fn install(app: &App) -> tauri::Result<()> {
-    let open = MenuItem::with_id(app, OPEN_ID, "Open Dashboard", true, None::<&str>)?;
-    let quit = MenuItem::with_id(app, QUIT_ID, "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&open, &quit])?;
+    let menu = build_menu(app)?;
 
     let icon = app
         .default_window_icon()
         .cloned()
         .unwrap_or(fallback_tray_icon()?);
 
-    TrayIconBuilder::with_id("main-tray")
+    TrayIconBuilder::with_id(TRAY_ID)
         .icon(icon)
         .tooltip("TokenTracker")
         .menu(&menu)
@@ -43,6 +90,8 @@ pub fn install(app: &App) -> tauri::Result<()> {
             _ => {}
         })
         .build(app)?;
+
+    republish_menu(app.handle());
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

On Linux the tray menu intermittently renders as blank rows — the two entries are there, correctly sized, with no text. Restarting the app sometimes fixes it, sometimes not.

Measured on GNOME 50.3 / Wayland / Fedora, with `dbus-monitor` on `interface='com.canonical.dbusmenu'`: **5 of 6 launches never fetched the labels at all**.

## Cause

Two independent halves that combine badly.

**Our side** — libappindicator exports the menu in two passes: the structure first, then the item properties ~47ms later as `ItemsPropertiesUpdated` plus a second `LayoutUpdated`. This happens on every launch, once the GTK main loop starts:

```
854.154899  LayoutUpdated            <- pass 1, structure
854.186861  GetLayout                <- shell reads it
854.201529  ItemsPropertiesUpdated   <- pass 2, the labels
854.201543  LayoutUpdated
854.203867  GetLayout                <- shell reads it again
            (no GetGroupProperties — labels never fetched)
```

**The extension side** (`appindicatorsupport@rgcjonas.gmail.com/dbusMenu.js`) cannot absorb that:

- `GetLayout` deliberately requests only `type` and `children-display`, never `label`. Labels come from a separate `GetGroupProperties` scheduled on an idle callback.
- A new `LayoutUpdated` cancels the previous update's cancellable (`_layoutUpdateUpdateAsync`), killing that pending fetch.
- The re-run finds the item ids already in `this._items` and early-returns before `_requestProperties` (line 420).
- The `ItemsPropertiesUpdated` that did carry the labels arrived before the extension had created those items, so `_onPropertiesUpdated` dropped it (`if (!item) return`).

The label property therefore never reaches the shell, and its default is `''` — blank rows. Whether a given launch wins or loses the race is what makes it intermittent.

## Fix

Publish a freshly built menu 1.5s after startup, once the export storm is over. A new menu gets new dbusmenu item ids, so the extension has to create the items from scratch and fetch their properties, and nothing is racing the request that time.

This is a mitigation for a race in the GNOME extension, not a fix for the extension itself — but it is the only side we control.

## Testing

- `cargo test`, `cargo fmt --check` — pass.
- Instrumented 6 unpatched launches (5/6 blank) and 8 patched launches on the same machine, comparing the `dbusmenu` traffic.
- Ran the patched build interactively on GNOME 50 / Wayland: the menu has not come up blank since.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tray menu reliability on GNOME-based Linux desktops.
  - Prevented tray menu labels from appearing blank after the application starts.
  - Refined tray menu refresh behavior to ensure labels are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->