### PR TITLE
feat(pricing): add Qwen3.8 Flash and Max rates with full cache pricing

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -290,6 +290,14 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    cache_write = input. ──
   "step-3.7-flash": { input: 0.2, output: 1.15, cache_read: 0.04, cache_write: 0.2 },
   "step-3.5-flash": { input: 0.1, output: 0.3, cache_read: 0.02, cache_write: 0.1 },
+  // ── Alibaba Qwen3.8 (mirrored from src/lib/pricing/curated-overrides.json).
+  //    Official rates per MTok in/read/write/out: Flash $0.15/$0.016/$0.20/
+  //    $0.47, Max $2/$0.25/$2.50/$6 (verified 2026-09-05). LiteLLM carries
+  //    together_ai/Qwen/Qwen3.8-Flash without cache fields and
+  //    dashscope/qwen3.8-max without cache-write, so cache-heavy rows
+  //    undercounted ~48x until these were pinned. ──
+  "qwen3.8-flash": { input: 0.15, output: 0.47, cache_read: 0.016, cache_write: 0.2 },
+  "qwen3.8-max": { input: 2, output: 6, cache_read: 0.25, cache_write: 2.5 },
 };
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
 
@@ -388,6 +396,12 @@ function getModelPricing(model: string) {
   if (lower.includes("step-3.7-flash")) return MODEL_PRICING["step-3.7-flash"];
   if (lower.includes("step-3.5-flash")) return MODEL_PRICING["step-3.5-flash"];
   if (lower.includes("stepfun")) return MODEL_PRICING["step-3.7-flash"];
+  // Qwen3.8 ordering: Flash and Max are distinct SKUs; neither needle is a
+  // substring of the other, so flash-first mirrors the cheap-SKU-first GLM
+  // convention without changing behaviour. Catches cased/dated variants like
+  // "Qwen3.8-Flash" that miss the exact table key.
+  if (lower.includes("qwen3.8-flash")) return MODEL_PRICING["qwen3.8-flash"];
+  if (lower.includes("qwen3.8-max")) return MODEL_PRICING["qwen3.8-max"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
 }

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -266,6 +266,14 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    cache_write = input. ──
   "step-3.7-flash": { input: 0.2, output: 1.15, cache_read: 0.04, cache_write: 0.2 },
   "step-3.5-flash": { input: 0.1, output: 0.3, cache_read: 0.02, cache_write: 0.1 },
+  // ── Alibaba Qwen3.8 (mirrored from src/lib/pricing/curated-overrides.json).
+  //    Official rates per MTok in/read/write/out: Flash $0.15/$0.016/$0.20/
+  //    $0.47, Max $2/$0.25/$2.50/$6 (verified 2026-09-05). LiteLLM carries
+  //    together_ai/Qwen/Qwen3.8-Flash without cache fields and
+  //    dashscope/qwen3.8-max without cache-write, so cache-heavy rows
+  //    undercounted ~48x until these were pinned. ──
+  "qwen3.8-flash": { input: 0.15, output: 0.47, cache_read: 0.016, cache_write: 0.2 },
+  "qwen3.8-max": { input: 2, output: 6, cache_read: 0.25, cache_write: 2.5 },
 };
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
 
@@ -364,6 +372,12 @@ function getModelPricing(model: string) {
   if (lower.includes("step-3.7-flash")) return MODEL_PRICING["step-3.7-flash"];
   if (lower.includes("step-3.5-flash")) return MODEL_PRICING["step-3.5-flash"];
   if (lower.includes("stepfun")) return MODEL_PRICING["step-3.7-flash"];
+  // Qwen3.8 ordering: Flash and Max are distinct SKUs; neither needle is a
+  // substring of the other, so flash-first mirrors the cheap-SKU-first GLM
+  // convention without changing behaviour. Catches cased/dated variants like
+  // "Qwen3.8-Flash" that miss the exact table key.
+  if (lower.includes("qwen3.8-flash")) return MODEL_PRICING["qwen3.8-flash"];
+  if (lower.includes("qwen3.8-max")) return MODEL_PRICING["qwen3.8-max"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
 }

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -291,6 +291,14 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    cache_write = input. ──
   "step-3.7-flash": { input: 0.2, output: 1.15, cache_read: 0.04, cache_write: 0.2 },
   "step-3.5-flash": { input: 0.1, output: 0.3, cache_read: 0.02, cache_write: 0.1 },
+  // ── Alibaba Qwen3.8 (mirrored from src/lib/pricing/curated-overrides.json).
+  //    Official rates per MTok in/read/write/out: Flash $0.15/$0.016/$0.20/
+  //    $0.47, Max $2/$0.25/$2.50/$6 (verified 2026-09-05). LiteLLM carries
+  //    together_ai/Qwen/Qwen3.8-Flash without cache fields and
+  //    dashscope/qwen3.8-max without cache-write, so cache-heavy rows
+  //    undercounted ~48x until these were pinned. ──
+  "qwen3.8-flash": { input: 0.15, output: 0.47, cache_read: 0.016, cache_write: 0.2 },
+  "qwen3.8-max": { input: 2, output: 6, cache_read: 0.25, cache_write: 2.5 },
 };
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
 
