### PR TITLE
fix(pricing): price GLM-5.3 and GLM-5.3-Flash at their own rates

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -207,6 +207,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    matcher requires the user-supplied model name to CONTAIN the LiteLLM
   //    key, so the bare `glm-5.1` / `glm-4.6` strings reported by Claude
   //    Code-compatible GLM endpoints never match. Curate them here. ──
+  // GLM-5.3: flagship keeps the 5.2 list rate; Flash is a distinct cheap SKU
+  // (LiteLLM `zai/glm-5.3-flash`: $0.15/$0.50/$0.03 per MTok in/out/cache-read).
+  "glm-5.3": { input: 1.4, output: 4.4, cache_read: 0.26 },
+  "glm-5.3-flash": { input: 0.15, output: 0.5, cache_read: 0.03 },
   "glm-5.2": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5.1": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5": { input: 1.0, output: 3.2, cache_read: 0.2 },
@@ -368,6 +372,8 @@ function getModelPricing(model: string) {
   if (lower.includes("glm-4.7-flash")) return MODEL_PRICING["glm-4.7-flash"];
   if (lower.includes("glm-4.7")) return MODEL_PRICING["glm-4.7"];
   if (lower.includes("glm-4.6")) return MODEL_PRICING["glm-4.6"];
+  if (lower.includes("glm-5.3-flash")) return MODEL_PRICING["glm-5.3-flash"];
+  if (lower.includes("glm-5.3")) return MODEL_PRICING["glm-5.3"];
   if (lower.includes("glm-5-turbo")) return MODEL_PRICING["glm-5-turbo"];
   if (lower.includes("glm-5.2")) return MODEL_PRICING["glm-5.2"];
   if (lower.includes("glm-5.1")) return MODEL_PRICING["glm-5.1"];

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -183,6 +183,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    matcher requires the user-supplied model name to CONTAIN the LiteLLM
   //    key, so the bare `glm-5.1` / `glm-4.6` strings reported by Claude
   //    Code-compatible GLM endpoints never match. Curate them here. ──
+  // GLM-5.3: flagship keeps the 5.2 list rate; Flash is a distinct cheap SKU
+  // (LiteLLM `zai/glm-5.3-flash`: $0.15/$0.50/$0.03 per MTok in/out/cache-read).
+  "glm-5.3": { input: 1.4, output: 4.4, cache_read: 0.26 },
+  "glm-5.3-flash": { input: 0.15, output: 0.5, cache_read: 0.03 },
   "glm-5.2": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5.1": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5": { input: 1.0, output: 3.2, cache_read: 0.2 },
@@ -344,6 +348,8 @@ function getModelPricing(model: string) {
   if (lower.includes("glm-4.7-flash")) return MODEL_PRICING["glm-4.7-flash"];
   if (lower.includes("glm-4.7")) return MODEL_PRICING["glm-4.7"];
   if (lower.includes("glm-4.6")) return MODEL_PRICING["glm-4.6"];
+  if (lower.includes("glm-5.3-flash")) return MODEL_PRICING["glm-5.3-flash"];
+  if (lower.includes("glm-5.3")) return MODEL_PRICING["glm-5.3"];
   if (lower.includes("glm-5-turbo")) return MODEL_PRICING["glm-5-turbo"];
   if (lower.includes("glm-5.2")) return MODEL_PRICING["glm-5.2"];
   if (lower.includes("glm-5.1")) return MODEL_PRICING["glm-5.1"];

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -208,6 +208,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    matcher requires the user-supplied model name to CONTAIN the LiteLLM
   //    key, so the bare `glm-5.1` / `glm-4.6` strings reported by Claude
   //    Code-compatible GLM endpoints never match. Curate them here. ──
+  // GLM-5.3: flagship keeps the 5.2 list rate; Flash is a distinct cheap SKU
+  // (LiteLLM `zai/glm-5.3-flash`: $0.15/$0.50/$0.03 per MTok in/out/cache-read).
+  "glm-5.3": { input: 1.4, output: 4.4, cache_read: 0.26 },
+  "glm-5.3-flash": { input: 0.15, output: 0.5, cache_read: 0.03 },
   "glm-5.2": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5.1": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5": { input: 1.0, output: 3.2, cache_read: 0.2 },
@@ -369,6 +373,8 @@ function getModelPricing(model: string) {
   if (lower.includes("glm-4.7-flash")) return MODEL_PRICING["glm-4.7-flash"];
   if (lower.includes("glm-4.7")) return MODEL_PRICING["glm-4.7"];
   if (lower.includes("glm-4.6")) return MODEL_PRICING["glm-4.6"];
+  if (lower.includes("glm-5.3-flash")) return MODEL_PRICING["glm-5.3-flash"];
+  if (lower.includes("glm-5.3")) return MODEL_PRICING["glm-5.3"];
   if (lower.includes("glm-5-turbo")) return MODEL_PRICING["glm-5-turbo"];
   if (lower.includes("glm-5.2")) return MODEL_PRICING["glm-5.2"];
   if (lower.includes("glm-5.1")) return MODEL_PRICING["glm-5.1"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -180,6 +180,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    matcher requires the user-supplied model name to CONTAIN the LiteLLM
   //    key, so the bare `glm-5.1` / `glm-4.6` strings reported by Claude
   //    Code-compatible GLM endpoints never match. Curate them here. ──
+  // GLM-5.3: flagship keeps the 5.2 list rate; Flash is a distinct cheap SKU
+  // (LiteLLM `zai/glm-5.3-flash`: $0.15/$0.50/$0.03 per MTok in/out/cache-read).
+  "glm-5.3": { input: 1.4, output: 4.4, cache_read: 0.26 },
+  "glm-5.3-flash": { input: 0.15, output: 0.5, cache_read: 0.03 },
   "glm-5.2": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5.1": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5": { input: 1.0, output: 3.2, cache_read: 0.2 },
@@ -341,6 +345,8 @@ function getModelPricing(model: string) {
   if (lower.includes("glm-4.7-flash")) return MODEL_PRICING["glm-4.7-flash"];
   if (lower.includes("glm-4.7")) return MODEL_PRICING["glm-4.7"];
   if (lower.includes("glm-4.6")) return MODEL_PRICING["glm-4.6"];
+  if (lower.includes("glm-5.3-flash")) return MODEL_PRICING["glm-5.3-flash"];
+  if (lower.includes("glm-5.3")) return MODEL_PRICING["glm-5.3"];
   if (lower.includes("glm-5-turbo")) return MODEL_PRICING["glm-5-turbo"];
   if (lower.includes("glm-5.2")) return MODEL_PRICING["glm-5.2"];
   if (lower.includes("glm-5.1")) return MODEL_PRICING["glm-5.1"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -222,6 +222,10 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    matcher requires the user-supplied model name to CONTAIN the LiteLLM
   //    key, so the bare `glm-5.1` / `glm-4.6` strings reported by Claude
   //    Code-compatible GLM endpoints never match. Curate them here. ──
+  // GLM-5.3: flagship keeps the 5.2 list rate; Flash is a distinct cheap SKU
+  // (LiteLLM `zai/glm-5.3-flash`: $0.15/$0.50/$0.03 per MTok in/out/cache-read).
+  "glm-5.3": { input: 1.4, output: 4.4, cache_read: 0.26 },
+  "glm-5.3-flash": { input: 0.15, output: 0.5, cache_read: 0.03 },
   "glm-5.2": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5.1": { input: 1.4, output: 4.4, cache_read: 0.26 },
   "glm-5": { input: 1.0, output: 3.2, cache_read: 0.2 },
@@ -383,6 +387,8 @@ function getModelPricing(model: string) {
   if (lower.includes("glm-4.7-flash")) return MODEL_PRICING["glm-4.7-flash"];
   if (lower.includes("glm-4.7")) return MODEL_PRICING["glm-4.7"];
   if (lower.includes("glm-4.6")) return MODEL_PRICING["glm-4.6"];
+  if (lower.includes("glm-5.3-flash")) return MODEL_PRICING["glm-5.3-flash"];
+  if (lower.includes("glm-5.3")) return MODEL_PRICING["glm-5.3"];
   if (lower.includes("glm-5-turbo")) return MODEL_PRICING["glm-5-turbo"];
   if (lower.includes("glm-5.2")) return MODEL_PRICING["glm-5.2"];
   if (lower.includes("glm-5.1")) return MODEL_PRICING["glm-5.1"];

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -254,6 +254,16 @@
       "cache_read": 0.3,
       "note": "Bare alias emitted by Kimi Code (modelAlias \"kimi-code/k3\" -> \"k3\"). Same rates as kimi-k3."
     },
+    "glm-5.3": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "glm-5.3-flash": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
     "glm-5.2": {
       "input": 1.4,
       "output": 4.4,
@@ -515,6 +525,14 @@
     {
       "match": "glm-4.6",
       "ref": "glm-4.6"
+    },
+    {
+      "match": "glm-5.3-flash",
+      "ref": "glm-5.3-flash"
+    },
+    {
+      "match": "glm-5.3",
+      "ref": "glm-5.3"
     },
     {
       "match": "glm-5-turbo",

--- a/test/edge-pricing-parity.test.js
+++ b/test/edge-pricing-parity.test.js
@@ -70,6 +70,8 @@ test("canonical pricing block retains regression-prone entries and matcher order
     '"mimo-v2-flash"',
     '"cursor-grok-4.5"',
     '"cursor-grok-4.5-fast"',
+    '"glm-5.3"',
+    '"glm-5.3-flash"',
   ]) {
     assert.ok(block.includes(`${key}:`), `canonical table lost ${key}`);
   }
@@ -102,6 +104,11 @@ test("canonical pricing block retains regression-prone entries and matcher order
     'lower.includes("grok-4.5"))',
   );
   order('lower.includes("grok-4.5"))', 'lower.includes("grok-4"))');
+  // GLM-5.3 Flash is a distinct cheap SKU ($0.15/$0.50 vs the flagship's
+  // $1.4/$4.4); its matcher must precede the base glm-5.3 matcher (substring)
+  // and glm-5.3 must precede glm-5, or flash rows bill at 6.7x.
+  order('lower.includes("glm-5.3-flash")', 'lower.includes("glm-5.3")');
+  order('lower.includes("glm-5.3")', 'lower.includes("glm-5")');
 });
 
 test("all cloud cost paths keep Pi Copilot subscription rows at zero cost", () => {

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -184,6 +184,36 @@ test("matcher: lookupPricing fuzzy match restores `digit-digit` to `digit.digit`
   assert.equal(r.value.input, 1.4);
 });
 
+test("matcher: GLM-5.3 and GLM-5.3-Flash resolve to their own curated rates (not the glm-5 fallback)", () => {
+  const curated = require("../src/lib/pricing/curated-overrides.json");
+  // LiteLLM keys the GLM-5.3 family only under provider prefixes
+  // (`zai/glm-5.3`, `zai/glm-5.3-flash`), so bare queue names must resolve
+  // via curated. Before these exact entries existed both ids fell through to
+  // the "glm-5" fuzzy needle, billing the flash SKU at $1.0/$3.2 per MTok —
+  // 6.7x its real rate.
+  const litellm = {};
+  const cases = [
+    // flagship 5.3 keeps the 5.2 list rate (LiteLLM `zai/glm-5.3`)
+    ["glm-5.3", 1.4, 4.4, 0.26, "curated:exact"],
+    // flash SKU mirrors LiteLLM `zai/glm-5.3-flash`
+    ["glm-5.3-flash", 0.15, 0.5, 0.03, "curated:exact"],
+    // cased / suffixed variants land on the flash entry via fuzzy
+    ["GLM-5.3-Flash", 0.15, 0.5, 0.03, "curated:fuzzy"],
+    ["glm-5.3-flash-thinking", 0.15, 0.5, 0.03, "curated:fuzzy"],
+    // droid dash-forms restore the dot and hit exact-dot
+    ["glm-5-3-flash", 0.15, 0.5, 0.03, "curated:exact-dot"],
+    ["glm-5-3", 1.4, 4.4, 0.26, "curated:exact-dot"],
+  ];
+  for (const [model, input, output, cache_read, source] of cases) {
+    const r = matcher.lookupPricing(model, { curated, litellm });
+    assert.equal(r.hit, true, `${model} should resolve`);
+    assert.equal(r.value.input, input, `${model} input`);
+    assert.equal(r.value.output, output, `${model} output`);
+    assert.equal(r.value.cache_read, cache_read, `${model} cache_read`);
+    if (source) assert.equal(r.source, source, `${model} source`);
+  }
+});
+
 test("matcher: lookupPricing strips a LiteLLM provider prefix for bare queue models", () => {
   // Queue rows store bare model names; LiteLLM keys are provider-qualified.
   const curated = { exact: {}, alias: {}, fuzzy: [] };
@@ -599,6 +629,35 @@ test("index: getModelPricing resolves GLM-5.2 from CURATED for ZCode rows", asyn
     reasoning_output_tokens: 0,
   });
   assert.equal(cost, 1.4);
+});
+
+test("index: getModelPricing resolves glm-5.3-flash at the LiteLLM flash rate, not glm-5", async () => {
+  pricing.resetPricingForTests();
+  const cachePath = tmpCachePath();
+  await pricing.ensurePricingLoaded({
+    cachePath,
+    fetchImpl: makeFetchImpl(FIXTURE_LITELLM),
+  });
+  // GLM-5.3-Flash reported by Claude Code-compatible GLM endpoints reaches
+  // the queue as a bare model name. It previously resolved through the
+  // "glm-5" fuzzy fallback ($1.0/$3.2 per MTok — 6.7x the real flash rate)
+  // because LiteLLM only keys it under the provider prefix `zai/glm-5.3-flash`.
+  const flash = pricing.getModelPricing("glm-5.3-flash", { source: "claude" });
+  assert.equal(flash.input, 0.15);
+  assert.equal(flash.output, 0.5);
+  assert.equal(flash.cache_read, 0.03);
+  // End-to-end: 1M input + 1M output must cost $0.65, not the $4.20 the
+  // glm-5 fallback charged.
+  const cost = pricing.computeRowCost({
+    source: "claude",
+    model: "glm-5.3-flash",
+    input_tokens: 1_000_000,
+    output_tokens: 1_000_000,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_output_tokens: 0,
+  });
+  assert.equal(cost, 0.65);
 });
 
 test("index: getModelPricing resolves Sakana Fugu Ultra from CURATED (issue #214)", async () => {


### PR DESCRIPTION
Bare 'glm-5.3-flash' rows (as reported by Claude Code-compatible GLM endpoints) previously fell through the curated fuzzy chain to the 'glm-5' needle and were billed at 1.0/3.2 per MTok - ~6.7x the real flash rate. LiteLLM keys the family only under provider prefixes ('zai/glm-5.3-flash'), so the bare names never match it directly.

Pin both tiers in curated overrides and mirror them into the canonical edge block across all five edge functions:

- glm-5.3:      1.4 / 4.4 / 0.26 per MTok (same list rate as 5.2)
- glm-5.3-flash 0.15 / 0.50 / 0.03 per MTok (LiteLLM zai/glm-5.3-flash)

The glm-5.3-flash matcher precedes glm-5.3 (substring), which precedes glm-5, so flash rows never fall back to the flagship rate.

Adds regression coverage in test/pricing.test.js (matcher + end-to-end cost) and locks the entries/order into test/edge-pricing-parity.test.js so the five edge files cannot drift.

## Summary

<!-- One sentence: what does this PR do, and why? -->

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [ ] `npm test` passes
- [ ] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [ ] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [ ] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

-

### Boundary matrix (list at least 3)

-

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

### Most likely regression surface

-

### Verification method (choose at least one)

-

### Uncovered scope

-

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pricing support for GLM-5.3 and GLM-5.3 Flash models.
  * Model usage and costs now resolve to the correct rates, including cached input pricing.

* **Bug Fixes**
  * Prevented GLM-5.3 Flash usage from being incorrectly billed using broader GLM-5 fallback rates.

* **Tests**
  * Added coverage for model matching, pricing resolution, cost calculations, and consistency across supported views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->