### PR TITLE
feat(dashboard): show period date range and cross-month week hint

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -728,6 +728,7 @@ usage.overview.cache_hit_rate_label,ui,DashboardPage,UsageOverview,cache_hit_rat
 usage.overview.cache_hit_rate_detail,ui,DashboardPage,UsageOverview,cache_hit_rate_detail,"{{reused}} reused / {{input}} input",,active
 usage.overview.antigravity_notice_title,ui,DashboardPage,UsageOverview,antigravity_notice_title,"Estimated tokens",,active
 usage.overview.antigravity_notice_body,ui,DashboardPage,UsageOverview,antigravity_notice_body,"Antigravity transcripts don't record real usage numbers. These counts are estimated from text length (~4 chars/token) and don't reflect Gemini's prompt-cache discount, so treat them as an upper bound, not a billing figure.",,active
+usage.overview.week_cross_month_hint,ui,DashboardPage,UsageOverview,week_cross_month_hint,"This week spans two calendar months, so its total is not directly comparable with a single month's usage",,active
 limits.panel.title,ui,LimitsPage,UsageLimitsPanel,title,"Usage Limits",,active
 limits.panel.mode_separator,ui,LimitsPage,UsageLimitsPanel,title_separator," · ",,active
 limits.label.cursor_plan,ui,LimitsPage,UsageLimitsPanel,cursor_plan,"Plan",,active

--- a/dashboard/src/content/i18n/de/dashboard.json
+++ b/dashboard/src/content/i18n/de/dashboard.json
@@ -2,6 +2,7 @@
   "usage.overview.all_tools": "Alle",
   "usage.overview.all_models": "Alle Modelle",
   "usage.overview.all_models_note": "Gleichnamige Modelle werden werkzeugübergreifend zusammengeführt und nach Gesamtnutzung sortiert.",
+  "usage.overview.week_cross_month_hint": "Diese Woche umfasst zwei Kalendermonate, sodass die Summe nicht direkt mit dem Verbrauch eines einzelnen Monats vergleichbar ist",
   "usage.overview.all_tools_card_aria": "Alle Werkzeuge: {{tokens}} Token, {{cost}}, {{count}} Modelle. Zusammengeführte Modellrangliste anzeigen",
   "usage.overview.antigravity_notice_title": "Token sind Schätzwerte",
   "usage.overview.antigravity_notice_body": "Antigravity-Lokalprotokolle enthalten keine tatsächlichen Nutzungsdaten, daher werden die Werte hier aus der Zeichenanzahl (ca. 4 Zeichen/Token) geschätzt, ohne Gemini Prompt-Cache-Rabatte. Betrachte diese Werte als grobe Obergrenze und nicht als Rechnungsgrundlage.",

--- a/dashboard/src/content/i18n/ja/dashboard.json
+++ b/dashboard/src/content/i18n/ja/dashboard.json
@@ -2,6 +2,7 @@
   "usage.overview.all_tools": "すべて",
   "usage.overview.all_models": "すべてのモデル",
   "usage.overview.all_models_note": "同じ名前のモデルはツールをまたいで集計され、合計使用量順に表示されます。",
+  "usage.overview.week_cross_month_hint": "この週は2つの暦月にまたがるため、合計は単一の月の使用量と直接比較できません",
   "usage.overview.all_tools_card_aria": "すべてのツール：{{tokens}}トークン、{{cost}}、{{count}}モデル。統合モデルランキングを表示",
   "usage.overview.antigravity_notice_title": "トークンは推定値です",
   "usage.overview.cache_hit_rate_label": "キャッシュヒット率",

--- a/dashboard/src/content/i18n/ko/dashboard.json
+++ b/dashboard/src/content/i18n/ko/dashboard.json
@@ -2,6 +2,7 @@
   "usage.overview.all_tools": "전체",
   "usage.overview.all_models": "전체 모델",
   "usage.overview.all_models_note": "이름이 같은 모델은 도구 전체에서 합산되어 총사용량순으로 표시됩니다.",
+  "usage.overview.week_cross_month_hint": "이 주는 두 개의 달에 걸쳐 있으므로 합계를 한 달 사용량과 직접 비교할 수 없습니다",
   "usage.overview.all_tools_card_aria": "전체 도구: {{tokens}} 토큰, {{cost}}, 모델 {{count}}개. 통합 모델 순위 표시",
   "usage.overview.antigravity_notice_title": "추정 토큰",
   "usage.overview.cache_hit_rate_label": "캐시 적중률",

--- a/dashboard/src/content/i18n/zh-TW/dashboard.json
+++ b/dashboard/src/content/i18n/zh-TW/dashboard.json
@@ -2,6 +2,7 @@
   "usage.overview.all_tools": "全部",
   "usage.overview.all_models": "全部模型",
   "usage.overview.all_models_note": "同名模型會跨工具合併，並按總用量排序。",
