### PR TITLE
feat(cli): add update command and print help for unknown commands

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -70,6 +70,7 @@ tokentracker status       # Hook-Status prüfen
 tokentracker status --json     # Maschinenlesbare Ausgabe (für jq, AI-Agenten)
 tokentracker status --light    # Reine ASCII-Tabelle (CI / SSH, kein Spinner)
 tokentracker doctor       # Health Check
+tokentracker update       # Dieses CLI aktualisieren
 ```
 
 ### 🍺 Homebrew (macOS)

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,6 +67,7 @@ tokentracker              # ダッシュボードを開く
 tokentracker sync         # 手動同期
 tokentracker status       # hook の状態を確認
 tokentracker doctor       # ヘルスチェック
+tokentracker update       # この CLI を更新
 ```
 
 ### 🍺 Homebrew (macOS)

--- a/README.ko.md
+++ b/README.ko.md
@@ -67,6 +67,7 @@ tokentracker              # 대시보드 열기
 tokentracker sync         # 수동 동기화
 tokentracker status       # hook 상태 확인
 tokentracker doctor       # 헬스 체크
+tokentracker update       # 이 CLI 업데이트
 ```
 
 ### 🍺 Homebrew (macOS)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ tokentracker status       # Check hook status
 tokentracker status --json     # Machine-readable summary (pipe to jq, ingest from AI agents)
 tokentracker status --light    # Plain ASCII table (CI / SSH, no spinner)
 tokentracker doctor       # Health check
+tokentracker update       # Update this CLI
 ```
 
 ### 🍺 Homebrew (macOS)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,7 @@ tokentracker status       # 查看 hook 挂接状态
 tokentracker status --json   # 机器可读 JSON（pipe 到 jq、给 AI agent 喂数据）
 tokentracker status --light  # 纯 ASCII 表（CI / SSH 用，无 spinner）
 tokentracker doctor       # 健康检查
