### PR TITLE
perf(backend): scan account usage once

### DIFF
--- a/migrations/20260904083630_add-single-scan-account-usage-candidate.sql
+++ b/migrations/20260904083630_add-single-scan-account-usage-candidate.sql
@@ -1,0 +1,154 @@
+-- Candidate implementation for the account dashboard aggregation hot path.
+-- It preserves the existing deduplication and pricing semantics while reading
+-- the large hourly table only once per request. Runtime callers keep using the
+-- existing function until equivalence and EXPLAIN checks pass in production.
+
+CREATE OR REPLACE FUNCTION public.account_usage_grouped_single_scan_candidate(
+  p_user_id uuid,
+  p_device_ids uuid[],
+  p_from timestamptz,
+  p_to timestamptz,
+  p_trunc text,
+  p_tz text,
+  p_offset_min integer
+) RETURNS jsonb
+LANGUAGE sql STABLE
+SET search_path TO public, pg_temp
+SET statement_timeout TO '8s'
+AS $func$
+  WITH tzr AS (
+    SELECT CASE
+      WHEN p_tz IS NOT NULL AND p_tz <> ''
+       AND EXISTS (SELECT 1 FROM pg_timezone_names WHERE name = p_tz)
+      THEN p_tz ELSE NULL
+    END AS tz
+  ), base AS MATERIALIZED (
+    SELECT
+      h.device_id, h.hour_start, h.source, h.model,
+      h.total_tokens::bigint AS total_tokens,
+      h.input_tokens::bigint AS input_tokens,
+      h.output_tokens::bigint AS output_tokens,
+      h.cached_input_tokens::bigint AS cached_input_tokens,
+      h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
+      h.reasoning_output_tokens::bigint AS reasoning_output_tokens,
+      h.conversations::bigint AS conversations,
+      h.updated_at
+    FROM public.tokentracker_hourly h
+    WHERE h.user_id = p_user_id
+      AND h.hour_start >= p_from AND h.hour_start < p_to
+      AND (
+        h.source = 'cursor'
+        OR (
+          h.source NOT IN ('cursor', 'trae-cn')
+          AND h.device_id = ANY(p_device_ids)
+        )
+      )
+  ), hourly AS (
+    SELECT mac.hour_start, mac.source, mac.model,
+      mac.total_tokens, mac.input_tokens, mac.output_tokens,
+      mac.cached_input_tokens, mac.cache_creation_input_tokens,
+      mac.reasoning_output_tokens, mac.conversations
+    FROM (
+      SELECT DISTINCT ON (
+        COALESCE(dm.machine_cluster_id, h.device_id::text),
+        h.hour_start, h.source, h.model
+      )
+        h.hour_start, h.source, h.model,
+        h.total_tokens, h.input_tokens, h.output_tokens,
+        h.cached_input_tokens, h.cache_creation_input_tokens,
+        h.reasoning_output_tokens, h.conversations
+      FROM base h
+      LEFT JOIN public.tokentracker_device_machine dm ON dm.device_id = h.device_id
+      WHERE h.source NOT IN ('cursor', 'trae-cn')
+        AND h.device_id = ANY(p_device_ids)
+      ORDER BY COALESCE(dm.machine_cluster_id, h.device_id::text),
+        h.hour_start, h.source, h.model, h.total_tokens DESC, h.updated_at DESC
+    ) mac
+
+    UNION ALL
+
+    SELECT d.hour_start, d.source, d.model,
+      d.total_tokens, d.input_tokens, d.output_tokens,
+      d.cached_input_tokens, d.cache_creation_input_tokens,
+      d.reasoning_output_tokens, d.conversations
+    FROM (
+      SELECT DISTINCT ON (h.hour_start, h.source, h.model)
+        h.hour_start, h.source, h.model,
+        h.total_tokens, h.input_tokens, h.output_tokens,
+        h.cached_input_tokens, h.cache_creation_input_tokens,
+        h.reasoning_output_tokens, h.conversations
+      FROM base h
+      WHERE h.source = 'cursor'
+      ORDER BY h.hour_start, h.source, h.model, h.total_tokens DESC, h.updated_at DESC
+    ) d
+
+    UNION ALL
+
+    SELECT s.bucket_start, s.source, s.model,
+      SUM(s.total_tokens)::bigint, SUM(s.input_tokens)::bigint,
+      SUM(s.output_tokens)::bigint, SUM(s.cached_input_tokens)::bigint,
+      SUM(s.cache_creation_input_tokens)::bigint,
+      SUM(s.reasoning_output_tokens)::bigint, COUNT(*)::bigint
+    FROM public.tokentracker_account_session_states s
+    WHERE s.user_id = p_user_id
+      AND s.bucket_start >= p_from AND s.bucket_start < p_to
+      AND s.source = 'trae-cn'
+    GROUP BY s.bucket_start, s.source, s.model
+  ), located AS (
+    SELECT
+      CASE p_trunc
+        WHEN 'hour' THEN to_char(date_trunc('hour', local_ts), 'YYYY-MM-DD"T"HH24:00:00')
+        WHEN 'day' THEN to_char(date_trunc('day', local_ts), 'YYYY-MM-DD')
+        WHEN 'month' THEN to_char(date_trunc('month', local_ts), 'YYYY-MM')
+        ELSE ''
+      END AS bucket,
+      source, model,
+      CASE
+        WHEN lower(model) LIKE '%deepseek-v4-flash%'
+          OR lower(model) LIKE '%deepseek-v4-pro%'
+        THEN CASE
+          WHEN (
+            extract(hour FROM hour_start AT TIME ZONE 'UTC') >= 1
+            AND extract(hour FROM hour_start AT TIME ZONE 'UTC') < 4
+          ) OR (
+            extract(hour FROM hour_start AT TIME ZONE 'UTC') >= 6
+            AND extract(hour FROM hour_start AT TIME ZONE 'UTC') < 10
+          ) THEN 'peak' ELSE 'off_peak'
+        END
+        ELSE 'peak'
+      END AS pricing_tier,
+      total_tokens, input_tokens, output_tokens, cached_input_tokens,
+      cache_creation_input_tokens, reasoning_output_tokens, conversations
+    FROM hourly CROSS JOIN tzr
+    CROSS JOIN LATERAL (
+      SELECT CASE
+        WHEN tzr.tz IS NOT NULL THEN hour_start AT TIME ZONE tzr.tz
+        WHEN p_offset_min IS NOT NULL
+          THEN (hour_start AT TIME ZONE 'UTC') + make_interval(mins => p_offset_min)
+        ELSE hour_start AT TIME ZONE 'UTC'
+      END AS local_ts
+    ) local_time
+  ), grouped AS (
+    SELECT bucket, source, model, pricing_tier,
+      SUM(total_tokens)::bigint AS total_tokens,
+      SUM(input_tokens)::bigint AS input_tokens,
+      SUM(output_tokens)::bigint AS output_tokens,
+      SUM(cached_input_tokens)::bigint AS cached_input_tokens,
+      SUM(cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+      SUM(reasoning_output_tokens)::bigint AS reasoning_output_tokens,
+      SUM(conversations)::bigint AS conversations
+    FROM located
+    GROUP BY bucket, source, model, pricing_tier
+  )
+  SELECT COALESCE(
+    jsonb_agg(to_jsonb(grouped.*) ORDER BY bucket, source, model, pricing_tier),
+    '[]'::jsonb
+  ) FROM grouped
+$func$;
+
+REVOKE ALL ON FUNCTION public.account_usage_grouped_single_scan_candidate(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_usage_grouped_single_scan_candidate(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) TO project_admin;

--- a/migrations/20260904090000_promote-single-scan-account-usage.sql
+++ b/migrations/20260904090000_promote-single-scan-account-usage.sql
@@ -1,0 +1,59 @@
+-- Promote the verified single-scan candidate without copying its large SQL
+-- body. Replacing account_usage_grouped_v2 makes its SQL-language binding
+-- resolve the promoted function OID; the cached wrapper keeps its own stable
+-- OID and therefore needs no recreation or cache-key churn.
+
+ALTER FUNCTION public.account_usage_grouped(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) RENAME TO account_usage_grouped_pre_single_scan;
+
+ALTER FUNCTION public.account_usage_grouped_single_scan_candidate(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) RENAME TO account_usage_grouped;
+
+CREATE OR REPLACE FUNCTION public.account_usage_grouped_v2(
+  p_user_id uuid,
+  p_device_id uuid,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_trunc text,
+  p_tz text,
+  p_offset_min integer
+) RETURNS jsonb
+LANGUAGE sql STABLE
+SET search_path TO public, pg_temp
+SET statement_timeout TO '8s'
+AS $func$
+  WITH active AS (
+    SELECT COALESCE(array_agg(d.id ORDER BY d.id), ARRAY[]::uuid[]) AS ids
+    FROM public.tokentracker_devices d
+    WHERE d.user_id = p_user_id AND d.revoked_at IS NULL
+  ), scoped AS (
+    SELECT ids,
+      CASE WHEN p_device_id IS NOT NULL AND p_device_id = ANY(ids)
+        THEN ARRAY[p_device_id]::uuid[] ELSE ids END AS selected_ids
+    FROM active
+  )
+  SELECT CASE WHEN cardinality(ids) = 0 THEN '[]'::jsonb
+    ELSE public.account_usage_grouped(
+      p_user_id, selected_ids, p_from, p_to, p_trunc, p_tz, p_offset_min
+    ) END
+  FROM scoped
+$func$;
+
+DROP FUNCTION public.account_usage_grouped_pre_single_scan(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+);
+
+REVOKE ALL ON FUNCTION public.account_usage_grouped(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_usage_grouped(
+  uuid, uuid[], timestamptz, timestamptz, text, text, integer
+) TO project_admin;
+REVOKE ALL ON FUNCTION public.account_usage_grouped_v2(
+  uuid, uuid, timestamptz, timestamptz, text, text, integer
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_usage_grouped_v2(
+  uuid, uuid, timestamptz, timestamptz, text, text, integer
+) TO project_admin;

--- a/scripts/ops/account-usage-grouped-rpc.sql
+++ b/scripts/ops/account-usage-grouped-rpc.sql
@@ -106,6 +106,31 @@ AS $func$
   cfg AS (
     SELECT ARRAY['cursor', 'trae-cn']::text[] AS account_sources
   ),
+  -- Read the large per-user hourly slice once. Machine-level and Cursor
+  -- canonicalization below rescan only this bounded materialized result.
+  base AS MATERIALIZED (
+    SELECT
+      h.device_id, h.hour_start, h.source, h.model,
+      h.total_tokens::bigint                AS total_tokens,
+      h.input_tokens::bigint                AS input_tokens,
+      h.output_tokens::bigint               AS output_tokens,
+      h.cached_input_tokens::bigint         AS cached_input_tokens,
+      h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
+      h.reasoning_output_tokens::bigint     AS reasoning_output_tokens,
+      h.conversations::bigint               AS conversations,
+      h.updated_at
+    FROM tokentracker_hourly h CROSS JOIN cfg
+    WHERE h.user_id = p_user_id
+      AND h.hour_start >= p_from
+      AND h.hour_start < p_to
+      AND (
+        h.source = 'cursor'
+        OR (
+          NOT (h.source = ANY(cfg.account_sources))
+          AND h.device_id = ANY(p_device_ids)
+        )
+      )
+  ),
   -- Stage 1: canonicalize to the raw hour grain.
   hourly AS (
     -- Machine-level: ONE canonical whole row per (hour, source, model) across
@@ -162,12 +187,9 @@ AS $func$
         h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
         h.reasoning_output_tokens::bigint     AS reasoning_output_tokens,
         h.conversations::bigint               AS conversations
-      FROM tokentracker_hourly h CROSS JOIN cfg
+      FROM base h
       LEFT JOIN tokentracker_device_machine dm ON dm.device_id = h.device_id
-      WHERE h.user_id = p_user_id
-        AND h.hour_start >= p_from
-        AND h.hour_start <  p_to
-        AND NOT (h.source = ANY(cfg.account_sources))
+      WHERE h.source NOT IN ('cursor', 'trae-cn')
         AND h.device_id = ANY(p_device_ids)
       ORDER BY COALESCE(dm.machine_cluster_id, h.device_id::text),
                h.hour_start, h.source, h.model, h.total_tokens DESC, h.updated_at DESC
@@ -193,11 +215,8 @@ AS $func$
         h.cache_creation_input_tokens::bigint AS cache_creation_input_tokens,
         h.reasoning_output_tokens::bigint     AS reasoning_output_tokens,
         h.conversations::bigint               AS conversations
-      FROM tokentracker_hourly h
-      WHERE h.user_id = p_user_id
-        AND h.hour_start >= p_from
-        AND h.hour_start <  p_to
-        AND h.source = 'cursor'
+      FROM base h
+      WHERE h.source = 'cursor'
       ORDER BY h.hour_start, h.source, h.model, h.total_tokens DESC, h.updated_at DESC
     ) d
 

--- a/test/backend-hot-path-guardrails.test.js
+++ b/test/backend-hot-path-guardrails.test.js
@@ -106,6 +106,52 @@ test("DeepSeek V4 time pricing survives account and leaderboard aggregation", ()
   assert.match(source, /REVOKE ALL ON FUNCTION public\.leaderboard_deepseek_v4_grouped/u);
 });
 
+test("single-scan account candidate preserves dedup and pricing without rereading hourly", () => {
+  const source = readMigrationBySuffix("add-single-scan-account-usage-candidate");
+
+  assert.match(source, /base AS MATERIALIZED/u);
+  assert.equal(
+    (source.match(/FROM public\.tokentracker_hourly h/gu) ?? []).length,
+    1,
+    "the large hourly table must be read once per aggregation",
+  );
+  assert.match(source, /COALESCE\(dm\.machine_cluster_id, h\.device_id::text\)/u);
+  assert.match(source, /h\.source = 'cursor'/u);
+  assert.match(source, /FROM public\.tokentracker_account_session_states s/u);
+  assert.match(source, /THEN 'peak' ELSE 'off_peak'/u);
+  assert.doesNotMatch(source, /account_usage_grouped_legacy_v1\(/u);
+  assert.doesNotMatch(source, /account_usage_deepseek_v4_grouped\(/u);
+  assert.match(
+    source,
+    /REVOKE ALL ON FUNCTION public\.account_usage_grouped_single_scan_candidate[\s\S]*FROM PUBLIC, anon, authenticated/u,
+  );
+});
+
+test("single-scan account aggregation is promoted without invalidating the shared cache", () => {
+  const migration = readMigrationBySuffix("promote-single-scan-account-usage");
+  const opsSource = read("scripts/ops/account-usage-grouped-rpc.sql");
+
+  assert.match(
+    migration,
+    /account_usage_grouped_single_scan_candidate[\s\S]*RENAME TO account_usage_grouped/u,
+  );
+  assert.match(migration, /CREATE OR REPLACE FUNCTION public\.account_usage_grouped_v2/u);
+  assert.match(migration, /DROP FUNCTION public\.account_usage_grouped_pre_single_scan/u);
+  assert.doesNotMatch(
+    migration,
+    /CREATE OR REPLACE FUNCTION public\.account_usage_grouped_cached/u,
+    "the stable cached wrapper and exact-result cache key must remain warm",
+  );
+  assert.match(opsSource, /base AS MATERIALIZED/u);
+  assert.equal(
+    (opsSource.match(/FROM tokentracker_hourly h/gu) ?? []).length,
+    1,
+    "the standalone deployment source must match the promoted single scan",
+  );
+  assert.doesNotMatch(opsSource, /account_usage_grouped_legacy_v1\(/u);
+  assert.doesNotMatch(opsSource, /account_usage_deepseek_v4_grouped\(/u);
+});
+
 test("leaderboard refresh fetches all user metadata with one RPC", () => {
   const source = read("dashboard/edge-patches/tokentracker-leaderboard-refresh.ts");
   assert.match(source, /rpc\("leaderboard_user_metadata"/u);


### PR DESCRIPTION
## Summary
- materialize each account hourly slice once before machine and Cursor deduplication
- price DeepSeek V4 inline instead of re-reading hourly data through a second RPC
- promote only after production result-equivalence and EXPLAIN validation

## Production evidence
- 7/7 anonymous semantic comparisons matched the previous implementation exactly
- 366-day heavy-user query: 9.72s -> 2.06s; shared buffers 58,999 -> 27,036
- 32-day shared-cache RPC: 713ms cold, 21ms warm
- post-deploy: no active >5s queries and no waiting locks

## Verification
- `npm run ci:local`
- production function definition, ACL, migration history, cold/warm RPC read-back

No app version bump is required because this changes migrations, ops SQL, and tests only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved account usage reporting performance by processing hourly usage data more efficiently.
  * Increased consistency of grouped usage totals across devices and usage sources.
  * Preserved usage deduplication, pricing tiers, timezone handling, and local-time grouping.
* **Security**
  * Restricted account usage reporting access to authorized administrative operations.
* **Tests**
  * Added safeguards covering usage accuracy, performance, access controls, and deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->