### PR TITLE
fix(leaderboard): keep total refresh within backend limits

### DIFF
--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -38,7 +38,7 @@ targets:
         PRODUCT_NAME: TokenTracker
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.95.0"
+        MARKETING_VERSION: "0.95.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -89,7 +89,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.95.0"
+        MARKETING_VERSION: "0.95.1"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/TokenTrackerLinux/package-lock.json
+++ b/TokenTrackerLinux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-linux",
-      "version": "0.95.0",
+      "version": "0.95.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
         "pngjs": "^7.0.0"

--- a/TokenTrackerLinux/package.json
+++ b/TokenTrackerLinux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-linux",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
+++ b/TokenTrackerLinux/packaging/arch/tokentracker-linux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: local
 pkgname=tokentracker-linux
-pkgver=0.95.0
+pkgver=0.95.1
 pkgrel=1
 pkgdesc='Local TokenTracker Linux desktop client for Arch KDE'
 arch=('x86_64')

--- a/TokenTrackerLinux/src-tauri/Cargo.lock
+++ b/TokenTrackerLinux/src-tauri/Cargo.lock
@@ -3611,7 +3611,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokentracker-linux"
-version = "0.95.0"
+version = "0.95.1"
 dependencies = [
  "libc",
  "once_cell",

--- a/TokenTrackerLinux/src-tauri/Cargo.toml
+++ b/TokenTrackerLinux/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokentracker-linux"
-version = "0.95.0"
+version = "0.95.1"
 description = "TokenTracker Linux desktop client"
 authors = ["TokenTracker"]
 edition = "2021"

--- a/TokenTrackerLinux/src-tauri/tauri.conf.json
+++ b/TokenTrackerLinux/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TokenTracker",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "identifier": "cc.tokentracker.linux",
   "build": {
     "beforeDevCommand": "",

--- a/TokenTrackerWin/TokenTrackerWin.csproj
+++ b/TokenTrackerWin/TokenTrackerWin.csproj
@@ -22,7 +22,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>assets\trayicon.ico</ApplicationIcon>
     <!-- Keep in sync with package.json / project.yml on release. -->
-    <Version>0.95.0</Version>
+    <Version>0.95.1</Version>
     <Product>TokenTracker</Product>
     <Company>TokenTracker</Company>
     <!-- App UI strings live in TrayStrings/NativeLocalization (no .resx), so the

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -112,6 +112,16 @@ async function authorizeRefresh(req: Request): Promise<RefreshAuthorization | nu
 
 type Period = "week" | "month" | "total";
 const ALL_PERIODS: Period[] = ["week", "month", "total"];
+const TOTAL_USER_SHARDS = [
+  { from: "00000000-0000-0000-0000-000000000000", to: "20000000-0000-0000-0000-000000000000" },
+  { from: "20000000-0000-0000-0000-000000000000", to: "40000000-0000-0000-0000-000000000000" },
+  { from: "40000000-0000-0000-0000-000000000000", to: "60000000-0000-0000-0000-000000000000" },
+  { from: "60000000-0000-0000-0000-000000000000", to: "80000000-0000-0000-0000-000000000000" },
+  { from: "80000000-0000-0000-0000-000000000000", to: "a0000000-0000-0000-0000-000000000000" },
+  { from: "a0000000-0000-0000-0000-000000000000", to: "c0000000-0000-0000-0000-000000000000" },
+  { from: "c0000000-0000-0000-0000-000000000000", to: "e0000000-0000-0000-0000-000000000000" },
+  { from: "e0000000-0000-0000-0000-000000000000", to: null },
+] as const;
 const RAW_BLOCKED_LEADERBOARD_USER_IDS = Deno.env.get("LEADERBOARD_BLOCKED_USER_IDS");
 /**
  * Whether the block list was configured at all. An unset secret and a
@@ -919,10 +929,42 @@ export default async function (req: Request): Promise<Response> {
     }
 
     const __t0 = Date.now();
-    const { data: groupedData, error: rpcErr } = await client.database.rpc(
-      "leaderboard_usage_grouped",
-      { p_from: rangeStart, p_to: rangeEnd },
-    );
+    let groupedData: unknown;
+    let rpcErr: { message: string } | null = null;
+    if (period === "total") {
+      // A single all-time RPC response eventually exceeded the database
+      // client's fixed 10s transport budget even after the historical scan was
+      // replaced by a compact rollup. Eight disjoint UUID ranges keep every
+      // response bounded while retaining model/pricing-tier rows for the one
+      // canonical TypeScript pricing implementation below.
+      const totalRows: unknown[] = [];
+      for (let shardIndex = 0; shardIndex < TOTAL_USER_SHARDS.length; shardIndex += 2) {
+        const shardBatch = await Promise.all(
+          TOTAL_USER_SHARDS.slice(shardIndex, shardIndex + 2).map(({ from, to }) =>
+            client.database.rpc(
+              "leaderboard_usage_grouped_total_shard",
+              { p_to: rangeEnd, p_user_from: from, p_user_to: to },
+            )
+          ),
+        );
+        const failedShard = shardBatch.find((result) => result.error);
+        if (failedShard?.error) {
+          rpcErr = failedShard.error;
+          break;
+        }
+        for (const result of shardBatch) {
+          if (Array.isArray(result.data)) totalRows.push(...result.data);
+        }
+      }
+      groupedData = rpcErr ? null : totalRows;
+    } else {
+      const result = await client.database.rpc(
+        "leaderboard_usage_grouped",
+        { p_from: rangeStart, p_to: rangeEnd },
+      );
+      groupedData = result.data;
+      rpcErr = result.error;
+    }
     const __tAfterRpc = Date.now();
     if (rpcErr) {
       logRefreshEvent({
@@ -936,7 +978,7 @@ export default async function (req: Request): Promise<Response> {
         error: rpcErr.message,
         duration_ms: Date.now() - periodStartedAt,
       });
-      return json({ error: rpcErr.message }, 500);
+      return json({ error: rpcErr.message, stage: "rpc_aggregate" }, 500);
     }
     const grouped = (Array.isArray(groupedData) ? groupedData : []) as HourlyRow[];
     const scannedRows = grouped.length; // pre-aggregated groups (not raw rows)

--- a/migrations/20260821060000_ban-confirmed-leaderboard-manipulation.sql
+++ b/migrations/20260821060000_ban-confirmed-leaderboard-manipulation.sql
@@ -1,0 +1,125 @@
+-- Operator-confirmed leaderboard manipulation from the 2026-08-20 23:41 UTC scan.
+--
+-- Keep identities out of source control: the evidence predicate below selects
+-- exactly the two reviewed accounts (three flagged user-days). The DO block is
+-- one transaction, preserves every hourly row in quarantine before deletion,
+-- and aborts if the expected target/evidence counts drift.
+DO $ban$
+DECLARE
+  v_target_users integer;
+  v_target_flags integer;
+  v_hourly_rows bigint;
+  v_quarantined_rows bigint;
+  v_deleted_rows bigint;
+  v_banned_flags integer;
+BEGIN
+  CREATE TEMP TABLE tt_confirmed_ban_targets ON COMMIT DROP AS
+  SELECT DISTINCT f.user_id
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  WHERE f.status = 'auto_excluded'
+    AND f.reviewed_at IS NULL
+    AND f.detected_at >= '2026-08-20 23:41:00+00'::timestamptz
+    AND f.detected_at <  '2026-08-20 23:42:00+00'::timestamptz
+    AND f.cohort_ratio >= 10;
+
+  SELECT count(*) INTO v_target_users FROM tt_confirmed_ban_targets;
+  SELECT count(*) INTO v_target_flags
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  JOIN tt_confirmed_ban_targets t USING (user_id)
+  WHERE f.status IN ('auto_excluded', 'review');
+
+  IF v_target_users <> 2 OR v_target_flags <> 3 THEN
+    RAISE EXCEPTION
+      'confirmed ban target drift: expected 2 users/3 flags, got % users/% flags',
+      v_target_users, v_target_flags;
+  END IF;
+
+  -- Serialize against ingestion while evidence is copied and removed. The
+  -- edge blocklist was updated before this migration, so new requests fail too.
+  LOCK TABLE public.tokentracker_hourly IN SHARE ROW EXCLUSIVE MODE;
+
+  SELECT count(*) INTO v_hourly_rows
+  FROM public.tokentracker_hourly h
+  JOIN tt_confirmed_ban_targets t USING (user_id);
+
+  IF v_hourly_rows = 0 THEN
+    RAISE EXCEPTION 'confirmed ban target has no hourly evidence';
+  END IF;
+
+  INSERT INTO public.tokentracker_hourly_quarantine (
+    user_id, device_id, source, model, hour_start,
+    input_tokens, cached_input_tokens, cache_creation_input_tokens,
+    output_tokens, reasoning_output_tokens, total_tokens,
+    billable_total_tokens, conversations, created_at, updated_at,
+    total_cost_usd, quarantined_at, quarantine_reason
+  )
+  SELECT
+    h.user_id, h.device_id, h.source, h.model, h.hour_start,
+    h.input_tokens, h.cached_input_tokens, h.cache_creation_input_tokens,
+    h.output_tokens, h.reasoning_output_tokens, h.total_tokens,
+    h.billable_total_tokens, h.conversations, h.created_at, h.updated_at,
+    h.total_cost_usd, clock_timestamp(),
+    'confirmed leaderboard manipulation; operator ban 2026-08-21'
+  FROM public.tokentracker_hourly h
+  JOIN tt_confirmed_ban_targets t USING (user_id);
+
+  GET DIAGNOSTICS v_quarantined_rows = ROW_COUNT;
+  IF v_quarantined_rows <> v_hourly_rows THEN
+    RAISE EXCEPTION
+      'quarantine mismatch: expected %, copied %',
+      v_hourly_rows, v_quarantined_rows;
+  END IF;
+
+  DELETE FROM public.tokentracker_hourly h
+  USING tt_confirmed_ban_targets t
+  WHERE h.user_id = t.user_id;
+  GET DIAGNOSTICS v_deleted_rows = ROW_COUNT;
+
+  IF v_deleted_rows <> v_hourly_rows THEN
+    RAISE EXCEPTION
+      'hourly deletion mismatch: expected %, deleted %',
+      v_hourly_rows, v_deleted_rows;
+  END IF;
+
+  UPDATE public.tokentracker_device_tokens dt
+  SET revoked_at = COALESCE(dt.revoked_at, clock_timestamp())
+  FROM tt_confirmed_ban_targets t
+  WHERE dt.user_id = t.user_id;
+
+  UPDATE public.tokentracker_devices d
+  SET revoked_at = COALESCE(d.revoked_at, clock_timestamp())
+  FROM tt_confirmed_ban_targets t
+  WHERE d.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_daily r
+  USING tt_confirmed_ban_targets t
+  WHERE r.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_daily_v2 r
+  USING tt_confirmed_ban_targets t
+  WHERE r.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_snapshots s
+  USING tt_confirmed_ban_targets t
+  WHERE s.user_id = t.user_id;
+
+  DELETE FROM public.agentmeter_leaderboard_snapshots s
+  USING tt_confirmed_ban_targets t
+  WHERE s.user_id = t.user_id;
+
+  UPDATE public.tokentracker_leaderboard_anomaly_flags f
+  SET status = 'banned',
+      reviewed_at = clock_timestamp(),
+      note = 'confirmed leaderboard manipulation; usage quarantined, credentials revoked, and account blocklisted by operator on 2026-08-21'
+  FROM tt_confirmed_ban_targets t
+  WHERE f.user_id = t.user_id
+    AND f.status IN ('auto_excluded', 'review');
+
+  GET DIAGNOSTICS v_banned_flags = ROW_COUNT;
+  IF v_banned_flags <> v_target_flags THEN
+    RAISE EXCEPTION
+      'flag transition mismatch: expected %, banned %',
+      v_target_flags, v_banned_flags;
+  END IF;
+END
+$ban$;

--- a/migrations/20260821062000_add-project-admin-leaderboard-rpcs.sql
+++ b/migrations/20260821062000_add-project-admin-leaderboard-rpcs.sql
@@ -1,0 +1,236 @@
+CREATE OR REPLACE FUNCTION public.leaderboard_hourly_dedup_v3(
+  p_from timestamptz, p_to timestamptz
+) RETURNS TABLE (
+  user_id uuid, source text, model text, hour_start timestamptz,
+  total_tokens bigint, input_tokens bigint, output_tokens bigint,
+  cached_input_tokens bigint, cache_creation_input_tokens bigint,
+  reasoning_output_tokens bigint
+)
+LANGUAGE sql STABLE
+AS $func$
+  WITH cfg AS (
+    SELECT ARRAY['cursor', 'trae-cn']::text[] AS account_sources
+  )
+  SELECT mac.user_id, mac.source, mac.model, mac.hour_start,
+    SUM(mac.total_tokens)::bigint, SUM(mac.input_tokens)::bigint,
+    SUM(mac.output_tokens)::bigint, SUM(mac.cached_input_tokens)::bigint,
+    SUM(mac.cache_creation_input_tokens)::bigint,
+    SUM(mac.reasoning_output_tokens)::bigint
+  FROM (
+    SELECT DISTINCT ON (
+      h.user_id, COALESCE(dm.machine_cluster_id, h.device_id::text),
+      h.source, h.model, h.hour_start
+    )
+      h.user_id, COALESCE(dm.machine_cluster_id, h.device_id::text) AS machine_cluster_id,
+      h.source, h.model, h.hour_start, h.total_tokens::bigint AS total_tokens,
+      h.input_tokens::bigint AS input_tokens, h.output_tokens::bigint AS output_tokens,
+      h.cached_input_tokens::bigint AS cached_input_tokens,
+      h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
+      h.reasoning_output_tokens::bigint AS reasoning_output_tokens
+    FROM public.tokentracker_hourly h
+    CROSS JOIN cfg
+    JOIN public.tokentracker_devices d ON d.id = h.device_id AND d.revoked_at IS NULL
+    LEFT JOIN public.tokentracker_device_machine dm ON dm.device_id = h.device_id
+    WHERE h.hour_start >= p_from AND h.hour_start < p_to
+      AND NOT (h.source = ANY(cfg.account_sources))
+    ORDER BY h.user_id, COALESCE(dm.machine_cluster_id, h.device_id::text),
+      h.source, h.model, h.hour_start, h.total_tokens DESC, h.updated_at DESC
+  ) mac
+  GROUP BY mac.user_id, mac.source, mac.model, mac.hour_start
+
+  UNION ALL
+
+  SELECT acct.user_id, acct.source, acct.model, acct.hour_start,
+    acct.total_tokens, acct.input_tokens, acct.output_tokens,
+    acct.cached_input_tokens, acct.cache_creation_input_tokens,
+    acct.reasoning_output_tokens
+  FROM (
+    SELECT DISTINCT ON (h.user_id, h.source, h.model, h.hour_start)
+      h.user_id, h.source, h.model, h.hour_start,
+      h.total_tokens::bigint AS total_tokens, h.input_tokens::bigint AS input_tokens,
+      h.output_tokens::bigint AS output_tokens,
+      h.cached_input_tokens::bigint AS cached_input_tokens,
+      h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
+      h.reasoning_output_tokens::bigint AS reasoning_output_tokens
+    FROM public.tokentracker_hourly h
+    WHERE h.hour_start >= p_from AND h.hour_start < p_to AND h.source = 'cursor'
+    ORDER BY h.user_id, h.source, h.model, h.hour_start, h.total_tokens DESC, h.updated_at DESC
+  ) acct
+
+  UNION ALL
+
+  SELECT s.user_id, s.source, s.model, s.bucket_start,
+    SUM(s.total_tokens)::bigint, SUM(s.input_tokens)::bigint,
+    SUM(s.output_tokens)::bigint, SUM(s.cached_input_tokens)::bigint,
+    SUM(s.cache_creation_input_tokens)::bigint,
+    SUM(s.reasoning_output_tokens)::bigint
+  FROM public.tokentracker_account_session_states s
+  WHERE s.bucket_start >= p_from AND s.bucket_start < p_to AND s.source = 'trae-cn'
+  GROUP BY s.user_id, s.source, s.model, s.bucket_start
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_hourly_dedup_v3(timestamptz, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.leaderboard_hourly_dedup_v3(timestamptz, timestamptz)
+  TO project_admin;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_rollup_daily_replace_v3(
+  p_from timestamptz, p_to timestamptz
+) RETURNS void
+LANGUAGE plpgsql
+SET work_mem TO '16MB'
+SET hash_mem_multiplier TO '2'
+SET statement_timeout TO '25s'
+AS $func$
+DECLARE v_day timestamptz;
+BEGIN
+  v_day := date_trunc('day', p_from AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  WHILE v_day < p_to LOOP
+    DELETE FROM public.tokentracker_leaderboard_rollup_daily_v2
+    WHERE day = (v_day AT TIME ZONE 'UTC')::date;
+    INSERT INTO public.tokentracker_leaderboard_rollup_daily_v2 (
+      user_id, source, model, day, total_tokens, input_tokens, output_tokens,
+      cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens
+    )
+    SELECT d.user_id, d.source, d.model,
+      (d.hour_start AT TIME ZONE 'UTC')::date,
+      SUM(d.total_tokens), SUM(d.input_tokens), SUM(d.output_tokens),
+      SUM(d.cached_input_tokens), SUM(d.cache_creation_input_tokens),
+      SUM(d.reasoning_output_tokens)
+    FROM public.leaderboard_hourly_dedup_v3(v_day, v_day + interval '1 day') d
+    GROUP BY d.user_id, d.source, d.model, (d.hour_start AT TIME ZONE 'UTC')::date;
+    v_day := v_day + interval '1 day';
+  END LOOP;
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_rollup_daily_replace_v3(timestamptz, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.leaderboard_rollup_daily_replace_v3(timestamptz, timestamptz)
+  TO project_admin;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_rollup_daily_advance_v3()
+RETURNS void
+LANGUAGE plpgsql
+SET work_mem TO '16MB'
+SET hash_mem_multiplier TO '2'
+SET statement_timeout TO '25s'
+AS $func$
+DECLARE
+  v_from timestamptz;
+  v_target timestamptz := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  v_until timestamptz;
+  v_min_day date;
+  v_repair_from date;
+  v_seed_gap_day date;
+BEGIN
+  SELECT (date_trunc('day', MIN(h.hour_start) AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::date
+  INTO v_min_day FROM public.tokentracker_hourly h;
+  v_min_day := COALESCE(v_min_day, (v_target AT TIME ZONE 'UTC')::date);
+
+  SELECT m.through, m.repair_from INTO v_from, v_repair_from
+  FROM public.tokentracker_leaderboard_rollup_meta_v2 m WHERE m.id = 1 FOR UPDATE;
+  IF v_from IS NULL THEN
+    v_from := v_min_day::timestamp AT TIME ZONE 'UTC';
+    v_repair_from := v_min_day;
+    INSERT INTO public.tokentracker_leaderboard_rollup_meta_v2
+      (id, through, repair_from, rebuilt_at)
+    VALUES (1, v_from, v_repair_from, now());
+  END IF;
+  IF v_from < v_target THEN
+    v_until := LEAST(v_target, v_from + interval '7 days');
+    PERFORM public.leaderboard_rollup_daily_replace_v3(v_from, v_until);
+    UPDATE public.tokentracker_leaderboard_rollup_meta_v2
+    SET through = v_until, rebuilt_at = now() WHERE id = 1;
+    RETURN;
+  END IF;
+  IF v_repair_from >= (v_target AT TIME ZONE 'UTC')::date THEN
+    v_repair_from := v_min_day;
+  END IF;
+  SELECT MIN((s.bucket_start AT TIME ZONE 'UTC')::date) INTO v_seed_gap_day
+  FROM public.tokentracker_account_session_states s
+  WHERE s.source = 'trae-cn'
+    AND (s.bucket_start AT TIME ZONE 'UTC')::date < (v_target AT TIME ZONE 'UTC')::date
+    AND NOT EXISTS (
+      SELECT 1 FROM public.tokentracker_leaderboard_rollup_daily_v2 r
+      WHERE r.user_id = s.user_id AND r.source = 'trae-cn'
+        AND r.day = (s.bucket_start AT TIME ZONE 'UTC')::date
+    );
+  IF v_seed_gap_day IS NOT NULL THEN v_repair_from := v_seed_gap_day; END IF;
+  v_until := LEAST(v_target,
+    (v_repair_from::timestamp AT TIME ZONE 'UTC') + interval '7 days');
+  PERFORM public.leaderboard_rollup_daily_replace_v3(
+    v_repair_from::timestamp AT TIME ZONE 'UTC', v_until
+  );
+  UPDATE public.tokentracker_leaderboard_rollup_meta_v2
+  SET repair_from = CASE WHEN v_until >= v_target THEN v_min_day
+      ELSE (v_until AT TIME ZONE 'UTC')::date END, rebuilt_at = now()
+  WHERE id = 1;
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_rollup_daily_advance_v3()
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.leaderboard_rollup_daily_advance_v3() TO project_admin;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_usage_grouped_v3(
+  p_from timestamptz, p_to timestamptz
+) RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SET work_mem TO '96MB'
+SET hash_mem_multiplier TO '4'
+SET statement_timeout TO '25s'
+AS $func$
+DECLARE v_through timestamptz; v_cut timestamptz; v_result jsonb;
+BEGIN
+  SELECT m.through INTO v_through
+  FROM public.tokentracker_leaderboard_rollup_meta_v2 m WHERE m.id = 1;
+  v_cut := date_trunc('day', LEAST(v_through, p_to) AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  IF v_through IS NOT NULL
+     AND p_from = (date_trunc('day', p_from AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')
+     AND v_cut > p_from THEN
+    SELECT jsonb_agg(to_jsonb(x.*) ORDER BY x.user_id, x.source, x.model) INTO v_result
+    FROM (
+      SELECT u.user_id, u.source, u.model, SUM(u.total_tokens)::bigint total_tokens,
+        SUM(u.input_tokens)::bigint input_tokens, SUM(u.output_tokens)::bigint output_tokens,
+        SUM(u.cached_input_tokens)::bigint cached_input_tokens,
+        SUM(u.cache_creation_input_tokens)::bigint cache_creation_input_tokens,
+        SUM(u.reasoning_output_tokens)::bigint reasoning_output_tokens
+      FROM (
+        SELECT r.user_id, r.source, r.model, r.total_tokens, r.input_tokens,
+          r.output_tokens, r.cached_input_tokens, r.cache_creation_input_tokens,
+          r.reasoning_output_tokens
+        FROM public.tokentracker_leaderboard_rollup_daily_v2 r
+        WHERE r.day >= (p_from AT TIME ZONE 'UTC')::date
+          AND r.day < (v_cut AT TIME ZONE 'UTC')::date
+        UNION ALL
+        SELECT t.user_id, t.source, t.model, t.total_tokens, t.input_tokens,
+          t.output_tokens, t.cached_input_tokens, t.cache_creation_input_tokens,
+          t.reasoning_output_tokens
+        FROM public.leaderboard_hourly_dedup_v3(v_cut, p_to) t
+      ) u GROUP BY u.user_id, u.source, u.model
+    ) x;
+  ELSE
+    SELECT jsonb_agg(to_jsonb(x.*) ORDER BY x.user_id, x.source, x.model) INTO v_result
+    FROM (
+      SELECT d.user_id, d.source, d.model, SUM(d.total_tokens)::bigint total_tokens,
+        SUM(d.input_tokens)::bigint input_tokens, SUM(d.output_tokens)::bigint output_tokens,
+        SUM(d.cached_input_tokens)::bigint cached_input_tokens,
+        SUM(d.cache_creation_input_tokens)::bigint cache_creation_input_tokens,
+        SUM(d.reasoning_output_tokens)::bigint reasoning_output_tokens
+      FROM public.leaderboard_hourly_dedup_v3(p_from, p_to) d
+      GROUP BY d.user_id, d.source, d.model
+    ) x;
+  END IF;
+  RETURN COALESCE(v_result, '[]'::jsonb);
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_usage_grouped_v3(timestamptz, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.leaderboard_usage_grouped_v3(timestamptz, timestamptz)
+  TO project_admin;

--- a/migrations/20260821065000_ban-repeated-token-template-manipulation.sql
+++ b/migrations/20260821065000_ban-repeated-token-template-manipulation.sql
@@ -1,0 +1,137 @@
+-- Operator-confirmed leaderboard manipulation from the 2026-08-21 05:41 UTC scan.
+--
+-- Keep the account identity out of source control: the evidence predicate
+-- selects the one reviewed account that repeatedly submitted the exact same
+-- synthetic token-column template under multiple model names. The transaction
+-- preserves every hourly row in quarantine before removing leaderboard data
+-- and revoking credentials.
+DO $ban$
+DECLARE
+  v_target_users integer;
+  v_target_flags integer;
+  v_hourly_rows bigint;
+  v_quarantined_rows bigint;
+  v_deleted_rows bigint;
+  v_banned_flags integer;
+BEGIN
+  LOCK TABLE public.tokentracker_hourly IN SHARE ROW EXCLUSIVE MODE;
+
+  CREATE TEMP TABLE tt_confirmed_template_ban_targets ON COMMIT DROP AS
+  SELECT DISTINCT f.user_id
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  WHERE f.status = 'review'
+    AND f.reviewed_at IS NULL
+    AND f.detected_at >= '2026-08-21 05:41:00+00'::timestamptz
+    AND f.detected_at <  '2026-08-21 05:42:00+00'::timestamptz
+    AND EXISTS (
+      SELECT 1
+      FROM public.tokentracker_hourly h
+      WHERE h.user_id = f.user_id
+        AND h.source = 'codex'
+        AND h.total_tokens = 713570000
+        AND h.input_tokens = 57200000
+        AND h.output_tokens = 5720000
+        AND h.cached_input_tokens = 650650000
+        AND h.cache_creation_input_tokens = 0
+        AND h.reasoning_output_tokens = 1430000
+      GROUP BY h.user_id
+      HAVING count(*) >= 10 AND count(DISTINCT h.model) >= 2
+    );
+
+  SELECT count(*) INTO v_target_users FROM tt_confirmed_template_ban_targets;
+  SELECT count(*) INTO v_target_flags
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  JOIN tt_confirmed_template_ban_targets t USING (user_id)
+  WHERE f.status IN ('auto_excluded', 'review');
+
+  IF v_target_users <> 1 OR v_target_flags <> 3 THEN
+    RAISE EXCEPTION
+      'template ban target drift: expected 1 user/3 flags, got % users/% flags',
+      v_target_users, v_target_flags;
+  END IF;
+
+  SELECT count(*) INTO v_hourly_rows
+  FROM public.tokentracker_hourly h
+  JOIN tt_confirmed_template_ban_targets t USING (user_id);
+
+  IF v_hourly_rows = 0 THEN
+    RAISE EXCEPTION 'template ban target has no hourly evidence';
+  END IF;
+
+  INSERT INTO public.tokentracker_hourly_quarantine (
+    user_id, device_id, source, model, hour_start,
+    input_tokens, cached_input_tokens, cache_creation_input_tokens,
+    output_tokens, reasoning_output_tokens, total_tokens,
+    billable_total_tokens, conversations, created_at, updated_at,
+    total_cost_usd, quarantined_at, quarantine_reason
+  )
+  SELECT
+    h.user_id, h.device_id, h.source, h.model, h.hour_start,
+    h.input_tokens, h.cached_input_tokens, h.cache_creation_input_tokens,
+    h.output_tokens, h.reasoning_output_tokens, h.total_tokens,
+    h.billable_total_tokens, h.conversations, h.created_at, h.updated_at,
+    h.total_cost_usd, clock_timestamp(),
+    'confirmed repeated token-template manipulation; operator ban 2026-08-21'
+  FROM public.tokentracker_hourly h
+  JOIN tt_confirmed_template_ban_targets t USING (user_id);
+
+  GET DIAGNOSTICS v_quarantined_rows = ROW_COUNT;
+  IF v_quarantined_rows <> v_hourly_rows THEN
+    RAISE EXCEPTION
+      'quarantine mismatch: expected %, copied %',
+      v_hourly_rows, v_quarantined_rows;
+  END IF;
+
+  DELETE FROM public.tokentracker_hourly h
+  USING tt_confirmed_template_ban_targets t
+  WHERE h.user_id = t.user_id;
+  GET DIAGNOSTICS v_deleted_rows = ROW_COUNT;
+
+  IF v_deleted_rows <> v_hourly_rows THEN
+    RAISE EXCEPTION
+      'hourly deletion mismatch: expected %, deleted %',
+      v_hourly_rows, v_deleted_rows;
+  END IF;
+
+  UPDATE public.tokentracker_device_tokens dt
+  SET revoked_at = COALESCE(dt.revoked_at, clock_timestamp())
+  FROM tt_confirmed_template_ban_targets t
+  WHERE dt.user_id = t.user_id;
+
+  UPDATE public.tokentracker_devices d
+  SET revoked_at = COALESCE(d.revoked_at, clock_timestamp())
+  FROM tt_confirmed_template_ban_targets t
+  WHERE d.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_daily r
+  USING tt_confirmed_template_ban_targets t
+  WHERE r.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_daily_v2 r
+  USING tt_confirmed_template_ban_targets t
+  WHERE r.user_id = t.user_id;
+
+  DELETE FROM public.tokentracker_leaderboard_snapshots s
+  USING tt_confirmed_template_ban_targets t
+  WHERE s.user_id = t.user_id;
+
+  DELETE FROM public.agentmeter_leaderboard_snapshots s
+  USING tt_confirmed_template_ban_targets t
+  WHERE s.user_id = t.user_id;
+
+  UPDATE public.tokentracker_leaderboard_anomaly_flags f
+  SET status = 'banned',
+      reviewed_at = clock_timestamp(),
+      note = 'confirmed repeated token-template manipulation; usage quarantined, credentials revoked, and account blocklisted by operator on 2026-08-21'
+  FROM tt_confirmed_template_ban_targets t
+  WHERE f.user_id = t.user_id
+    AND f.status IN ('auto_excluded', 'review');
+
+  GET DIAGNOSTICS v_banned_flags = ROW_COUNT;
+  IF v_banned_flags <> v_target_flags THEN
+    RAISE EXCEPTION
+      'flag transition mismatch: expected %, banned %',
+      v_target_flags, v_banned_flags;
+  END IF;
+END
+$ban$;

--- a/migrations/20260821070000_clear-verified-k8s-farm-false-positive.sql
+++ b/migrations/20260821070000_clear-verified-k8s-farm-false-positive.sql
@@ -1,0 +1,61 @@
+-- Clear the verified multi-node K8s farm caught by the 2026-08-21 05:41 UTC
+-- threshold-splitting heuristic. Cleared (user, day) rows are terminal review
+-- decisions and the detector deliberately never re-flags them.
+DO $clear$
+DECLARE
+  v_target_users integer;
+  v_target_flags integer;
+  v_cleared_flags integer;
+BEGIN
+  CREATE TEMP TABLE tt_verified_k8s_targets ON COMMIT DROP AS
+  SELECT f.user_id
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  WHERE f.detected_at >= '2026-08-21 05:41:00+00'::timestamptz
+    AND f.detected_at <  '2026-08-21 05:42:00+00'::timestamptz
+    AND f.status = 'auto_excluded'
+    AND f.reviewed_at IS NULL
+    AND f.peak_source = 'codex'
+    AND f.peak_model = 'gpt-5.6-sol'
+    AND f.note LIKE 'automatic threshold-splitting signal:%'
+    AND EXISTS (
+      SELECT 1
+      FROM public.tokentracker_devices d
+      WHERE d.user_id = f.user_id
+      GROUP BY d.user_id
+      HAVING count(*) >= 4
+    );
+
+  SELECT count(*) INTO v_target_users FROM tt_verified_k8s_targets;
+  SELECT count(*) INTO v_target_flags
+  FROM public.tokentracker_leaderboard_anomaly_flags f
+  JOIN tt_verified_k8s_targets t USING (user_id)
+  WHERE f.detected_at >= '2026-08-21 05:41:00+00'::timestamptz
+    AND f.detected_at <  '2026-08-21 05:42:00+00'::timestamptz
+    AND f.status IN ('auto_excluded', 'review')
+    AND f.reviewed_at IS NULL;
+
+  IF v_target_users <> 1 OR v_target_flags <> 2 THEN
+    RAISE EXCEPTION
+      'verified K8s target drift: expected 1 user/2 flags, got % users/% flags',
+      v_target_users, v_target_flags;
+  END IF;
+
+  UPDATE public.tokentracker_leaderboard_anomaly_flags f
+  SET status = 'cleared',
+      reviewed_at = clock_timestamp(),
+      note = 'verified legitimate multi-node K8s agent farm; false positive cleared by operator on 2026-08-21'
+  FROM tt_verified_k8s_targets t
+  WHERE f.user_id = t.user_id
+    AND f.detected_at >= '2026-08-21 05:41:00+00'::timestamptz
+    AND f.detected_at <  '2026-08-21 05:42:00+00'::timestamptz
+    AND f.status IN ('auto_excluded', 'review')
+    AND f.reviewed_at IS NULL;
+
+  GET DIAGNOSTICS v_cleared_flags = ROW_COUNT;
+  IF v_cleared_flags <> v_target_flags THEN
+    RAISE EXCEPTION
+      'verified K8s clear mismatch: expected %, cleared %',
+      v_target_flags, v_cleared_flags;
+  END IF;
+END
+$clear$;

--- a/migrations/20260904064000_cache-leaderboard-total-rollup.sql
+++ b/migrations/20260904064000_cache-leaderboard-total-rollup.sql
@@ -1,0 +1,353 @@
+-- The public total leaderboard used to regroup every closed-day rollup row on
+-- every refresh. By 2026-09-04 that meant 421k daily rows -> 54k model groups,
+-- and the JSON RPC repeatedly exceeded its 25s edge/database budget (#575).
+--
+-- Keep an all-time aggregate keyed by the exact dimensions required for edge
+-- pricing. Statement-level transition-table triggers apply every closed-day
+-- repair incrementally, so the online total refresh reads the compact aggregate
+-- plus only the current live tail. Bounded week/month requests retain the daily
+-- rollup path and therefore preserve their existing date semantics.
+
+CREATE TABLE IF NOT EXISTS public.tokentracker_leaderboard_rollup_total_v2 (
+  user_id uuid NOT NULL,
+  source text NOT NULL,
+  model text NOT NULL,
+  pricing_tier text NOT NULL,
+  total_tokens bigint NOT NULL DEFAULT 0,
+  input_tokens bigint NOT NULL DEFAULT 0,
+  output_tokens bigint NOT NULL DEFAULT 0,
+  cached_input_tokens bigint NOT NULL DEFAULT 0,
+  cache_creation_input_tokens bigint NOT NULL DEFAULT 0,
+  reasoning_output_tokens bigint NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, source, model, pricing_tier)
+);
+
+ALTER TABLE public.tokentracker_leaderboard_rollup_total_v2 ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.tokentracker_leaderboard_rollup_total_v2
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.tokentracker_leaderboard_rollup_total_v2 TO project_admin;
+
+-- Close the backfill/trigger installation race: no closed-day writer may
+-- commit between the snapshot used below and the trigger creation later in
+-- this transaction.
+LOCK TABLE public.tokentracker_leaderboard_rollup_daily_v2
+  IN SHARE ROW EXCLUSIVE MODE;
+
+TRUNCATE public.tokentracker_leaderboard_rollup_total_v2;
+INSERT INTO public.tokentracker_leaderboard_rollup_total_v2 (
+  user_id, source, model, pricing_tier,
+  total_tokens, input_tokens, output_tokens,
+  cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens
+)
+SELECT
+  user_id, source, model, pricing_tier,
+  SUM(total_tokens)::bigint,
+  SUM(input_tokens)::bigint,
+  SUM(output_tokens)::bigint,
+  SUM(cached_input_tokens)::bigint,
+  SUM(cache_creation_input_tokens)::bigint,
+  SUM(reasoning_output_tokens)::bigint
+FROM public.tokentracker_leaderboard_rollup_daily_v2
+GROUP BY user_id, source, model, pricing_tier;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_rollup_total_v2_after_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO public, pg_temp
+AS $func$
+BEGIN
+  INSERT INTO public.tokentracker_leaderboard_rollup_total_v2 AS total (
+    user_id, source, model, pricing_tier,
+    total_tokens, input_tokens, output_tokens,
+    cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens
+  )
+  SELECT
+    user_id, source, model, pricing_tier,
+    SUM(total_tokens)::bigint,
+    SUM(input_tokens)::bigint,
+    SUM(output_tokens)::bigint,
+    SUM(cached_input_tokens)::bigint,
+    SUM(cache_creation_input_tokens)::bigint,
+    SUM(reasoning_output_tokens)::bigint
+  FROM new_rows
+  GROUP BY user_id, source, model, pricing_tier
+  ON CONFLICT (user_id, source, model, pricing_tier) DO UPDATE SET
+    total_tokens = total.total_tokens + EXCLUDED.total_tokens,
+    input_tokens = total.input_tokens + EXCLUDED.input_tokens,
+    output_tokens = total.output_tokens + EXCLUDED.output_tokens,
+    cached_input_tokens = total.cached_input_tokens + EXCLUDED.cached_input_tokens,
+    cache_creation_input_tokens = total.cache_creation_input_tokens
+      + EXCLUDED.cache_creation_input_tokens,
+    reasoning_output_tokens = total.reasoning_output_tokens
+      + EXCLUDED.reasoning_output_tokens;
+  RETURN NULL;
+END
+$func$;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_rollup_total_v2_after_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO public, pg_temp
+AS $func$
+BEGIN
+  UPDATE public.tokentracker_leaderboard_rollup_total_v2 AS total
+  SET
+    total_tokens = total.total_tokens - removed.total_tokens,
+    input_tokens = total.input_tokens - removed.input_tokens,
+    output_tokens = total.output_tokens - removed.output_tokens,
+    cached_input_tokens = total.cached_input_tokens - removed.cached_input_tokens,
+    cache_creation_input_tokens = total.cache_creation_input_tokens
+      - removed.cache_creation_input_tokens,
+    reasoning_output_tokens = total.reasoning_output_tokens
+      - removed.reasoning_output_tokens
+  FROM (
+    SELECT
+      user_id, source, model, pricing_tier,
+      SUM(total_tokens)::bigint AS total_tokens,
+      SUM(input_tokens)::bigint AS input_tokens,
+      SUM(output_tokens)::bigint AS output_tokens,
+      SUM(cached_input_tokens)::bigint AS cached_input_tokens,
+      SUM(cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+      SUM(reasoning_output_tokens)::bigint AS reasoning_output_tokens
+    FROM old_rows
+    GROUP BY user_id, source, model, pricing_tier
+  ) AS removed
+  WHERE total.user_id = removed.user_id
+    AND total.source = removed.source
+    AND total.model = removed.model
+    AND total.pricing_tier = removed.pricing_tier;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_total_v2
+  WHERE total_tokens = 0
+    AND input_tokens = 0
+    AND output_tokens = 0
+    AND cached_input_tokens = 0
+    AND cache_creation_input_tokens = 0
+    AND reasoning_output_tokens = 0;
+  RETURN NULL;
+END
+$func$;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_rollup_total_v2_after_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO public, pg_temp
+AS $func$
+BEGIN
+  UPDATE public.tokentracker_leaderboard_rollup_total_v2 AS total
+  SET
+    total_tokens = total.total_tokens - removed.total_tokens,
+    input_tokens = total.input_tokens - removed.input_tokens,
+    output_tokens = total.output_tokens - removed.output_tokens,
+    cached_input_tokens = total.cached_input_tokens - removed.cached_input_tokens,
+    cache_creation_input_tokens = total.cache_creation_input_tokens
+      - removed.cache_creation_input_tokens,
+    reasoning_output_tokens = total.reasoning_output_tokens
+      - removed.reasoning_output_tokens
+  FROM (
+    SELECT
+      user_id, source, model, pricing_tier,
+      SUM(total_tokens)::bigint AS total_tokens,
+      SUM(input_tokens)::bigint AS input_tokens,
+      SUM(output_tokens)::bigint AS output_tokens,
+      SUM(cached_input_tokens)::bigint AS cached_input_tokens,
+      SUM(cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+      SUM(reasoning_output_tokens)::bigint AS reasoning_output_tokens
+    FROM old_rows
+    GROUP BY user_id, source, model, pricing_tier
+  ) AS removed
+  WHERE total.user_id = removed.user_id
+    AND total.source = removed.source
+    AND total.model = removed.model
+    AND total.pricing_tier = removed.pricing_tier;
+
+  INSERT INTO public.tokentracker_leaderboard_rollup_total_v2 AS total (
+    user_id, source, model, pricing_tier,
+    total_tokens, input_tokens, output_tokens,
+    cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens
+  )
+  SELECT
+    user_id, source, model, pricing_tier,
+    SUM(total_tokens)::bigint,
+    SUM(input_tokens)::bigint,
+    SUM(output_tokens)::bigint,
+    SUM(cached_input_tokens)::bigint,
+    SUM(cache_creation_input_tokens)::bigint,
+    SUM(reasoning_output_tokens)::bigint
+  FROM new_rows
+  GROUP BY user_id, source, model, pricing_tier
+  ON CONFLICT (user_id, source, model, pricing_tier) DO UPDATE SET
+    total_tokens = total.total_tokens + EXCLUDED.total_tokens,
+    input_tokens = total.input_tokens + EXCLUDED.input_tokens,
+    output_tokens = total.output_tokens + EXCLUDED.output_tokens,
+    cached_input_tokens = total.cached_input_tokens + EXCLUDED.cached_input_tokens,
+    cache_creation_input_tokens = total.cache_creation_input_tokens
+      + EXCLUDED.cache_creation_input_tokens,
+    reasoning_output_tokens = total.reasoning_output_tokens
+      + EXCLUDED.reasoning_output_tokens;
+
+  DELETE FROM public.tokentracker_leaderboard_rollup_total_v2
+  WHERE total_tokens = 0
+    AND input_tokens = 0
+    AND output_tokens = 0
+    AND cached_input_tokens = 0
+    AND cache_creation_input_tokens = 0
+    AND reasoning_output_tokens = 0;
+  RETURN NULL;
+END
+$func$;
+
+DROP TRIGGER IF EXISTS tokentracker_leaderboard_rollup_daily_v2_total_insert
+  ON public.tokentracker_leaderboard_rollup_daily_v2;
+CREATE TRIGGER tokentracker_leaderboard_rollup_daily_v2_total_insert
+AFTER INSERT ON public.tokentracker_leaderboard_rollup_daily_v2
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.leaderboard_rollup_total_v2_after_insert();
+
+DROP TRIGGER IF EXISTS tokentracker_leaderboard_rollup_daily_v2_total_delete
+  ON public.tokentracker_leaderboard_rollup_daily_v2;
+CREATE TRIGGER tokentracker_leaderboard_rollup_daily_v2_total_delete
+AFTER DELETE ON public.tokentracker_leaderboard_rollup_daily_v2
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.leaderboard_rollup_total_v2_after_delete();
+
+DROP TRIGGER IF EXISTS tokentracker_leaderboard_rollup_daily_v2_total_update
+  ON public.tokentracker_leaderboard_rollup_daily_v2;
+CREATE TRIGGER tokentracker_leaderboard_rollup_daily_v2_total_update
+AFTER UPDATE ON public.tokentracker_leaderboard_rollup_daily_v2
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.leaderboard_rollup_total_v2_after_update();
+
+REVOKE ALL ON FUNCTION public.leaderboard_rollup_total_v2_after_insert()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.leaderboard_rollup_total_v2_after_delete()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.leaderboard_rollup_total_v2_after_update()
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.leaderboard_usage_grouped(
+  p_from timestamptz,
+  p_to timestamptz
+) RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SET search_path TO public, pg_temp
+SET work_mem TO '96MB'
+SET hash_mem_multiplier TO '4'
+SET statement_timeout TO '25s'
+AS $func$
+DECLARE
+  v_through timestamptz;
+  v_cut timestamptz;
+  v_base jsonb;
+BEGIN
+  SELECT m.through INTO v_through
+  FROM public.tokentracker_leaderboard_rollup_meta_v2 m
+  WHERE m.id = 1;
+  v_cut := date_trunc(
+    'day',
+    LEAST(v_through, p_to) AT TIME ZONE 'UTC'
+  ) AT TIME ZONE 'UTC';
+
+  IF v_through IS NOT NULL
+     AND p_from = date_trunc('day', p_from AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+     AND v_cut > p_from THEN
+    IF p_from = TIMESTAMPTZ '1970-01-01 00:00:00+00'
+       AND p_to >= v_through THEN
+      -- The all-time period is the only caller allowed to use the aggregate
+      -- without a day predicate. It still merges the open live tail so today
+      -- remains current before the next closed-day rollup advance.
+      SELECT COALESCE(jsonb_agg(to_jsonb(per_usm.*)), '[]'::jsonb)
+      INTO v_base
+      FROM (
+        SELECT
+          u.user_id, u.source, u.model, u.pricing_tier,
+          SUM(u.total_tokens)::bigint AS total_tokens,
+          SUM(u.input_tokens)::bigint AS input_tokens,
+          SUM(u.output_tokens)::bigint AS output_tokens,
+          SUM(u.cached_input_tokens)::bigint AS cached_input_tokens,
+          SUM(u.cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+          SUM(u.reasoning_output_tokens)::bigint AS reasoning_output_tokens
+        FROM (
+          SELECT
+            r.user_id, r.source, r.model, r.pricing_tier,
+            r.total_tokens, r.input_tokens, r.output_tokens,
+            r.cached_input_tokens, r.cache_creation_input_tokens,
+            r.reasoning_output_tokens
+          FROM public.tokentracker_leaderboard_rollup_total_v2 r
+          UNION ALL
+          SELECT
+            t.user_id, t.source, t.model,
+            public.leaderboard_pricing_tier(t.model, t.hour_start) AS pricing_tier,
+            t.total_tokens, t.input_tokens, t.output_tokens,
+            t.cached_input_tokens, t.cache_creation_input_tokens,
+            t.reasoning_output_tokens
+          FROM public.leaderboard_hourly_dedup_v2(v_cut, p_to) t
+        ) u
+        GROUP BY u.user_id, u.source, u.model, u.pricing_tier
+      ) per_usm;
+    ELSE
+      SELECT COALESCE(jsonb_agg(to_jsonb(per_usm.*)), '[]'::jsonb)
+      INTO v_base
+      FROM (
+        SELECT
+          u.user_id, u.source, u.model, u.pricing_tier,
+          SUM(u.total_tokens)::bigint AS total_tokens,
+          SUM(u.input_tokens)::bigint AS input_tokens,
+          SUM(u.output_tokens)::bigint AS output_tokens,
+          SUM(u.cached_input_tokens)::bigint AS cached_input_tokens,
+          SUM(u.cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+          SUM(u.reasoning_output_tokens)::bigint AS reasoning_output_tokens
+        FROM (
+          SELECT
+            r.user_id, r.source, r.model, r.pricing_tier,
+            r.total_tokens, r.input_tokens, r.output_tokens,
+            r.cached_input_tokens, r.cache_creation_input_tokens,
+            r.reasoning_output_tokens
+          FROM public.tokentracker_leaderboard_rollup_daily_v2 r
+          WHERE r.day >= (p_from AT TIME ZONE 'UTC')::date
+            AND r.day < (v_cut AT TIME ZONE 'UTC')::date
+          UNION ALL
+          SELECT
+            t.user_id, t.source, t.model,
+            public.leaderboard_pricing_tier(t.model, t.hour_start) AS pricing_tier,
+            t.total_tokens, t.input_tokens, t.output_tokens,
+            t.cached_input_tokens, t.cache_creation_input_tokens,
+            t.reasoning_output_tokens
+          FROM public.leaderboard_hourly_dedup_v2(v_cut, p_to) t
+        ) u
+        GROUP BY u.user_id, u.source, u.model, u.pricing_tier
+      ) per_usm;
+    END IF;
+  ELSE
+    SELECT COALESCE(jsonb_agg(to_jsonb(per_usm.*)), '[]'::jsonb)
+    INTO v_base
+    FROM (
+      SELECT
+        d.user_id, d.source, d.model,
+        public.leaderboard_pricing_tier(d.model, d.hour_start) AS pricing_tier,
+        SUM(d.total_tokens)::bigint AS total_tokens,
+        SUM(d.input_tokens)::bigint AS input_tokens,
+        SUM(d.output_tokens)::bigint AS output_tokens,
+        SUM(d.cached_input_tokens)::bigint AS cached_input_tokens,
+        SUM(d.cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+        SUM(d.reasoning_output_tokens)::bigint AS reasoning_output_tokens
+      FROM public.leaderboard_hourly_dedup_v2(p_from, p_to) d
+      GROUP BY
+        d.user_id, d.source, d.model,
+        public.leaderboard_pricing_tier(d.model, d.hour_start)
+    ) per_usm;
+  END IF;
+
+  RETURN COALESCE(v_base, '[]'::jsonb);
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_usage_grouped(timestamptz, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.leaderboard_usage_grouped(timestamptz, timestamptz)
+  TO project_admin;
+
+ANALYZE public.tokentracker_leaderboard_rollup_total_v2;

--- a/migrations/20260904064500_shard-leaderboard-total-read.sql
+++ b/migrations/20260904064500_shard-leaderboard-total-read.sql
@@ -1,0 +1,81 @@
+-- The trigger-maintained total rollup removes the 421k-row regroup, but one
+-- 52k-row JSON response still exceeds the Edge database client's fixed 10s
+-- request timeout. Split only the all-time read into UUID ranges. Each
+-- range remains independently complete for its users, so Edge can concatenate
+-- the responses and keep its single canonical pricing implementation.
+
+CREATE OR REPLACE FUNCTION public.leaderboard_usage_grouped_total_shard(
+  p_to timestamptz,
+  p_user_from uuid,
+  p_user_to uuid
+) RETURNS jsonb
+LANGUAGE plpgsql STABLE
+SET search_path TO public, pg_temp
+SET work_mem TO '48MB'
+SET hash_mem_multiplier TO '2'
+SET statement_timeout TO '8s'
+AS $func$
+DECLARE
+  v_through timestamptz;
+  v_cut timestamptz;
+  v_result jsonb;
+BEGIN
+  SELECT m.through INTO v_through
+  FROM public.tokentracker_leaderboard_rollup_meta_v2 m
+  WHERE m.id = 1;
+
+  IF v_through IS NULL THEN
+    RAISE EXCEPTION 'leaderboard v2 rollup is not initialized';
+  END IF;
+
+  v_cut := date_trunc(
+    'day',
+    LEAST(v_through, p_to) AT TIME ZONE 'UTC'
+  ) AT TIME ZONE 'UTC';
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(per_usm.*)), '[]'::jsonb)
+  INTO v_result
+  FROM (
+    SELECT
+      u.user_id, u.source, u.model, u.pricing_tier,
+      SUM(u.total_tokens)::bigint AS total_tokens,
+      SUM(u.input_tokens)::bigint AS input_tokens,
+      SUM(u.output_tokens)::bigint AS output_tokens,
+      SUM(u.cached_input_tokens)::bigint AS cached_input_tokens,
+      SUM(u.cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+      SUM(u.reasoning_output_tokens)::bigint AS reasoning_output_tokens
+    FROM (
+      SELECT
+        r.user_id, r.source, r.model, r.pricing_tier,
+        r.total_tokens, r.input_tokens, r.output_tokens,
+        r.cached_input_tokens, r.cache_creation_input_tokens,
+        r.reasoning_output_tokens
+      FROM public.tokentracker_leaderboard_rollup_total_v2 r
+      WHERE (p_user_from IS NULL OR r.user_id >= p_user_from)
+        AND (p_user_to IS NULL OR r.user_id < p_user_to)
+
+      UNION ALL
+
+      SELECT
+        t.user_id, t.source, t.model,
+        public.leaderboard_pricing_tier(t.model, t.hour_start) AS pricing_tier,
+        t.total_tokens, t.input_tokens, t.output_tokens,
+        t.cached_input_tokens, t.cache_creation_input_tokens,
+        t.reasoning_output_tokens
+      FROM public.leaderboard_hourly_dedup_v2(v_cut, p_to) t
+      WHERE (p_user_from IS NULL OR t.user_id >= p_user_from)
+        AND (p_user_to IS NULL OR t.user_id < p_user_to)
+    ) u
+    GROUP BY u.user_id, u.source, u.model, u.pricing_tier
+  ) per_usm;
+
+  RETURN COALESCE(v_result, '[]'::jsonb);
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.leaderboard_usage_grouped_total_shard(
+  timestamptz, uuid, uuid
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.leaderboard_usage_grouped_total_shard(
+  timestamptz, uuid, uuid
+) TO project_admin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-cli",
-      "version": "0.95.0",
+      "version": "0.95.1",
       "license": "MIT",
       "dependencies": {
         "@mongodb-js/zstd": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "description": "Local-first AI coding token usage and cost tracker for 36 tools, with a dashboard, desktop pet, widgets, achievements, and native macOS/Windows apps.",
   "main": "src/cli.js",
   "bin": {

--- a/test/backend-hot-path-guardrails.test.js
+++ b/test/backend-hot-path-guardrails.test.js
@@ -117,11 +117,94 @@ test("leaderboard refresh fetches all user metadata with one RPC", () => {
 test("total leaderboard advances the cluster-aware rollup before reading it", () => {
   const source = read("dashboard/edge-patches/tokentracker-leaderboard-refresh.ts");
   const advance = source.indexOf('rpc(\n        "leaderboard_rollup_daily_advance_v2"');
-  const aggregate = source.indexOf('rpc(\n      "leaderboard_usage_grouped"');
+  const aggregate = source.indexOf('"leaderboard_usage_grouped_total_shard"', advance);
 
   assert.ok(advance > 0, "total refresh must advance the v2 closed-day rollup");
-  assert.ok(aggregate > advance, "aggregation must read only after the rollup advance succeeds");
+  assert.ok(aggregate > advance, "total shards must read only after the rollup advance succeeds");
   assert.match(source.slice(advance, aggregate), /if \(advanceErr\)[\s\S]*stage: "rollup_advance"/u);
+});
+
+test("total leaderboard reads a trigger-maintained all-time aggregate plus the live tail", () => {
+  const source = readMigrationBySuffix("cache-leaderboard-total-rollup");
+
+  assert.match(
+    source,
+    /CREATE TABLE IF NOT EXISTS public\.tokentracker_leaderboard_rollup_total_v2/u,
+    "the compact all-time aggregate must be durable",
+  );
+  assert.match(
+    source,
+    /LOCK TABLE public\.tokentracker_leaderboard_rollup_daily_v2\s+IN SHARE ROW EXCLUSIVE MODE/u,
+    "backfill and trigger installation must not race closed-day writers",
+  );
+  assert.match(
+    source,
+    /FROM public\.tokentracker_leaderboard_rollup_daily_v2\s+GROUP BY user_id, source, model, pricing_tier/u,
+    "the initial aggregate must preserve every pricing dimension",
+  );
+  for (const transition of [
+    "REFERENCING NEW TABLE AS new_rows",
+    "REFERENCING OLD TABLE AS old_rows",
+    "REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows",
+  ]) {
+    assert.match(source, new RegExp(transition), `${transition} must keep the aggregate current`);
+  }
+
+  const totalBranch = source.indexOf("p_from = TIMESTAMPTZ '1970-01-01 00:00:00+00'");
+  const boundedBranch = source.indexOf("ELSE", totalBranch);
+  assert.ok(totalBranch > 0, "only the exact all-time sentinel may use the total aggregate");
+  assert.match(
+    source.slice(totalBranch, boundedBranch),
+    /FROM public\.tokentracker_leaderboard_rollup_total_v2/u,
+    "the all-time branch must avoid regrouping the full daily history",
+  );
+  assert.match(
+    source.slice(totalBranch, boundedBranch),
+    /FROM public\.leaderboard_hourly_dedup_v2\(v_cut, p_to\)/u,
+    "the all-time branch must retain the current live tail",
+  );
+  assert.match(
+    source.slice(boundedBranch),
+    /FROM public\.tokentracker_leaderboard_rollup_daily_v2/u,
+    "bounded periods must retain their day-filtered rollup semantics",
+  );
+  assert.match(source, /ENABLE ROW LEVEL SECURITY/u);
+  assert.match(
+    source,
+    /REVOKE ALL ON public\.tokentracker_leaderboard_rollup_total_v2\s+FROM PUBLIC, anon, authenticated/u,
+  );
+});
+
+test("total leaderboard shards the model-granular response without changing pricing semantics", () => {
+  const migration = readMigrationBySuffix("shard-leaderboard-total-read");
+  const edgeSource = read("dashboard/edge-patches/tokentracker-leaderboard-refresh.ts");
+
+  assert.match(migration, /CREATE OR REPLACE FUNCTION public\.leaderboard_usage_grouped_total_shard/u);
+  assert.match(migration, /FROM public\.tokentracker_leaderboard_rollup_total_v2/u);
+  assert.match(migration, /FROM public\.leaderboard_hourly_dedup_v2\(v_cut, p_to\)/u);
+  assert.match(migration, /r\.user_id >= p_user_from/u);
+  assert.match(migration, /r\.user_id < p_user_to/u);
+  assert.match(migration, /GROUP BY u\.user_id, u\.source, u\.model, u\.pricing_tier/u);
+  assert.match(
+    migration,
+    /REVOKE ALL ON FUNCTION public\.leaderboard_usage_grouped_total_shard\([\s\S]*FROM PUBLIC, anon, authenticated/u,
+  );
+
+  assert.match(edgeSource, /const TOTAL_USER_SHARDS = \[/u);
+  assert.equal(
+    (edgeSource.match(/\{ from: "[0-9a-f-]+", to: (?:"[0-9a-f-]+"|null) \}/gu) ?? []).length,
+    8,
+    "total refresh must keep every model-granular response below the RPC timeout",
+  );
+  assert.match(edgeSource, /shardIndex \+= 2/u);
+  assert.match(edgeSource, /TOTAL_USER_SHARDS\.slice\(shardIndex, shardIndex \+ 2\)\.map/u);
+  assert.match(edgeSource, /"leaderboard_usage_grouped_total_shard"/u);
+  assert.match(edgeSource, /totalRows\.push\(\.\.\.result\.data\)/u);
+  assert.match(
+    edgeSource,
+    /for \(const row of grouped\)[\s\S]*agg\.estimated_cost_usd \+= computeRowCost\(row\)/u,
+    "sharded rows must still use the canonical edge pricing function",
+  );
 });
 
 test("signed-in users cannot trigger expensive month, total, or all-period leaderboard refreshes", () => {


### PR DESCRIPTION
Fixes the production total-leaderboard refresh timeout behind #575.

- maintain an all-time model/pricing-tier aggregate from the closed-day rollup
- shard the model-granular total read into bounded RPC responses
- preserve the live tail and the existing TypeScript pricing semantics
- sync the missing production migration baseline
- bump all managed clients to v0.95.1 for the unreleased Qoder/Linux fixes already on main

Production verification: total refresh returned HTTP 200 in 9.46s and updated 1,802 snapshots; the independent freshness workflow passed and auto-closed #575.

Tests: `npm test` (2605 passed, 0 failed, 2 skipped); focused backend rollup suite (32 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to 0.95.1 across supported platforms.

- **Improvements**
  - Improved all-time leaderboard refresh performance and reliability through cached aggregation and sharded processing.
  - Enhanced leaderboard data accuracy by combining historical totals with recent activity.
  - Added stronger safeguards for detecting and handling leaderboard manipulation.

- **Bug Fixes**
  - Corrected a verified false-positive anomaly classification in leaderboard monitoring.
  - Removed confirmed fraudulent activity from leaderboard results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->