+tokentracker update       # 更新本 CLI
 ```
 
 ### 🍺 Homebrew（macOS）

--- a/bin/tracker.js
+++ b/bin/tracker.js
@@ -40,7 +40,11 @@ if (applyResult && applyResult.unprotected === true) {
 }
 
 run(argv).catch((err) => {
-  console.error(err?.stack || String(err));
+  if (!debug && isUsageError(err)) {
+    console.error(err.message);
+  } else {
+    console.error(err?.stack || String(err));
+  }
   if (debug) {
     if (typeof err?.status === 'number') {
       console.error(`Status: ${err.status}`);
@@ -58,3 +62,8 @@ run(argv).catch((err) => {
   }
   process.exitCode = 1;
 });
+
+function isUsageError(err) {
+  const message = typeof err?.message === "string" ? err.message : "";
+  return message.startsWith("Unknown command:") || message.startsWith("Unknown option:");
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,7 @@ const { cmdServe } = require("./commands/serve");
 const { cmdDeviceLogin } = require("./commands/device-login");
 const { cmdWrapped } = require("./commands/wrapped");
 const { cmdSessions } = require("./commands/sessions");
+const { cmdUpdate } = require("./commands/update");
 
 async function run(argv) {
   const [command, ...rest] = argv;
@@ -18,7 +19,7 @@ async function run(argv) {
     return;
   }
 
-  if (command === "-h" || command === "--help") {
+  if (command === "-h" || command === "--help" || command === "help") {
     printHelp();
     return;
   }
@@ -60,9 +61,20 @@ async function run(argv) {
     case "sessions":
       await cmdSessions(rest);
       return;
+    case "update":
+    case "upgrade":
+      await cmdUpdate(rest);
+      return;
     default:
-      throw new Error(`Unknown command: ${command}`);
+      printUnknownCommand(command);
+      process.exitCode = 1;
+      return;
   }
+}
+
+function printUnknownCommand(command) {
+  process.stderr.write(`Unknown command: ${command}\n\n`);
+  printHelp();
 }
 
 function printHelp() {
@@ -73,6 +85,7 @@ function printHelp() {
       "",
       "Usage:",
       "  npx tokentracker                                         Open local dashboard",
+      "  npx tokentracker -h, --help                              Show this help",
       "  npx tokentracker -v, --version                           Show version info",
       "  npx tokentracker [--debug] serve [--port 7680] [--no-open] [--no-sync]",
       "  npx tokentracker [--debug] init [--yes] [--dry-run] [--no-open] [--link-code <code>]",
@@ -84,6 +97,7 @@ function printHelp() {
       "  npx tokentracker [--debug] device-login [--json] [--base-url <url>]",
       "  npx tokentracker [--debug] wrapped [--year 2026] [--json]",
       "  npx tokentracker sessions [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--format json|csv] [--out file] [--refresh] [--no-git]",
+      "  npx tokentracker [--debug] update",
       "",
       "Notes:",
       "  - init: consent first, local setup next, browser sign-in last.",
@@ -99,9 +113,10 @@ function printHelp() {
       "  - --debug shows original backend errors.",
       "  - device-login pairs a headless CLI / SSH session with a browser sign-in (15-min code).",
       "  - sessions exports metadata-only Claude/Codex efficiency analytics; no prompt or response text is retained.",
+      "  - update delegates to npm, bun, pnpm, yarn, or Homebrew. It will not switch install methods.",
       "",
     ].join("\n"),
   );
 }
 
-module.exports = { run };
+module.exports = { run, printHelp };

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const { detectInstallChannel, formatCommandLine } = require("../lib/install-channel");
+
+async function cmdUpdate(argv = [], deps = {}) {
+  const opts = parseArgs(argv);
+  const stdout = deps.stdout || process.stdout;
+  const stderr = deps.stderr || process.stderr;
+
+  if (opts.help) {
+    stdout.write(updateHelpText());
+    return;
+  }
+
+  const detect = deps.detectInstallChannel || detectInstallChannel;
+  const channel = detect({
+    entryPath: deps.entryPath || process.argv[1],
+    realpathSync: deps.realpathSync,
+    existsSync: deps.existsSync,
+    readFileSync: deps.readFileSync,
+  });
+
+  stdout.write(`Detected install: ${channel.method}\n`);
+
+  if (!channel.action) {
+    stderr.write(`${channel.reason}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const command = channel.command || formatCommandLine(channel.action);
+  stdout.write(`Updating TokenTracker via \`${command}\`...\n`);
+  const run = deps.spawnSync || spawnSync;
+  const result = run(channel.action.bin, channel.action.args, {
+    stdio: "inherit",
+    env: deps.env || process.env,
+    shell: (deps.platform || process.platform) === "win32",
+  });
+
+  if (result?.error) {
+    stderr.write(`Failed to run \`${channel.action.bin}\`: ${result.error.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (result?.status !== 0) {
+    process.exitCode = typeof result?.status === "number" ? result.status : 1;
+    return;
+  }
+
+  stdout.write("Update finished. Restart any long-running `tokentracker serve` process to pick up the new version.\n");
+}
+
+function parseArgs(argv) {
+  const out = { help: false };
+  for (const arg of argv) {
+    if (arg === "-h" || arg === "--help") out.help = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  return out;
+}
+
+function updateHelpText() {
+  return [
+    "tokentracker update",
+    "",
+    "Usage:",
+    "  tokentracker update",
+    "",
+    "Delegates to the package manager that owns this copy (npm, bun, pnpm, yarn, or Homebrew).",
+    "npx launches, desktop app bundles, and source checkouts are left unchanged.",
+    "",
+  ].join("\n");
+}
+
+module.exports = { cmdUpdate, parseArgs, updateHelpText };

--- a/src/lib/install-channel.js
+++ b/src/lib/install-channel.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PACKAGE_NAME = "tokentracker-cli";
+const BREW_FORMULA = "xiufengsun/tokentracker/tokentracker";
+const RELEASES_URL = "https://github.com/xiufengsun/TokenTracker/releases/latest";
+
+const UPDATE_ACTIONS = {
+  npm: { bin: "npm", args: ["install", "-g", `${PACKAGE_NAME}@latest`] },
+  bun: { bin: "bun", args: ["install", "-g", `${PACKAGE_NAME}@latest`] },
+  pnpm: { bin: "pnpm", args: ["add", "-g", `${PACKAGE_NAME}@latest`] },
+  yarn: { bin: "yarn", args: ["global", "add", `${PACKAGE_NAME}@latest`] },
+  brew: { bin: "brew", args: ["upgrade", BREW_FORMULA] },
+};
+
+function toPosix(p) {
+  return String(p || "").replace(/\\/g, "/");
+}
+
+function resolveEntryPath(entryPath, realpathSync) {
+  if (typeof entryPath !== "string" || !entryPath.trim()) return "";
+  const resolved = path.resolve(entryPath.trim());
+  try {
+    return realpathSync(resolved);
+  } catch (_err) {
+    return resolved;
+  }
+}
+
+function isDesktopPath(posixLower) {
+  return /(^|\/)embeddedserver(\/|$)/.test(posixLower);
+}
+
+function isBrewFormulaPath(posixLower) {
+  if (/\/cellar\/tokentracker\//.test(posixLower)) return true;
+  const homebrewish =
+    posixLower.includes("/homebrew/") ||
+    posixLower.includes("/linuxbrew/") ||
+    posixLower.startsWith("/usr/local/opt/tokentracker");
+  return homebrewish && /\/opt\/tokentracker(\/|$)/.test(posixLower);
+}
+
+function isNpxPath(posixLower) {
+  return /\/_npx\//.test(posixLower);
+}
+
+function isBunPath(posixLower) {
+  return posixLower.includes("/.bun/install/global/") || posixLower.includes("/.bun/bin/");
+}
+
+function isPnpmPath(posixLower) {
+  return posixLower.includes("/.pnpm/") || /\/pnpm\/global\//.test(posixLower);
+}
+
+function isYarnGlobalPath(posixLower) {
+  return posixLower.includes("/yarn/global/");
+}
+
+function isNpmPackagePath(posixLower) {
+  return posixLower.includes(`/node_modules/${PACKAGE_NAME}/`);
+}
+
+function findSourceTree(entryPath, existsSync, readFileSync) {
+  if (!entryPath) return null;
+  let dir = path.dirname(path.resolve(entryPath));
+  const { root } = path.parse(dir);
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    const cliPath = path.join(dir, "src", "cli.js");
+    if (existsSync(pkgPath) && existsSync(cliPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+        if (pkg && pkg.name === PACKAGE_NAME) {
+          return {
+            root: dir,
+            git: existsSync(path.join(dir, ".git")),
+          };
+        }
+      } catch (_err) {
+        // Unreadable or invalid package.json — keep walking.
+      }
+    }
+    if (dir === root) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function formatCommandLine(action) {
+  if (!action || typeof action.bin !== "string") return "";
+  const args = Array.isArray(action.args) ? action.args : [];
+  return [action.bin, ...args].join(" ");
+}
+
+function unmanagedReason({ method, entryPath, sourceRoot, git }) {
+  if (method === "npx") {
+    return (
+      `This TokenTracker was launched via npx (${entryPath}). ` +
+      `Re-run \`npx ${PACKAGE_NAME}@latest\`, or install a managed copy with \`npm i -g ${PACKAGE_NAME}\`.`
+    );
+  }
+  if (method === "desktop") {
+    return (
+      `This TokenTracker is bundled inside the desktop app (${entryPath}). ` +
+      `Use the app's built-in updater, or download a new build from ${RELEASES_URL}`
+    );
+  }
+  if (sourceRoot && git) {
+    return (
+      `Could not detect a managed install (npm, bun, pnpm, yarn, or Homebrew) at ${entryPath}. ` +
+      `This looks like a git checkout at ${sourceRoot}. ` +
+      `Update it the same way you installed it (for example \`git -C ${sourceRoot} pull\`); ` +
+      `TokenTracker will not switch install methods.`
+    );
+  }
+  if (sourceRoot) {
+    return (
+      `Could not detect a managed install (npm, bun, pnpm, yarn, or Homebrew) at ${entryPath}. ` +
+      `This looks like a source tree at ${sourceRoot}. ` +
+      `Update it the same way you installed it; TokenTracker will not switch install methods.`
+    );
+  }
+  return (
+    `Could not detect a managed install (npm, bun, pnpm, yarn, or Homebrew) at ${entryPath || "(unknown path)"}. ` +
+    `Update TokenTracker the same way you installed it. See https://github.com/xiufengsun/TokenTracker#quick-start`
+  );
+}
+
+function detectInstallChannel({
+  entryPath = process.argv[1],
+  realpathSync,
+  existsSync,
+  readFileSync,
+} = {}) {
+  const resolveReal = typeof realpathSync === "function" ? realpathSync : fs.realpathSync;
+  const exists = typeof existsSync === "function" ? existsSync : fs.existsSync;
+  const readFile = typeof readFileSync === "function" ? readFileSync : fs.readFileSync;
+  const resolved = resolveEntryPath(entryPath, resolveReal);
+  const posixLower = toPosix(resolved).toLowerCase();
+
+  let method = "other";
+  if (isDesktopPath(posixLower)) method = "desktop";
+  else if (isBrewFormulaPath(posixLower)) method = "brew";
+  else if (isNpxPath(posixLower)) method = "npx";
+  else if (isBunPath(posixLower)) method = "bun";
+  else if (isPnpmPath(posixLower)) method = "pnpm";
+  else if (isYarnGlobalPath(posixLower)) method = "yarn";
+  else if (isNpmPackagePath(posixLower)) method = "npm";
+
+  const source =
+    method === "other" ? findSourceTree(resolved || entryPath, exists, readFile) : null;
+  const action = UPDATE_ACTIONS[method] || null;
+
+  return {
+    method,
+    entryPath: resolved || String(entryPath || ""),
+    action,
+    command: formatCommandLine(action),
+    sourceRoot: source?.root || null,
+    git: Boolean(source?.git),
+    reason: action ? null : unmanagedReason({
+      method,
+      entryPath: resolved || String(entryPath || ""),
+      sourceRoot: source?.root || null,
+      git: Boolean(source?.git),
+    }),
+  };
+}
+
+module.exports = {
+  PACKAGE_NAME,
+  BREW_FORMULA,
+  UPDATE_ACTIONS,
+  detectInstallChannel,
+  formatCommandLine,
+};