@@ -389,6 +397,12 @@ function getModelPricing(model: string) {
   if (lower.includes("step-3.7-flash")) return MODEL_PRICING["step-3.7-flash"];
   if (lower.includes("step-3.5-flash")) return MODEL_PRICING["step-3.5-flash"];
   if (lower.includes("stepfun")) return MODEL_PRICING["step-3.7-flash"];
+  // Qwen3.8 ordering: Flash and Max are distinct SKUs; neither needle is a
+  // substring of the other, so flash-first mirrors the cheap-SKU-first GLM
+  // convention without changing behaviour. Catches cased/dated variants like
+  // "Qwen3.8-Flash" that miss the exact table key.
+  if (lower.includes("qwen3.8-flash")) return MODEL_PRICING["qwen3.8-flash"];
+  if (lower.includes("qwen3.8-max")) return MODEL_PRICING["qwen3.8-max"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
 }

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -263,6 +263,14 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    cache_write = input. ──
   "step-3.7-flash": { input: 0.2, output: 1.15, cache_read: 0.04, cache_write: 0.2 },
   "step-3.5-flash": { input: 0.1, output: 0.3, cache_read: 0.02, cache_write: 0.1 },
+  // ── Alibaba Qwen3.8 (mirrored from src/lib/pricing/curated-overrides.json).
+  //    Official rates per MTok in/read/write/out: Flash $0.15/$0.016/$0.20/
+  //    $0.47, Max $2/$0.25/$2.50/$6 (verified 2026-09-05). LiteLLM carries
+  //    together_ai/Qwen/Qwen3.8-Flash without cache fields and
+  //    dashscope/qwen3.8-max without cache-write, so cache-heavy rows
+  //    undercounted ~48x until these were pinned. ──
+  "qwen3.8-flash": { input: 0.15, output: 0.47, cache_read: 0.016, cache_write: 0.2 },
+  "qwen3.8-max": { input: 2, output: 6, cache_read: 0.25, cache_write: 2.5 },
 };
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
 
@@ -361,6 +369,12 @@ function getModelPricing(model: string) {
   if (lower.includes("step-3.7-flash")) return MODEL_PRICING["step-3.7-flash"];
   if (lower.includes("step-3.5-flash")) return MODEL_PRICING["step-3.5-flash"];
   if (lower.includes("stepfun")) return MODEL_PRICING["step-3.7-flash"];
+  // Qwen3.8 ordering: Flash and Max are distinct SKUs; neither needle is a
+  // substring of the other, so flash-first mirrors the cheap-SKU-first GLM
+  // convention without changing behaviour. Catches cased/dated variants like
+  // "Qwen3.8-Flash" that miss the exact table key.
+  if (lower.includes("qwen3.8-flash")) return MODEL_PRICING["qwen3.8-flash"];
+  if (lower.includes("qwen3.8-max")) return MODEL_PRICING["qwen3.8-max"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
 }

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -305,6 +305,14 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   //    cache_write = input. ──
   "step-3.7-flash": { input: 0.2, output: 1.15, cache_read: 0.04, cache_write: 0.2 },
   "step-3.5-flash": { input: 0.1, output: 0.3, cache_read: 0.02, cache_write: 0.1 },
+  // ── Alibaba Qwen3.8 (mirrored from src/lib/pricing/curated-overrides.json).
+  //    Official rates per MTok in/read/write/out: Flash $0.15/$0.016/$0.20/
+  //    $0.47, Max $2/$0.25/$2.50/$6 (verified 2026-09-05). LiteLLM carries
+  //    together_ai/Qwen/Qwen3.8-Flash without cache fields and
+  //    dashscope/qwen3.8-max without cache-write, so cache-heavy rows
+  //    undercounted ~48x until these were pinned. ──
+  "qwen3.8-flash": { input: 0.15, output: 0.47, cache_read: 0.016, cache_write: 0.2 },
+  "qwen3.8-max": { input: 2, output: 6, cache_read: 0.25, cache_write: 2.5 },
 };
 const ZERO_PRICING = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
 
