### PR TITLE
fix(sync): preserve ZCode history that repairs cannot re-replicate

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -4283,16 +4283,22 @@ async function resetUploadOffsetForZcodeRepair(queueStatePath, note) {
   return true;
 }
 
-async function dropZcodeQueueRows(filePath, { retainRetractions = false } = {}) {
+// Drops zcode rows ahead of a from-scratch re-parse. The re-parse can only
+// cover rows still present in the source DB, and ZCode prunes old sessions —
+// so keys the fresh parse cannot re-replicate must keep their last uploaded
+// value. Write those rows back verbatim instead of zero retractions: a
+// replay of zero rows permanently erases real history on the cloud (latest
+// per bucket key wins) for every key the fresh parse does not cover.
+async function dropZcodeQueueRows(filePath, { preserveLatestRows = false } = {}) {
   let raw;
   try {
     raw = await fs.readFile(filePath, "utf8");
   } catch (error) {
-    if (error?.code === "ENOENT") return { removed: 0, retractions: 0 };
+    if (error?.code === "ENOENT") return { removed: 0, preserved: 0 };
     throw error;
   }
   const kept = [];
-  const retractions = new Map();
+  const preservedRows = new Map();
   let removed = 0;
   for (const line of raw.split("\n")) {
     if (!line.trim()) continue;
@@ -4309,34 +4315,28 @@ async function dropZcodeQueueRows(filePath, { retainRetractions = false } = {}) 
         ? row.model.trim()
         : "unknown";
       const hourStart = typeof row.hour_start === "string" ? row.hour_start : "";
-      if (retainRetractions && hourStart) {
-        retractions.set(`${model}|${hourStart}`, {
-          source: "zcode",
+      if (preserveLatestRows && hourStart) {
+        const bucketKey = [
+          typeof row.project_key === "string" ? row.project_key.trim() : "",
           model,
-          hour_start: hourStart,
-          input_tokens: 0,
-          cached_input_tokens: 0,
-          cache_creation_input_tokens: 0,
-          output_tokens: 0,
-          reasoning_output_tokens: 0,
-          total_tokens: 0,
-          conversation_count: 0,
-        });
+          hourStart,
+        ].filter(Boolean).join("|");
+        preservedRows.set(bucketKey, line);
       }
       continue;
     }
     kept.push(line);
   }
-  if (removed === 0) return { removed: 0, retractions: 0 };
+  if (removed === 0) return { removed: 0, preserved: 0 };
   await backupExistingFile(filePath);
   const tmp = `${filePath}.zcoderepair.${process.pid}.${Date.now()}`;
   const rewritten = [
     ...kept,
-    ...[...retractions.values()].map((row) => JSON.stringify(row)),
+    ...preservedRows.values(),
   ];
   await fs.writeFile(tmp, rewritten.length ? rewritten.join("\n") + "\n" : "", "utf8");
   await fs.rename(tmp, filePath);
-  return { removed, retractions: retractions.size };
+  return { removed, preserved: preservedRows.size };
 }
 
 async function repairZcodeUsageMigration({
@@ -4352,10 +4352,10 @@ async function repairZcodeUsageMigration({
   const migrations = (cursors.migrations ||= {});
   if (migrations[migrationKey]) return false;
 
-  const mainRepair = await dropZcodeQueueRows(queuePath, { retainRetractions: true });
+  const mainRepair = await dropZcodeQueueRows(queuePath, { preserveLatestRows: true });
   const projectRepair = projectQueuePath
-    ? await dropZcodeQueueRows(projectQueuePath)
-    : { removed: 0, retractions: 0 };
+    ? await dropZcodeQueueRows(projectQueuePath, { preserveLatestRows: true })
+    : { removed: 0, preserved: 0 };
 
   const hourly = cursors.hourly && typeof cursors.hourly === "object" ? cursors.hourly : null;
   if (hourly?.buckets) {
@@ -4388,7 +4388,7 @@ async function repairZcodeUsageMigration({
     appliedAt: new Date().toISOString(),
     removedMain: mainRepair.removed,
     removedProject: projectRepair.removed,
-    retractions: mainRepair.retractions,
+    preservedRows: mainRepair.preserved,
   };
   return true;
 }

--- a/test/sync-zcode-native-migration.test.js
+++ b/test/sync-zcode-native-migration.test.js
@@ -24,7 +24,7 @@ function row(source, model, hour, total) {
   });
 }
 
-test("native ZCode migration purges legacy rows once and preserves unrelated usage", async () => {
+test("native ZCode migration preserves legacy rows once and keeps unrelated usage", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-zcode-native-repair-"));
   try {
     const queuePath = path.join(tmp, "queue.jsonl");
@@ -63,10 +63,18 @@ test("native ZCode migration purges legacy rows once and preserves unrelated usa
     });
     assert.equal(changed, true);
     const mainRows = (await fs.readFile(queuePath, "utf8")).trim().split("\n").map(JSON.parse);
-    const zcodeRetractions = mainRows.filter((entry) => entry.source === "zcode");
-    assert.equal(zcodeRetractions.length, 1, "cloud replay retains one zero for the removed key");
-    assert.equal(zcodeRetractions[0].total_tokens, 0);
-    assert.equal((await fs.readFile(projectQueuePath, "utf8")).includes('"source":"zcode"'), false);
+    const preservedZcode = mainRows.filter((entry) => entry.source === "zcode");
+    // The re-parse may not be able to re-replicate this row (the source DB
+    // prunes old sessions), so its last uploaded value must survive verbatim
+    // instead of being replayed as a zero retraction.
+    assert.equal(preservedZcode.length, 1, "the removed key keeps one row with its original value");
+    assert.equal(preservedZcode[0].total_tokens, 12);
+    assert.ok(!mainRows.some((entry) => entry.source === "zcode" && entry.total_tokens === 0),
+      "no zero retractions may be emitted");
+    const projectRows = (await fs.readFile(projectQueuePath, "utf8")).trim().split("\n").map(JSON.parse);
+    assert.equal(projectRows.filter((entry) => entry.source === "zcode").length, 1,
+      "project queue keeps the legacy row with its original value too");
+    assert.equal(projectRows.find((entry) => entry.source === "zcode").total_tokens, 12);
     assert.ok(cursors.hourly.buckets[`codex|gpt-5|${hour}`]);
     assert.ok(!Object.keys(cursors.hourly.buckets).some((key) => key.startsWith("zcode|")));
     assert.ok(!Object.keys(cursors.projectHourly.buckets).some((key) => key.includes("|zcode|")));
@@ -87,7 +95,7 @@ test("native ZCode migration purges legacy rows once and preserves unrelated usa
   }
 });
 
-test("inclusive-token ZCode migration retracts prior totals and resets replay once", async () => {
+test("inclusive-token ZCode migration preserves prior totals and resets replay once", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-zcode-inclusive-repair-"));
   try {
     const queuePath = path.join(tmp, "queue.jsonl");
@@ -125,8 +133,10 @@ test("inclusive-token ZCode migration retracts prior totals and resets replay on
       projectQueueStatePath,
     }), true);
     const replayRows = (await fs.readFile(queuePath, "utf8")).trim().split("\n").map(JSON.parse);
-    assert.equal(replayRows.filter((entry) => entry.source === "zcode").length, 1);
-    assert.equal(replayRows.find((entry) => entry.source === "zcode").total_tokens, 0);
+    const zcodeRows = replayRows.filter((entry) => entry.source === "zcode");
+    assert.equal(zcodeRows.length, 1);
+    assert.equal(zcodeRows[0].total_tokens, 100,
+      "the legacy value survives the repair instead of being zeroed");
     assert.equal(JSON.parse(await fs.readFile(queueStatePath, "utf8")).note,
       "reset_after_zcode_inclusive_token_repair_2026_09");
     assert.equal(JSON.parse(await fs.readFile(projectQueueStatePath, "utf8")).note,
@@ -140,6 +150,56 @@ test("inclusive-token ZCode migration retracts prior totals and resets replay on
       projectQueuePath,
       projectQueueStatePath,
     }), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("repair keeps history for keys the re-parse cannot re-replicate and yields to fresh values elsewhere", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-zcode-repair-nonlossy-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const queueStatePath = path.join(tmp, "queue.state.json");
+    const hourA = "2026-06-10T08:00:00Z";
+    const hourB = "2026-06-11T08:00:00Z";
+    // Multiple cumulative snapshots for key A; a single row for key B.
+    await fs.writeFile(queuePath, [
+      row("zcode", "GLM-5.2", hourA, 10),
+      row("zcode", "GLM-5.2", hourA, 30),
+      row("zcode", "GLM-5.2", hourA, 50),
+      row("zcode", "GLM-5.2", hourB, 70),
+      row("codex", "gpt-5", hourA, 20),
+    ].join("\n") + "\n");
+    await fs.writeFile(queueStatePath, JSON.stringify({ offset: 100 }));
+    const cursors = {
+      zcode: { messages: { "legacy|row": { lastTotals: { total_tokens: 50 } } } },
+      hourly: { buckets: {}, groupQueued: {} },
+      projectHourly: { buckets: {} },
+      migrations: {},
+    };
+
+    assert.equal(await repairZcodeNativeUsageMigration({
+      cursors,
+      queuePath,
+      queueStatePath,
+    }), true);
+
+    // Simulate the from-scratch re-parse: key A is re-replicated with a
+    // corrected value; key B is gone from the source DB and never re-queued.
+    await fs.appendFile(queuePath, row("zcode", "GLM-5.2", hourA, 40) + "\n");
+
+    const rows = (await fs.readFile(queuePath, "utf8")).trim().split("\n").map(JSON.parse);
+    const latestByKey = new Map();
+    for (const entry of rows) {
+      if (entry.source !== "zcode") continue;
+      latestByKey.set(`${entry.model}|${entry.hour_start}`, entry);
+    }
+    assert.equal(latestByKey.get(`GLM-5.2|${hourA}`).total_tokens, 40,
+      "fresh parse values win for keys the re-parse covers");
+    assert.equal(latestByKey.get(`GLM-5.2|${hourB}`).total_tokens, 70,
+      "keys the re-parse cannot cover keep their last uploaded value");
+    assert.ok(!rows.some((entry) => entry.source === "zcode" && entry.total_tokens === 0),
+      "the repair must not zero any bucket");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Why

The ZCode queue repair migrations (`zcodeNativeUsageRepair_2026_08`, `zcodeInclusiveTokenRepair_2026_09`) rewrite every removed `zcode` bucket key with a **zero retraction**, then re-parse the source DB and re-queue whatever it still holds.

That is lossy for real users: ZCode itself prunes old sessions from `db.sqlite` over time, so the fresh parse cannot always re-replicate what was originally parsed. Because consumers keep the latest row per `(source, model, hour_start)`, the zero retractions permanently erased real uploaded history — both in the local dedup view and on the cloud after the replay — for every key the fresh parse could not cover.

Measured on a real multi-week install: June GLM-5.2 buckets held ~402M tokens after the `2026_08` repair rebuilt them from a then-complete DB, while the same DB now returns ~323M for those rows (ZCode pruning). A further repair pass would zero those buckets outright. On multi-device accounts the per-device repairs made account totals visibly shrink after each device updated.

## What

- `dropZcodeQueueRows` now writes back the **last uploaded row per bucket key verbatim** (including project rows) instead of zero retractions. Keys the fresh parse covers are overwritten by the new values as usual; keys it cannot cover keep their last known value. Nothing is zeroed.
- The migration record logs `preservedRows` instead of `retractions`.
- Tests updated to assert preservation, plus a regression test proving: covered keys yield to fresh values, uncovered keys keep history, and no zero rows are emitted.

Follow-up to #545, which fixed the parser side of ZCode usage; this fixes the destructive side of the repair migration itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZCode usage synchronization now preserves the latest available cloud usage when historical sessions cannot be re-created.
  * Freshly re-parsed usage takes precedence where available, while unrecovered usage remains intact instead of being reset to zero.
  * The same preservation behavior now applies across main and project usage queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->