### PR TITLE
fix(windows): re-check for updates periodically while the tray is resident

### DIFF
--- a/TokenTrackerWin/TrayApplicationContext.cs
+++ b/TokenTrackerWin/TrayApplicationContext.cs
@@ -81,6 +81,14 @@ internal sealed class TrayApplicationContext : ApplicationContext
     // WebView (to read the currency) once the dashboard has been opened.
     private readonly System.Windows.Forms.Timer _refreshTimer = new() { Interval = 2000 };
     private readonly System.Windows.Forms.Timer _syncTimer = new() { Interval = 5 * 60 * 1000 };
+    // Tray apps stay resident for days, so the launch-time update check alone can
+    // miss releases for as long as the app runs. Re-check periodically; the checker
+    // self-skips while a check/download is already in flight.
+    private const int UpdateCheckIntervalMinutes = 6 * 60;
+    private readonly System.Windows.Forms.Timer _updateCheckTimer = new()
+    {
+        Interval = UpdateCheckIntervalMinutes * 60 * 1000,
+    };
     // WebView currency reads are asynchronous. Timer ticks, menu opens, and
     // poller callbacks can arrive while one read is still pending; keep one
     // pass active and request one follow-up pass for the newest stats instead
@@ -239,6 +247,8 @@ internal sealed class TrayApplicationContext : ApplicationContext
         });
         _updateChecker.QuitRequested += () => PostToUi(Quit);
         _ = _updateChecker.CheckAsync(silent: true);
+        _updateCheckTimer.Tick += (_, _) => _ = _updateChecker.CheckAsync(silent: true);
+        _updateCheckTimer.Start();
 
         // The desktop pet is the app's visible presence now — the dashboard no longer
         // auto-opens. A stored preference (user toggled the pet at least once) always
@@ -1139,6 +1149,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         {
             _refreshTimer.Dispose();
             _syncTimer.Dispose();
+            _updateCheckTimer.Dispose();
             _poller.Dispose();
             _server.Dispose();
             _trayIcon.Dispose();

--- a/test/windows-update-check-scheduling.test.js
+++ b/test/windows-update-check-scheduling.test.js
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+
+function readTrayContext() {
+  return fs
+    .readFileSync(path.join(repoRoot, "TokenTrackerWin/TrayApplicationContext.cs"), "utf8")
+    .replace(/\r\n/g, "\n");
+}
+
+test("Windows tray schedules periodic silent update checks while resident", () => {
+  const source = readTrayContext();
+
+  // A long-lived tray process must re-check for updates, not only once at launch.
+  assert.match(
+    source,
+    /private const int UpdateCheckIntervalMinutes = \d+ \* 60;/,
+    "update check interval must be defined in hours worth of minutes",
+  );
+  assert.match(
+    source,
+    /private readonly System\.Windows\.Forms\.Timer _updateCheckTimer = new\(\)\n\s*\{\n\s*Interval = UpdateCheckIntervalMinutes \* 60 \* 1000,\n\s*\};/,
+    "a dedicated timer must drive periodic update checks",
+  );
+  assert.match(
+    source,
+    /_updateCheckTimer\.Tick \+= \(_, _\) => _ = _updateChecker\.CheckAsync\(silent: true\);\n\s*_updateCheckTimer\.Start\(\);/,
+    "timer ticks must run the same silent check as launch",
+  );
+  // The launch check stays in place.
+  assert.match(
+    source,
+    /_ = _updateChecker\.CheckAsync\(silent: true\);\n\s*_updateCheckTimer\.Tick/,
+    "the launch-time check must be kept alongside the periodic one",
+  );
+});
+
+test("periodic update check timer is disposed with the tray context", () => {
+  const source = readTrayContext();
+  const disposeStart = source.indexOf("protected override void Dispose(bool disposing)");
+  assert.notEqual(disposeStart, -1, "Dispose override must exist");
+  const dispose = source.slice(disposeStart);
+
+  assert.match(
+    dispose,
+    /_updateCheckTimer\.Dispose\(\);/,
+    "the update check timer must be disposed to avoid leaks after quit",
+  );
+});


### PR DESCRIPTION
## Problem

The silent update check ran **only once at launch** (`TrayApplicationContext` constructor). A tray app stays resident for days, so any release published after launch went unnoticed until the next full restart.

Evidence from a real install's `windows-host.log` (this machine):

- every `[update]` check line corresponds 1:1 with an app launch;
- releases 0.95.x / 0.96.0 sat unnoticed for days while the tray kept running;
- combined with slow/failing GitHub downloads from CN networks (timeouts, 20-minute installer downloads), auto-update felt like it "never works".

## Fix

Add a 6-hour `System.Windows.Forms.Timer` that re-runs the exact same silent check while the app is resident:

```csharp
_updateCheckTimer.Tick += (_, _) => _ = _updateChecker.CheckAsync(silent: true);
_updateCheckTimer.Start();
```

Safety properties already in place and unchanged:

- `CheckAsync` self-skips while a check/download/install is already in flight;
- dev builds (no embedded server) and auto-update-disabled installs are still skipped by the existing gates;
- the timer is disposed with the tray context.

## Verification

- new static lifecycle test `test/windows-update-check-scheduling.test.js` asserts the periodic tick, the kept launch check, and the dispose (2/2 pass)
- `dotnet build -c Release`: 0 warnings, 0 errors
- full `node --test test/*.test.js`: no new failures vs clean `main` (pre-existing environment-dependent flake set unchanged; my tests pass)

---

Note: this fixes the *scheduling* half only. The *download* half (GitHub release assets being slow/unreachable from CN networks) is tracked in a separate issue — mirrors are better handled by the maintainer for supply-chain safety, since the downloaded installer is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Windows tray application now silently checks for updates every six hours while running.
  * The existing update check at application launch remains available.

* **Bug Fixes**
  * Update-check resources are properly cleaned up when the tray application closes.

* **Tests**
  * Added automated coverage for update-check scheduling, launch behavior, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->