### PR TITLE
fix(pricing): add GPT-6 Astra short-context rates and update GPT-5.6 Sol pricing

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -168,11 +168,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // (suffix-strip → gpt-5.4 at 2.5/15) by 40% until 2026-06.
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
+  // Standard short-context rates, verified 2026-09-07:
+  // https://developers.openai.com/api/docs/pricing. No long-context uplift.
+  "gpt-6-astra": { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
   // Three durable capability tiers: sol (flagship) / terra (balanced default) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  // Sol promotional pricing is available at least through 2026-11-21.
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -305,6 +309,7 @@ function getModelPricing(model: string) {
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
   // fallback (which defaults to the balanced terra tier).
+  if (lower.includes("gpt-6-astra")) return MODEL_PRICING["gpt-6-astra"];
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -144,11 +144,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // (suffix-strip → gpt-5.4 at 2.5/15) by 40% until 2026-06.
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
+  // Standard short-context rates, verified 2026-09-07:
+  // https://developers.openai.com/api/docs/pricing. No long-context uplift.
+  "gpt-6-astra": { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
   // Three durable capability tiers: sol (flagship) / terra (balanced default) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  // Sol promotional pricing is available at least through 2026-11-21.
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -281,6 +285,7 @@ function getModelPricing(model: string) {
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
   // fallback (which defaults to the balanced terra tier).
+  if (lower.includes("gpt-6-astra")) return MODEL_PRICING["gpt-6-astra"];
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -169,11 +169,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // (suffix-strip → gpt-5.4 at 2.5/15) by 40% until 2026-06.
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
+  // Standard short-context rates, verified 2026-09-07:
+  // https://developers.openai.com/api/docs/pricing. No long-context uplift.
+  "gpt-6-astra": { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
   // Three durable capability tiers: sol (flagship) / terra (balanced default) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  // Sol promotional pricing is available at least through 2026-11-21.
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -306,6 +310,7 @@ function getModelPricing(model: string) {
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
   // fallback (which defaults to the balanced terra tier).
+  if (lower.includes("gpt-6-astra")) return MODEL_PRICING["gpt-6-astra"];
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-profile.ts
@@ -141,11 +141,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // (suffix-strip → gpt-5.4 at 2.5/15) by 40% until 2026-06.
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
+  // Standard short-context rates, verified 2026-09-07:
+  // https://developers.openai.com/api/docs/pricing. No long-context uplift.
+  "gpt-6-astra": { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
   // Three durable capability tiers: sol (flagship) / terra (balanced default) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  // Sol promotional pricing is available at least through 2026-11-21.
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -278,6 +282,7 @@ function getModelPricing(model: string) {
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
   // fallback (which defaults to the balanced terra tier).
+  if (lower.includes("gpt-6-astra")) return MODEL_PRICING["gpt-6-astra"];
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];

--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -173,11 +173,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   // (suffix-strip → gpt-5.4 at 2.5/15) by 40% until 2026-06.
   "gpt-5.4-pro": { input: 30, output: 180, cache_read: 3 },
   "gpt-5.5": { input: 5, output: 30, cache_read: 0.5 },
+  // Standard short-context rates, verified 2026-09-07:
+  // https://developers.openai.com/api/docs/pricing. No long-context uplift.
+  "gpt-6-astra": { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
   // GPT-5.6 family (public 2026-07-09), developers.openai.com/api/docs/pricing.
   // Three durable capability tiers: sol (flagship) / terra (balanced default) /
   // luna (lightweight). Codex reports the tier in the model id (gpt-5.6-sol,
   // + reasoning-effort variants like gpt-5.6-solhigh). Not yet in LiteLLM.
-  "gpt-5.6-sol": { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+  // Sol promotional pricing is available at least through 2026-11-21.
+  "gpt-5.6-sol": { input: 4, output: 20, cache_read: 0.4, cache_write: 5 },
   "gpt-5.6-terra": { input: 2, output: 12, cache_read: 0.2, cache_write: 2.5 },
   "gpt-5.6-luna": { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
   "gpt-5-mini": { input: 0.25, output: 2, cache_read: 0.025 },
@@ -310,6 +314,7 @@ function getModelPricing(model: string) {
   // gpt-5.6 tiers: sol/terra/luna carry reasoning-effort suffixes (solhigh,
   // etc.), so match by substring. Specific tiers precede the generic gpt-5.6
   // fallback (which defaults to the balanced terra tier).
+  if (lower.includes("gpt-6-astra")) return MODEL_PRICING["gpt-6-astra"];
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
   if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -47,12 +47,19 @@
       "cache_write": 1.25,
       "note": "Canonical undated alias emitted by Cursor. Pin to the same rates as claude-haiku-4-5-20251001 so local cost does not depend on which dated LiteLLM aliases are present in the current cache."
     },
+    "gpt-6-astra": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5,
+      "note": "Official Standard short-context USD/MTok verified 2026-09-07: https://developers.openai.com/api/docs/pricing. Matches the existing short-context estimation policy; long-context rates are not applied. Reasoning-effort variants are covered by fuzzy matching."
+    },
     "gpt-5.6-sol": {
-      "input": 5,
-      "output": 30,
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "note": "GPT-5.6 family (public 2026-07-09). Flagship tier. Not yet in LiteLLM. developers.openai.com/api/docs/pricing short-context: $5/$30 per MTok, cached input 0.1x, cache write 1.25x. Codex emits gpt-5.6-sol (+ reasoning-effort variants like gpt-5.6-solhigh, caught by fuzzy). Remove once LiteLLM carries it."
+      "input": 4,
+      "output": 20,
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "note": "Official Standard short-context promotional USD/MTok verified 2026-09-07: https://developers.openai.com/api/docs/pricing. Promotion available at least through 2026-11-21. Replaces the previous $5/$30 input/output rates. Reasoning-effort variants are covered by fuzzy matching; long-context rates are not applied."
     },
     "gpt-5.6-terra": {
       "input": 2,
@@ -404,6 +411,10 @@
     "auto": "composer-1"
   },
   "fuzzy": [
+    {
+      "match": "gpt-6-astra",
+      "ref": "gpt-6-astra"
+    },
     {
       "match": "gpt-5.6-sol",
       "ref": "gpt-5.6-sol"

--- a/test/edge-pricing-parity.test.js
+++ b/test/edge-pricing-parity.test.js
@@ -59,6 +59,28 @@ test("MODEL_PRICING + getModelPricing are byte-identical across all 5 edge files
   }
 });
 
+test("cloud Astra and Sol pricing matches current local short-context rates", () => {
+  const { getModelPricing } = require("../src/lib/pricing");
+  const block = extractBlock(CANONICAL);
+  const cases = [
+    ["gpt-6-astra", { input: 10, output: 50, cache_read: 1, cache_write: 12.5 }],
+    ["gpt-5.6-sol", { input: 4, output: 20, cache_read: 0.4, cache_write: 5 }],
+  ];
+  for (const [model, rates] of cases) {
+    for (const [field, value] of Object.entries(rates)) {
+      assert.strictEqual(getModelPricing(model)[field], value, `${model} local ${field}`);
+    }
+    assert.ok(
+      block.includes(`"${model}": { input: ${rates.input}, output: ${rates.output}, cache_read: ${rates.cache_read}, cache_write: ${rates.cache_write} },`),
+      `${model} cloud rates must match the official short-context rates`,
+    );
+    assert.ok(
+      block.includes(`if (lower.includes("${model}")) return MODEL_PRICING["${model}"];`),
+      `${model} cloud matcher must cover reasoning-effort variants`,
+    );
+  }
+});
+
 test("canonical pricing block retains regression-prone entries and matcher order", () => {
   const block = extractBlock(CANONICAL);
 

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -129,12 +129,12 @@ test("matcher: GPT-5.6 codex tiers resolve to their real curated rates (not the 
   // LiteLLM has no gpt-5.6 yet; simulate that so curated must win.
   const litellm = { "gpt-5": { input: 1.25, output: 10, cache_read: 0.125 } };
   const cases = [
-    ["gpt-5.6-sol", 5, 30, "curated:exact"],
+    ["gpt-5.6-sol", 4, 20, "curated:exact"],
     ["gpt-5.6-terra", 2, 12, "curated:exact"],
     ["gpt-5.6-luna", 0.2, 1.2, "curated:exact"],
     // reasoning-effort variants codex appends must still land on the right tier
-    ["gpt-5.6-sol-high", 5, 30, null],
-    ["gpt-5.6-solhigh", 5, 30, "curated:fuzzy"],
+    ["gpt-5.6-sol-high", 4, 20, null],
+    ["gpt-5.6-solhigh", 4, 20, "curated:fuzzy"],
     ["gpt-5.6-terrahigh", 2, 12, "curated:fuzzy"],
     // bare / unknown-tier falls back to the balanced terra tier, never gpt-5
     ["gpt-5.6", 2, 12, "curated:fuzzy"],
@@ -145,6 +145,31 @@ test("matcher: GPT-5.6 codex tiers resolve to their real curated rates (not the 
     assert.equal(r.value.input, input, `${model} input`);
     assert.equal(r.value.output, output, `${model} output`);
     if (source) assert.equal(r.source, source, `${model} source`);
+  }
+});
+
+test("index: Astra and Sol use current short-context rates for all token categories and effort variants", () => {
+  // Official Standard short-context USD/MTok, verified 2026-09-07.
+  const cases = [
+    ["gpt-6-astra", { input: 10, output: 50, cache_read: 1, cache_write: 12.5 }],
+    ["gpt-5.6-sol", { input: 4, output: 20, cache_read: 0.4, cache_write: 5 }],
+  ];
+  const tokenFields = {
+    input: "input_tokens",
+    output: "output_tokens",
+    cache_read: "cached_input_tokens",
+    cache_write: "cache_creation_input_tokens",
+  };
+  for (const [baseModel, rates] of cases) {
+    for (const model of [baseModel, `${baseModel}-high`, `${baseModel}high`, `openai/${baseModel}-xhigh`]) {
+      for (const [category, field] of Object.entries(tokenFields)) {
+        assert.equal(
+          pricing.computeRowCost({ source: "codex", model, [field]: 1_000_000 }),
+          rates[category],
+          `${model} ${field} must retain short-context pricing even for large aggregate rows`,
+        );
+      }
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Add GPT-6 Astra pricing so its estimated cost no longer defaults to $0 with bundled pricing data, and update GPT-5.6 Sol to the current official Standard short-context rates.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

N/A

## Changes

- Add GPT-6 Astra rates: $10 input, $1 cached input, $12.50 cache writes, and $50 output per million tokens.
- Update GPT-5.6 Sol rates to $4 input, $0.40 cached input, $5 cache writes, and $20 output per million tokens.
- Synchronize local pricing and all five cloud edge functions.
- Support reasoning-effort suffixes and provider-prefixed model IDs.
- Retain short-context estimation without introducing long-context pricing or historical price versioning.
- Document the official pricing source and Sol's promotional pricing, available at least through November 21, 2026.

Source: https://developers.openai.com/api/docs/pricing

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manual testing completed

All 81 tests in the three relevant test files passed:
`node --test test/pricing.test.js test/edge-pricing-parity.test.js test/model-breakdown.test.js`

Regression coverage includes all four token categories, model variants, and pricing consistency across the five cloud functions. The full repository test suite was not run.

The local server started successfully and returned HTTP 200. Manual UI verification of pricing remains pending.

## Screenshots (if applicable)

N/A. No UI changes.

## Checklist

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Breaking changes documented

Pricing notes were updated in the configuration and source comments. No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pricing support for the GPT-6 Astra model, including provider-prefixed and reasoning-effort variants.
* **Updates**
  * Reduced GPT-5.6 Sol pricing across input, output, and cached-token categories.
  * Updated pricing consistency across dashboard views and cloud pricing data.
* **Tests**
  * Added coverage verifying Astra and Sol pricing parity across model variants, token categories, and aggregate usage rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->