--- a/test/cli-help.test.js
+++ b/test/cli-help.test.js
@@ -1,24 +1,87 @@
 const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const { test } = require("node:test");
 
 const { run } = require("../src/cli");
 
-test("help output uses TokenTracker identifiers", async () => {
-  const prevWrite = process.stdout.write;
-  let out = "";
+const TRACKER = path.resolve(__dirname, "..", "bin", "tracker.js");
 
+async function captureRun(argv) {
+  const prevOut = process.stdout.write;
+  const prevErr = process.stderr.write;
+  const prevExit = process.exitCode;
+  let out = "";
+  let err = "";
   try {
     process.stdout.write = (chunk) => {
       out += String(chunk || "");
       return true;
     };
-
-    await run(["-h"]);
+    process.stderr.write = (chunk) => {
+      err += String(chunk || "");
+      return true;
+    };
+    await run(argv);
+    return { out, err, exitCode: process.exitCode };
   } finally {
-    process.stdout.write = prevWrite;
+    process.stdout.write = prevOut;
+    process.stderr.write = prevErr;
+    process.exitCode = prevExit;
   }
+}
+
+test("help output uses TokenTracker identifiers", async () => {
+  const { out } = await captureRun(["-h"]);
 
   assert.match(out, /tokentracker/);
   assert.ok(!out.includes("vibe"));
   assert.match(out, /doctor/);
+  assert.match(out, /npx tokentracker \[--debug\] update/);
+  assert.doesNotMatch(out, /update \[--dry-run\]/);
+});
+
+test("unknown command prints help without throwing", async () => {
+  const { out, err, exitCode } = await captureRun(["not-a-command"]);
+  assert.equal(exitCode, 1);
+  assert.match(err, /Unknown command: not-a-command/);
+  assert.match(out, /Usage:/);
+  assert.match(out, /npx tokentracker \[--debug\] update/);
+  assert.equal(err.includes("    at "), false);
+});
+
+test("help command prints the same usage text", async () => {
+  const { out, exitCode } = await captureRun(["help"]);
+  assert.ok(!exitCode);
+  assert.match(out, /Usage:/);
+});
+
+test("upgrade is an alias of update help", async () => {
+  const { out, err, exitCode } = await captureRun(["upgrade", "--help"]);
+  assert.ok(!exitCode);
+  assert.equal(err, "");
+  assert.match(out, /tokentracker update/);
+  assert.equal(out.includes("--dry-run"), false);
+});
+
+test("CLI process prints help and no stack for an unknown command", () => {
+  const res = spawnSync(process.execPath, [TRACKER, "not-a-command"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  assert.notEqual(res.status, 0);
+  const text = `${res.stdout}${res.stderr}`;
+  assert.match(text, /Unknown command: not-a-command/);
+  assert.match(text, /Usage:/);
+  assert.doesNotMatch(res.stderr, /at run \(/);
+});
+
+test("update --dry-run is rejected without a stack trace", () => {
+  const res = spawnSync(process.execPath, [TRACKER, "update", "--dry-run"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  assert.notEqual(res.status, 0);
+  assert.match(`${res.stdout}${res.stderr}`, /Unknown option: --dry-run/);
+  assert.doesNotMatch(res.stderr, /at parseArgs/);
 });

--- a/test/install-channel.test.js
+++ b/test/install-channel.test.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const {
+  detectInstallChannel,
+  PACKAGE_NAME,
+  BREW_FORMULA,
+} = require("../src/lib/install-channel");
+
+function detect(entryPath) {
+  return detectInstallChannel({
+    entryPath,
+    realpathSync: (p) => p,
+  });
+}
+
+test("detects brew keg even when the formula vendor copy lives in node_modules", () => {
+  const channel = detect(
+    "/opt/homebrew/Cellar/tokentracker/0.96.2/libexec/lib/node_modules/tokentracker-cli/bin/tracker.js",
+  );
+  assert.equal(channel.method, "brew");
+  assert.equal(channel.command, `brew upgrade ${BREW_FORMULA}`);
+});
+
+test("detects brew opt prefix", () => {
+  const channel = detect("/opt/homebrew/opt/tokentracker/libexec/bin/tracker.js");
+  assert.equal(channel.method, "brew");
+});
+
+test("does not treat Homebrew's npm global prefix as a brew formula", () => {
+  const channel = detect("/opt/homebrew/lib/node_modules/tokentracker-cli/bin/tracker.js");
+  assert.equal(channel.method, "npm");
+  assert.equal(channel.command, `npm install -g ${PACKAGE_NAME}@latest`);
+});
+
+test("detects a user-local npm prefix as npm, not a source tree", () => {
+  const channel = detect("/home/u/.local/lib/node_modules/tokentracker-cli/bin/tracker.js");
+  assert.equal(channel.method, "npm");
+  assert.equal(channel.action.bin, "npm");
+});
+
+test("detects linuxbrew Cellar installs as brew", () => {
+  const channel = detect(
+    "/home/linuxbrew/.linuxbrew/Cellar/tokentracker/0.96.2/libexec/lib/node_modules/tokentracker-cli/bin/tracker.js",
+  );
+  assert.equal(channel.method, "brew");
+});
+
+test("detects npm, bun, pnpm, yarn, and npx from their install layouts", () => {
+  assert.equal(
+    detect("/home/u/.nvm/versions/node/v20.11.0/lib/node_modules/tokentracker-cli/bin/tracker.js").method,
+    "npm",
+  );
+  assert.equal(
+    detect("/home/u/.bun/install/global/node_modules/tokentracker-cli/bin/tracker.js").method,
+    "bun",
+  );
+  assert.equal(
+    detect(
+      "/home/u/.local/share/pnpm/global/5/node_modules/.pnpm/tokentracker-cli@0.96.2/node_modules/tokentracker-cli/bin/tracker.js",
+    ).method,
+    "pnpm",
+  );
+  assert.equal(
+    detect("/home/u/.config/yarn/global/node_modules/tokentracker-cli/bin/tracker.js").method,
+    "yarn",
+  );
+  const npx = detect("/home/u/.npm/_npx/123abc/node_modules/tokentracker-cli/bin/tracker.js");
+  assert.equal(npx.method, "npx");
+  assert.equal(npx.action, null);
+  assert.match(npx.reason, /npx tokentracker-cli@latest/);
+});
+
+test("detects desktop EmbeddedServer bundles on POSIX and Windows paths", () => {
+  const mac = detect(
+    "/Applications/TokenTracker.app/Contents/Resources/EmbeddedServer/tokentracker/bin/tracker.js",
+  );
+  assert.equal(mac.method, "desktop");
+  assert.equal(mac.action, null);
+  assert.match(mac.reason, /desktop app/);
+
+  const win = detect(
+    "C:\\Program Files\\TokenTracker\\EmbeddedServer\\tokentracker\\bin\\tracker.js",
+  );
+  assert.equal(win.method, "desktop");
+});
+
+test("refuses unmanaged source checkouts and mentions git pull when .git exists", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tt-install-"));
+  try {
+    fs.mkdirSync(path.join(root, "src"));
+    fs.mkdirSync(path.join(root, "bin"));
+    fs.mkdirSync(path.join(root, ".git"));
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: PACKAGE_NAME, version: "0.0.0" }),
+    );
+    fs.writeFileSync(path.join(root, "src", "cli.js"), "module.exports = {};\n");
+    const entry = path.join(root, "bin", "tracker.js");
+    fs.writeFileSync(entry, "");
+    const channel = detect(entry);
+    assert.equal(channel.method, "other");
+    assert.equal(channel.action, null);
+    assert.equal(channel.sourceRoot, root);
+    assert.equal(channel.git, true);
+    assert.match(channel.reason, /git checkout/);
+    assert.match(channel.reason, /git -C /);
+    assert.ok(channel.reason.includes(root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("detects the repository checkout from bin/tracker.js", () => {
+  const channel = detectInstallChannel({
+    entryPath: path.join(__dirname, "..", "bin", "tracker.js"),
+  });
+  assert.equal(channel.method, "other");
+  assert.equal(channel.git, true);
+  assert.match(channel.reason, /git checkout/);
+});

--- a/test/status-json-light.test.js
+++ b/test/status-json-light.test.js
@@ -83,6 +83,7 @@ test("status --bogus rejects unknown flag", () => {
   const res = runStatus(["--bogus"]);
   assert.notEqual(res.status, 0, "unknown flag must be rejected");
   assert.match(res.stderr + res.stdout, /Unknown option: --bogus/);
+  assert.doesNotMatch(res.stderr, /at parseArgs/);
 });
 
 test("status --json --no-spinner is accepted (no-spinner is a no-op for status)", () => {

--- a/test/update-cli-e2e.test.js
+++ b/test/update-cli-e2e.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { test } = require("node:test");
+
+const REPO = path.resolve(__dirname, "..");
+const TRACKER_SRC = path.join(REPO, "bin", "tracker.js");
+
+function stageNpmPrefix(tmp) {
+  const pkgRoot = path.join(tmp, "lib", "node_modules", "tokentracker-cli");
+  fs.mkdirSync(path.join(pkgRoot, "bin"), { recursive: true });
+  fs.cpSync(path.join(REPO, "src"), path.join(pkgRoot, "src"), { recursive: true });
+  fs.copyFileSync(TRACKER_SRC, path.join(pkgRoot, "bin", "tracker.js"));
+  fs.copyFileSync(path.join(REPO, "package.json"), path.join(pkgRoot, "package.json"));
+  return path.join(pkgRoot, "bin", "tracker.js");
+}
+
+function writeFakeNpm(tmp) {
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const npmPath = path.join(binDir, "npm");
+  fs.writeFileSync(
+    npmPath,
+    [
+      "#!/bin/sh",
+      "printf '%s\\n' \"$*\" >> \"${TOKENTRACKER_TEST_NPM_LOG}\"",
+      "exit \"${TOKENTRACKER_TEST_NPM_EXIT:-0}\"",
+      "",
+    ].join("\n"),
+    { encoding: "utf8" },
+  );
+  fs.chmodSync(npmPath, 0o755);
+  return binDir;
+}
+
+function runTracker(entry, args, extraEnv = {}) {
+  return spawnSync(process.execPath, [entry, ...args], {
+    encoding: "utf8",
+    timeout: 20_000,
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+test("npm-prefix layout runs npm install -g and does not treat the tree as a git checkout", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-update-npm-"));
+  try {
+    const entry = stageNpmPrefix(tmp);
+    const fakeBin = writeFakeNpm(tmp);
+    const npmLog = path.join(tmp, "npm.log");
+    const res = runTracker(entry, ["update"], {
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+      TOKENTRACKER_TEST_NPM_LOG: npmLog,
+    });
+    const text = `${res.stdout}${res.stderr}`;
+    assert.equal(res.status, 0, text);
+    assert.match(res.stdout, /Detected install: npm/);
+    assert.match(res.stdout, /Updating TokenTracker via `npm install -g tokentracker-cli@latest`/);
+    assert.match(res.stdout, /Update finished/);
+    assert.equal(fs.readFileSync(npmLog, "utf8").trim(), "install -g tokentracker-cli@latest");
+    assert.doesNotMatch(text, /git checkout/);
+    assert.doesNotMatch(res.stderr, /at run \(/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("npm-prefix update forwards a failing npm exit code", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-update-npm-fail-"));
+  try {
+    const entry = stageNpmPrefix(tmp);
+    const fakeBin = writeFakeNpm(tmp);
+    const npmLog = path.join(tmp, "npm.log");
+    const res = runTracker(entry, ["update"], {
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+      TOKENTRACKER_TEST_NPM_LOG: npmLog,
+      TOKENTRACKER_TEST_NPM_EXIT: "3",
+    });
+    assert.equal(res.status, 3);
+    assert.match(res.stdout, /Detected install: npm/);
+    assert.doesNotMatch(res.stdout, /Update finished/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("this repository checkout refuses to self-update", () => {
+  const res = runTracker(TRACKER_SRC, ["update"]);
+  assert.notEqual(res.status, 0);
+  assert.match(res.stdout, /Detected install: other/);
+  assert.match(res.stderr, /git checkout/);
+  assert.match(res.stderr, /git -C /);
+  assert.doesNotMatch(`${res.stdout}${res.stderr}`, /Updating TokenTracker via/);
+});
+
+test("unknown command from an npm-prefix install prints help without a stack", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tt-update-unknown-"));
+  try {
+    const entry = stageNpmPrefix(tmp);
+    const res = runTracker(entry, ["not-a-command"]);
+    assert.notEqual(res.status, 0);
+    const text = `${res.stdout}${res.stderr}`;
+    assert.match(text, /Unknown command: not-a-command/);
+    assert.match(text, /Usage:/);
+    assert.match(text, /\[--debug\] update/);
+    assert.doesNotMatch(res.stderr, /at run \(/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/update-command.test.js
+++ b/test/update-command.test.js
@@ -1,0 +1,144 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { cmdUpdate, parseArgs, updateHelpText } = require("../src/commands/update");
+const { PACKAGE_NAME, BREW_FORMULA } = require("../src/lib/install-channel");
+
+function createStreams() {
+  const out = { stdout: "", stderr: "" };
+  return {
+    out,
+    stdout: {
+      write(chunk) {
+        out.stdout += String(chunk || "");
+        return true;
+      },
+    },
+    stderr: {
+      write(chunk) {
+        out.stderr += String(chunk || "");
+        return true;
+      },
+    },
+  };
+}
+
+async function runUpdate(argv, extra = {}) {
+  const streams = createStreams();
+  const prevExit = process.exitCode;
+  const calls = [];
+  try {
+    await cmdUpdate(argv, {
+      entryPath: extra.entryPath,
+      realpathSync: extra.realpathSync || ((p) => p),
+      spawnSync: extra.spawnSync || ((bin, args) => {
+        calls.push({ bin, args });
+        return extra.spawnResult || { status: 0 };
+      }),
+      platform: extra.platform,
+      stdout: streams.stdout,
+      stderr: streams.stderr,
+    });
+    return {
+      out: streams.out.stdout,
+      err: streams.out.stderr,
+      calls,
+      exitCode: process.exitCode,
+    };
+  } finally {
+    process.exitCode = prevExit;
+  }
+}
+
+test("parseArgs rejects unknown flags including --dry-run", () => {
+  assert.deepEqual(parseArgs([]), { help: false });
+  assert.deepEqual(parseArgs(["--help"]), { help: true });
+  assert.throws(() => parseArgs(["--dry-run"]), /Unknown option: --dry-run/);
+});
+
+test("update help does not mention --dry-run", () => {
+  const help = updateHelpText();
+  assert.match(help, /tokentracker update/);
+  assert.equal(help.includes("--dry-run"), false);
+});
+
+test("update delegates npm-global installs to npm", async () => {
+  const result = await runUpdate([], {
+    entryPath: "/home/u/.nvm/versions/node/v20.11.0/lib/node_modules/tokentracker-cli/bin/tracker.js",
+  });
+  assert.deepEqual(result.calls, [{ bin: "npm", args: ["install", "-g", `${PACKAGE_NAME}@latest`] }]);
+  assert.match(result.out, /Detected install: npm/);
+  assert.match(result.out, /Updating TokenTracker via `npm install -g tokentracker-cli@latest`/);
+  assert.match(result.out, /Update finished/);
+  assert.equal(result.err, "");
+});
+
+test("update delegates Homebrew keg installs to brew upgrade", async () => {
+  const result = await runUpdate([], {
+    entryPath:
+      "/opt/homebrew/Cellar/tokentracker/0.96.2/libexec/lib/node_modules/tokentracker-cli/bin/tracker.js",
+  });
+  assert.deepEqual(result.calls, [{ bin: "brew", args: ["upgrade", BREW_FORMULA] }]);
+  assert.match(result.out, /Detected install: brew/);
+});
+
+test("update uses a Windows shell when spawning npm", async () => {
+  let shell;
+  await runUpdate([], {
+    entryPath: "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\tokentracker-cli\\bin\\tracker.js",
+    platform: "win32",
+    spawnSync: (bin, args, opts) => {
+      shell = opts.shell;
+      return { status: 0 };
+    },
+  });
+  assert.equal(shell, true);
+});
+
+test("update refuses source checkouts without spawning a package manager", async () => {
+  const result = await runUpdate([], {
+    entryPath: path.join(__dirname, "..", "bin", "tracker.js"),
+    realpathSync: undefined,
+  });
+  assert.deepEqual(result.calls, []);
+  assert.equal(result.exitCode, 1);
+  assert.match(result.out, /Detected install: other/);
+  assert.match(result.err, /git checkout|source tree|managed install/);
+});
+
+test("update refuses npx and desktop installs", async () => {
+  const npx = await runUpdate([], {
+    entryPath: "/home/u/.npm/_npx/xyz/node_modules/tokentracker-cli/bin/tracker.js",
+  });
+  assert.deepEqual(npx.calls, []);
+  assert.equal(npx.exitCode, 1);
+  assert.match(npx.err, /launched via npx/);
+
+  const desktop = await runUpdate([], {
+    entryPath: "/Applications/TokenTracker.app/Contents/Resources/EmbeddedServer/tokentracker/bin/tracker.js",
+  });
+  assert.deepEqual(desktop.calls, []);
+  assert.equal(desktop.exitCode, 1);
+  assert.match(desktop.err, /desktop app/);
+});
+
+test("update --help prints subcommand help without spawning", async () => {
+  const result = await runUpdate(["--help"], {
+    entryPath: "/home/u/.nvm/versions/node/v20.11.0/lib/node_modules/tokentracker-cli/bin/tracker.js",
+  });
+  assert.deepEqual(result.calls, []);
+  assert.match(result.out, /Delegates to the package manager/);
+  assert.equal(result.out.includes("--dry-run"), false);
+});
+
+test("update surfaces a missing package-manager binary", async () => {
+  const result = await runUpdate([], {
+    entryPath: "/home/u/.nvm/versions/node/v20.11.0/lib/node_modules/tokentracker-cli/bin/tracker.js",
+    spawnResult: { error: new Error("spawn npm ENOENT"), status: null },
+  });
+  assert.equal(result.exitCode, 1);
+  assert.match(result.err, /Failed to run `npm`/);
+});


### PR DESCRIPTION
## Summary

Headless CLI installs had no way to update TokenTracker in-place, and a mistyped subcommand dumped a Node stack trace. This PR adds `tokentracker update`, which detects the install channel (npm, bun, pnpm, yarn, Homebrew) and delegates to that package manager — matching Codex's approach — and prints help instead of a stack for unknown commands/options.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [x] Docs / CI / config

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text)
- [x] Commits follow conventional style (`feat:` / `fix:` / `refactor:` / `docs:` / `chore:` / `test:` / `ci:`)
- [x] PR description explains *why*, not just *what*

CLI help remains in `src/cli.js`, same as the existing command list. Dashboard copy registry is unchanged.

## Behavior

`tokentracker update` (alias: `upgrade`) inspects the running entrypoint and:

- **npm / bun / pnpm / yarn / Homebrew** — runs that channel's upgrade command
- **npx, desktop EmbeddedServer bundles, git/source checkouts** — refuses and tells the user how to update without switching install methods

Unknown commands print `Unknown command: …` plus help and exit 1, with no stack. Usage errors (`Unknown option:`) also omit the stack unless `--debug` is set.

## Tests

- Channel detection for brew keg vs Homebrew's npm global prefix, npm/bun/pnpm/yarn/npx, desktop bundles, and git checkouts
- End-to-end: a real `node bin/tracker.js update` from an npm-prefix layout invokes `npm install -g tokentracker-cli@latest` (fake `npm` on `PATH`, no registry)
- Unknown commands and `update --dry-run` print help/errors without a stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `tokentracker update` and `upgrade` commands to update the CLI through its detected installation method.
  - Added support for `help` as an alias for CLI help.
  - Update guidance now covers npm, bun, pnpm, yarn, and Homebrew installations.

- **Bug Fixes**
  - Unknown commands and options now display concise error messages without stack traces.
  - Unsupported or locally installed dependencies no longer trigger inappropriate global updates and instead provide guidance.

- **Documentation**
  - Added update-command examples to English, German, Japanese, Korean, and Chinese quick-start guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->