### PR TITLE
fix(antigravity): read sqlite context size without inferring cache hits

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -18722,6 +18722,113 @@ async function parseAntigravityIncremental({
   return { filesProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
 }
 
+function decodeAntigravityVarint(buf, offset) {
+  let res = 0;
+  let shift = 0;
+  while (offset < buf.length) {
+    const b = buf[offset++];
+    res += (b & 0x7f) * 2 ** shift;
+    if (!(b & 0x80)) break;
+    shift += 7;
+  }
+  return [res, offset];
+}
+
+function findAntigravityProtoFields(buf) {
+  const fields = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    const [tag, next] = decodeAntigravityVarint(buf, offset);
+    offset = next;
+    const fieldNum = tag >> 3;
+    const wireType = tag & 7;
+    if (wireType === 0) {
+      const [val, vNext] = decodeAntigravityVarint(buf, offset);
+      offset = vNext;
+      fields.push({ num: fieldNum, val });
+    } else if (wireType === 2) {
+      const [len, lNext] = decodeAntigravityVarint(buf, offset);
+      offset = lNext;
+      fields.push({ num: fieldNum, val: buf.subarray(offset, offset + len) });
+      offset += len;
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      break;
+    }
+  }
+  return fields;
+}
+
+function extractAntigravityGenInfo(buf) {
+  const root = findAntigravityProtoFields(buf);
+  const f1 = root.find((f) => f.num === 1)?.val;
+  if (!f1) return null;
+
+  const inner = findAntigravityProtoFields(f1);
+  let model = null;
+  const f19 = inner.find((f) => f.num === 19)?.val;
+  if (f19) model = Buffer.from(f19).toString("utf8").trim();
+
+  let contextTokens = 0;
+  const f9 = inner.find((f) => f.num === 9)?.val;
+  if (f9) {
+    const f10 = findAntigravityProtoFields(f9).find((f) => f.num === 10)?.val;
+    if (f10) {
+      const tok = findAntigravityProtoFields(f10).find((f) => f.num === 1)?.val;
+      if (Number.isFinite(tok)) contextTokens = tok;
+    }
+  }
+
+  let lastStepIndex = null;
+  for (const f of inner) {
+    if (f.num !== 20 || !f.val) continue;
+    const kv = findAntigravityProtoFields(f.val);
+    const k = kv.find((x) => x.num === 1)?.val;
+    const v = kv.find((x) => x.num === 2)?.val;
+    if (k && Buffer.from(k).toString("utf8") === "last_step_index" && v) {
+      const parsed = parseInt(Buffer.from(v).toString("utf8"), 10);
+      if (Number.isFinite(parsed)) lastStepIndex = parsed;
+    }
+  }
+
+  return { model, contextTokens, lastStepIndex };
+}
+
+function resolveAntigravityDbPath(transcriptPath) {
+  if (!transcriptPath || typeof transcriptPath !== "string") return null;
+  const m = transcriptPath.match(/^(.*)[/\\]brain[/\\]([^/\\]+)[/\\]\.system_generated[/\\]logs[/\\]transcript.*\.jsonl$/);
+  if (!m) return null;
+  return path.join(m[1], "conversations", `${m[2]}.db`);
+}
+
+function readAntigravityConversationDb(dbPath) {
+  if (!dbPath) return null;
+  try {
+    const rows = readSqliteJsonRows(
+      dbPath,
+      "SELECT idx, quote(data) as hex FROM gen_metadata ORDER BY idx",
+      { readOnly: true },
+    );
+    if (!Array.isArray(rows) || rows.length === 0) return null;
+
+    const stepMap = new Map();
+    for (const r of rows) {
+      if (!r || typeof r.hex !== "string" || !r.hex.startsWith("X'")) continue;
+      const buf = Buffer.from(r.hex.slice(2, -1), "hex");
+      const info = extractAntigravityGenInfo(buf);
+      if (info && info.lastStepIndex != null && info.contextTokens > 0) {
+        stepMap.set(info.lastStepIndex + 1, info);
+      }
+    }
+    return stepMap.size > 0 ? stepMap : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 async function parseAntigravityFile({
   filePath,
   lastLine,
@@ -18773,6 +18880,9 @@ async function parseAntigravityFile({
   let previousContextTokens = resumed ? cachedPrev : 0;
   let lastCompletedLine = Math.min(Number.isFinite(lastLine) ? lastLine : 0, lines.length);
 
+  const dbPath = resolveAntigravityDbPath(filePath);
+  const stepMap = dbPath ? readAntigravityConversationDb(dbPath) : null;
+
   for (let i = scanStart; i < lines.length; i++) {
     const line = lines[i];
 
@@ -18795,7 +18905,12 @@ async function parseAntigravityFile({
     const eventContextTokens = antigravityContextTokens(parsed);
 
     if (!isNewEvent) {
-      contextTokens += eventContextTokens;
+      const dbTurn = stepMap && Number.isFinite(parsed.step_index) ? stepMap.get(parsed.step_index) : null;
+      if (dbTurn && dbTurn.contextTokens > 0) {
+        contextTokens = dbTurn.contextTokens;
+      } else {
+        contextTokens += eventContextTokens;
+      }
       lastCompletedLine = i + 1;
       continue;
     }
@@ -18822,17 +18937,36 @@ async function parseAntigravityFile({
       const content = typeof parsed.content === "string" ? parsed.content : "";
       const thinking = typeof parsed.thinking === "string" ? parsed.thinking : "";
 
-      const inputDelta = Math.max(0, contextTokens - previousContextTokens);
+      const dbTurn = stepMap && Number.isFinite(parsed.step_index) ? stepMap.get(parsed.step_index) : null;
+      let inputDelta = 0;
+      let cachedInputTokens = 0;
+
+      if (dbTurn && dbTurn.contextTokens > 0) {
+        if (dbTurn.model) {
+          const norm = normalizeAntigravityTranscriptModel(dbTurn.model);
+          if (norm) model = norm;
+        }
+        const curTokens = dbTurn.contextTokens;
+        if (previousContextTokens === 0) {
+          inputDelta = curTokens;
+        } else {
+          cachedInputTokens = Math.min(curTokens, previousContextTokens);
+          inputDelta = Math.max(0, curTokens - previousContextTokens);
+        }
+        contextTokens = curTokens;
+      } else {
+        inputDelta = Math.max(0, contextTokens - previousContextTokens);
+      }
+
       const outputTokens =
         antigravityValueTokens(content) + antigravityValueTokens(parsed.tool_calls);
       const reasoningTokens = antigravityValueTokens(thinking);
 
       delta.input_tokens = inputDelta;
+      delta.cached_input_tokens = cachedInputTokens;
       delta.output_tokens = outputTokens;
       delta.reasoning_output_tokens = reasoningTokens;
-      // Match the mainstream convention (Codebuddy / Kilocode / OMP / Hermes):
-      // total_tokens = sum of every token column. No cache columns here.
-      delta.total_tokens = inputDelta + outputTokens + reasoningTokens;
+      delta.total_tokens = inputDelta + cachedInputTokens + outputTokens + reasoningTokens;
       delta.billable_total_tokens = delta.total_tokens;
       delta.conversation_count = 1;
       billedPlanner = delta.total_tokens > 0;
@@ -20457,6 +20591,9 @@ module.exports = {
   parseAntigravityIncremental,
   estimateAntigravityTokens,
   isCjkCodePoint,
+  resolveAntigravityDbPath,
+  extractAntigravityGenInfo,
+  readAntigravityConversationDb,
 
   // Trae SOLO (ByteDance AI IDE)
   resolveTraePath,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -18859,15 +18859,18 @@ async function parseAntigravityFile({
     .map((line) => line.trim())
     .filter(Boolean);
   let eventsAggregated = 0;
+  const dbPath = resolveAntigravityDbPath(filePath);
+  const stepMap = dbPath ? readAntigravityConversationDb(dbPath) : null;
   // Resume cached context-token total + model so historical lines (i < lastLine)
   // don't need to be re-tokenized on every sync. Falls back to a full re-walk
-  // when the cached state is missing (legacy cursor) or the file rotated.
+  // when the cached state is missing (legacy cursor), the file rotated, or
+  // SQLite metadata is present so estimated cursors can be reconciled.
   const canResume =
     Number.isFinite(lastLine) && lastLine > 0 && lastLine <= lines.length;
   const cachedTokens = Number.isFinite(initialContextTokens) ? initialContextTokens : 0;
   const cachedPrev = Number.isFinite(initialPrevContext) ? initialPrevContext : 0;
   const cachedModel = typeof initialModel === "string" ? initialModel : null;
-  const resumed = canResume && (cachedTokens > 0 || cachedModel !== null);
+  const resumed = canResume && (cachedTokens > 0 || cachedModel !== null) && !stepMap;
   const scanStart = resumed ? lastLine : 0;
   let currentModel = resumed ? cachedModel : null;
   if (!currentModel) {
@@ -18878,10 +18881,8 @@ async function parseAntigravityFile({
   // tokens accumulated AFTER that point count as new input on the next planner
   // call — prevents O(N²) double-counting of the full history every turn.
   let previousContextTokens = resumed ? cachedPrev : 0;
+  let lastPlannerModel = resumed ? cachedModel : null;
   let lastCompletedLine = Math.min(Number.isFinite(lastLine) ? lastLine : 0, lines.length);
-
-  const dbPath = resolveAntigravityDbPath(filePath);
-  const stepMap = dbPath ? readAntigravityConversationDb(dbPath) : null;
 
   for (let i = scanStart; i < lines.length; i++) {
     const line = lines[i];
@@ -18903,11 +18904,25 @@ async function parseAntigravityFile({
     }
 
     const eventContextTokens = antigravityContextTokens(parsed);
+    const dbTurn =
+      parsed.type === "PLANNER_RESPONSE" && stepMap && Number.isFinite(parsed.step_index)
+        ? stepMap.get(parsed.step_index)
+        : null;
+    const dbContextTokens = dbTurn && dbTurn.contextTokens > 0 ? dbTurn.contextTokens : 0;
+    if (dbTurn && dbTurn.model) {
+      const norm = normalizeAntigravityTranscriptModel(dbTurn.model);
+      if (norm) currentModel = norm;
+    }
 
     if (!isNewEvent) {
-      const dbTurn = stepMap && Number.isFinite(parsed.step_index) ? stepMap.get(parsed.step_index) : null;
-      if (dbTurn && dbTurn.contextTokens > 0) {
-        contextTokens = dbTurn.contextTokens;
+      if (parsed.type === "PLANNER_RESPONSE") {
+        if (dbContextTokens > 0) {
+          contextTokens = dbContextTokens;
+        } else {
+          contextTokens += eventContextTokens;
+        }
+        previousContextTokens = contextTokens;
+        lastPlannerModel = currentModel;
       } else {
         contextTokens += eventContextTokens;
       }
@@ -18937,36 +18952,22 @@ async function parseAntigravityFile({
       const content = typeof parsed.content === "string" ? parsed.content : "";
       const thinking = typeof parsed.thinking === "string" ? parsed.thinking : "";
 
-      const dbTurn = stepMap && Number.isFinite(parsed.step_index) ? stepMap.get(parsed.step_index) : null;
-      let inputDelta = 0;
-      let cachedInputTokens = 0;
-
-      if (dbTurn && dbTurn.contextTokens > 0) {
-        if (dbTurn.model) {
-          const norm = normalizeAntigravityTranscriptModel(dbTurn.model);
-          if (norm) model = norm;
-        }
-        const curTokens = dbTurn.contextTokens;
-        if (previousContextTokens === 0) {
-          inputDelta = curTokens;
-        } else {
-          cachedInputTokens = Math.min(curTokens, previousContextTokens);
-          inputDelta = Math.max(0, curTokens - previousContextTokens);
-        }
-        contextTokens = curTokens;
-      } else {
-        inputDelta = Math.max(0, contextTokens - previousContextTokens);
+      if (dbContextTokens > 0) {
+        contextTokens = dbContextTokens;
       }
+      if (lastPlannerModel && model !== lastPlannerModel) {
+        previousContextTokens = 0;
+      }
+      const inputDelta = Math.max(0, contextTokens - previousContextTokens);
 
       const outputTokens =
         antigravityValueTokens(content) + antigravityValueTokens(parsed.tool_calls);
       const reasoningTokens = antigravityValueTokens(thinking);
 
       delta.input_tokens = inputDelta;
-      delta.cached_input_tokens = cachedInputTokens;
       delta.output_tokens = outputTokens;
       delta.reasoning_output_tokens = reasoningTokens;
-      delta.total_tokens = inputDelta + cachedInputTokens + outputTokens + reasoningTokens;
+      delta.total_tokens = inputDelta + outputTokens + reasoningTokens;
       delta.billable_total_tokens = delta.total_tokens;
       delta.conversation_count = 1;
       billedPlanner = delta.total_tokens > 0;
@@ -18999,6 +19000,7 @@ async function parseAntigravityFile({
     // so they MUST be billed as input on the next planner — don't fold them into
     // previousContextTokens or that history vanishes from the totals.
     previousContextTokens = contextTokens;
+    lastPlannerModel = model;
     contextTokens += eventContextTokens;
     lastCompletedLine = i + 1;
   }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -18934,11 +18934,10 @@ async function parseAntigravityFile({
       if (parsed.type === "PLANNER_RESPONSE") {
         if (dbContextTokens > 0) {
           contextTokens = dbContextTokens;
-        } else {
-          contextTokens += eventContextTokens;
         }
         previousContextTokens = contextTokens;
         lastPlannerModel = currentModel;
+        contextTokens += eventContextTokens;
       } else {
         contextTokens += eventContextTokens;
       }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -18654,6 +18654,9 @@ async function parseAntigravityIncremental({
     const initialContextTokens = sameFile ? Number(prev.contextTokens || 0) : 0;
     const initialPrevContext = sameFile ? Number(prev.previousContextTokens || 0) : 0;
     const initialModel = sameFile && typeof prev.currentModel === "string" ? prev.currentModel : null;
+    const initialLastPlannerModel =
+      sameFile && typeof prev.lastPlannerModel === "string" ? prev.lastPlannerModel : null;
+    const initialUsageSource = sameFile && typeof prev.usageSource === "string" ? prev.usageSource : null;
 
     const projectContext = projectEnabled
       ? await resolveProjectContextForFile({
@@ -18673,6 +18676,8 @@ async function parseAntigravityIncremental({
       initialContextTokens,
       initialPrevContext,
       initialModel,
+      initialLastPlannerModel,
+      initialUsageSource,
       hourlyState,
       touchedBuckets,
       source: fileSource,
@@ -18690,6 +18695,8 @@ async function parseAntigravityIncremental({
       contextTokens: result.contextTokens,
       previousContextTokens: result.previousContextTokens,
       currentModel: result.currentModel,
+      lastPlannerModel: result.lastPlannerModel,
+      usageSource: result.usageSource,
       updatedAt: new Date().toISOString(),
     };
 
@@ -18835,6 +18842,8 @@ async function parseAntigravityFile({
   initialContextTokens,
   initialPrevContext,
   initialModel,
+  initialLastPlannerModel,
+  initialUsageSource,
   hourlyState,
   touchedBuckets,
   source,
@@ -18851,6 +18860,8 @@ async function parseAntigravityFile({
       contextTokens: 0,
       previousContextTokens: 0,
       currentModel: null,
+      lastPlannerModel: null,
+      usageSource: "estimated",
     };
   }
 
@@ -18863,14 +18874,15 @@ async function parseAntigravityFile({
   const stepMap = dbPath ? readAntigravityConversationDb(dbPath) : null;
   // Resume cached context-token total + model so historical lines (i < lastLine)
   // don't need to be re-tokenized on every sync. Falls back to a full re-walk
-  // when the cached state is missing (legacy cursor), the file rotated, or
-  // SQLite metadata is present so estimated cursors can be reconciled.
+  // when the cached state is missing (legacy cursor) or the file rotated.
   const canResume =
     Number.isFinite(lastLine) && lastLine > 0 && lastLine <= lines.length;
   const cachedTokens = Number.isFinite(initialContextTokens) ? initialContextTokens : 0;
   const cachedPrev = Number.isFinite(initialPrevContext) ? initialPrevContext : 0;
   const cachedModel = typeof initialModel === "string" ? initialModel : null;
-  const resumed = canResume && (cachedTokens > 0 || cachedModel !== null) && !stepMap;
+  const sqliteCursor = initialUsageSource === "sqlite";
+  const resumed =
+    canResume && (cachedTokens > 0 || cachedModel !== null) && (!stepMap || sqliteCursor);
   const scanStart = resumed ? lastLine : 0;
   let currentModel = resumed ? cachedModel : null;
   if (!currentModel) {
@@ -18881,7 +18893,11 @@ async function parseAntigravityFile({
   // tokens accumulated AFTER that point count as new input on the next planner
   // call — prevents O(N²) double-counting of the full history every turn.
   let previousContextTokens = resumed ? cachedPrev : 0;
-  let lastPlannerModel = resumed ? cachedModel : null;
+  let lastPlannerModel = null;
+  if (resumed) {
+    lastPlannerModel =
+      typeof initialLastPlannerModel === "string" ? initialLastPlannerModel : cachedModel;
+  }
   let lastCompletedLine = Math.min(Number.isFinite(lastLine) ? lastLine : 0, lines.length);
 
   for (let i = scanStart; i < lines.length; i++) {
@@ -19011,6 +19027,8 @@ async function parseAntigravityFile({
     contextTokens,
     previousContextTokens,
     currentModel,
+    lastPlannerModel,
+    usageSource: stepMap ? "sqlite" : "estimated",
   };
 }
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -12922,6 +12922,165 @@ test("parseAntigravityIncremental resumes a sqlite cursor without re-walking est
   }
 });
 
+test("parseAntigravityIncremental sparse sqlite full scan matches incremental append", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-sparse-full-inc-"));
+  try {
+    const planner1 = "hi";
+    const user2 = "next prompt";
+    const firstLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: planner1,
+        thinking: "think1",
+      },
+    ]);
+    const allLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: planner1,
+        thinking: "think1",
+      },
+      {
+        userStep: 2,
+        userAt: "2026-04-05T14:02:00.000Z",
+        userContent: user2,
+        plannerStep: 3,
+        plannerAt: "2026-04-05T14:03:00.000Z",
+        plannerContent: "done",
+        thinking: "think2",
+      },
+    ]);
+    const protos = [
+      buildAntigravityTestProto({
+        model: "gemini-3.8-flash",
+        contextTokens: 25000,
+        lastStepIndex: 0,
+      }),
+    ];
+
+    const fullDir = path.join(tmp, "full");
+    const incDir = path.join(tmp, "inc");
+    await fs.mkdir(fullDir, { recursive: true });
+    await fs.mkdir(incDir, { recursive: true });
+
+    const full = await setupAntigravitySqliteSession(fullDir, { protos, lines: allLines });
+    await parseAntigravityIncremental({
+      sessionFiles: [full.transcriptPath],
+      cursors: { version: 1, files: {}, updatedAt: null },
+      queuePath: full.queuePath,
+    });
+    const fullQueued = await readJsonLines(full.queuePath);
+
+    const inc = await setupAntigravitySqliteSession(incDir, { protos, lines: firstLines });
+    const incCursors = { version: 1, files: {}, updatedAt: null };
+    await parseAntigravityIncremental({
+      sessionFiles: [inc.transcriptPath],
+      cursors: incCursors,
+      queuePath: inc.queuePath,
+    });
+    await fs.writeFile(inc.transcriptPath, allLines.map((line) => JSON.stringify(line)).join("\n"));
+    await parseAntigravityIncremental({
+      sessionFiles: [inc.transcriptPath],
+      cursors: incCursors,
+      queuePath: inc.queuePath,
+    });
+    const incLatest = (await readJsonLines(inc.queuePath)).at(-1);
+    const fullLatest = fullQueued.at(-1);
+    const expectedSecondInput = antigravityTestTokens(planner1) + antigravityTestTokens(user2);
+
+    assert.equal(fullLatest.input_tokens, 25000 + expectedSecondInput);
+    assert.equal(incLatest.input_tokens, fullLatest.input_tokens);
+    assert.equal(incLatest.cached_input_tokens, 0);
+    assert.equal(fullLatest.cached_input_tokens, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental re-walk with sparse sqlite keeps prior planner output", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-sparse-rewalk-"));
+  try {
+    const planner1 = "hi";
+    const user2 = "next prompt";
+    const firstLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: planner1,
+        thinking: "think1",
+      },
+    ]);
+    const allLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: planner1,
+        thinking: "think1",
+      },
+      {
+        userStep: 2,
+        userAt: "2026-04-05T14:02:00.000Z",
+        userContent: user2,
+        plannerStep: 3,
+        plannerAt: "2026-04-05T14:03:00.000Z",
+        plannerContent: "done",
+        thinking: "think2",
+      },
+    ]);
+    const { transcriptPath, dbPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [],
+      lines: firstLines,
+    });
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+
+    sqliteCli.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO gen_metadata (idx, data) VALUES (0, X'${buildAntigravityTestProto({
+        model: "gemini-3.8-flash",
+        contextTokens: 25000,
+        lastStepIndex: 0,
+      }).toString("hex")}');`,
+    ]);
+    await fs.writeFile(transcriptPath, allLines.map((line) => JSON.stringify(line)).join("\n"));
+    const second = await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(second.eventsAggregated, 1);
+
+    const sqliteRow = (await readJsonLines(queuePath))
+      .filter((row) => row.model === "gemini-3.8-flash")
+      .at(-1);
+    assert.equal(
+      sqliteRow.input_tokens,
+      antigravityTestTokens(planner1) + antigravityTestTokens(user2),
+    );
+    assert.equal(sqliteRow.cached_input_tokens, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 // ── Kimi Code official (@moonshot-ai/kimi-code) ──────────────────────────────
 
 test("parseKimiCodeIncremental reads step.end events with Anthropic-style usage", async () => {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -12415,6 +12415,63 @@ function buildAntigravityTestProto({ model, contextTokens, lastStepIndex }) {
   return encodeAntigravityTestLd(1, Buffer.concat(parts));
 }
 
+async function setupAntigravitySqliteSession(tmp, { convId = "conv-123", protos, lines } = {}) {
+  const brainDir = path.join(
+    tmp,
+    "antigravity",
+    "brain",
+    convId,
+    ".system_generated",
+    "logs",
+  );
+  const convDir = path.join(tmp, "antigravity", "conversations");
+  await fs.mkdir(brainDir, { recursive: true });
+  await fs.mkdir(convDir, { recursive: true });
+  const transcriptPath = path.join(brainDir, "transcript.jsonl");
+  const dbPath = path.join(convDir, `${convId}.db`);
+  sqliteCli.execFileSync("sqlite3", [
+    dbPath,
+    "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);",
+  ]);
+  if (Array.isArray(protos) && protos.length > 0) {
+    const values = protos
+      .map((proto, idx) => `(${idx}, X'${proto.toString("hex")}')`)
+      .join(", ");
+    sqliteCli.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO gen_metadata (idx, data) VALUES ${values};`,
+    ]);
+  }
+  if (Array.isArray(lines)) {
+    await fs.writeFile(transcriptPath, lines.map((line) => JSON.stringify(line)).join("\n"));
+  }
+  return {
+    transcriptPath,
+    dbPath,
+    queuePath: path.join(tmp, "queue.jsonl"),
+  };
+}
+
+function antigravityPlannerLines(turns) {
+  const lines = [];
+  for (const turn of turns) {
+    lines.push({
+      type: "USER_INPUT",
+      step_index: turn.userStep,
+      created_at: turn.userAt,
+      content: turn.userContent,
+    });
+    lines.push({
+      type: "PLANNER_RESPONSE",
+      step_index: turn.plannerStep,
+      created_at: turn.plannerAt,
+      content: turn.plannerContent,
+      thinking: turn.thinking,
+    });
+  }
+  return lines;
+}
+
 test("resolveAntigravityDbPath maps brain transcript logs to conversations database", () => {
   const transcriptPath =
     "/Users/test/.gemini/antigravity/brain/session-abc-123/.system_generated/logs/transcript.jsonl";
@@ -12441,29 +12498,311 @@ test("extractAntigravityGenInfo extracts model, context tokens, and step index f
   });
 });
 
-test("parseAntigravityIncremental reads accurate usage and cache from SQLite gen_metadata", async () => {
+test("parseAntigravityIncremental uses SQLite context size without inferring cache hits", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-sqlite-"));
   try {
-    const brainDir = path.join(
-      tmp,
-      "antigravity",
-      "brain",
-      "conv-123",
-      ".system_generated",
-      "logs",
-    );
-    const convDir = path.join(tmp, "antigravity", "conversations");
-    await fs.mkdir(brainDir, { recursive: true });
-    await fs.mkdir(convDir, { recursive: true });
-    const transcriptPath = path.join(brainDir, "transcript.jsonl");
-    const dbPath = path.join(convDir, "conv-123.db");
-    const queuePath = path.join(tmp, "queue.jsonl");
+    const { transcriptPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 25000,
+          lastStepIndex: 0,
+        }),
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 30000,
+          lastStepIndex: 2,
+        }),
+      ],
+      lines: antigravityPlannerLines([
+        {
+          userStep: 0,
+          userAt: "2026-04-05T14:00:00.000Z",
+          userContent: "hello",
+          plannerStep: 1,
+          plannerAt: "2026-04-05T14:01:00.000Z",
+          plannerContent: "hi",
+          thinking: "think1",
+        },
+        {
+          userStep: 2,
+          userAt: "2026-04-05T14:02:00.000Z",
+          userContent: "next prompt",
+          plannerStep: 3,
+          plannerAt: "2026-04-05T14:03:00.000Z",
+          plannerContent: "done",
+          thinking: "think2",
+        },
+      ]),
+    });
     const cursors = { version: 1, files: {}, updatedAt: null };
 
-    sqliteCli.execFileSync("sqlite3", [
-      dbPath,
-      "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);",
+    const result = await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "antigravity");
+    assert.equal(queued[0].model, "gemini-3.8-flash");
+    assert.equal(queued[0].input_tokens, 30000);
+    assert.equal(queued[0].cached_input_tokens, 0);
+    assert.equal(queued[0].conversation_count, 2);
+    assert.equal(
+      queued[0].total_tokens,
+      queued[0].input_tokens + queued[0].output_tokens + queued[0].reasoning_output_tokens,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental does not invent cache hits on a repeated context", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-cold-cache-"));
+  try {
+    const { transcriptPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 25000,
+          lastStepIndex: 0,
+        }),
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 25000,
+          lastStepIndex: 2,
+        }),
+      ],
+      lines: antigravityPlannerLines([
+        {
+          userStep: 0,
+          userAt: "2026-04-05T14:00:00.000Z",
+          userContent: "hello",
+          plannerStep: 1,
+          plannerAt: "2026-04-05T14:01:00.000Z",
+          plannerContent: "hi",
+          thinking: "think1",
+        },
+        {
+          userStep: 2,
+          userAt: "2026-04-05T14:02:00.000Z",
+          userContent: "again",
+          plannerStep: 3,
+          plannerAt: "2026-04-05T14:03:00.000Z",
+          plannerContent: "still hi",
+          thinking: "think2",
+        },
+      ]),
+    });
+
+    await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors: { version: 1, files: {}, updatedAt: null },
+      queuePath,
+    });
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued[0].input_tokens, 25000);
+    assert.equal(queued[0].cached_input_tokens, 0);
+    assert.equal(queued[0].conversation_count, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental bills full context after a model switch", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-model-switch-"));
+  try {
+    const { transcriptPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 25000,
+          lastStepIndex: 0,
+        }),
+        buildAntigravityTestProto({
+          model: "claude-sonnet-4-6",
+          contextTokens: 40000,
+          lastStepIndex: 2,
+        }),
+      ],
+      lines: antigravityPlannerLines([
+        {
+          userStep: 0,
+          userAt: "2026-04-05T14:00:00.000Z",
+          userContent: "hello",
+          plannerStep: 1,
+          plannerAt: "2026-04-05T14:01:00.000Z",
+          plannerContent: "hi",
+          thinking: "think1",
+        },
+        {
+          userStep: 2,
+          userAt: "2026-04-05T14:02:00.000Z",
+          userContent: "switch",
+          plannerStep: 3,
+          plannerAt: "2026-04-05T14:03:00.000Z",
+          plannerContent: "ok",
+          thinking: "think2",
+        },
+      ]),
+    });
+
+    await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors: { version: 1, files: {}, updatedAt: null },
+      queuePath,
+    });
+    const queued = await readJsonLines(queuePath);
+    const byModel = Object.fromEntries(queued.map((row) => [row.model, row]));
+    assert.equal(byModel["gemini-3.8-flash"].input_tokens, 25000);
+    assert.equal(byModel["gemini-3.8-flash"].cached_input_tokens, 0);
+    assert.equal(byModel["claude-sonnet-4-6"].input_tokens, 40000);
+    assert.equal(byModel["claude-sonnet-4-6"].cached_input_tokens, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental SQLite full scan matches incremental append", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-full-vs-inc-"));
+  try {
+    const firstLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
     ]);
+    const allLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
+      {
+        userStep: 2,
+        userAt: "2026-04-05T14:02:00.000Z",
+        userContent: "next prompt",
+        plannerStep: 3,
+        plannerAt: "2026-04-05T14:03:00.000Z",
+        plannerContent: "done",
+        thinking: "think2",
+      },
+    ]);
+    const protos = [
+      buildAntigravityTestProto({
+        model: "gemini-3.8-flash",
+        contextTokens: 25000,
+        lastStepIndex: 0,
+      }),
+      buildAntigravityTestProto({
+        model: "gemini-3.8-flash",
+        contextTokens: 30000,
+        lastStepIndex: 2,
+      }),
+    ];
+
+    const fullDir = path.join(tmp, "full");
+    const incDir = path.join(tmp, "inc");
+    await fs.mkdir(fullDir, { recursive: true });
+    await fs.mkdir(incDir, { recursive: true });
+
+    const full = await setupAntigravitySqliteSession(fullDir, { protos, lines: allLines });
+    await parseAntigravityIncremental({
+      sessionFiles: [full.transcriptPath],
+      cursors: { version: 1, files: {}, updatedAt: null },
+      queuePath: full.queuePath,
+    });
+    const fullQueued = await readJsonLines(full.queuePath);
+
+    const inc = await setupAntigravitySqliteSession(incDir, { protos, lines: firstLines });
+    const incCursors = { version: 1, files: {}, updatedAt: null };
+    await parseAntigravityIncremental({
+      sessionFiles: [inc.transcriptPath],
+      cursors: incCursors,
+      queuePath: inc.queuePath,
+    });
+    await fs.writeFile(inc.transcriptPath, allLines.map((line) => JSON.stringify(line)).join("\n"));
+    await parseAntigravityIncremental({
+      sessionFiles: [inc.transcriptPath],
+      cursors: incCursors,
+      queuePath: inc.queuePath,
+    });
+    const incQueued = await readJsonLines(inc.queuePath);
+    const incLatest = incQueued.at(-1);
+    const fullLatest = fullQueued.at(-1);
+
+    assert.equal(incLatest.input_tokens, fullLatest.input_tokens);
+    assert.equal(incLatest.cached_input_tokens, 0);
+    assert.equal(fullLatest.cached_input_tokens, 0);
+    assert.equal(incLatest.output_tokens, fullLatest.output_tokens);
+    assert.equal(incLatest.conversation_count, fullLatest.conversation_count);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental reconciles a legacy estimated cursor with SQLite context", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-legacy-cursor-"));
+  try {
+    const firstLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
+    ]);
+    const allLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
+      {
+        userStep: 2,
+        userAt: "2026-04-05T14:02:00.000Z",
+        userContent: "next prompt",
+        plannerStep: 3,
+        plannerAt: "2026-04-05T14:03:00.000Z",
+        plannerContent: "done",
+        thinking: "think2",
+      },
+    ]);
+    const { transcriptPath, dbPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [],
+      lines: firstLines,
+    });
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    const afterEstimate = await readJsonLines(queuePath);
+    const estimatedInput = afterEstimate[0].input_tokens;
+    assert.ok(estimatedInput > 0);
+    assert.ok(estimatedInput < 1000);
+    assert.equal(afterEstimate[0].cached_input_tokens, 0);
+
     const turn1Proto = buildAntigravityTestProto({
       model: "gemini-3.8-flash",
       contextTokens: 25000,
@@ -12478,55 +12817,22 @@ test("parseAntigravityIncremental reads accurate usage and cache from SQLite gen
       dbPath,
       `INSERT INTO gen_metadata (idx, data) VALUES (0, X'${turn1Proto.toString("hex")}'), (1, X'${turn2Proto.toString("hex")}');`,
     ]);
-
-    const lines = [
-      {
-        type: "USER_INPUT",
-        step_index: 0,
-        created_at: "2026-04-05T14:00:00.000Z",
-        content: "hello",
-      },
-      {
-        type: "PLANNER_RESPONSE",
-        step_index: 1,
-        created_at: "2026-04-05T14:01:00.000Z",
-        content: "hi",
-        thinking: "think1",
-      },
-      {
-        type: "USER_INPUT",
-        step_index: 2,
-        created_at: "2026-04-05T14:02:00.000Z",
-        content: "next prompt",
-      },
-      {
-        type: "PLANNER_RESPONSE",
-        step_index: 3,
-        created_at: "2026-04-05T14:03:00.000Z",
-        content: "done",
-        thinking: "think2",
-      },
-    ];
-    await fs.writeFile(transcriptPath, lines.map((l) => JSON.stringify(l)).join("\n"));
-
-    const result = await parseAntigravityIncremental({
+    await fs.writeFile(transcriptPath, allLines.map((line) => JSON.stringify(line)).join("\n"));
+    const second = await parseAntigravityIncremental({
       sessionFiles: [transcriptPath],
       cursors,
       queuePath,
     });
-    assert.equal(result.eventsAggregated, 2);
+    assert.equal(second.eventsAggregated, 1);
 
     const queued = await readJsonLines(queuePath);
-    assert.equal(queued.length, 1);
-    assert.equal(queued[0].source, "antigravity");
-    assert.equal(queued[0].model, "gemini-3.8-flash");
-    assert.equal(queued[0].input_tokens, 30000);
-    assert.equal(queued[0].cached_input_tokens, 25000);
-    assert.equal(queued[0].conversation_count, 2);
-    assert.equal(
-      queued[0].total_tokens,
-      30000 + 25000 + queued[0].output_tokens + queued[0].reasoning_output_tokens,
-    );
+    const estimatedRow = queued.find((row) => row.model === afterEstimate[0].model);
+    const sqliteRow = queued.filter((row) => row.model === "gemini-3.8-flash").at(-1);
+    assert.equal(estimatedRow.input_tokens, estimatedInput);
+    assert.equal(estimatedRow.cached_input_tokens, 0);
+    assert.equal(sqliteRow.input_tokens, 5000);
+    assert.equal(sqliteRow.cached_input_tokens, 0);
+    assert.equal(sqliteRow.conversation_count, 1);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -12555,6 +12555,7 @@ test("parseAntigravityIncremental uses SQLite context size without inferring cac
       queued[0].total_tokens,
       queued[0].input_tokens + queued[0].output_tokens + queued[0].reasoning_output_tokens,
     );
+    assert.equal(cursors.files[transcriptPath].usageSource, "sqlite");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -12802,6 +12803,7 @@ test("parseAntigravityIncremental reconciles a legacy estimated cursor with SQLi
     assert.ok(estimatedInput > 0);
     assert.ok(estimatedInput < 1000);
     assert.equal(afterEstimate[0].cached_input_tokens, 0);
+    assert.equal(cursors.files[transcriptPath].usageSource, "estimated");
 
     const turn1Proto = buildAntigravityTestProto({
       model: "gemini-3.8-flash",
@@ -12833,6 +12835,88 @@ test("parseAntigravityIncremental reconciles a legacy estimated cursor with SQLi
     assert.equal(sqliteRow.input_tokens, 5000);
     assert.equal(sqliteRow.cached_input_tokens, 0);
     assert.equal(sqliteRow.conversation_count, 1);
+    assert.equal(cursors.files[transcriptPath].usageSource, "sqlite");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseAntigravityIncremental resumes a sqlite cursor without re-walking estimated history", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-sqlite-resume-"));
+  try {
+    const firstLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
+    ]);
+    const allLines = antigravityPlannerLines([
+      {
+        userStep: 0,
+        userAt: "2026-04-05T14:00:00.000Z",
+        userContent: "hello",
+        plannerStep: 1,
+        plannerAt: "2026-04-05T14:01:00.000Z",
+        plannerContent: "hi",
+        thinking: "think1",
+      },
+      {
+        userStep: 2,
+        userAt: "2026-04-05T14:02:00.000Z",
+        userContent: "next prompt",
+        plannerStep: 3,
+        plannerAt: "2026-04-05T14:03:00.000Z",
+        plannerContent: "done",
+        thinking: "think2",
+      },
+    ]);
+    const { transcriptPath, dbPath, queuePath } = await setupAntigravitySqliteSession(tmp, {
+      protos: [
+        buildAntigravityTestProto({
+          model: "gemini-3.8-flash",
+          contextTokens: 25000,
+          lastStepIndex: 0,
+        }),
+      ],
+      lines: firstLines,
+    });
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(cursors.files[transcriptPath].usageSource, "sqlite");
+    assert.equal(cursors.files[transcriptPath].previousContextTokens, 25000);
+
+    sqliteCli.execFileSync("sqlite3", [dbPath, "DELETE FROM gen_metadata;"]);
+    const turn2Proto = buildAntigravityTestProto({
+      model: "gemini-3.8-flash",
+      contextTokens: 30000,
+      lastStepIndex: 2,
+    });
+    sqliteCli.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO gen_metadata (idx, data) VALUES (0, X'${turn2Proto.toString("hex")}');`,
+    ]);
+    await fs.writeFile(transcriptPath, allLines.map((line) => JSON.stringify(line)).join("\n"));
+    const second = await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(second.eventsAggregated, 1);
+
+    const queued = await readJsonLines(queuePath);
+    const latest = queued.filter((row) => row.model === "gemini-3.8-flash").at(-1);
+    assert.equal(latest.input_tokens, 30000);
+    assert.equal(latest.cached_input_tokens, 0);
+    assert.equal(cursors.files[transcriptPath].usageSource, "sqlite");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -64,6 +64,9 @@ const {
   parseAntigravityIncremental,
   listAntigravitySessionFiles,
   estimateAntigravityTokens,
+  resolveAntigravityDbPath,
+  extractAntigravityGenInfo,
+  readAntigravityConversationDb,
   parseKimiCodeIncremental,
   resolveKimiHome,
   resolveKimiCodeHome,
@@ -12373,6 +12376,161 @@ for (const eventType of ["USER_INPUT", "USER_SETTINGS_CHANGE"]) {
     }
   });
 }
+
+function encodeAntigravityTestVarint(val) {
+  const bytes = [];
+  let n = val;
+  while (n >= 0x80) {
+    bytes.push((n & 0x7f) | 0x80);
+    n = Math.floor(n / 128);
+  }
+  bytes.push(n & 0x7f);
+  return Buffer.from(bytes);
+}
+function encodeAntigravityTestTag(f, wire) {
+  return encodeAntigravityTestVarint((f << 3) | wire);
+}
+function encodeAntigravityTestLd(f, buf) {
+  const b = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+  return Buffer.concat([encodeAntigravityTestTag(f, 2), encodeAntigravityTestVarint(b.length), b]);
+}
+function encodeAntigravityTestVi(f, val) {
+  return Buffer.concat([encodeAntigravityTestTag(f, 0), encodeAntigravityTestVarint(val)]);
+}
+
+function buildAntigravityTestProto({ model, contextTokens, lastStepIndex }) {
+  const parts = [];
+  if (model) parts.push(encodeAntigravityTestLd(19, model));
+  if (Number.isFinite(contextTokens)) {
+    const f1 = encodeAntigravityTestVi(1, contextTokens);
+    const f10 = encodeAntigravityTestLd(10, f1);
+    const f9 = encodeAntigravityTestLd(9, f10);
+    parts.push(f9);
+  }
+  if (lastStepIndex != null) {
+    const k = encodeAntigravityTestLd(1, "last_step_index");
+    const v = encodeAntigravityTestLd(2, String(lastStepIndex));
+    parts.push(encodeAntigravityTestLd(20, Buffer.concat([k, v])));
+  }
+  return encodeAntigravityTestLd(1, Buffer.concat(parts));
+}
+
+test("resolveAntigravityDbPath maps brain transcript logs to conversations database", () => {
+  const transcriptPath =
+    "/Users/test/.gemini/antigravity/brain/session-abc-123/.system_generated/logs/transcript.jsonl";
+  const expectedDb = path.join(
+    "/Users/test/.gemini/antigravity",
+    "conversations",
+    "session-abc-123.db",
+  );
+  assert.equal(resolveAntigravityDbPath(transcriptPath), expectedDb);
+  assert.equal(resolveAntigravityDbPath("/var/tmp/other.jsonl"), null);
+});
+
+test("extractAntigravityGenInfo extracts model, context tokens, and step index from protobuf payload", () => {
+  const proto = buildAntigravityTestProto({
+    model: "gemini-3.8-flash",
+    contextTokens: 25000,
+    lastStepIndex: 0,
+  });
+  const info = extractAntigravityGenInfo(proto);
+  assert.deepEqual(info, {
+    model: "gemini-3.8-flash",
+    contextTokens: 25000,
+    lastStepIndex: 0,
+  });
+});
+
+test("parseAntigravityIncremental reads accurate usage and cache from SQLite gen_metadata", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-antigravity-sqlite-"));
+  try {
+    const brainDir = path.join(
+      tmp,
+      "antigravity",
+      "brain",
+      "conv-123",
+      ".system_generated",
+      "logs",
+    );
+    const convDir = path.join(tmp, "antigravity", "conversations");
+    await fs.mkdir(brainDir, { recursive: true });
+    await fs.mkdir(convDir, { recursive: true });
+    const transcriptPath = path.join(brainDir, "transcript.jsonl");
+    const dbPath = path.join(convDir, "conv-123.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    sqliteCli.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);",
+    ]);
+    const turn1Proto = buildAntigravityTestProto({
+      model: "gemini-3.8-flash",
+      contextTokens: 25000,
+      lastStepIndex: 0,
+    });
+    const turn2Proto = buildAntigravityTestProto({
+      model: "gemini-3.8-flash",
+      contextTokens: 30000,
+      lastStepIndex: 2,
+    });
+    sqliteCli.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO gen_metadata (idx, data) VALUES (0, X'${turn1Proto.toString("hex")}'), (1, X'${turn2Proto.toString("hex")}');`,
+    ]);
+
+    const lines = [
+      {
+        type: "USER_INPUT",
+        step_index: 0,
+        created_at: "2026-04-05T14:00:00.000Z",
+        content: "hello",
+      },
+      {
+        type: "PLANNER_RESPONSE",
+        step_index: 1,
+        created_at: "2026-04-05T14:01:00.000Z",
+        content: "hi",
+        thinking: "think1",
+      },
+      {
+        type: "USER_INPUT",
+        step_index: 2,
+        created_at: "2026-04-05T14:02:00.000Z",
+        content: "next prompt",
+      },
+      {
+        type: "PLANNER_RESPONSE",
+        step_index: 3,
+        created_at: "2026-04-05T14:03:00.000Z",
+        content: "done",
+        thinking: "think2",
+      },
+    ];
+    await fs.writeFile(transcriptPath, lines.map((l) => JSON.stringify(l)).join("\n"));
+
+    const result = await parseAntigravityIncremental({
+      sessionFiles: [transcriptPath],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "antigravity");
+    assert.equal(queued[0].model, "gemini-3.8-flash");
+    assert.equal(queued[0].input_tokens, 30000);
+    assert.equal(queued[0].cached_input_tokens, 25000);
+    assert.equal(queued[0].conversation_count, 2);
+    assert.equal(
+      queued[0].total_tokens,
+      30000 + 25000 + queued[0].output_tokens + queued[0].reasoning_output_tokens,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
 
 // ── Kimi Code official (@moonshot-ai/kimi-code) ──────────────────────────────
 


### PR DESCRIPTION
## Why
Antigravity's local SQLite metadata records prompt context size and model name. It does not record cache reads or output counts. Inferring cache hits understated cost.

## Scope
`parseAntigravityFile` in `src/lib/rollout.js` bills SQLite context growth as `input_tokens`, leaves `cached_input_tokens` at 0, and resets the snapshot on a model switch. Tests in `test/rollout-parser.test.js` cover repeated context, model switch, incremental vs full scan, and a legacy estimated cursor.

## Tradeoffs
Input from SQLite is still a session-incremental estimate, not per-request billed tokens. That matches the existing Antigravity heuristic. Without a cache counter, a true cold cache mid-session still cannot be distinguished.

## Blast radius
Only the Antigravity parser and its tests. Other providers are untouched. The dashboard Estimated tokens notice is unchanged.

## Verification
`node --test --test-name-pattern 'Antigravity' test/rollout-parser.test.js` reported 19 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Antigravity usage tracking now incorporates metadata from associated conversation databases.
  - Usage data identifies whether values are estimated or derived from stored metadata.
  - Incremental conversations can resume using database-backed progress.

- **Bug Fixes**
  - Corrected token counts for repeated context, incremental conversations, and model switches.
  - Prevented cache-hit tokens from being incorrectly inferred or added to total usage.
  - Improved reconciliation when transitioning from estimated usage to database-derived usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->