@@ -403,6 +411,12 @@ function getModelPricing(model: string) {
   if (lower.includes("step-3.7-flash")) return MODEL_PRICING["step-3.7-flash"];
   if (lower.includes("step-3.5-flash")) return MODEL_PRICING["step-3.5-flash"];
   if (lower.includes("stepfun")) return MODEL_PRICING["step-3.7-flash"];
+  // Qwen3.8 ordering: Flash and Max are distinct SKUs; neither needle is a
+  // substring of the other, so flash-first mirrors the cheap-SKU-first GLM
+  // convention without changing behaviour. Catches cased/dated variants like
+  // "Qwen3.8-Flash" that miss the exact table key.
+  if (lower.includes("qwen3.8-flash")) return MODEL_PRICING["qwen3.8-flash"];
+  if (lower.includes("qwen3.8-max")) return MODEL_PRICING["qwen3.8-max"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
 }

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -388,6 +388,20 @@
       "cache_write": 0.1,
       "note": "StepFun Step 3.5 Flash incl. dated snapshots like step-3.5-flash-2603 (issue #283). Official platform.stepfun.ai pricing: $0.10 / $0.02 (cache hit) / $0.30 per MTok in/read/out. No published cache-write surcharge, so cache_write = input."
     },
+    "qwen3.8-flash": {
+      "input": 0.15,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2,
+      "note": "Alibaba Qwen3.8 Flash official pricing (verified 2026-09-05): $0.15 / $0.016 (cache read) / $0.20 (cache write) / $0.47 per MTok in/read/write/out. LiteLLM carries together_ai/Qwen/Qwen3.8-Flash with matching in/out but NO cache fields, so cache-heavy rows billed ~48x low until pinned here."
+    },
+    "qwen3.8-max": {
+      "input": 2,
+      "output": 6,
+      "cache_read": 0.25,
+      "cache_write": 2.5,
+      "note": "Alibaba Qwen3.8 Max official pricing (verified 2026-09-05): $2 / $0.25 (cache read) / $2.50 (cache write) / $6 per MTok in/read/write/out. LiteLLM dashscope/qwen3.8-max omits cache_write; the pin also covers offline/fresh installs whose bundled seed predates the model."
+    },
     "grok-4.5-build": {
       "input": 2.0,
       "output": 6.0,
@@ -569,6 +583,14 @@
     {
       "match": "stepfun",
       "ref": "step-3.7-flash"
+    },
+    {
+      "match": "qwen3.8-flash",
+      "ref": "qwen3.8-flash"
+    },
+    {
+      "match": "qwen3.8-max",
+      "ref": "qwen3.8-max"
     }
   ]
 }

--- a/test/edge-pricing-parity.test.js
+++ b/test/edge-pricing-parity.test.js
@@ -72,6 +72,8 @@ test("canonical pricing block retains regression-prone entries and matcher order
     '"cursor-grok-4.5-fast"',
     '"glm-5.3"',
     '"glm-5.3-flash"',
+    '"qwen3.8-flash"',
+    '"qwen3.8-max"',
   ]) {
     assert.ok(block.includes(`${key}:`), `canonical table lost ${key}`);
   }

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -214,6 +214,38 @@ test("matcher: GLM-5.3 and GLM-5.3-Flash resolve to their own curated rates (not
   }
 });
 
+test("matcher: Qwen3.8 Flash and Max resolve to their own curated rates (cache prices included)", () => {
+  const curated = require("../src/lib/pricing/curated-overrides.json");
+  // LiteLLM carries `together_ai/Qwen/Qwen3.8-Flash` without cache fields and
+  // `dashscope/qwen3.8-max` without cache_write. Before the curated pins,
+  // prefix-strip resolved those incomplete entries and cache-heavy dsh rows
+  // billed ~48x low. Curated must win even when LiteLLM has the model.
+  const litellm = {
+    "together_ai/Qwen/Qwen3.8-Flash": { input: 0.15, output: 0.47 },
+    "dashscope/qwen3.8-max": { input: 2, output: 6, cache_read: 0.25 },
+  };
+  const cases = [
+    ["qwen3.8-flash", 0.15, 0.47, 0.016, 0.2, "curated:exact"],
+    ["qwen3.8-max", 2, 6, 0.25, 2.5, "curated:exact"],
+    // cased / suffixed variants land on the right entry via fuzzy
+    ["Qwen3.8-Flash", 0.15, 0.47, 0.016, 0.2, "curated:fuzzy"],
+    ["qwen3.8-flash-thinking", 0.15, 0.47, 0.016, 0.2, "curated:fuzzy"],
+    ["QWEN3.8-MAX", 2, 6, 0.25, 2.5, "curated:fuzzy"],
+    // dash forms restore the dot and hit exact-dot
+    ["qwen3-8-flash", 0.15, 0.47, 0.016, 0.2, "curated:exact-dot"],
+    ["qwen3-8-max", 2, 6, 0.25, 2.5, "curated:exact-dot"],
+  ];
+  for (const [model, input, output, cache_read, cache_write, source] of cases) {
+    const r = matcher.lookupPricing(model, { curated, litellm });
+    assert.equal(r.hit, true, `${model} should resolve`);
+    assert.equal(r.value.input, input, `${model} input`);
+    assert.equal(r.value.output, output, `${model} output`);
+    assert.equal(r.value.cache_read, cache_read, `${model} cache_read`);
+    assert.equal(r.value.cache_write, cache_write, `${model} cache_write`);
+    assert.equal(r.source, source, `${model} source`);
+  }
+});
+
 test("matcher: lookupPricing strips a LiteLLM provider prefix for bare queue models", () => {
   // Queue rows store bare model names; LiteLLM keys are provider-qualified.
   const curated = { exact: {}, alias: {}, fuzzy: [] };
@@ -890,6 +922,53 @@ test("index: Cursor Fast SKUs keep their distinct curated pricing (#446)", () =>
     input_tokens: 1_000_000,
     output_tokens: 1_000_000,
   }), 60);