+  "usage.overview.week_cross_month_hint": "本週跨越兩個自然月，總量與單一自然月的用量並不直接可比",
   "usage.overview.all_tools_card_aria": "全部工具：{{tokens}} Token，{{cost}}，{{count}} 個模型。顯示合併後的模型排行",
   "usage.overview.antigravity_notice_title": "Token 為估算值",
   "usage.overview.cache_hit_rate_label": "快取命中率",

--- a/dashboard/src/content/i18n/zh/dashboard.json
+++ b/dashboard/src/content/i18n/zh/dashboard.json
@@ -2,6 +2,7 @@
   "usage.overview.all_tools": "全部",
   "usage.overview.all_models": "全部模型",
   "usage.overview.all_models_note": "同名模型会跨工具合并，并按总用量排序。",
+  "usage.overview.week_cross_month_hint": "本周跨越两个自然月，总量与单个自然月的用量并不直接可比",
   "usage.overview.all_tools_card_aria": "全部工具：{{tokens}} Token，{{cost}}，{{count}} 个模型。显示合并后的模型排行",
   "usage.overview.antigravity_notice_title": "Token 为估算值",
   "usage.overview.cache_hit_rate_label": "缓存命中率",

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -234,6 +234,19 @@ export function UsageOverview({
   const tabs = normalizePeriods(periods);
   const dateLocale = getDateFnsLocale(getCopyLocale());
   const summaryCounterValue = parseAnimatedCounterValue(String(summaryValue ?? ""));
+  // Weeks run Monday–Sunday, so a week selected near a month boundary can
+  // hold more usage than the month-to-date it overlaps. Spell out the covered
+  // dates and flag the straddle so the week/month totals read as different
+  // windows, not as a miscount.
+  const showCrossMonthHint =
+    period === "week" &&
+    typeof from === "string" &&
+    typeof to === "string" &&
+    from.slice(0, 7) !== to.slice(0, 7);
+  const periodRangeLabel =
+    from && to
+      ? `${formatDateShort(from, dateLocale)} — ${formatDateShort(to, dateLocale)}`
+      : null;
   // The digit-by-digit Counter renders at a fixed 72px and would clip on
   // phones. Below sm we drop it and render the plain value, which scales
   // with the responsive font class below. 639px == one below Tailwind's
@@ -476,6 +489,14 @@ export function UsageOverview({
               )}
             </div>
           )}
+          {periodRangeLabel ? (
+            <div className="mt-3 flex flex-col items-center gap-1 text-[11px] leading-snug text-oai-gray-400 dark:text-oai-gray-500">
+              <span className="tabular-nums">{periodRangeLabel}</span>
+              {showCrossMonthHint ? (
+                <span>{copy("usage.overview.week_cross_month_hint")}</span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         {/* Provider Distribution */}

--- a/dashboard/src/ui/dashboard/components/__tests__/UsageOverview.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/UsageOverview.test.jsx
@@ -385,4 +385,38 @@ describe("UsageOverview", () => {
     ).toBeNull();
     expect(screen.getByTitle("1,234,567,890")).toHaveTextContent("1.23B");
   });
+
+  it("shows the covered date range and flags a week that spans two calendar months", () => {
+    render(
+      <UsageOverview
+        period="week"
+        periods={[]}
+        summaryLabel="Total"
+        summaryValue="123"
+        fleetData={[]}
+        from="2026-08-31"
+        to="2026-09-06"
+      />,
+    );
+
+    expect(screen.getByText("Aug 31 — Sep 6")).toBeTruthy();
+    expect(screen.getByText(copy("usage.overview.week_cross_month_hint"))).toBeTruthy();
+  });
+
+  it("omits the cross-month hint when the selected week stays inside one month", () => {
+    render(
+      <UsageOverview
+        period="week"
+        periods={[]}
+        summaryLabel="Total"
+        summaryValue="123"
+        fleetData={[]}
+        from="2026-09-01"
+        to="2026-09-07"
+      />,
+    );
+
+    expect(screen.getByText("Sep 1 — Sep 7")).toBeTruthy();
+    expect(screen.queryByText(copy("usage.overview.week_cross_month_hint"))).toBeNull();
+  });
 });


### PR DESCRIPTION
## Why

The Overview card's **week** window runs Monday-Sunday, so near a month boundary it overlaps two calendar months. Users switching between the week and month tabs can see a week total far **above** the month total and read it as a miscount: a Mon-Sun week legitimately includes days the month window does not (e.g. selecting week on Sep 6, 2026 covers Aug 31-Sep 6, so the week includes a heavy Aug 31 that the September window never sees).

The numbers are correct; the windows are just not self-describing.

## What

- Render the concrete covered range (`Aug 31 — Sep 6`, locale-aware via `formatDateShort`) under the period total.
- When the selected week crosses a calendar month boundary, add a one-line hint that the two windows are not directly comparable.
- Ships localized for all five locales (zh, zh-TW, de, ja, ko) + copy registry entry; UI-hardcode/locale/copy validators pass; dashboard build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usage summaries now display the selected date range beneath the cost.
  - Weekly periods spanning two calendar months show a helpful comparison note.
  - The new guidance is available in German, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->