### PR TITLE
fix(macos): recover usage limits after a system clock rollback

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Models/UsageLimits.swift
@@ -111,10 +111,21 @@ extension UsageLimitsResponse {
 
 enum UsageLimitsCache {
     static let defaultsKey = "UsageLimitsLastGoodResponse"
+    private static let maximumFutureSkew: TimeInterval = 5 * 60
 
-    static func load(defaults: UserDefaults = .standard) -> UsageLimitsResponse? {
+    static func load(
+        defaults: UserDefaults = .standard,
+        now: Date = Date()
+    ) -> UsageLimitsResponse? {
         guard let data = defaults.data(forKey: defaultsKey) else { return nil }
-        return try? JSONDecoder().decode(UsageLimitsResponse.self, from: data)
+        guard let limits = try? JSONDecoder().decode(UsageLimitsResponse.self, from: data) else {
+            return nil
+        }
+        if let fetchedAt = parseTimestamp(limits.fetchedAt),
+           fetchedAt.timeIntervalSince(now) > maximumFutureSkew {
+            return nil
+        }
+        return limits
     }
 
     static func save(
@@ -124,6 +135,14 @@ enum UsageLimitsCache {
         guard limits.hasAnyProviderWithoutError,
               let data = try? JSONEncoder().encode(limits) else { return }
         defaults.set(data, forKey: defaultsKey)
+    }
+
+    private static func parseTimestamp(_ rawValue: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: rawValue) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: rawValue)
     }
 }
 

--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -28,6 +28,10 @@ actor APIClient {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
         config.timeoutIntervalForResource = 30
+        // Local API responses are live state. A future system clock can otherwise
+        // leave URLCache entries "fresh" after the clock is restored.
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
         self.session = URLSession(configuration: config)
 
         let syncConfig = URLSessionConfiguration.default

--- a/TokenTrackerBar/TokenTrackerBarTests/UsageLimitsRetentionTests.swift
+++ b/TokenTrackerBar/TokenTrackerBarTests/UsageLimitsRetentionTests.swift
@@ -29,6 +29,22 @@ final class UsageLimitsRetentionTests: XCTestCase {
         XCTAssertNil(UsageLimitsCache.load(defaults: defaults))
     }
 
+    func testFutureDatedLastGoodCacheIsIgnoredAfterClockRollback() throws {
+        let suiteName = "UsageLimitsRetentionTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let futureResponse = try decodeResponse(overrides: [
+            "fetched_at": "2026-11-01T00:59:36.105Z",
+            "codex": ["configured": true],
+        ])
+        let now = try XCTUnwrap(
+            ISO8601DateFormatter().date(from: "2026-09-07T00:00:00Z")
+        )
+
+        UsageLimitsCache.save(futureResponse, defaults: defaults)
+
+        XCTAssertNil(UsageLimitsCache.load(defaults: defaults, now: now))
+    }
 
     // MARK: - hasAnyProviderWithoutError
 

--- a/test/macos-usage-limits-timeout.test.js
+++ b/test/macos-usage-limits-timeout.test.js
@@ -58,3 +58,13 @@ test("macOS usage-limits hydrates the last good record before refreshing", () =>
     "A successful background refresh should persist the replacement record.",
   );
 });
+
+test("macOS local API session bypasses URLCache after a system clock rollback", () => {
+  const source = readAPIClient();
+
+  assert.match(
+    source,
+    /let config = URLSessionConfiguration\.default[\s\S]*config\.requestCachePolicy = \.reloadIgnoringLocalCacheData[\s\S]*config\.urlCache = nil[\s\S]*self\.session = URLSession\(configuration: config\)/,
+    "Dynamic localhost responses must not be replayed from a future-dated URLCache entry.",
+  );
+});


### PR DESCRIPTION
## Summary

I ran into this edge case while working on an agent scheduling feature and temporarily setting the macOS system time into the future. After restoring the correct time, TokenTracker's native menu-bar usage limits continued showing an old Codex percentage and reset time, even though the local endpoint and dashboard were already returning current data.

This is not required for normal operation, but refresh and relaunch did not recover the native view without manually clearing the cache. This PR proposes a small defensive fix in case the maintainers think the edge case is worth handling.

## Why it happens

A response fetched while the clock is in the future can be persisted by URLCache with a future timestamp. Once the clock is moved back, URLSession may continue treating that response as fresh. The last-good usage-limits snapshot in UserDefaults can also be future-dated, so it may be shown again at launch.

## Suggested change

- Bypass URLCache for the macOS client's dynamic localhost API reads.
- Ignore a persisted last-good usage-limits response when its fetched_at value is more than five minutes ahead of the current time.
- Add regression coverage for both the URLCache policy and the clock-rollback case.

## Scope

- [ ] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [x] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Verification

- `npm test` — 2,639 passed, 0 failed, 2 skipped
- `node --test test/macos-usage-limits-timeout.test.js` — 3 passed
- Swift type-check of `UsageLimits.swift` and the new cache-loading path

## Checklist

- [x] `npm test` passes
- [x] No new user-facing strings were added
- [x] Commit follows the repository's conventional style
- [x] The description explains both the observed behavior and why the proposed fix helps

Thanks for taking a look. I'm happy to adjust the approach if you would prefer a narrower cache policy or a different clock-skew threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale or future-dated usage-limit data from being displayed after system clock changes.
  - Ensured usage-limit requests retrieve fresh data instead of relying on locally cached responses.
  - Improved handling of invalid or unreadable cached data.

- **Tests**
  - Added coverage for clock rollbacks, future-dated cached responses, and cache-bypass behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->