+});
+
+test("index: qwen3.8 cache-heavy rows bill cache reads and writes at the pinned rates", async () => {
+  pricing.resetPricingForTests();
+  const cachePath = tmpCachePath();
+  await pricing.ensurePricingLoaded({
+    cachePath,
+    fetchImpl: makeFetchImpl({
+      "together_ai/Qwen/Qwen3.8-Flash": {
+        input_cost_per_token: 1.5e-7,
+        output_cost_per_token: 4.7e-7,
+      },
+      "dashscope/qwen3.8-max": {
+        input_cost_per_token: 2e-6,
+        output_cost_per_token: 6e-6,
+        cache_read_input_token_cost: 2.5e-7,
+      },
+    }),
+  });
+  // Real dsh queue numbers (2026-09-05T13:00Z): 456 fresh input vs 2.54M
+  // cache reads + 264K cache writes. Without the curated cache prices this
+  // row cost $0.0048 instead of $0.0983.
+  const flash = pricing.computeRowCost({
+    source: "dsh",
+    model: "qwen3.8-flash",
+    hour_start: "2026-09-05T13:00:00.000Z",
+    input_tokens: 456,
+    output_tokens: 10106,
+    cached_input_tokens: 2540760,
+    cache_creation_input_tokens: 264343,
+    reasoning_output_tokens: 0,
+  });
+  assert.ok(
+    Math.abs(flash - (456 * 0.15 + 10106 * 0.47 + 2540760 * 0.016 + 264343 * 0.2) / 1e6) < 1e-9,
+    `flash cost ${flash} != pinned-rate expectation`,
+  );
+  // Max carries an explicit cache_write ($2.5/M) that LiteLLM omits entirely.
+  const max = pricing.computeRowCost({
+    source: "dsh",
+    model: "qwen3.8-max",
+    input_tokens: 1000,
+    output_tokens: 2000,
+    cached_input_tokens: 500000,
+    cache_creation_input_tokens: 100000,
+    reasoning_output_tokens: 0,
+  });
+  assert.equal(max, 0.389);
 });
 
 test("index: getModelPricing finds LiteLLM mainstream models with correct unit conversion", async () => {


### PR DESCRIPTION
LiteLLM's together_ai/Qwen/Qwen3.8-Flash entry omits cache read/write costs and dashscope/qwen3.8-max omits cache-write, so cache-heavy dsh rows undercounted ~48x. Pin both models in curated-overrides.json (input/output/cache_read/cache_write per MTok) plus the canonical edge block mirrored verbatim into the four other edge files; cover exact/fuzzy/cased/dot lookup variants and a computeRowCost regression on a real cache-dominated row.

## Summary

<!-- One sentence: what does this PR do, and why? -->

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [ ] `npm test` passes
- [ ] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [ ] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [ ] PR description explains *why*, not just *what*

---

<details>
<summary><strong>Risk layer addendum</strong> — expand if this PR touches any trigger below</summary>

### Risk layer triggers

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth / session / token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

### Rules / invariants

-

### Boundary matrix (list at least 3)

-

### Public exposure checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback

</details>

<details>
<summary><strong>Codex review context</strong> — fill when requesting <code>@codex</code> review</summary>

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

### Most likely regression surface

-

### Verification method (choose at least one)

-

### Uncovered scope

-

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pricing support for Alibaba Qwen3.8 Flash and Qwen3.8 Max models.
  * Model identifiers are now matched consistently across capitalization, provider prefixes, date suffixes, and formatting variations.
  * Token usage costs include input, output, cache-read, and cache-write rates.

* **Bug Fixes**
  * Corrected cost calculations for Qwen3.8 model usage, including cache-heavy requests.

* **Tests**
  * Added coverage to verify pricing resolution and billing accuracy for both models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->