### PR TITLE
fix(pi): backfill project usage from session headers

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2407,6 +2407,7 @@ async function cmdSync(argv, context = {}) {
           sessionFiles: piFiles,
           cursors,
           queuePath,
+          projectQueuePath,
           env: process.env,
           onProgress: (p) => {
             if (!progress?.enabled) return;

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -15046,6 +15046,8 @@ async function parsePiLikeIncremental({
   sessionFiles,
   cursors,
   queuePath,
+  projectQueuePath,
+  publicRepoResolver,
   onProgress,
   env,
   defaultModel,
@@ -15055,6 +15057,7 @@ async function parsePiLikeIncremental({
   sourceForProvider,
 } = {}) {
   await ensureDir(path.dirname(queuePath));
+  const projectEnabled = typeof projectQueuePath === "string" && projectQueuePath.length > 0;
   const providerState = cursors[stateKey] && typeof cursors[stateKey] === "object"
     ? cursors[stateKey]
     : {};
@@ -15063,6 +15066,9 @@ async function parsePiLikeIncremental({
     providerState.fileOffsets && typeof providerState.fileOffsets === "object"
       ? { ...providerState.fileOffsets }
       : {};
+
+  const projectSeenIds = new Set(Array.isArray(providerState.projectSeenIds) ? providerState.projectSeenIds : []);
+  const projectFileOffsets = { ...(providerState.projectFileOffsets || {}) };
 
   const files = Array.isArray(sessionFiles)
     ? sessionFiles
@@ -15076,11 +15082,33 @@ async function parsePiLikeIncremental({
       fileOffsets,
       updatedAt: new Date().toISOString(),
     };
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0, projectBucketsQueued: 0 };
   }
 
   const hourlyState = normalizeHourlyState(cursors?.hourly);
   const touchedBuckets = new Set();
+  const projectState = projectEnabled ? normalizeProjectState(cursors?.projectHourly) : null;
+  const projectTouchedBuckets = projectEnabled ? new Set() : null;
+  const projectMetaCache = projectEnabled ? new Map() : null;
+  const publicRepoCache = projectEnabled ? new Map() : null;
+  // Both queues must publish before cursor progress is acknowledged. Normalized
+  // bucket maps still alias their values, so stage this provider's buckets to
+  // keep a failed project append from mutating the caller's aggregate state.
+  const family = sourceForProvider(null);
+  const ownsSource = (source) => source === family || source.startsWith(`${family}-`);
+  hourlyState.groupQueued = { ...(hourlyState.groupQueued || {}) };
+  for (const [key, bucket] of Object.entries(hourlyState.buckets)) {
+    if (ownsSource(parseBucketKey(key).source || "")) {
+      hourlyState.buckets[key] = { ...bucket, totals: { ...bucket.totals } };
+    }
+  }
+  if (projectState) {
+    for (const [key, bucket] of Object.entries(projectState.buckets)) {
+      if (ownsSource(bucket.source || "")) {
+        projectState.buckets[key] = { ...bucket, totals: { ...bucket.totals } };
+      }
+    }
+  }
   const cb = typeof onProgress === "function" ? onProgress : null;
   let recordsProcessed = 0;
   let eventsAggregated = 0;
@@ -15219,6 +15247,135 @@ async function parsePiLikeIncremental({
     };
   }
 
+  // Project attribution has an independent cursor so upgrading an existing
+  // installation can backfill already-consumed Pi sessions without adding
+  // those messages to the total-usage buckets a second time. Current Pi
+  // session headers persist the real cwd; unlike the encoded session folder,
+  // it is lossless even when path components contain dashes.
+  if (projectEnabled) {
+    for (const filePath of files) {
+      let stat;
+      try { stat = fssync.statSync(filePath); } catch { continue; }
+
+      const prevEntry = projectFileOffsets[filePath] || {};
+      const prevSize = Number(prevEntry.size) || 0;
+      const prevIno = prevEntry.ino;
+      const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
+      const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
+      if (stat.size <= startOffset) continue;
+
+      const cwd = await resolveOmpFileCwd(filePath);
+      const projectContext = cwd
+        ? await resolveProjectContextForPath({
+            startDir: wsl.mapWslCwdToUnc(cwd, filePath),
+            projectMetaCache,
+            publicRepoCache,
+            publicRepoResolver,
+            projectState,
+          })
+        : null;
+      const projectRef = projectContext?.projectRef || null;
+      const projectKey = projectContext?.projectKey || null;
+
+      let lastCompleteOffset = startOffset;
+      if (projectKey && projectRef) {
+        let stream;
+        try {
+          stream = fssync.createReadStream(filePath, {
+            encoding: "utf8",
+            start: startOffset,
+          });
+        } catch {
+          continue;
+        }
+        let streamedBytes = 0;
+        stream.on("data", (chunk) => {
+          const newlineIndex = chunk.lastIndexOf("\n");
+          if (newlineIndex !== -1) {
+            lastCompleteOffset = startOffset + streamedBytes
+              + Buffer.byteLength(chunk.slice(0, newlineIndex + 1), "utf8");
+          }
+          streamedBytes += Buffer.byteLength(chunk, "utf8");
+        });
+        const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+        for await (const line of rl) {
+          if (!line || !line.trim()) continue;
+          let entry;
+          try { entry = JSON.parse(line); } catch { continue; }
+          const msg = entry?.type === "message" ? entry.message : null;
+          const usage = msg?.role === "assistant" ? msg.usage : null;
+          if (!usage || typeof usage !== "object") continue;
+
+          const entryId = typeof entry.id === "string" && entry.id ? entry.id : null;
+          if (!entryId || projectSeenIds.has(entryId)) continue;
+
+          const input = toNonNegativeInt(usage.input);
+          const output = toNonNegativeInt(usage.output);
+          const cacheRead = toNonNegativeInt(usage.cacheRead);
+          const cacheWrite = toNonNegativeInt(usage.cacheWrite);
+          const reasoningTokens = toNonNegativeInt(usage.reasoningTokens);
+          if (
+            input === 0 &&
+            output === 0 &&
+            cacheRead === 0 &&
+            cacheWrite === 0 &&
+            reasoningTokens === 0
+          ) {
+            projectSeenIds.add(entryId);
+            continue;
+          }
+
+          let tsMs = null;
+          if (Number.isFinite(Number(msg.timestamp)) && Number(msg.timestamp) > 0) {
+            tsMs = Number(msg.timestamp);
+          } else if (typeof entry.timestamp === "string" && entry.timestamp) {
+            const parsed = Date.parse(entry.timestamp);
+            if (Number.isFinite(parsed) && parsed > 0) tsMs = parsed;
+          }
+          const bucketStart = tsMs == null
+            ? null
+            : toUtcHalfHourStart(new Date(tsMs).toISOString());
+          if (!bucketStart) {
+            projectSeenIds.add(entryId);
+            continue;
+          }
+
+          const totalTokens =
+            Number.isFinite(Number(usage.totalTokens)) && Number(usage.totalTokens) > 0
+              ? toNonNegativeInt(usage.totalTokens)
+              : input + output + cacheRead + cacheWrite + reasoningTokens;
+          const delta = {
+            input_tokens: input,
+            cached_input_tokens: cacheRead,
+            cache_creation_input_tokens: cacheWrite,
+            output_tokens: output,
+            reasoning_output_tokens: reasoningTokens,
+            total_tokens: totalTokens,
+            conversation_count: 1,
+          };
+          const projectBucket = getProjectBucket(
+            projectState,
+            projectKey,
+            sourceForProvider(msg.provider),
+            bucketStart,
+            projectRef,
+          );
+          addTotals(projectBucket.totals, delta);
+          projectTouchedBuckets.add(projectBucketKey(projectKey, sourceForProvider(msg.provider), bucketStart));
+          projectSeenIds.add(entryId);
+        }
+      }
+
+      let postStat = stat;
+      try { postStat = fssync.statSync(filePath); } catch {}
+      projectFileOffsets[filePath] = {
+        size: Math.min(lastCompleteOffset, postStat.size),
+        mtimeMs: postStat.mtimeMs,
+        ino: postStat.ino,
+      };
+    }
+  }
+
   const seenArr = Array.from(seenIds);
   const cappedSeen =
     seenArr.length > 10_000 ? seenArr.slice(seenArr.length - 10_000) : seenArr;
@@ -15228,17 +15385,28 @@ async function parsePiLikeIncremental({
     hourlyState,
     touchedBuckets,
   });
+  const projectBucketsQueued = projectEnabled
+    ? await enqueueTouchedProjectBuckets({ projectQueuePath, projectState, projectTouchedBuckets })
+    : 0;
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
+  if (projectState) {
+    projectState.updatedAt = updatedAt;
+    cursors.projectHourly = projectState;
+  }
   cursors[stateKey] = {
     ...providerState,
     seenIds: cappedSeen,
     fileOffsets,
+    ...(projectEnabled ? {
+      projectSeenIds: Array.from(projectSeenIds).slice(-10_000),
+      projectFileOffsets,
+    } : {}),
     updatedAt,
   };
 
-  return { recordsProcessed, eventsAggregated, bucketsQueued };
+  return { recordsProcessed, eventsAggregated, bucketsQueued, projectBucketsQueued };
 }
 
 async function parsePiIncremental(options = {}) {

--- a/test/pi-project-usage.test.js
+++ b/test/pi-project-usage.test.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { parsePiIncremental } = require("../src/lib/rollout");
+
+const time = Date.UTC(2026, 8, 12, 10);
+const message = (id, provider = "anthropic", input = 100) => JSON.stringify({
+  type: "message", id,
+  message: {
+    role: "assistant", provider, model: "claude-sonnet-4-6", timestamp: time,
+    usage: { input, output: 20, cacheRead: 30, cacheWrite: 10, totalTokens: input + 60 },
+  },
+});
+
+async function fixture(t) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-project-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const project = path.join(dir, "path-with-dashes", "project");
+  await fs.mkdir(path.join(project, ".git"), { recursive: true });
+  await fs.writeFile(path.join(project, ".git", "config"),
+    '[remote "origin"]\n\turl = https://github.com/example/pi-project.git\n');
+  const file = path.join(dir, "session.jsonl");
+  await fs.writeFile(file, JSON.stringify({ type: "session", id: "session", cwd: project }) + "\n");
+  return {
+    file, dir, cursors: {}, queuePath: path.join(dir, "queue.jsonl"),
+    projectQueuePath: path.join(dir, "project.queue.jsonl"),
+    sessionFiles: [file], publicRepoResolver: async ({ projectRef }) => ({
+      status: "public_verified", projectKey: "example/pi-project", projectRef,
+    }),
+  };
+}
+
+async function rows(file) {
+  return (await fs.readFile(file, "utf8")).trim().split("\n").filter(Boolean).map(JSON.parse);
+}
+
+test("Pi projects backfill consumed history with provider-specific sources and remain idempotent", async (t) => {
+  const f = await fixture(t);
+  await fs.appendFile(f.file, [message("a"), message("b", "github-copilot", 300), ""].join("\n"));
+  await parsePiIncremental({ ...f, projectQueuePath: undefined });
+  const aggregateBefore = await fs.readFile(f.queuePath, "utf8");
+  f.cursors = JSON.parse(JSON.stringify(f.cursors));
+  const backfill = await parsePiIncremental(f);
+  assert.equal(backfill.eventsAggregated, 0);
+  assert.equal(backfill.projectBucketsQueued, 2);
+  const bySource = new Map((await rows(f.projectQueuePath)).map((row) => [row.source, row]));
+  assert.equal(bySource.get("pi-anthropic").total_tokens, 160);
+  assert.equal(bySource.get("pi-github-copilot").total_tokens, 360);
+  for (const row of bySource.values()) {
+    assert.equal(row.project_key, "example/pi-project");
+    assert.equal(row.project_ref, "https://github.com/example/pi-project");
+    assert.equal(row.conversation_count, 1);
+  }
+  assert.equal(await fs.readFile(f.queuePath, "utf8"), aggregateBefore);
+  const projectBefore = await fs.readFile(f.projectQueuePath, "utf8");
+  f.cursors = JSON.parse(JSON.stringify(f.cursors));
+  const repeated = await parsePiIncremental(f);
+  assert.equal(repeated.projectBucketsQueued, 0);
+  assert.equal(await fs.readFile(f.projectQueuePath, "utf8"), projectBefore);
+  await fs.appendFile(f.file, message("c", "anthropic", 50) + "\n");
+  await parsePiIncremental(f);
+  assert.equal((await rows(f.projectQueuePath)).at(-1).total_tokens, 270);
+  assert.equal((await rows(f.queuePath)).at(-1).total_tokens, 270);
+});
+
+test("Pi project cursor retries a partial final record without losing or doubling it", async (t) => {
+  const f = await fixture(t);
+  await fs.appendFile(f.file, message("first", undefined, 100) + "\n");
+  await parsePiIncremental(f);
+  const tail = message("second", undefined, 200);
+  await fs.appendFile(f.file, tail.slice(0, -4));
+  await parsePiIncremental(f);
+  await fs.appendFile(f.file, tail.slice(-4) + "\n");
+  f.cursors = JSON.parse(JSON.stringify(f.cursors));
+  await parsePiIncremental(f);
+  assert.equal((await rows(f.projectQueuePath)).at(-1).total_tokens, 420);
+  assert.equal((await rows(f.queuePath)).at(-1).total_tokens, 420);
+  const before = await fs.readFile(f.projectQueuePath, "utf8");
+  await parsePiIncremental(f);
+  assert.equal(await fs.readFile(f.projectQueuePath, "utf8"), before);
+});
+
+test("Pi project append failure preserves cursors so both queues recover on retry", async (t) => {
+  const f = await fixture(t);
+  await fs.appendFile(f.file, message("first") + "\n");
+  await parsePiIncremental(f);
+  await fs.appendFile(f.file, message("second") + "\n");
+  const before = JSON.stringify(f.cursors);
+  const blocked = path.join(f.dir, "blocked-queue");
+  await fs.mkdir(blocked);
+  await assert.rejects(parsePiIncremental({ ...f, projectQueuePath: blocked }));
+  assert.equal(JSON.stringify(f.cursors), before);
+  f.cursors = JSON.parse(before);
+  await parsePiIncremental(f);
+  assert.equal((await rows(f.queuePath)).at(-1).total_tokens, 320);
+  assert.equal((await rows(f.projectQueuePath)).at(-1).total_tokens, 320);
+});
+
+test("Pi project attribution requires a session cwd and never guesses from the file path", async (t) => {
+  const f = await fixture(t);
+  await fs.writeFile(f.file, JSON.stringify({ type: "session", id: "no-cwd" }) + "\n" + message("first") + "\n");
+  const result = await parsePiIncremental(f);
+  assert.equal(result.eventsAggregated, 1);
+  assert.equal(result.projectBucketsQueued, 0);
+  assert.equal((await rows(f.queuePath)).at(-1).total_tokens, 160);
+  await assert.rejects(fs.access(f.projectQueuePath), { code: "ENOENT" });
+});


### PR DESCRIPTION
Pi usage currently reaches total-usage buckets but never the project queue. Read the session header cwd and backfill project usage with an independent cursor, preserving each pi-* provider source and leaving previously counted totals unchanged. Stage both queues' bucket state until publication succeeds so a failed project append can be retried without double-counting.

Validation: four new regression tests cover provider-separated backfill, serialized repeat sync, appends, partial tails, failed project publication/retry, and missing cwd. The 18 existing Pi/Prime/OMP parser tests and `npm run ci:local` pass (2,772 passed, 2 skipped). No release is included. References #617; keep the issue open until publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pi session usage is now attributed to the relevant project during synchronization.
  - Project-level usage totals are queued for reporting and aggregation.

- **Bug Fixes**
  - Improved incremental processing prevents usage from being missed or duplicated.
  - Synchronization now recovers more reliably from partial records, file changes, and temporary append failures.
  - Project attribution only occurs when a valid session working directory is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->