### PR TITLE
fix(parser): preserve Claude reasoning usage without double billing

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -4458,6 +4458,9 @@ function claudeMessageDedupKey(obj) {
 function normalizeClaudeUsage(u) {
   const inputTokens = toNonNegativeInt(u?.input_tokens);
   const outputTokens = toNonNegativeInt(u?.output_tokens);
+  const reasoningTokens = Math.min(outputTokens, toNonNegativeInt(
+    u?.output_tokens_details?.thinking_tokens ?? u?.output_tokens_details?.reasoning_tokens,
+  ));
   const cacheCreation = toNonNegativeInt(u?.cache_creation_input_tokens);
   const cacheRead = toNonNegativeInt(u?.cache_read_input_tokens);
   const totalTokens = inputTokens + outputTokens + cacheCreation + cacheRead;
@@ -4465,8 +4468,9 @@ function normalizeClaudeUsage(u) {
     input_tokens: inputTokens,
     cached_input_tokens: cacheRead,
     cache_creation_input_tokens: cacheCreation,
-    output_tokens: outputTokens,
-    reasoning_output_tokens: 0,
+    // Claude rows price reasoning separately; it is already included in usage.output_tokens.
+    output_tokens: outputTokens - reasoningTokens,
+    reasoning_output_tokens: reasoningTokens,
     total_tokens: totalTokens,
   };
 }

--- a/test/claude-reasoning-usage.test.js
+++ b/test/claude-reasoning-usage.test.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { parseClaudeIncremental } = require("../src/lib/rollout");
+const { computeRowCost } = require("../src/lib/pricing");
+
+test("Claude reasoning details survive incremental parsing without double billing", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-reasoning-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const cases = [
+    [{ thinking_tokens: 163 }, 163],
+    [{ reasoning_tokens: 163 }, 163],
+    [{ thinking_tokens: 0, reasoning_tokens: 163 }, 0],
+    [{ thinking_tokens: 0 }, 0],
+    [undefined, 0],
+    [null, 0],
+    [{}, 0],
+    [{ thinking_tokens: -1 }, 0],
+    [{ thinking_tokens: "invalid" }, 0],
+    [{ thinking_tokens: 9999 }, 518],
+  ];
+  for (const [index, [details, reasoning]] of cases.entries()) {
+    const file = path.join(dir, `session-${index}.jsonl`);
+    const queuePath = path.join(dir, `queue-${index}.jsonl`);
+    fs.writeFileSync(file, JSON.stringify({
+      type: "assistant", timestamp: "2026-09-07T03:00:00Z",
+      message: { id: `m-${index}`, model: "claude-sonnet-4-6", usage: {
+        input_tokens: 420, cache_read_input_tokens: 100,
+        cache_creation_input_tokens: 20, output_tokens: 518,
+        output_tokens_details: details,
+      } },
+    }) + "\n");
+    const options = { projectFiles: [file], queuePath, cursors: {}, source: "claude" };
+    await parseClaudeIncremental(options);
+    const saved = fs.readFileSync(queuePath, "utf8");
+    const row = JSON.parse(saved.trim().split("\n").at(-1));
+    assert.equal(row.reasoning_output_tokens, reasoning, `case ${index}`);
+    assert.equal(row.output_tokens, 518 - reasoning);
+    assert.equal(row.total_tokens, 1058);
+    assert.equal(row.input_tokens + row.cached_input_tokens + row.cache_creation_input_tokens + row.output_tokens + row.reasoning_output_tokens, row.total_tokens);
+    const beforeCost = computeRowCost({ ...row, output_tokens: 518, reasoning_output_tokens: 0 });
+    assert.ok(beforeCost > 0);
+    assert.ok(Math.abs(computeRowCost(row) - beforeCost) < 1e-12);
+    await parseClaudeIncremental(options);
+    assert.equal(fs.readFileSync(queuePath, "utf8"), saved);
+  }
+});


### PR DESCRIPTION
## Summary

Preserve reported reasoning usage from Claude Code / Anthropic-compatible session records instead of always storing zero.

- Read `output_tokens_details.thinking_tokens`, falling back to `reasoning_tokens` when absent (not when explicitly zero).
- Clamp to a non-negative integer within the inclusive output count.
- Split reasoning out of queue `output_tokens`: Claude rows price reasoning separately, so simply adding the detail would double bill it. Keep total tokens and cost unchanged.

## Validation

- Regression reproduced before patch: reported 163 became 0.
- 17 focused tests pass: new regression, Claude categorizer, WSL dual-install tests.
- New numeric-only fixture covers ten detail variants, token conservation, cost conservation and a second incremental parse with no queue changes.
- `validate:guardrails`, `validate:versions`, `git diff --check` pass.
- Full `npm test` is not green locally: Copilot SQLite-sidecar and sync-store tests failed (unmodified areas); full results will be appended when the run finishes. Initial run before installing dependencies also failed on missing packages; that is not claimed as validation.
- Self-reviewed diff for missing versus explicit zero, input/cache conservation, and billing invariants. Maintainer review is still required.

## Scope / limitations

No conversation content or credentials included. No release, version bump, deployment, or local service changes; release coordination belongs to the maintainer.

This fixes newly parsed queue usage, not historical backfill, session discovery, or context-category estimation. Existing logs with the detail omitted cannot reconstruct it. Upstream proxies must preserve the field first: https://github.com/router-for-me/CLIProxyAPI/issues/5587.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude usage reporting now separately accounts for reasoning tokens while preventing double billing.
  - Output token counts and cost calculations are more accurate when reasoning details are provided.
  - Incremental usage parsing remains consistent across repeated processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->